### PR TITLE
Fix failing package loading tests

### DIFF
--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -158,8 +158,10 @@ namespace Dynamo.PackageManager
 
         /// <summary>
         ///     Load the package into Dynamo (including all node libraries and custom nodes)
-        ///     and add to LocalPackages
+        ///     and add to LocalPackages.
+        ///     NOTE: This method DOES NOT import ZT packages into Dynamo VM. Use LoadPackages() instead.
         /// </summary>
+        /// TODO: For internal use only. Consider renaming method and make internal in 3.0 (Refer to PR #9736).
         public void Load(Package package)
         {
             this.Add(package);

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -157,12 +157,11 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        ///     Load the package into Dynamo (including all node libraries and custom nodes)
-        ///     and add to LocalPackages.
-        ///     NOTE: This method DOES NOT import ZT packages into Dynamo VM. Use LoadPackages() instead.
+        /// Try loading package into Library (including all node libraries and custom nodes)
+        /// and add to LocalPackages.
         /// </summary>
-        /// TODO: For internal use only. Consider renaming method and make internal in 3.0 (Refer to PR #9736).
-        public void Load(Package package)
+        /// <param name="package"></param>
+        internal void TryLoadPackageIntoLibrary(Package package)
         {
             this.Add(package);
 
@@ -216,6 +215,21 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
+        ///     Load the package into Dynamo (including all node libraries and custom nodes)
+        ///     and add to LocalPackages.
+        /// </summary>
+        // TODO: Remove in 3.0 (Refer to PR #9736).
+        [Obsolete("This API will be deprecated in 3.0. Use LoadPackages(IEnumerable<Package> packages) instead.")]
+        public void Load(Package package)
+        {
+            TryLoadPackageIntoLibrary(package);
+
+            var assemblies =
+                LocalPackages.SelectMany(x => x.EnumerateAssembliesInBinDirectory().Where(y => y.IsNodeLibrary));
+            OnPackagesLoaded(assemblies.Select(x => x.Assembly));
+        }
+
+        /// <summary>
         ///     Scan the PackagesDirectory for packages and attempt to load all of them.  Beware! Fails silently for duplicates.
         /// </summary>
         public void LoadAll(LoadPackageParams loadPackageParams)
@@ -245,7 +259,7 @@ namespace Dynamo.PackageManager
         {
             foreach (var pkg in packages)
             {
-                Load(pkg);
+                TryLoadPackageIntoLibrary(pkg);
             }
 
             var assemblies =

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -233,13 +233,7 @@ namespace ProtoFFI
                 }
                 else
                 {
-                    CLRDLLModule dllModule = null;
-                    if (!SupressesImport(type))
-                    {
-                        dllModule = DLLFFIHandler.GetModule(type.Assembly.Location) as CLRDLLModule;
-                        if (dllModule != null && dllModule.Module == null) dllModule = null;
-                    }
-                    protoCoreType = GetInstance(type, dllModule, string.Empty).ProtoCoreType;
+                    protoCoreType = GetInstance(type, null, string.Empty).ProtoCoreType;
                 }
             }
             else

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -221,17 +221,31 @@ namespace ProtoFFI
         {
             ProtoCore.Type protoCoreType;
             if (mTypeMaps.TryGetValue(type, out protoCoreType))
+            {
                 return protoCoreType;
+            }
 
             if (type == typeof(object) || !CLRObjectMarshaler.IsMarshaledAsNativeType(type))
             {
                 if (type.IsEnum)
-                    protoCoreType = CLRModuleType.GetInstance(type, module, string.Empty).ProtoCoreType;
+                {
+                    protoCoreType = GetInstance(type, module, string.Empty).ProtoCoreType;
+                }
                 else
-                    protoCoreType = CLRModuleType.GetInstance(type, null, string.Empty).ProtoCoreType;
+                {
+                    CLRDLLModule dllModule = null;
+                    if (!SupressesImport(type))
+                    {
+                        dllModule = DLLFFIHandler.GetModule(type.Assembly.Location) as CLRDLLModule;
+                        if (dllModule != null && dllModule.Module == null) dllModule = null;
+                    }
+                    protoCoreType = GetInstance(type, dllModule, string.Empty).ProtoCoreType;
+                }
             }
             else
+            {
                 protoCoreType = CLRObjectMarshaler.GetProtoCoreType(type);
+            }
 
             lock (mTypeMaps)
             {

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -221,25 +221,17 @@ namespace ProtoFFI
         {
             ProtoCore.Type protoCoreType;
             if (mTypeMaps.TryGetValue(type, out protoCoreType))
-            {
                 return protoCoreType;
-            }
 
             if (type == typeof(object) || !CLRObjectMarshaler.IsMarshaledAsNativeType(type))
             {
                 if (type.IsEnum)
-                {
-                    protoCoreType = GetInstance(type, module, string.Empty).ProtoCoreType;
-                }
+                    protoCoreType = CLRModuleType.GetInstance(type, module, string.Empty).ProtoCoreType;
                 else
-                {
-                    protoCoreType = GetInstance(type, null, string.Empty).ProtoCoreType;
-                }
+                    protoCoreType = CLRModuleType.GetInstance(type, null, string.Empty).ProtoCoreType;
             }
             else
-            {
                 protoCoreType = CLRObjectMarshaler.GetProtoCoreType(type);
-            }
 
             lock (mTypeMaps)
             {

--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Models;
+using Dynamo.PackageManager;
 using Dynamo.Scheduler;
 using Dynamo.Selection;
 using Dynamo.Tests;
@@ -167,6 +168,17 @@ namespace Dynamo
                 var index = CurrentDynamoModel.Workspaces.IndexOf(workspaceToSwitch);
                 CurrentDynamoModel.ExecuteCommand(new DynamoModel.SwitchTabCommand(index));
             }
+        }
+
+        protected PackageLoader GetPackageLoader()
+        {
+            var extensions = CurrentDynamoModel.ExtensionManager.Extensions.OfType<PackageManagerExtension>();
+            if (extensions.Any())
+            {
+                return extensions.First().PackageLoader;
+            }
+
+            return null;
         }
     }
 }

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -2258,7 +2258,7 @@ namespace Dynamo.Tests
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package which includes migrations
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
 
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");

--- a/test/DynamoCoreTests/Nodes/DropDownTests.cs
+++ b/test/DynamoCoreTests/Nodes/DropDownTests.cs
@@ -30,7 +30,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -56,7 +56,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -83,7 +83,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -112,7 +112,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -141,7 +141,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -170,7 +170,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -195,7 +195,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 
@@ -227,7 +227,7 @@ namespace Dynamo.Tests.Nodes
             var pkg = loader.ScanPackageDirectory(pkgDir);
 
             // Load the sample package
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
             // Assert expected package was loaded
             Assert.AreEqual(pkg.Name, "Dynamo Samples");
 

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -28,22 +28,12 @@ namespace Dynamo.Tests
             base.GetLibrariesToPreload(libraries);
         }
 
