### PR TITLE
Add command options to run standard config and model only performance benchmarks

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/PerformanceTestConsoleApp.cs
+++ b/tools/Performance/DynamoPerformanceTests/PerformanceTestConsoleApp.cs
@@ -75,6 +75,7 @@ namespace DynamoPerformanceTests
                 case Command.Benchmark:
                     DynamoViewPerformanceTestBase.testDirectory = testDirectory;
                     var runSummaryWithUI = BenchmarkRunner.Run<DynamoViewPerformanceTestBase>(config);
+
                     goto case Command.ModelOnlyBenchmark;
 
                 case Command.ModelOnlyBenchmark:

--- a/tools/Performance/DynamoPerformanceTests/PerformanceTestConsoleApp.cs
+++ b/tools/Performance/DynamoPerformanceTests/PerformanceTestConsoleApp.cs
@@ -14,6 +14,8 @@ namespace DynamoPerformanceTests
             NonOptimizedBenchmark,
             DebugInProcess,
             Compare,
+            ModelOnlyBenchmark,
+            StandardConfigModelOnlyBenchmark
         }
 
         public static void Main(string[] args)
@@ -73,16 +75,19 @@ namespace DynamoPerformanceTests
                 case Command.Benchmark:
                     DynamoViewPerformanceTestBase.testDirectory = testDirectory;
                     var runSummaryWithUI = BenchmarkRunner.Run<DynamoViewPerformanceTestBase>(config);
+                    goto case Command.ModelOnlyBenchmark;
 
+                case Command.ModelOnlyBenchmark:
                     DynamoModelPerformanceTestBase.testDirectory = testDirectory;
                     var runSummaryWithoutUI = BenchmarkRunner.Run<DynamoModelPerformanceTestBase>(config);
                     break;
 
+                case Command.StandardConfigModelOnlyBenchmark:
+                    config = PerformanceTestHelper.getReleaseConfig();
+                    goto case Command.ModelOnlyBenchmark;
+
                 case Command.Compare:
                     Compare(baseResultsPath, newResultsPath, saveComparisonPath);
-                    break;
-
-                default:
                     break;
             }
         }


### PR DESCRIPTION
### Purpose

Add command options to run standard config and model only performance benchmarks

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@mjkkirschner @QilongTang @scottmitchell 
