### PR TITLE
Selective shift + click output connections grabs connectors for selected nodes only

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -362,21 +362,31 @@ namespace Dynamo.Models
             PortModel selectedPort = node.OutPorts[portIndex];
 
             var connectorsForDeletion = new List<ModelBase>();
-            int numOfConnectors = selectedPort.Connectors.Count;
+
+            var selectedConnectors = new List<ConnectorModel>();
+            selectedConnectors = selectedPort.Connectors.Where(x => x.End.Owner.IsSelected).ToList();
+
+            // If no connectors are selected, process all of the associated nodes
+            if (selectedConnectors.Count() <= 0)
+            {
+                selectedConnectors = selectedPort.Connectors.ToList();
+            }
+
+            int numOfConnectors = selectedConnectors.Count();
             if (numOfConnectors == 0) return;
             
             activeStartPorts = new PortModel[numOfConnectors];
 
             for (int i = 0; i < numOfConnectors; i++)
             {
-                ConnectorModel connector = selectedPort.Connectors[i];
+                ConnectorModel connector = selectedConnectors[i];
                 connectorsForDeletion.Add(connector);
                 activeStartPorts[i] = connector.End;
             }
             CurrentWorkspace.SaveAndDeleteModels(connectorsForDeletion);
             for (int i = 0; i < numOfConnectors; i++) //delete the connectors
             {
-                selectedPort.Connectors[0].Delete();
+                selectedConnectors[i].Delete();
             }
             return;
         }

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -361,8 +361,6 @@ namespace Dynamo.Models
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
-            var connectorsForDeletion = new List<ModelBase>();
-
             var selectedConnectors = new List<ConnectorModel>();
             selectedConnectors = selectedPort.Connectors.Where(x => x.End.Owner.IsSelected).ToList();
 
@@ -380,10 +378,9 @@ namespace Dynamo.Models
             for (int i = 0; i < numOfConnectors; i++)
             {
                 ConnectorModel connector = selectedConnectors[i];
-                connectorsForDeletion.Add(connector);
                 activeStartPorts[i] = connector.End;
             }
-            CurrentWorkspace.SaveAndDeleteModels(connectorsForDeletion);
+            CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>());
             for (int i = 0; i < numOfConnectors; i++) //delete the connectors
             {
                 selectedConnectors[i].Delete();

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -209,13 +209,23 @@ namespace Dynamo.ViewModels
 
             PortModel portModel = node.OutPorts[portIndex];
             if (portModel.Connectors.Count <= 0) return;
-            
-            var connectorsAr = new ConnectorViewModel[portModel.Connectors.Count];
-            for (int i = 0; i < portModel.Connectors.Count; i++)
+
+            // Try to obtain connectors for selected nodes
+            var selected = portModel.Connectors.Where(x => x.End.Owner.IsSelected).Select(y => y.End);
+
+            // If there are no selected nodes, obtain all the associated connectors
+            if (selected.Count() <= 0)
             {
-                var c = new ConnectorViewModel(this, portModel.Connectors[i].End);
+                selected = portModel.Connectors.Select(y => y.End);
+            }
+
+            var connectorsAr = new ConnectorViewModel[selected.Count()];
+            for (int i = 0; i < selected.Count(); i++)
+            {
+                var c = new ConnectorViewModel(this, selected.ElementAt(i));
                 connectorsAr[i] = c;
-             }
+            }
+
             this.SetActiveConnectors(connectorsAr);
             return;
         }

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1211,6 +1211,115 @@ namespace DynamoCoreWpfTests
             AssertPreviewValue("5a42348373b94a11920feeaa680834fd", 10);
         }
 
