### PR TITLE
Fix return keyword as it appears in code completion

### DIFF
--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -151,7 +151,7 @@ namespace ProtoCore
                 primitiveTypeNames[PrimitiveType.Array] = DSDefinitions.Keyword.Array;
                 primitiveTypeNames[PrimitiveType.Pointer] = DSDefinitions.Keyword.PointerReserved;
                 primitiveTypeNames[PrimitiveType.FunctionPointer] = DSDefinitions.Keyword.FunctionPointer;
-                primitiveTypeNames[PrimitiveType.Return] = "return_reserved";
+                primitiveTypeNames[PrimitiveType.Return] = DSDefinitions.Keyword.Return;
             }
             return primitiveTypeNames[type];
         }
@@ -267,7 +267,7 @@ namespace ProtoCore
             cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "func");
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.FunctionPointer);
 
-            cnode = new ClassNode { Name = "return_reserved", Rank = 0, TypeSystem = this };
+            cnode = new ClassNode { Name = DSDefinitions.Keyword.Return, Rank = 0, TypeSystem = this };
             cnode.ID = (int)PrimitiveType.Return;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.Return);
         }


### PR DESCRIPTION
### Purpose

Fix return keyword as it appears in code completion.

Before:
![image](https://user-images.githubusercontent.com/5710686/55976774-3a376900-5c5b-11e9-92c6-09117fb62ad8.png)

After:
![image](https://user-images.githubusercontent.com/5710686/55976701-065c4380-5c5b-11e9-9ed1-a996d8ca0882.png)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@QilongTang 

