### PR TITLE
DYN-1681b: Edit Note Window title and minimum size

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -10,8 +10,6 @@
 
 namespace Dynamo.Wpf.Properties
 {
-    
-    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Dynamo.Wpf.Properties
 {
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -2201,6 +2201,15 @@ namespace Dynamo.Wpf.Properties
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Write note here.
+        /// </summary>
+        public static string EditNoteWindowTitle {
+            get {
+                return ResourceManager.GetString("EditNoteWindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Accept.
         /// </summary>
         public static string EditWindowAcceptButton {
@@ -3404,7 +3413,7 @@ namespace Dynamo.Wpf.Properties
                 return ResourceManager.GetString("NodeContextMenuShowLabels", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to See more on the Dynamo Dictionary....
         /// </summary>
@@ -3413,7 +3422,7 @@ namespace Dynamo.Wpf.Properties
                 return ResourceManager.GetString("NodeHelpWindowDynamoDictionary", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CATEGORY.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -10,6 +10,8 @@
 
 namespace Dynamo.Wpf.Properties
 {
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -3411,7 +3413,7 @@ namespace Dynamo.Wpf.Properties
                 return ResourceManager.GetString("NodeContextMenuShowLabels", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to See more on the Dynamo Dictionary....
         /// </summary>
@@ -3420,7 +3422,7 @@ namespace Dynamo.Wpf.Properties
                 return ResourceManager.GetString("NodeHelpWindowDynamoDictionary", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CATEGORY.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2187,4 +2187,7 @@ Do you want to install the latest Dynamo update?</value>
   <data name="PackageSearchViewSearchTextBoxSyncing" xml:space="preserve">
     <value>Please wait...</value>
   </data>
+  <data name="EditNoteWindowTitle" xml:space="preserve">
+    <value>Write note here</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2190,4 +2190,7 @@ Want to publish a different package?</value>
   <data name="PackageSearchViewSearchTextBoxSyncing" xml:space="preserve">
     <value>Please wait...</value>
   </data>
+  <data name="EditNoteWindowTitle" xml:space="preserve">
+    <value>Write note here</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
@@ -6,7 +6,8 @@
         Title="{x:Static p:Resources.EditWindowTitle}" 
         MaxHeight="{x:Static SystemParameters.PrimaryScreenHeight}"
         MaxWidth="{x:Static SystemParameters.PrimaryScreenWidth}"
-        MinHeight="130" Height="200" Width="400">
+        MinHeight="170" MinWidth="300"
+        Height="200" Width="400">
 
     <Grid>
 

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -86,7 +86,10 @@ namespace Dynamo.Nodes
         {
             // Setup a binding with the edit window's text field
             var dynamoViewModel = ViewModel.WorkspaceViewModel.DynamoViewModel;
-            var editWindow = new EditWindow(dynamoViewModel, true);
+            var editWindow = new EditWindow(dynamoViewModel, true)
+            {
+                Title = Dynamo.Wpf.Properties.Resources.EditNoteWindowTitle
+            };
             editWindow.BindToProperty(DataContext, new Binding("Text")
             {
                 Mode = BindingMode.TwoWay,


### PR DESCRIPTION
### Purpose

This PR is a follow-up to #9600 and does the following:

* Sets `MinHeight` and `MinWidth` for the Edit Note Window.
* Sets the title of the window to "Write note here".
  * Creates `EditNoteWindowTitle` resource.

The window now looks like this at minimum size:

![editnoteminsize](https://user-images.githubusercontent.com/11542519/56440091-646dd400-62b6-11e9-80fa-6c95238640d2.PNG)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@alfarok 

### FYI
@Amoursol