+        /// <summary>
+        /// The following recorded test verifies that selecting a subset of nodes
+        /// and shift-clicking the parent output of these nodes only grabs the
+        /// connectors from the node that are selected. 
+        /// This is accomplished in the following steps: 
+        /// 1) Start with 2 code blocks with output values of 5 and 10.
+        /// 2) Create 3 code blocks with variables a, b, c
+        /// 3) Connnect the initial code block with a value of 5 to a, b, c
+        /// 3) Select code blocks containing variables a and c
+        /// 4) Shift click the output of the code block which contains the value of 5
+        /// 5) This should grab the connectors from only a and c (skipping b as it was not selected)
+        /// 6) Place these connectors on the code block containing a value of 10
+        /// 7) Verify a, b, c sums to 25 (a=10, b=5, c=10)
+        /// </summary>
+        [Test]
+        public void TestSelectiveShiftClickOutput()
+        {
+            RunCommandsFromFile("SelectiveShiftClickTest_Recording.xml");
+
+            // Verify final node and connector state
+            Assert.AreEqual(7, workspace.Nodes.Count());
+            Assert.AreEqual(7, workspace.Connectors.Count());
+
+            // Value of a
+            AssertPreviewValue("36a4604aeb684e1ca310a53e4d2c96c3", 10);
+            // Value of b
+            AssertPreviewValue("39842043c1894371899c5e1666e596ee", 5);
+            // Value of c
+            AssertPreviewValue("96007af3534d4581bca84d053f7ec043", 10);
+            // Value of a + b + c
+            AssertPreviewValue("e15ad50a3cd54c3485b482a21c786d46", 25);
+        }
+
+        /// <summary>
+        /// This test follows very similar logic compared withTestSelectiveShiftClickOutput()
+        /// but it makes calls an undo command after moving connectors with selective shift click
+        /// putting the graph back into its original state.
+        /// </summary>
+        [Test]
+        public void TestSelectiveShiftClickdOutputUndo()
+        {
+            RunCommandsFromFile("SelectiveShiftClickTestUndo_Recording.xml");
+
+            // Verify final node and connector state
+            Assert.AreEqual(7, workspace.Nodes.Count());
+            Assert.AreEqual(7, workspace.Connectors.Count());
+
+            // Value of a
+            AssertPreviewValue("9c757fd3c692490d85a13962c52114c8", 5);
+            // Value of b
+            AssertPreviewValue("1d45a1ba9d604687a509bd942852c276", 5);
+            // Value of c
+            AssertPreviewValue("26125cb52f5b4f289fefdcc0a9356f97", 5);
+            // Value of a + b + c
+            AssertPreviewValue("e7b387ded1ca422581eb09c2e2ad0c71", 15);
+        }
+
+        /// <summary>
+        /// This test follows very similar logic compared withTestSelectiveShiftClickOutput()
+        /// and TestSelectiveShiftClickdOutputUndo() but conducts undo's back to an empty workspace
+        /// and redo's back to the final state.
+        /// </summary>
+        [Test]
+        public void TestSelectiveShiftClickdOutputUndoRedo()
+        {
+            RunCommandsFromFile("SelectiveShiftClickTestUndoRedo_Recording.xml");
+
+            // Verify final node and connector state
+            Assert.AreEqual(7, workspace.Nodes.Count());
+            Assert.AreEqual(7, workspace.Connectors.Count());
+
+            // Value of a
+            AssertPreviewValue("6373cf7669a14d43a2f068f86bac30cb", 10);
+            // Value of b
+            AssertPreviewValue("ac768f631a2842e19a58c49974077d49", 5);
+            // Value of c
+            AssertPreviewValue("a693b9a7fb4648bd905df66394cba26a", 10);
+            // Value of a + b + c
+            AssertPreviewValue("4cfa20a57edf42588288f7ef2ed0a1c6", 25);
+        }
+
+        /// <summary>
+        /// Perform a large series of shift-clicks and ctrl-clicks with and without
+        /// selected nodes to test these commands in successive combinations
+        /// while verifying the graph still arrives at specific numeric state.
+        /// </summary>
+        [Test]
+        public void CombinationOfConnectorHotKeys()
+        {
+            RunCommandsFromFile("CombinationOfConnectorHotKeys_Recording.xml");
+
+            // Verify final node and connector state
+            Assert.AreEqual(6, workspace.Nodes.Count());
+            Assert.AreEqual(6, workspace.Connectors.Count());
+
+            // Code Block: value of 3
+            AssertPreviewValue("6f74b47d46e54a69b9de466c347531f0", 3);
+            // Code Block: value of 6
+            AssertPreviewValue("46ce4a8fcf354d1aa8f9ff0e7e587105", 6);
+            // Code Block: value of 9
+            AssertPreviewValue("6173dd048d5943898ed52e53aed57a00", 9);
+            
+            // Operation Result #1: 6 + 9
+            AssertPreviewValue("58c21031df374168a093f9b5eeacade7", 15);
+            // Operation Result #2: 3 + 6
+            AssertPreviewValue("f6929752825c4f49b5e9e70947eb8a03", 9);
+            // Operation Result #3: Result #1 * Result #2
+            AssertPreviewValue("50964fcc782d418a8ca6bec40e7ad440", 135);
+        }
         #endregion
 
         #region General Node Operations Test Cases

