### PR TITLE
Move initial setup of IsAnalyticsReportingApproved to PreferenceSettings constructor

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -322,6 +322,7 @@ namespace Dynamo.Configuration
             // Default Settings
             IsFirstRun = true;
             IsUsageReportingApproved = false;
+            IsAnalyticsReportingApproved = true;
             LibraryWidth = 304;
             ConsoleHeight = 0;
             ShowPreviewBubbles = true;

--- a/src/DynamoCoreWpf/Services/UsageReportingManager.cs
+++ b/src/DynamoCoreWpf/Services/UsageReportingManager.cs
@@ -152,9 +152,6 @@ namespace Dynamo.Services
             {
                 FirstRun = false;
 
-                //Analytics enable by defaultwa
-                IsAnalyticsReportingApproved = true;
-
                 //Prompt user for detailed reporting
                 if (!DynamoModel.IsTestMode)
                     ShowUsageReportingPrompt(ownerWindow);


### PR DESCRIPTION
### Purpose

Alias integration needs control over analytics tick on the first run.  To achieve this I moved the variable initialization from CheckIsFirstRun to PreferenceSettings constructor. This allows override IsAnalyticsReportingApproved  before creating DynamoCore if needed. The only change to default Dynamo behavior I see is that now IsAnalyticsReportingApproved option can now migrate from previous Dynamo version instead of always being "true" during the first run. Please inform me what is the wanted behavior.

### Declarations

Check these if you believe they are true
- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow 

### Reviewers
@mjkkirschner 
