### PR TITLE
DYN-1681a: As a Dynamo user, I want to resize the Set Value dialog

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
@@ -4,6 +4,8 @@
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
         Title="{x:Static p:Resources.EditWindowTitle}" 
+        MaxHeight="{x:Static SystemParameters.PrimaryScreenHeight}"
+        MaxWidth="{x:Static SystemParameters.PrimaryScreenWidth}"
         MinHeight="130" Height="200" Width="400">
 
     <Grid>

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
@@ -4,18 +4,24 @@
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
         Title="{x:Static p:Resources.EditWindowTitle}" 
-        MinHeight="130" MaxHeight="200" Width="400">
+        MinHeight="130" Height="200" Width="400">
 
-    <StackPanel>
+    <Grid>
 
-        <StackPanel.Background>
+        <Grid.Background>
             <LinearGradientBrush  StartPoint="0.5,0" EndPoint="0.5,1">
                 <GradientStop Color="#444" Offset="0.0" />
                 <GradientStop Color="#222" Offset="1.0" />
             </LinearGradientBrush>
-        </StackPanel.Background>
+        </Grid.Background>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
 
         <TextBox 
+                Grid.Row="0"
                 PreviewKeyDown="OnEditWindowPreviewKeyDown"
                 Margin="10"
                 x:FieldModifier="private" 
@@ -31,16 +37,15 @@
                 AcceptsReturn="True"
                 HorizontalScrollBarVisibility="Disabled"
                 VerticalScrollBarVisibility="Auto"
-                Height="80"
                 TextWrapping="Wrap"
                 AcceptsTab="True"/>
 
-        <StackPanel Orientation="Horizontal" FlowDirection="RightToLeft">
+        <StackPanel Grid.Row="1" Orientation="Horizontal" FlowDirection="RightToLeft">
             <!--<Button Content="Cancel" Style="{DynamicResource ResourceKey=STextButton}"  Margin="10" Name="button1" VerticalAlignment="Bottom" Click="CancelClick" />-->
             <Button Content="{x:Static p:Resources.EditWindowAcceptButton}" Style="{DynamicResource ResourceKey=STextButton}" Margin="10" Name="button2" VerticalAlignment="Bottom" Width="auto" MinWidth="75" Click="OkClick" />
         </StackPanel>
 
-    </StackPanel>
+    </Grid>
 
     <Window.Resources>        
         <ResourceDictionary>


### PR DESCRIPTION

### Purpose

This PR addresses the first part of [DYN-1681](https://jira.autodesk.com/browse/DYN-1681), which is to allow users to resize the Set Value dialog so that they can see more of the text they are editing.
This PR does not replicate Group text editing functionality for Notes.


![EditWindow_1](https://user-images.githubusercontent.com/11542519/55080072-d8300e80-5073-11e9-919d-6f6d6b34b7a1.gif)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

### FYIs