--- a/test/core/recorded/CombinationOfConnectorHotKeys_Recording.xml
+++ b/test/core/recorded/CombinationOfConnectorHotKeys_Recording.xml
@@ -1,0 +1,202 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="452" Y="192.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>6f74b47d-46e5-4a69-b9de-466c347531f0</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="6f74b47d-46e5-4a69-b9de-466c347531f0" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="360" y="161" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="3;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="3" WorkspaceGuid="deef1728-7b7a-43e2-9755-3d4419d83f97">
+    <ModelGuid>6f74b47d-46e5-4a69-b9de-466c347531f0</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="406" Y="317.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="359" y="262" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="6;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="6" WorkspaceGuid="deef1728-7b7a-43e2-9755-3d4419d83f97">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="370" Y="299.5" DragOperation="0" />
+  <DragSelectionCommand X="415" Y="275.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="643" Y="386.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>6173dd04-8d59-4389-8ed5-2e53aed57a00</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="6173dd04-8d59-4389-8ed5-2e53aed57a00" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="359" y="382" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="9;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <UpdateModelValueCommand Name="Code" Value="9" WorkspaceGuid="deef1728-7b7a-43e2-9755-3d4419d83f97">
+    <ModelGuid>6173dd04-8d59-4389-8ed5-2e53aed57a00</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6173dd04-8d59-4389-8ed5-2e53aed57a00</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="607" Y="368.5" DragOperation="0" />
+  <DragSelectionCommand X="415" Y="395.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="644" Y="346.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="58c21031-df37-4168-a093-f9b5eeacade7" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="+" x="551" y="188.5" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="+@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="689" Y="372.5" DragOperation="0" />
+  <DragSelectionCommand X="596" Y="214.5" DragOperation="1" />
+  <CreateNodeCommand X="719" Y="453.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="f6929752-825c-4f49-b5e9-e70947eb8a03" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="+" x="547" y="335.5" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="+@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="760" Y="470.5" DragOperation="0" />
+  <DragSelectionCommand X="588" Y="352.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="893" Y="354.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>50964fcc-782d-418a-8ca6-bec40e7ad440</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="50964fcc-782d-418a-8ca6-bec40e7ad440" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="819" y="263.5" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="true" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>50964fcc-782d-418a-8ca6-bec40e7ad440</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="917" Y="373.5" DragOperation="0" />
+  <DragSelectionCommand X="843" Y="282.5" DragOperation="1" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>50964fcc-782d-418a-8ca6-bec40e7ad440</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>50964fcc-782d-418a-8ca6-bec40e7ad440</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="PreviewPinned" Value="True" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>50964fcc-782d-418a-8ca6-bec40e7ad440</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>50964fcc-782d-418a-8ca6-bec40e7ad440</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>6f74b47d-46e5-4a69-b9de-466c347531f0</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>6173dd04-8d59-4389-8ed5-2e53aed57a00</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="6">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="7">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="7">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="5">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="542" Y="506.5" Width="0" Height="0" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="649" Y="409.5" DragOperation="0" />
+  <DragSelectionCommand X="649" Y="409.5" DragOperation="1" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>6f74b47d-46e5-4a69-b9de-466c347531f0</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>6173dd04-8d59-4389-8ed5-2e53aed57a00</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>6f74b47d-46e5-4a69-b9de-466c347531f0</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>46ce4a8f-cf35-4d1a-a8f9-ff0e7e587105</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="6">
+    <ModelGuid>58c21031-df37-4168-a093-f9b5eeacade7</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="7">
+    <ModelGuid>f6929752-825c-4f49-b5e9-e70947eb8a03</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="5">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="751" Y="316.5" Width="0" Height="0" IsCrossSelection="false" />
+</Commands>