-        private PackageLoader GetPackageLoader()
-        {
-            var extensions = CurrentDynamoModel.ExtensionManager.Extensions.OfType<PackageManagerExtension>();
-            if (extensions.Count() > 0)
-            {
-                return extensions.First().PackageLoader;
-            }
-            return null;
-        }
-
         private void LoadPackage(string packageDirectory)
         {
             CurrentDynamoModel.PreferenceSettings.CustomPackageFolders.Add(packageDirectory);
             var loader = GetPackageLoader();
             var pkg = loader.ScanPackageDirectory(packageDirectory);
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
         }
 
         private PackageDependencyInfo GetPackageInfo(string packageName)

--- a/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
@@ -187,7 +187,7 @@ namespace DynamoCoreWpfTests
                 viewLoaded = true;
                 var loader = Model.GetPackageManagerExtension().PackageLoader;
                 var pkg = loader.ScanPackageDirectory(pkgDir);
-                loader.Load(pkg);
+                loader.LoadPackages(new List<Package> {pkg});
                 Assert.AreEqual(0, loader.RequestedExtensions.Count());
                 Assert.AreEqual(2, this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
                 Assert.IsTrue(viewExtensionLoadStart);

--- a/test/Libraries/PackageManagerTests/PackageLoaderCustomTest.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderCustomTest.cs
@@ -66,17 +66,5 @@ namespace Dynamo.PackageManager.Tests
 
             Assert.AreEqual(1, nextPkg.LoadedCustomNodes.Count);
         }
