### PR TITLE
Update DefaultWatch3DViewModel.cs

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -328,7 +328,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in inherited classes.
         }
 
-        protected internal void UnregisterEventHandlers()
+        protected void UnregisterEventHandlers()
         {
             DynamoSelection.Instance.Selection.CollectionChanged -= SelectionChangedHandler;
 
@@ -557,7 +557,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             RegisterPortEventHandlers(node);
         }
 
-        internal void UnregisterNodeEventHandlers(NodeModel node)
+        protected internal void UnregisterNodeEventHandlers(NodeModel node)
         {
             node.PropertyChanged -= OnNodePropertyChanged;
             node.RenderPackagesUpdated -= OnRenderPackagesUpdated;


### PR DESCRIPTION
### Purpose

I modified the wrong method - 
`UnregisterEventHandlers` vs
`UnregisterNodeEventHandlers`


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang 
@alfredo-pozo