### PR TITLE
profiling tweaks

### DIFF
--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -182,6 +182,7 @@ namespace Dynamo.Engine
             }
             else
             {
+                astBuilder.ProfilingSession.Dispose();
                 astBuilder.ProfilingSession = null;
             }
 

--- a/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Engine.Profiling
         internal NodeProfilingData(NodeModel node)
         {
             this.node = node;
-            DataBridge.Instance.RegisterCallback(node.GUID.ToString(), RecordEvaluationState);
+            DataBridge.Instance.RegisterCallback(node.GUID.ToString()+ ProfilingSession.profilingID, RecordEvaluationState);
         }
 
         internal void Reset()

--- a/src/DynamoCore/Engine/Profiling/ProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingData.cs
@@ -87,7 +87,13 @@ namespace Dynamo.Engine.Profiling
 
         internal void UnregisterNode(Guid guid)
         {
-            nodeProfilingData.Remove(guid);
+            NodeProfilingData data = null;
+            if(nodeProfilingData.TryGetValue(guid, out data))
+            {
+                nodeProfilingData.Remove(guid);
+                data.Dispose();
+            }
+          
         }
 
         internal void UnregisterDeletedNodes(IEnumerable<NodeModel> modelNodes)

--- a/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
@@ -65,6 +65,7 @@ namespace Dynamo.Engine.Profiling
 
         private const string beginTag = "_beginCallback";
         private const string endTag = "_endCallback";
+        public const string profilingID = "_dynamo_profiling";
 
         internal BinaryExpressionNode CreatePreCompilationAstNode(NodeModel node, List<AssociativeNode> inputAstNodes)
         {
@@ -72,7 +73,7 @@ namespace Dynamo.Engine.Profiling
 
             string id = node.GUID.ToString();
             ExprListNode exprListNode = AstFactory.BuildExprList(inputAstNodes);
-            AssociativeNode bridgeData = DataBridge.GenerateBridgeDataAst(id, exprListNode);
+            AssociativeNode bridgeData = DataBridge.GenerateBridgeDataAst(id+ profilingID, exprListNode);
 
             return AstFactory.BuildAssignment(identifier, bridgeData);
         }
@@ -86,7 +87,7 @@ namespace Dynamo.Engine.Profiling
                 Enumerable.Range(0, node.OutPorts.Count).Select(
                     index => (AssociativeNode)node.GetAstIdentifierForOutputIndex(index)).ToList();
             ExprListNode exprListNode = AstFactory.BuildExprList(outPortNodeList);
-            AssociativeNode bridgeData = DataBridge.GenerateBridgeDataAst(id, exprListNode);
+            AssociativeNode bridgeData = DataBridge.GenerateBridgeDataAst(id+ profilingID, exprListNode);
 
             return AstFactory.BuildAssignment(identifier, bridgeData);
         }


### PR DESCRIPTION


### Purpose

a few small issues found while using the profiling APIs

* tried to dispose Disposables when they are going out of scope
* use a unique id for the particular callback because there is the possibility someone will add a databridge callback with the id of the node only and one will be overwritten by the other - this helps decrease the risk of this happening by combining the node guid with some other string.

I have been testing this with this small extension:
https://github.com/mjkkirschner/DynamoSamples/tree/proflingExtension


![Screen Shot 2019-05-24 at 2 02 54 PM](https://user-images.githubusercontent.com/508936/58348205-f9bc3500-7e2d-11e9-8605-7991606f654b.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ColinDayOrg 

### FYIs

@smangarole 