-
-        private PackageLoader GetPackageLoader()
-        {
-            var extensions = CurrentDynamoModel.ExtensionManager.Extensions.OfType<PackageManagerExtension>();
-            Assert.IsNotNull(extensions);
-            Assert.AreNotEqual(0, extensions.Count());
-
-            var packageLoader = extensions.First().PackageLoader;
-            Assert.IsNotNull(packageLoader);
-
-            return packageLoader;
-        }
     }
 }

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Dynamo.Extensions;
@@ -9,6 +10,13 @@ namespace Dynamo.PackageManager.Tests
     class PackageLoaderTests : DynamoModelTestBase
     {
         public string PackagesDirectory { get { return Path.Combine(TestDirectory, "pkgs"); } }
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
 
         [Test]
         public void ScanPackageDirectoryReturnsPackageForValidDirectory()

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -34,7 +34,7 @@ namespace Dynamo.PackageManager.Tests
                 + "Rounds a number *down* to a specified precision, Round To Precision - Rounds a number to a specified precision", pkg.Contents);
             Assert.AreEqual("0.5.2.10107", pkg.EngineVersion);
 
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
 
             Assert.AreEqual(3, pkg.LoadedCustomNodes.Count);
         }
@@ -70,7 +70,7 @@ namespace Dynamo.PackageManager.Tests
             };
 
             var pkg = loader.ScanPackageDirectory(pkgDir);
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
 
             Assert.IsTrue(loader.RequestedExtensions.Count() == 1);
             Assert.IsTrue(extensionLoad);
@@ -99,7 +99,7 @@ namespace Dynamo.PackageManager.Tests
             };
 
             var pkg = loader.ScanPackageDirectory(pkgDir);
-            loader.Load(pkg);
+            loader.LoadPackages(new List<Package> {pkg});
 
             Assert.IsTrue(!loader.RequestedExtensions.Any());
             Assert.IsFalse(viewExtensionLoad);

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -232,15 +232,5 @@ namespace Dynamo.PackageManager.Tests
 
         }
 
-        private PackageLoader GetPackageLoader()
-        {
-            var extensions = CurrentDynamoModel.ExtensionManager.Extensions.OfType<PackageManagerExtension>();
-            if (extensions.Any())
-            {
-                return extensions.First().PackageLoader;
-            }
-
-            return null;
-        }
     }
 }


### PR DESCRIPTION
### Purpose

This fixes failing cases: 
```
1. Test Error : Dynamo.Tests.PackageDependencyTests.PackageDependenciesUpdatedAfterPackageAndNodeAdded
   System.NullReferenceException : Object reference not set to an instance of an object.
   at Dynamo.Graph.Workspaces.WorkspaceModel.RegisterNode(NodeModel node) in E:\Builds\Dynamo_master\Dynamo\src\DynamoCore\Graph\Workspaces\WorkspaceModel.cs:line 1217
   at Dynamo.Graph.Workspaces.HomeWorkspaceModel.RegisterNode(NodeModel node) in E:\Builds\Dynamo_master\Dynamo\src\DynamoCore\Graph\Workspaces\HomeWorkspaceModel.cs:line 381
   at Dynamo.Graph.Workspaces.WorkspaceModel.AddAndRegisterNode(NodeModel node, Boolean centered) in E:\Builds\Dynamo_master\Dynamo\src\DynamoCore\Graph\Workspaces\WorkspaceModel.cs:line 1200
   at Dynamo.Tests.PackageDependencyTests.PackageDependenciesUpdatedAfterPackageAndNodeAdded()

2. Test Failure:
Dynamo.PackageManager.Tests.PackageLoaderTests.LoadPackagesReturnsAllValidPackagesInValidDirectory
     Expected: True
  But was:  False

at Dynamo.PackageManager.Tests.PackageLoaderTests.LoadPackagesReturnsAllValidPackagesInValidDirectory() in E:\Builds\Dynamo_master\Dynamo\test\Libraries\PackageManagerTests\PackageLoaderTests.cs:line 137
```
Explanation: TODO

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@mjkkirschner 
@scottmitchell 