### PR TITLE
Update vote button

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -8,7 +8,7 @@
         xmlns:controls="clr-namespace:Dynamo.Controls"
         xmlns:viewModels="clr-namespace:Dynamo.PackageManager.ViewModels"
         mc:Ignorable="d" 
-        Title="{x:Static p:Resources.PackageSearchViewTitle}" Name="PackageSearch"  Height="600" Width="520" MinWidth="520" MaxWidth="520">
+        Title="{x:Static p:Resources.PackageSearchViewTitle}" Name="PackageSearch"  Height="600" Width="510" MinWidth="510" MaxWidth="510">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -138,7 +138,7 @@
                            Visibility="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
                            Text="{x:Static p:Resources.PackageSearchViewSearchTextBox}"/>
 
-                <Button Width="auto" MinWidth="80" Grid.Column="1" Click="OnSortButtonClicked"
+                <Button Width="auto" MinWidth="100" Grid.Column="1" Click="OnSortButtonClicked"
                         Style="{DynamicResource ResourceKey=STextButton}" Content="{x:Static p:Resources.PackageSearchViewSortByButton}">
 
                     <Button.ContextMenu>
@@ -205,7 +205,7 @@
                     <DataTemplate DataType="viewModels:PackageManagerSearchElementViewModel">
                         <Border Name="ItemBG" BorderBrush="#444" BorderThickness="0,1,0,0" Background="#333">
 
-                            <StackPanel Width ="485" Name="SearchEle">
+                            <StackPanel Width ="475" Name="SearchEle">
 
                                 <TextBlock Text="{x:Static p:Resources.PackageSearchViewDeprecated}" 
                                            Padding="5" 
@@ -227,7 +227,7 @@
                                     </TextBlock.Style>
                                 </TextBlock>
 
-                                <StackPanel Orientation="Horizontal" Margin="1" Width="480">
+                                <StackPanel Orientation="Horizontal" Margin="1" Width="470">
 
                                     <StackPanel Orientation="Horizontal">
                                         <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#888"
@@ -293,13 +293,13 @@
                                                 </StackPanel>
                                             </Button>
 
-                                            <StackPanel Width="40"  Orientation="Vertical" Margin="3,0,0,0">
+                                            <StackPanel Width="55"  Orientation="Vertical" Margin="3,0,0,0">
                                                 <StackPanel Orientation="Horizontal">
                                                     <Button Name="UpvoteButton" 
                                                         FontSize="15" 
                                                         ToolTip="{x:Static p:Resources.PackageSearchViewUpvoteButtonTooltip}"  
                                                         Content="👍"
-                                                        Margin="0,0,5,0"
+                                                        Margin="0,0,8,0"
                                                         Foreground="Gray" 
                                                         Command="{Binding Path=UpvoteCommand}" 
                                                         Style="{StaticResource FlatButton}" />
@@ -311,12 +311,12 @@
                                                         Command="{Binding Path=DownvoteCommand}" 
                                                         Style="{StaticResource FlatButton}" />
                                                 </StackPanel>
-                                                <TextBlock FontSize="10" Width ="15" TextAlignment="Left" Margin="0,0,0,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
+                                                <TextBlock FontSize="10" TextAlignment="Center" Margin="0,0,0,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
                                             </StackPanel>
                                         </StackPanel>
 
                                         <Button Style="{StaticResource FlatButton}" Command="{Binding ToggleIsExpandedCommand }" Background="#333">
-                                            <TextBlock FontSize="11" Margin="3" Width="390" Foreground="#AAA" Text="{Binding Path=Model.Description}" TextWrapping="Wrap" TextTrimming="WordEllipsis" MaxHeight="20"/>
+                                            <TextBlock FontSize="11" Margin="3" Width="400" Foreground="#AAA" Text="{Binding Path=Model.Description}" TextWrapping="Wrap" TextTrimming="WordEllipsis" MaxHeight="20"/>
                                         </Button>
                                     </StackPanel>
                                 </StackPanel>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -8,7 +8,7 @@
         xmlns:controls="clr-namespace:Dynamo.Controls"
         xmlns:viewModels="clr-namespace:Dynamo.PackageManager.ViewModels"
         mc:Ignorable="d" 
-        Title="{x:Static p:Resources.PackageSearchViewTitle}" Name="PackageSearch"  Height="600" Width="490" MinWidth="490" MaxWidth="490">
+        Title="{x:Static p:Resources.PackageSearchViewTitle}" Name="PackageSearch"  Height="600" Width="520" MinWidth="520" MaxWidth="520">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -205,7 +205,7 @@
                     <DataTemplate DataType="viewModels:PackageManagerSearchElementViewModel">
                         <Border Name="ItemBG" BorderBrush="#444" BorderThickness="0,1,0,0" Background="#333">
 
-                            <StackPanel Width ="455" Name="SearchEle">
+                            <StackPanel Width ="485" Name="SearchEle">
 
                                 <TextBlock Text="{x:Static p:Resources.PackageSearchViewDeprecated}" 
                                            Padding="5" 
@@ -227,7 +227,7 @@
                                     </TextBlock.Style>
                                 </TextBlock>
 
-                                <StackPanel Orientation="Horizontal" Margin="1" Width="450">
+                                <StackPanel Orientation="Horizontal" Margin="1" Width="480">
 
                                     <StackPanel Orientation="Horizontal">
                                         <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#888"
@@ -298,8 +298,8 @@
                                                     <Button Name="UpvoteButton" 
                                                         FontSize="15" 
                                                         ToolTip="{x:Static p:Resources.PackageSearchViewUpvoteButtonTooltip}"  
-                                                        Content="⬆"
-                                                        Margin="0,0,8,0"
+                                                        Content="👍"
+                                                        Margin="0,0,5,0"
                                                         Foreground="Gray" 
                                                         Command="{Binding Path=UpvoteCommand}" 
                                                         Style="{StaticResource FlatButton}" />
@@ -307,11 +307,11 @@
                                                         FontSize="15" 
                                                         ToolTip="{x:Static p:Resources.PackageSearchViewDownvoteButtonTooltip}" 
                                                         Foreground="Gray" 
-                                                        Content="⬇"  
+                                                        Content="👎"  
                                                         Command="{Binding Path=DownvoteCommand}" 
                                                         Style="{StaticResource FlatButton}" />
                                                 </StackPanel>
-                                                <TextBlock FontSize="10" TextAlignment="Center" Margin="0,0,5,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
+                                                <TextBlock FontSize="10" Width ="15" TextAlignment="Left" Margin="0,0,0,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
                                             </StackPanel>
                                         </StackPanel>
 


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

There is long running issue that the downvote button in Dynamo Package Manager looks too similar than the download button so that user accidentally click downvote while their real intention is download. This PR is minimal work there to replace the button unicode and adjust the dialog based on the new width of buttons. And hopefully as a result of this change, we can truly ask Dynamo users to vote for packages they would love to recommend to other users.

Please find attached screenshot for comparison:
![image](https://user-images.githubusercontent.com/3942418/54724889-560b8b80-4b43-11e9-94c6-d6626654f380.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
Running
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Racel @kronz 

### FYIs

@DynamoDS/dynamo @johnpierson @Dewb @gregmarr 
