### PR TITLE
Fixing the API break that was caused by this PR (https://github.com/DynamoDS/Dynamo/pull/9665)

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1917,6 +1917,7 @@ namespace ProtoCore
             {
                 ret = PerformReturnTypeCoerce(finalFep, runtimeCore, ret);
             }
+
             return ret;
         }
 

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1,11 +1,3 @@
-using DynamoServices;
-using ProtoCore.DSASM;
-using ProtoCore.Exceptions;
-using ProtoCore.Lang;
-using ProtoCore.Lang.Replication;
-using ProtoCore.Properties;
-using ProtoCore.Runtime;
-using ProtoCore.Utils;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,6 +8,13 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Soap;
 using System.Text;
+using ProtoCore.DSASM;
+using ProtoCore.Exceptions;
+using ProtoCore.Lang;
+using ProtoCore.Lang.Replication;
+using ProtoCore.Properties;
+using ProtoCore.Runtime;
+using ProtoCore.Utils;
 using StackFrame = ProtoCore.DSASM.StackFrame;
 using Validity = ProtoCore.Utils.Validity;
 using WarningID = ProtoCore.Runtime.WarningID;
@@ -379,7 +378,7 @@ namespace ProtoCore
         private List<ISerializable> beforeFirstRunSerializables = new List<ISerializable>();
 
         //TODO(Luke): This should be loaded from the attribute
-        private string TRACE_KEY = TraceUtils.__TEMP_REVIT_TRACE_ID;
+        private string TRACE_KEY = DynamoServices.TraceUtils.__TEMP_REVIT_TRACE_ID;
 
         #endregion
 
@@ -1885,12 +1884,12 @@ namespace ProtoCore
             if (traceD != null)
             {
                 //There was data associated with the previous execution, push this into the TLS
-                TraceUtils.SetTraceData(TRACE_KEY, traceD);
+                DynamoServices.TraceUtils.SetTraceData(TRACE_KEY, traceD);
             }
             else
             {
                 //There was no trace data for this run
-                TraceUtils.ClearAllKnownTLSKeys();
+                DynamoServices.TraceUtils.ClearAllKnownTLSKeys();
             }
 
             //EXECUTE
@@ -1899,13 +1898,13 @@ namespace ProtoCore
             if (ret.IsNull)
             {
                 //wipe the trace cache
-                TraceUtils.ClearAllKnownTLSKeys();
+                DynamoServices.TraceUtils.ClearAllKnownTLSKeys();
                 newTraceData.Data = null;
             }
             else
             {
                 //TLS -> TraceCache
-                var traceRet = TraceUtils.GetTraceData(TRACE_KEY);
+                var traceRet = DynamoServices.TraceUtils.GetTraceData(TRACE_KEY);
 
                 if (traceRet != null)
                 {

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -149,7 +149,7 @@
     <Compile Include="Lang\FunctionPointerEvaluator.cs" />
     <Compile Include="Lang\Replication\ReplicationInstruction.cs" />
     <Compile Include="Lang\Replication\Replicator.cs" />
-	<Compile Include="Lang\TraceUtils.cs" />
+<Compile Include="Lang\TraceUtils.cs" />
     <Compile Include="Namespace\ElementRewriter.cs" />
     <Compile Include="Namespace\ElementResolver.cs" />
     <Compile Include="Namespace\SymbolTable.cs" />

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -149,7 +149,7 @@
     <Compile Include="Lang\FunctionPointerEvaluator.cs" />
     <Compile Include="Lang\Replication\ReplicationInstruction.cs" />
     <Compile Include="Lang\Replication\Replicator.cs" />
-<Compile Include="Lang\TraceUtils.cs" />
+   <Compile Include="Lang\TraceUtils.cs" />
     <Compile Include="Namespace\ElementRewriter.cs" />
     <Compile Include="Namespace\ElementResolver.cs" />
     <Compile Include="Namespace\SymbolTable.cs" />

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Lang\FunctionPointerEvaluator.cs" />
     <Compile Include="Lang\Replication\ReplicationInstruction.cs" />
     <Compile Include="Lang\Replication\Replicator.cs" />
+	<Compile Include="Lang\TraceUtils.cs" />
     <Compile Include="Namespace\ElementRewriter.cs" />
     <Compile Include="Namespace\ElementResolver.cs" />
     <Compile Include="Namespace\SymbolTable.cs" />

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -149,7 +149,7 @@
     <Compile Include="Lang\FunctionPointerEvaluator.cs" />
     <Compile Include="Lang\Replication\ReplicationInstruction.cs" />
     <Compile Include="Lang\Replication\Replicator.cs" />
-   <Compile Include="Lang\TraceUtils.cs" />
+    <Compile Include="Lang\TraceUtils.cs" />
     <Compile Include="Namespace\ElementRewriter.cs" />
     <Compile Include="Namespace\ElementResolver.cs" />
     <Compile Include="Namespace\SymbolTable.cs" />


### PR DESCRIPTION
### Purpose

This PR is to address the API break that was introduced by removing the "TraceUtils.cs" file from the ProtoCore project. 

JIRA task: https://jira.autodesk.com/browse/DYN-1898

Refer to this change: https://github.com/DynamoDS/Dynamo/commit/b859c7ba73fa4d086ab08d9bd95812a784be2ce0#r33609626

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