--- a/test/core/recorded/SelectiveShiftClickTestUndoRedo_Recording.xml
+++ b/test/core/recorded/SelectiveShiftClickTestUndoRedo_Recording.xml
@@ -1,0 +1,311 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="409" Y="187.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="8245477d-e100-404c-a662-5bbb48a939dc" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="317" y="156" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="5;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="5;" WorkspaceGuid="1b27684c-0048-4027-a057-bd816d99a276">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="377" Y="307.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="6b6b354d-9855-46e2-8693-a6c27bb99dd8" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="285" y="276" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="10;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="10;" WorkspaceGuid="1b27684c-0048-4027-a057-bd816d99a276">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="330" Y="292.5" DragOperation="0" />
+  <DragSelectionCommand X="361" Y="294.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="579" Y="86.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="6373cf76-69a1-4d43-a2f0-68f86bac30cb" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="487" y="55" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a;" WorkspaceGuid="1b27684c-0048-4027-a057-bd816d99a276">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="532" Y="199.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>ac768f63-1a28-42e1-9a58-c49974077d49</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ac768f63-1a28-42e1-9a58-c49974077d49" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="440" y="168" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="b" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b" WorkspaceGuid="1b27684c-0048-4027-a057-bd816d99a276">
+    <ModelGuid>ac768f63-1a28-42e1-9a58-c49974077d49</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="535" Y="342.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a693b9a7-fb46-48bd-905d-f66394cba26a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="443" y="311" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c" WorkspaceGuid="1b27684c-0048-4027-a057-bd816d99a276">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="490" Y="328.5" DragOperation="0" />
+  <DragSelectionCommand X="551" Y="326.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>ac768f63-1a28-42e1-9a58-c49974077d49</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="475" Y="177.5" DragOperation="0" />
+  <DragSelectionCommand X="530" Y="188.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="521" Y="73.5" DragOperation="0" />
+  <DragSelectionCommand X="532" Y="89.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="714" Y="227.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="80c2d0ba-919f-45ec-99e6-78a49ea50310" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="622" y="196" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="[a, b, c];" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <PortInfo index="1" default="False" name="b" />
+      <PortInfo index="2" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="[a, b, c];" WorkspaceGuid="1b27684c-0048-4027-a057-bd816d99a276">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="878" Y="226.5" Width="1" Height="2" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="718" Y="210.5" DragOperation="0" />
+  <DragSelectionCommand X="754" Y="183.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="1046" Y="208.5" Width="0" Height="1" IsCrossSelection="false" />
+  <CreateNodeCommand X="1035" Y="351.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>4cfa20a5-7edf-4258-8288-f7ef2ed0a1c6</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4cfa20a5-7edf-4258-8288-f7ef2ed0a1c6" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sum" x="1035" y="351.5" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sum@double[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>4cfa20a5-7edf-4258-8288-f7ef2ed0a1c6</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="1084" Y="370.5" DragOperation="0" />
+  <DragSelectionCommand X="895" Y="186.5" DragOperation="1" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>ac768f63-1a28-42e1-9a58-c49974077d49</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="2" Type="0" ConnectionMode="1">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>80c2d0ba-919f-45ec-99e6-78a49ea50310</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>4cfa20a5-7edf-4258-8288-f7ef2ed0a1c6</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>ac768f63-1a28-42e1-9a58-c49974077d49</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="555" Y="136.5" DragOperation="0" />
+  <DragSelectionCommand X="555" Y="136.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="4">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="554" Y="377.5" DragOperation="0" />
+  <DragSelectionCommand X="555" Y="377.5" DragOperation="1" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="534" Y="142.5" DragOperation="0" />
+  <DragSelectionCommand X="534" Y="142.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="543" Y="144.5" DragOperation="0" />
+  <DragSelectionCommand X="543" Y="144.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="4">
+    <ModelGuid>ac768f63-1a28-42e1-9a58-c49974077d49</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>6373cf76-69a1-4d43-a2f0-68f86bac30cb</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="532" Y="136.5" DragOperation="0" />
+  <DragSelectionCommand X="532" Y="136.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="4">
+    <ModelGuid>a693b9a7-fb46-48bd-905d-f66394cba26a</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>8245477d-e100-404c-a662-5bbb48a939dc</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>6b6b354d-9855-46e2-8693-a6c27bb99dd8</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+</Commands>

