### PR TITLE
DYN-1662 Follow Up: Return copy of PackageDependencyInfo instead of reference

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
@@ -98,5 +98,6 @@ namespace Dynamo.Graph.Workspaces
             }
             return false;
         }
+        //TODO override GetHashCode
     }
 }

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -196,12 +196,14 @@ namespace Dynamo.PackageManager
                 currentWorkspace = ws;
             }
         }
-
+        
         private PackageDependencyInfo GetNodePackageFromAssemblyName(AssemblyName assemblyName)
         {
             if (NodePackageDictionary != null && NodePackageDictionary.ContainsKey(assemblyName.FullName))
             {
                 var p = NodePackageDictionary[assemblyName.FullName].FirstOrDefault();
+                // Return a copy of the PackageDependencyInfo so that a workspace doesn't modify it
+                // TODO Split PackageDependencyInfo into two types
                 return new PackageDependencyInfo(p.Name, p.Version);
             }
             return null;
@@ -212,6 +214,7 @@ namespace Dynamo.PackageManager
             if (CustomNodePackageDictionary != null && CustomNodePackageDictionary.ContainsKey(functionID))
             {
                 var p = CustomNodePackageDictionary[functionID].FirstOrDefault();
+                // Return a copy of the PackageDependencyInfo so that a workspace doesn't modify it
                 return new PackageDependencyInfo(p.Name, p.Version);
             }
             return null;

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -199,9 +199,10 @@ namespace Dynamo.PackageManager
 
         private PackageDependencyInfo GetNodePackageFromAssemblyName(AssemblyName assemblyName)
         {
-            if (NodePackageDictionary!= null && NodePackageDictionary.ContainsKey(assemblyName.FullName))
+            if (NodePackageDictionary != null && NodePackageDictionary.ContainsKey(assemblyName.FullName))
             {
-                return NodePackageDictionary[assemblyName.FullName].FirstOrDefault();
+                var p = NodePackageDictionary[assemblyName.FullName].FirstOrDefault();
+                return new PackageDependencyInfo(p.Name, p.Version);
             }
             return null;
         }
@@ -210,7 +211,8 @@ namespace Dynamo.PackageManager
         {
             if (CustomNodePackageDictionary != null && CustomNodePackageDictionary.ContainsKey(functionID))
             {
-                return CustomNodePackageDictionary[functionID].FirstOrDefault();
+                var p = CustomNodePackageDictionary[functionID].FirstOrDefault();
+                return new PackageDependencyInfo(p.Name, p.Version);
             }
             return null;
         }


### PR DESCRIPTION
### Purpose

This PR follows up on https://github.com/DynamoDS/Dynamo/pull/9723. It fixes an issue where the IDs of deleted nodes would still be serialized inside of `PackageDependencies`. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 