### PR TITLE
Add quotation marks around comparison csv values

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
+++ b/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
@@ -270,7 +270,8 @@ namespace DynamoPerformanceTests
         /// <param name="filePath"></param>
         private void WriteResultsToCSV(List<BenchmarkComparison> comparisons, string filePath)
         {
-            var rows = GetComparisonDataRows(comparisons).Select(r => string.Join(",", r));
+            var rowData = GetComparisonDataRows(comparisons).Select(r => r.Select(x => "\"" + x + "\""));
+            var rows = rowData.Select(r => string.Join(",", r));
             var csv = new StringBuilder();
             foreach (var row in rows) csv.AppendLine(row);
             


### PR DESCRIPTION
### Purpose

Fixes a bug where numerical values in the comparison csv which contain commas were interpreted as multiple values. The fix here is to surround each value with quotation marks.

The csv text now looks like this: 
```
"RunGraph","Pottery","Base","9,867.57 ms","110.39 ms","39.36 ms"
"","","New","9,867.57 ms","110.39 ms","39.36 ms"
"","","","0%","0%","0%"
```

And it is now interpreted correctly by excel:
<img width="406" alt="csvExcel" src="https://user-images.githubusercontent.com/11542519/57313199-13831b80-70bd-11e9-9abd-0dfff61b38a7.png">


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