--- a/test/core/recorded/SelectiveShiftClickTestUndo_Recording.xml
+++ b/test/core/recorded/SelectiveShiftClickTestUndo_Recording.xml
@@ -1,0 +1,210 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="513" Y="214.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="d0f1cc1e-c6be-4f9b-8756-62bf94352af5" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="529" y="155" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="5;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="5" WorkspaceGuid="69931d3d-5db2-4332-826e-ed3bcfa78b62">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="468" Y="354.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>a89a9c09-5c47-42a5-bd6a-24a6f7601667</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a89a9c09-5c47-42a5-bd6a-24a6f7601667" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="529" y="281" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="10;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="10" WorkspaceGuid="69931d3d-5db2-4332-826e-ed3bcfa78b62">
+    <ModelGuid>a89a9c09-5c47-42a5-bd6a-24a6f7601667</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>a89a9c09-5c47-42a5-bd6a-24a6f7601667</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="433" Y="341.5" DragOperation="0" />
+  <DragSelectionCommand X="478" Y="327.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="774" Y="101.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>9c757fd3-c692-490d-85a1-3962c52114c8</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="9c757fd3-c692-490d-85a1-3962c52114c8" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="682" y="70" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a" WorkspaceGuid="69931d3d-5db2-4332-826e-ed3bcfa78b62">
+    <ModelGuid>9c757fd3-c692-490d-85a1-3962c52114c8</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="1029" Y="147.5" Width="7" Height="2" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="731" Y="246.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>1d45a1ba-9d60-4687-a509-bd942852c276</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="1d45a1ba-9d60-4687-a509-bd942852c276" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="672" y="215" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="b" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b" WorkspaceGuid="69931d3d-5db2-4332-826e-ed3bcfa78b62">
+    <ModelGuid>1d45a1ba-9d60-4687-a509-bd942852c276</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="974" Y="204.5" Width="2" Height="0" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>1d45a1ba-9d60-4687-a509-bd942852c276</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="668" Y="234.5" DragOperation="0" />
+  <DragSelectionCommand X="701" Y="234.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="897" Y="267.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>26125cb5-2f5b-4f28-9fef-dcc0a9356f97</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="26125cb5-2f5b-4f28-9fef-dcc0a9356f97" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="671" y="350" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c" WorkspaceGuid="69931d3d-5db2-4332-826e-ed3bcfa78b62">
+    <ModelGuid>26125cb5-2f5b-4f28-9fef-dcc0a9356f97</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="1016" Y="135.5" Width="9" Height="7.5" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>26125cb5-2f5b-4f28-9fef-dcc0a9356f97</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="864" Y="251.5" DragOperation="0" />
+  <DragSelectionCommand X="730" Y="365.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="417" Y="194.5" Width="166" Height="212" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="441" Y="197.5" DragOperation="0" />
+  <DragSelectionCommand X="549" Y="169.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="859" Y="241.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="be6a4466-7eb1-4f36-b2d8-d1990df9b358" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="813" y="194" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="[a, b, c];" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <PortInfo index="1" default="False" name="b" />
+      <PortInfo index="2" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="[a, b, c];" WorkspaceGuid="69931d3d-5db2-4332-826e-ed3bcfa78b62">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="990" Y="233.5" Width="2" Height="0" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="824" Y="223.5" DragOperation="0" />
+  <DragSelectionCommand X="870" Y="207.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="1121" Y="241.5" Width="0" Height="1" IsCrossSelection="false" />
+  <CreateNodeCommand X="1148" Y="335.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>e7b387de-d1ca-4225-81eb-09c2e2ad0c71</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e7b387de-d1ca-4225-81eb-09c2e2ad0c71" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sum" x="1016" y="207.5" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sum@double[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>e7b387de-d1ca-4225-81eb-09c2e2ad0c71</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="1186" Y="353.5" DragOperation="0" />
+  <DragSelectionCommand X="1054" Y="225.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="1026" Y="132.5" Width="1" Height="1" IsCrossSelection="false" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>9c757fd3-c692-490d-85a1-3962c52114c8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>1d45a1ba-9d60-4687-a509-bd942852c276</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>26125cb5-2f5b-4f28-9fef-dcc0a9356f97</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="2" Type="0" ConnectionMode="1">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>be6a4466-7eb1-4f36-b2d8-d1990df9b358</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>e7b387de-d1ca-4225-81eb-09c2e2ad0c71</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>9c757fd3-c692-490d-85a1-3962c52114c8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>1d45a1ba-9d60-4687-a509-bd942852c276</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>26125cb5-2f5b-4f28-9fef-dcc0a9356f97</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>9c757fd3-c692-490d-85a1-3962c52114c8</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="744" Y="137.5" DragOperation="0" />
+  <DragSelectionCommand X="744" Y="137.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="4">
+    <ModelGuid>26125cb5-2f5b-4f28-9fef-dcc0a9356f97</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>d0f1cc1e-c6be-4f9b-8756-62bf94352af5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>a89a9c09-5c47-42a5-bd6a-24a6f7601667</ModelGuid>
+  </MakeConnectionCommand>
+  <UndoRedoCommand CmdOperation="0" />
+</Commands>

