### PR TITLE
[DYN-1897] Adding the case to handle UserControl element in the extension sidebar API.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -215,8 +215,16 @@ namespace Dynamo.Controls
                 tab.Tag = viewExtension.GetType();
                 tab.HeaderTemplate = tabDynamic.FindResource("TabHeader") as DataTemplate;
 
-                // setting the extension window to the current tab content
-                tab.Content = contentControl.Content;
+                // setting the extension UI to the current tab content 
+                // based on whether it is a UserControl element or window element. 
+                if (contentControl.Template.TargetType.Name.Equals(new UserControl().GetType().Name))
+                {
+                    tab.Content = contentControl;
+                }
+                else
+                {
+                    tab.Content = contentControl.Content;
+                }
 
                 //Insert the tab at the end
                 TabItems.Insert(count, tab);

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -217,7 +217,7 @@ namespace Dynamo.Controls
 
                 // setting the extension UI to the current tab content 
                 // based on whether it is a UserControl element or window element. 
-                if (contentControl.Template.TargetType.Name.Equals(new UserControl().GetType().Name))
+                if (contentControl is UserControl)
                 {
                     tab.Content = contentControl;
                 }


### PR DESCRIPTION
### Purpose

This change will handle the scenario when the user creates a UserControl element in the extension view class. If the target element is a UserControl element we set the complete object to the tab content, else we will set the content of the target element to the tab content. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

