### PR TITLE
[DNM] Optimize loading watch node view

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -49,7 +49,7 @@ namespace CoreNodeModelsWpf.Nodes
             nodeView.PresentationGrid.Children.Add(watchTree);
             nodeView.PresentationGrid.Visibility = Visibility.Visible;
             // disable preview control
-            nodeView.TogglePreviewControlAllowance();
+            //nodeView.TogglePreviewControlAllowance();
 
             Bind(watchTree, nodeView);
 


### PR DESCRIPTION
### Purpose

Attempt at optimizing load time of watch node views. This was motivated by observing the large differences between graph opening times for View vs. Model for graphs containing lots of Watch nodes: https://autodesk.slack.com/archives/CCUTQCPMG/p1554994165090000. 

The following dotTrace call tree reflects the large proportion of time consumed while loading the node views for watch nodes:
![image](https://user-images.githubusercontent.com/5710686/55987466-a2904580-5c6f-11e9-9081-bdf24c643b9d.png)

 vs. after removing the call to `nodeView.TogglePreviewControlAllowance()`:
![image](https://user-images.githubusercontent.com/5710686/55987694-192d4300-5c70-11e9-892d-0159dc34ed12.png)

You can see that the proportion of time taken by the parent call to `NodeView.NodeReady` has decreased from nearly 82.7% to 9.39% as a result of removing the above call. 

The call to `nodeView.TogglePreviewControlAllowance()` seems unnecessary in `WatchNodeViewCustomization.CustomizeView`.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