--- a/test/core/recorded/SelectiveShiftClickTest_Recording.xml
+++ b/test/core/recorded/SelectiveShiftClickTest_Recording.xml
@@ -1,0 +1,208 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="398" Y="176.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="0ae467ef-f4d3-45a4-a12d-3cf37ce7999b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="306" y="145" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="5;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="5" WorkspaceGuid="881916e6-f2cf-4a27-b993-a0bbd64d8214">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="343" Y="295.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>4c9ed913-297f-47ce-8f29-2d681372fe17</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="4c9ed913-297f-47ce-8f29-2d681372fe17" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="300" y="257" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="10;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="10" WorkspaceGuid="881916e6-f2cf-4a27-b993-a0bbd64d8214">
+    <ModelGuid>4c9ed913-297f-47ce-8f29-2d681372fe17</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>4c9ed913-297f-47ce-8f29-2d681372fe17</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="285" Y="284.5" DragOperation="0" />
+  <DragSelectionCommand X="334" Y="277.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="582" Y="90.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>36a4604a-eb68-4e1c-a310-a53e4d2c96c3</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="36a4604a-eb68-4e1c-a310-a53e4d2c96c3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="490" y="59" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a" WorkspaceGuid="881916e6-f2cf-4a27-b993-a0bbd64d8214">
+    <ModelGuid>36a4604a-eb68-4e1c-a310-a53e4d2c96c3</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="537" Y="217.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>39842043-c189-4371-899c-5e1666e596ee</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="39842043-c189-4371-899c-5e1666e596ee" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="490" y="179" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="b" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b" WorkspaceGuid="881916e6-f2cf-4a27-b993-a0bbd64d8214">
+    <ModelGuid>39842043-c189-4371-899c-5e1666e596ee</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="738" Y="172.5" Width="1" Height="1" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>39842043-c189-4371-899c-5e1666e596ee</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="479" Y="210.5" DragOperation="0" />
+  <DragSelectionCommand X="524" Y="203.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="528" Y="352.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>96007af3-534d-4581-bca8-4d053f7ec043</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="96007af3-534d-4581-bca8-4d053f7ec043" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="483" y="314" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c" WorkspaceGuid="881916e6-f2cf-4a27-b993-a0bbd64d8214">
+    <ModelGuid>96007af3-534d-4581-bca8-4d053f7ec043</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="712.5" Y="310.5" Width="7.5" Height="2" IsCrossSelection="true" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>96007af3-534d-4581-bca8-4d053f7ec043</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="481" Y="340.5" DragOperation="0" />
+  <DragSelectionCommand X="528" Y="333.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="702" Y="227.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f62ddd73-f1f9-4a33-8c71-5506b23a8db5" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="647" y="177" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="[a, b, c];" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <PortInfo index="1" default="False" name="b" />
+      <PortInfo index="2" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="[a, b, c];" WorkspaceGuid="881916e6-f2cf-4a27-b993-a0bbd64d8214">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="875" Y="202.5" Width="0" Height="0" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="675" Y="212.5" DragOperation="0" />
+  <DragSelectionCommand X="712" Y="193.5" DragOperation="1" />
+  <CreateNodeCommand X="994" Y="331.5" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>e15ad50a-3cd5-4c34-85b4-82a21c786d46</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e15ad50a-3cd5-4c34-85b4-82a21c786d46" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sum" x="845" y="185.5" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sum@double[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>e15ad50a-3cd5-4c34-85b4-82a21c786d46</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="1026" Y="349.5" DragOperation="0" />
+  <DragSelectionCommand X="877" Y="203.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>36a4604a-eb68-4e1c-a310-a53e4d2c96c3</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>39842043-c189-4371-899c-5e1666e596ee</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>96007af3-534d-4581-bca8-4d053f7ec043</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="2" Type="0" ConnectionMode="1">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>f62ddd73-f1f9-4a33-8c71-5506b23a8db5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>e15ad50a-3cd5-4c34-85b4-82a21c786d46</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>36a4604a-eb68-4e1c-a310-a53e4d2c96c3</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="5">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </MakeConnectionCommand>
+  <DragSelectionCommand X="492" Y="109.5" DragOperation="0" />
+  <DragSelectionCommand X="492" Y="109.5" DragOperation="1" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>36a4604a-eb68-4e1c-a310-a53e4d2c96c3</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>39842043-c189-4371-899c-5e1666e596ee</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>96007af3-534d-4581-bca8-4d053f7ec043</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>36a4604a-eb68-4e1c-a310-a53e4d2c96c3</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="553" Y="122.5" DragOperation="0" />
+  <DragSelectionCommand X="553" Y="122.5" DragOperation="1" />
+  <SelectModelCommand Modifiers="4">
+    <ModelGuid>96007af3-534d-4581-bca8-4d053f7ec043</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="2">
+    <ModelGuid>0ae467ef-f4d3-45a4-a12d-3cf37ce7999b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="3">
+    <ModelGuid>4c9ed913-297f-47ce-8f29-2d681372fe17</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+</Commands>


### PR DESCRIPTION
### Purpose

![selective_shift_click_outport](https://user-images.githubusercontent.com/13341935/54558071-23bb2c00-4993-11e9-845c-cbcc5527f8ed.gif)

This PR pulls in the work originally completed by @yeexinc in #7900 and adds several tests that leverage recorded commands.  The recorded tests verify the proper connectors are grabbed when a `shift+click` operation occurs.  Only selected downstream nodes that are connected to the given output port will be removed upon `shift+click`ing.  Testing coverage also verifies the graph remains in a known state after several undo/redo commands are conducted after using selective shift-click operations.  The last test performs a large series of `shift+clicks` and `ctrl+clicks` with and without selected nodes to test these commands in successive combinations verifying the graph's final state produce a specific numeric combination.  All tests pass on the self-serve CI.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 