### PR TITLE
Refactor PackageDependencies property

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace Dynamo.Graph.Workspaces
 {
+    /// <summary>
+    /// Class containing info about a package
+    /// </summary>
     internal class PackageInfo
     {
         /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
@@ -3,11 +3,7 @@ using System.Collections.Generic;
 
 namespace Dynamo.Graph.Workspaces
 {
-    /// <summary>
-    /// Class containing info about a Dynamo package. 
-    /// Used for serialization.
-    /// </summary>
-    internal class PackageDependencyInfo
+    internal class PackageInfo
     {
         /// <summary>
         /// Name of the package
@@ -20,6 +16,77 @@ namespace Dynamo.Graph.Workspaces
         internal Version Version { get; set; }
 
         /// <summary>
+        /// Create a package info object from the package name and version
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        internal PackageInfo(string name, Version version)
+        {
+            Name = name;
+            Version = version;
+        }
+
+        /// <summary>
+        /// Checks whether two PackageInfos are equal
+        /// They are equal if their Name and Versions are equal
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+            if (!(obj is PackageInfo))
+            {
+                return false;
+            }
+
+            var other = obj as PackageInfo;
+            if (other.Name == this.Name && other.Version == this.Version)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the hashcode for this PackageInfo
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode() ^ Version.GetHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Class containing info about a workspace package dependency
+    /// </summary>
+    internal class PackageDependencyInfo
+    {
+        /// <summary>
+        /// PackageInfo for this package
+        /// </summary>
+        internal PackageInfo PackageInfo { get; set; }
+
+        /// <summary>
+        /// Name of the package
+        /// </summary>
+        internal string Name => PackageInfo.Name;
+
+        /// <summary>
+        /// Version of the package
+        /// </summary>
+        internal Version Version => PackageInfo.Version;
+
+        /// <summary>
+        /// Indicates whether this package is loaded in the current session
+        /// </summary>
+        internal bool IsLoaded { get; set; }
+
+        /// <summary>
         /// Guids of nodes in the workspace that are dependent on this package
         /// </summary>
         internal HashSet<Guid> Nodes
@@ -29,14 +96,23 @@ namespace Dynamo.Graph.Workspaces
         private HashSet<Guid> nodes;
         
         /// <summary>
-        /// Create a package info object from the package name and version
+        /// Create a package dependency from the package name and version
         /// </summary>
         /// <param name="name"></param>
         /// <param name="version"></param>
         internal PackageDependencyInfo(string name, Version version)
         {
-            Name = name;
-            Version = version;
+            PackageInfo = new PackageInfo(name, version);
+            nodes = new HashSet<Guid>();
+        }
+
+        /// <summary>
+        /// Create a package dependency from its package info
+        /// </summary>
+        /// <param name="packageInfo"></param>
+        internal PackageDependencyInfo(PackageInfo packageInfo)
+        {
+            PackageInfo = packageInfo;
             nodes = new HashSet<Guid>();
         }
 
@@ -71,7 +147,7 @@ namespace Dynamo.Graph.Workspaces
         }
 
         /// <summary>
-        /// Checks whether two PackageDependencyInfos are equal
+        /// Checks whether two PackageDependencyInfo instances are equal
         /// They are equal if their Name and Versions are equal
         /// </summary>
         /// <param name="obj"></param>

--- a/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/PackageDependencyInfo.cs
@@ -59,6 +59,15 @@ namespace Dynamo.Graph.Workspaces
         {
             return Name.GetHashCode() ^ Version.GetHashCode();
         }
+
+        /// <summary>
+        /// Get the string representing this PackageInfo
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return Name + ", Version=" + Version.ToString();
+        }
     }
 
     /// <summary>
@@ -178,6 +187,15 @@ namespace Dynamo.Graph.Workspaces
         public override int GetHashCode()
         {
             return Name.GetHashCode() ^ Version.GetHashCode();
+        }
+
+        /// <summary>
+        /// Get the string representing this PackageDependencyInfo
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return Name + ", Version=" + Version.ToString();
         }
     }
 }

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -756,17 +756,17 @@ namespace Dynamo.Graph.Workspaces
     }
 
     /// <summary>
-    /// PackageDependencyInfoConverter is used to serialize and deserialize graph package dependencies
+    /// PackageDependencyConverter is used to serialize and deserialize graph package dependencies
     /// </summary>
-    public class PackageDependencyInfoConverter : JsonConverter
+    public class PackageDependencyConverter : JsonConverter
     {
         private Logging.ILogger logger;
 
         /// <summary>
-        /// Constructs a PackageDependencyInfoConverter.
+        /// Constructs a PackageDependencyConverter.
         /// </summary>
         /// <param name="logger"></param>
-        public PackageDependencyInfoConverter(Logging.ILogger logger)
+        public PackageDependencyConverter(Logging.ILogger logger)
         {
             this.logger = logger;
         }

--- a/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Graph.Workspaces
                         new WorkspaceWriteConverter(engine),
                         new DummyNodeWriteConverter(),
                         new TypedParameterConverter(),
-                        new PackageDependencyInfoConverter(logger),
+                        new PackageDependencyConverter(logger),
                     },
                 ReferenceResolverProvider = () => { return new IdReferenceResolver(); }
             };

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -451,13 +451,13 @@ namespace Dynamo.Graph.Workspaces
         /// Event that is fired when the workspace is collecting custom node package dependencies.
         /// This event should only be subscribed to by the package manager.
         /// </summary>
-        internal event Func<Guid, PackageDependencyInfo> CollectingCustomNodePackageDependencies;
+        internal event Func<Guid, PackageInfo> CollectingCustomNodePackageDependencies;
 
         /// <summary>
         /// Event that is fired when the workspace is collecting node package dependencies.
         /// This event should only be subscribed to by the package manager.
         /// </summary>
-        internal event Func<AssemblyName, PackageDependencyInfo> CollectingNodePackageDependencies;
+        internal event Func<AssemblyName, PackageInfo> CollectingNodePackageDependencies;
 
         /// <summary>
         /// This handler handles the workspaceModel's request to populate a JSON with view data.
@@ -537,37 +537,59 @@ namespace Dynamo.Graph.Workspaces
         }
 
         /// <summary>
-        /// Gathers the loaded packages that nodes in this graph depend on
+        /// Packages that the nodes in this graph depend on
         /// </summary>
-        internal IEnumerable<PackageDependencyInfo> LoadedPackageDependencies
+        internal List<PackageDependencyInfo> PackageDependencies
         {
             get
             {
-                var guidPackageDictionary = new Dictionary<Guid, PackageDependencyInfo>();
-
-                // Collect package dependencies for zerotouch and nodemodel nodes
-                if (CollectingNodePackageDependencies != null)
+                var packageDependencies = new Dictionary<PackageInfo, PackageDependencyInfo>();
+                foreach (var node in Nodes)
                 {
-                    if (CollectingNodePackageDependencies.GetInvocationList().Count() > 1)
+                    var collected = GetNodePackage(node);
+                    if (collected != null)
                     {
-                        throw new Exception("There are multiple subscribers to Workspace.CollectingNodePackageDependencies. " +
-                            "Only PackageManagerExtension should subscribe to this event.");
-                    }
-                    foreach (var node in Nodes.Where(n => !(n is Function)))
-                    {
-                        var assemblyName = GetNameOfAssemblyReferencedByNode(node);
-                        if (assemblyName != null)
+                        if (!packageDependencies.ContainsKey(collected))
                         {
-                            var package = CollectingNodePackageDependencies(assemblyName);
-                            if (package != null)
-                            {
-                                guidPackageDictionary[node.GUID] = package;
-                            }
+                            packageDependencies[collected] = new PackageDependencyInfo(collected);
                         }
+                        packageDependencies[collected].AddDependent(node.GUID);
+                        packageDependencies[collected].IsLoaded = true;
+                    }
+                    else if (nodePackageDictionary.ContainsKey(node.GUID))
+                    {
+                        var saved = nodePackageDictionary[node.GUID];
+                        if (!packageDependencies.ContainsKey(saved))
+                        {
+                            packageDependencies[saved] = new PackageDependencyInfo(saved);
+                        }
+                        packageDependencies[saved].AddDependent(node.GUID);
+                        packageDependencies[saved].IsLoaded = false;
+                    }
+                }
+                return packageDependencies.Values.ToList();
+            }
+            set
+            {
+                foreach (var package in value)
+                {
+                    foreach (var node in package.Nodes)
+                    {
+                        nodePackageDictionary[node] = package.PackageInfo;
                     }
                 }
 
-                // Collect package dependencies for custom nodes
+                RaisePropertyChanged(nameof(PackageDependencies));
+            }
+        }
+
+        private Dictionary<Guid, PackageInfo> nodePackageDictionary = new Dictionary<Guid, PackageInfo>();
+
+        private PackageInfo GetNodePackage(NodeModel node)
+        {
+            // Collect package dependencies for custom node
+            if (node is Function)
+            {
                 if (CollectingCustomNodePackageDependencies != null)
                 {
                     if (CollectingCustomNodePackageDependencies.GetInvocationList().Count() > 1)
@@ -575,91 +597,31 @@ namespace Dynamo.Graph.Workspaces
                         throw new Exception("There are multiple subscribers to Workspace.CollectingCustomNodePackageDependencies. " +
                             "Only PackageManagerExtension should subscribe to this event.");
                     }
-                    foreach (Function node in Nodes.Where(node => node is Function))
-                    {
-                        var nodeID = node.GUID;
-                        var customNodeID = node.Definition.FunctionId;
-                        var package = CollectingCustomNodePackageDependencies(customNodeID);
-                        if (package != null)
-                        {
-                            guidPackageDictionary[nodeID] = package;
-                        }
-                    }
+                    var customNodeID = (node as Function).Definition.FunctionId;
+                    return CollectingCustomNodePackageDependencies(customNodeID);
                 }
-
-                // Flip package dependencies dictionary
-                var loadedPackageDependencies = new List<PackageDependencyInfo>();
-                foreach(var id in guidPackageDictionary.Keys)
-                {
-                    if (loadedPackageDependencies.Contains(guidPackageDictionary[id]))
-                    {
-                        var index = loadedPackageDependencies.IndexOf(guidPackageDictionary[id]);
-                        loadedPackageDependencies[index].AddDependent(id);
-                    }
-                    else
-                    {
-                        guidPackageDictionary[id].AddDependent(id);
-                        loadedPackageDependencies.Add(guidPackageDictionary[id]);
-                    }
-                }
-
-                return loadedPackageDependencies;
             }
-        }
 
-        /// <summary>
-        /// Packages that the nodes in this graph depend on.
-        /// May include packages that are not currently loaded, 
-        /// but that were loaded and depended upon during a previous
-        /// opening of this graph.
-        /// </summary>
-        internal List<PackageDependencyInfo> PackageDependencies
-        {
-            get
+            // Collect package dependencies for zerotouch or nodemodel node
+            else
             {
-                List<PackageDependencyInfo> currentPackageDependencies;
-                lock (packageDependencies)
+                if (CollectingNodePackageDependencies != null)
                 {
-                    currentPackageDependencies = packageDependencies.ToList();
-                    // Remove unnecessary package dependencies
-                    foreach (var package in currentPackageDependencies)
+                    if (CollectingNodePackageDependencies.GetInvocationList().Count() > 1)
                     {
-                        foreach (var guid in NodesRemovedSinceLastPackageDependenciesUpdate)
-                        {
-                            package.RemoveDependent(guid);
-                        }
+                        throw new Exception("There are multiple subscribers to Workspace.CollectingNodePackageDependencies. " +
+                            "Only PackageManagerExtension should subscribe to this event.");
                     }
-                    currentPackageDependencies = currentPackageDependencies.Where(pd => pd.Nodes.Count > 0).ToList();
-                    NodesRemovedSinceLastPackageDependenciesUpdate = new List<Guid>();
-
-                    // Merge LoadedPackageDependencies into PackageDependencies
-                    var loadedPDs = LoadedPackageDependencies;
-                    foreach (var loadedPD in loadedPDs)
+                    var assemblyName = GetNameOfAssemblyReferencedByNode(node);
+                    if (assemblyName != null)
                     {
-                        if (currentPackageDependencies.Contains(loadedPD))
-                        {
-                            var index = currentPackageDependencies.IndexOf(loadedPD);
-                            currentPackageDependencies[index].AddDependents(loadedPD.Nodes);
-                        }
-                        else
-                        {
-                            currentPackageDependencies.Add(loadedPD);
-                        }
+                        return CollectingNodePackageDependencies(assemblyName);
                     }
                 }
-                
-                return currentPackageDependencies;
             }
-            set
-            {
-                packageDependencies = value;
-                RaisePropertyChanged(nameof(PackageDependencies));
-            }
+
+            return null;
         }
-
-        private List<PackageDependencyInfo> packageDependencies;
-
-        private List<Guid> NodesRemovedSinceLastPackageDependenciesUpdate = new List<Guid>();
 
         /// <summary>
         ///     An author of the workspace
@@ -756,8 +718,6 @@ namespace Dynamo.Graph.Workspaces
             {
                 nodes.Add(node);
             }
-            
-            NodesRemovedSinceLastPackageDependenciesUpdate.Remove(node.GUID);
             
             OnNodeAdded(node);
         }
@@ -1001,7 +961,7 @@ namespace Dynamo.Graph.Workspaces
 
             this.annotations = new List<AnnotationModel>(annotations);
 
-            this.packageDependencies = new List<PackageDependencyInfo>();
+            this.PackageDependencies = new List<PackageDependencyInfo>();
 
             // Set workspace info from WorkspaceInfo object
             Name = info.Name;
@@ -1141,8 +1101,7 @@ namespace Dynamo.Graph.Workspaces
 
             ClearUndoRecorder();
             ResetWorkspace();
-
-            packageDependencies.Clear();
+            
             X = 0.0;
             Y = 0.0;
             Zoom = 1.0;
@@ -1261,8 +1220,6 @@ namespace Dynamo.Graph.Workspaces
             {
                 if (!nodes.Remove(model)) return;
             }
-
-            NodesRemovedSinceLastPackageDependenciesUpdate.Add(model.GUID);
 
             OnNodeRemoved(model);
 
@@ -1842,7 +1799,7 @@ namespace Dynamo.Graph.Workspaces
                         new WorkspaceReadConverter(engineController, scheduler, factory, isTestMode, verboseLogging),
                         new NodeReadConverter(manager, libraryServices, factory, isTestMode),
                         new TypedParameterConverter(),
-                        new PackageDependencyInfoConverter(logger)
+                        new PackageDependencyConverter(logger)
                     },
                 ReferenceResolverProvider = () => { return new IdReferenceResolver(); }
             };

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -546,17 +546,7 @@ namespace Dynamo.Graph.Workspaces
                 var packageDependencies = new Dictionary<PackageInfo, PackageDependencyInfo>();
                 foreach (var node in Nodes)
                 {
-                    var collected = GetNodePackage(node);
-                    if (collected != null)
-                    {
-                        if (!packageDependencies.ContainsKey(collected))
-                        {
-                            packageDependencies[collected] = new PackageDependencyInfo(collected);
-                        }
-                        packageDependencies[collected].AddDependent(node.GUID);
-                        packageDependencies[collected].IsLoaded = true;
-                    }
-                    else if (nodePackageDictionary.ContainsKey(node.GUID))
+                    if (nodePackageDictionary.ContainsKey(node.GUID))
                     {
                         var saved = nodePackageDictionary[node.GUID];
                         if (!packageDependencies.ContainsKey(saved))
@@ -565,6 +555,19 @@ namespace Dynamo.Graph.Workspaces
                         }
                         packageDependencies[saved].AddDependent(node.GUID);
                         packageDependencies[saved].IsLoaded = false;
+                    }
+                    else
+                    {
+                        var collected = GetNodePackage(node);
+                        if (collected != null)
+                        {
+                            if (!packageDependencies.ContainsKey(collected))
+                            {
+                                packageDependencies[collected] = new PackageDependencyInfo(collected);
+                            }
+                            packageDependencies[collected].AddDependent(node.GUID);
+                            packageDependencies[collected].IsLoaded = true;
+                        }
                     }
                 }
                 return packageDependencies.Values.ToList();
@@ -584,6 +587,16 @@ namespace Dynamo.Graph.Workspaces
         }
 
         private Dictionary<Guid, PackageInfo> nodePackageDictionary = new Dictionary<Guid, PackageInfo>();
+
+        /// <summary>
+        /// Removes a nodes deserialized package dependency, 
+        /// causing it to be updated during the next Package Dependencies update
+        /// </summary>
+        /// <param name="nodeID"></param>
+        internal void VoidNodeDependency(Guid nodeID)
+        {
+            nodePackageDictionary.Remove(nodeID);
+        }
 
         private PackageInfo GetNodePackage(NodeModel node)
         {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -587,54 +587,7 @@ namespace Dynamo.Graph.Workspaces
         }
 
         private Dictionary<Guid, PackageInfo> nodePackageDictionary = new Dictionary<Guid, PackageInfo>();
-
-        /// <summary>
-        /// Removes a nodes deserialized package dependency, 
-        /// causing it to be updated during the next Package Dependencies update
-        /// </summary>
-        /// <param name="nodeID"></param>
-        internal void VoidNodeDependency(Guid nodeID)
-        {
-            nodePackageDictionary.Remove(nodeID);
-        }
-
-        private PackageInfo GetNodePackage(NodeModel node)
-        {
-            // Collect package dependencies for custom node
-            if (node is Function)
-            {
-                if (CollectingCustomNodePackageDependencies != null)
-                {
-                    if (CollectingCustomNodePackageDependencies.GetInvocationList().Count() > 1)
-                    {
-                        throw new Exception("There are multiple subscribers to Workspace.CollectingCustomNodePackageDependencies. " +
-                            "Only PackageManagerExtension should subscribe to this event.");
-                    }
-                    var customNodeID = (node as Function).Definition.FunctionId;
-                    return CollectingCustomNodePackageDependencies(customNodeID);
-                }
-            }
-
-            // Collect package dependencies for zerotouch or nodemodel node
-            else
-            {
-                if (CollectingNodePackageDependencies != null)
-                {
-                    if (CollectingNodePackageDependencies.GetInvocationList().Count() > 1)
-                    {
-                        throw new Exception("There are multiple subscribers to Workspace.CollectingNodePackageDependencies. " +
-                            "Only PackageManagerExtension should subscribe to this event.");
-                    }
-                    var assemblyName = GetNameOfAssemblyReferencedByNode(node);
-                    if (assemblyName != null)
-                    {
-                        return CollectingNodePackageDependencies(assemblyName);
-                    }
-                }
-            }
-
-            return null;
-        }
+        
 
         /// <summary>
         ///     An author of the workspace
@@ -1698,6 +1651,54 @@ namespace Dynamo.Graph.Workspaces
                 assemblyName = AssemblyName.GetAssemblyName(assembly.Location);
             }
             return assemblyName;
+        }
+
+        /// <summary>
+        /// Removes a nodes deserialized package dependency, 
+        /// causing it to be updated during the next Package Dependencies update
+        /// </summary>
+        /// <param name="nodeID"></param>
+        internal void VoidNodeDependency(Guid nodeID)
+        {
+            nodePackageDictionary.Remove(nodeID);
+        }
+
+        private PackageInfo GetNodePackage(NodeModel node)
+        {
+            // Collect package dependencies for custom node
+            if (node is Function)
+            {
+                if (CollectingCustomNodePackageDependencies != null)
+                {
+                    if (CollectingCustomNodePackageDependencies.GetInvocationList().Count() > 1)
+                    {
+                        throw new Exception("There are multiple subscribers to Workspace.CollectingCustomNodePackageDependencies. " +
+                            "Only PackageManagerExtension should subscribe to this event.");
+                    }
+                    var customNodeID = (node as Function).Definition.FunctionId;
+                    return CollectingCustomNodePackageDependencies(customNodeID);
+                }
+            }
+
+            // Collect package dependencies for zerotouch or nodemodel node
+            else
+            {
+                if (CollectingNodePackageDependencies != null)
+                {
+                    if (CollectingNodePackageDependencies.GetInvocationList().Count() > 1)
+                    {
+                        throw new Exception("There are multiple subscribers to Workspace.CollectingNodePackageDependencies. " +
+                            "Only PackageManagerExtension should subscribe to this event.");
+                    }
+                    var assemblyName = GetNameOfAssemblyReferencedByNode(node);
+                    if (assemblyName != null)
+                    {
+                        return CollectingNodePackageDependencies(assemblyName);
+                    }
+                }
+            }
+
+            return null;
         }
 
         #endregion

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -546,6 +546,7 @@ namespace Dynamo.Graph.Workspaces
                 var packageDependencies = new Dictionary<PackageInfo, PackageDependencyInfo>();
                 foreach (var node in Nodes)
                 {
+                    var collected = GetNodePackage(node);
                     if (nodePackageDictionary.ContainsKey(node.GUID))
                     {
                         var saved = nodePackageDictionary[node.GUID];
@@ -554,11 +555,10 @@ namespace Dynamo.Graph.Workspaces
                             packageDependencies[saved] = new PackageDependencyInfo(saved);
                         }
                         packageDependencies[saved].AddDependent(node.GUID);
-                        packageDependencies[saved].IsLoaded = false;
+                        packageDependencies[saved].IsLoaded = saved.Equals(collected);
                     }
                     else
                     {
-                        var collected = GetNodePackage(node);
                         if (collected != null)
                         {
                             if (!packageDependencies.ContainsKey(collected))

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -33,13 +33,13 @@ namespace Dynamo.PackageManager
         /// Dictionary mapping a custom node functionID to the package that contains it.
         /// Used for package dependency serialization.
         /// </summary>
-        private Dictionary<Guid, List<PackageDependencyInfo>> CustomNodePackageDictionary;
+        private Dictionary<Guid, List<PackageInfo>> CustomNodePackageDictionary;
 
         /// <summary>
         /// Dictionary mapping the AssemblyName.FullName of an assembly to the package that contains it.
         /// Used for package dependency serialization.
         /// </summary>
-        private Dictionary<string, List<PackageDependencyInfo>> NodePackageDictionary;
+        private Dictionary<string, List<PackageInfo>> NodePackageDictionary;
 
         public string Name { get { return "DynamoPackageManager"; } }
 
@@ -209,25 +209,20 @@ namespace Dynamo.PackageManager
             }
         }
         
-        private PackageDependencyInfo GetNodePackageFromAssemblyName(AssemblyName assemblyName)
+        private PackageInfo GetNodePackageFromAssemblyName(AssemblyName assemblyName)
         {
             if (NodePackageDictionary != null && NodePackageDictionary.ContainsKey(assemblyName.FullName))
             {
-                var p = NodePackageDictionary[assemblyName.FullName].FirstOrDefault();
-                // Return a copy of the PackageDependencyInfo so that a workspace doesn't modify it
-                // TODO Split PackageDependencyInfo into two types
-                return new PackageDependencyInfo(p.Name, p.Version);
+                return NodePackageDictionary[assemblyName.FullName].Last();
             }
             return null;
         }
 
-        private PackageDependencyInfo GetCustomNodePackageFromID(Guid functionID)
+        private PackageInfo GetCustomNodePackageFromID(Guid functionID)
         {
             if (CustomNodePackageDictionary != null && CustomNodePackageDictionary.ContainsKey(functionID))
             {
-                var p = CustomNodePackageDictionary[functionID].FirstOrDefault();
-                // Return a copy of the PackageDependencyInfo so that a workspace doesn't modify it
-                return new PackageDependencyInfo(p.Name, p.Version);
+                return CustomNodePackageDictionary[functionID].Last();
             }
             return null;
         }
@@ -237,7 +232,7 @@ namespace Dynamo.PackageManager
             // Create NodePackageDictionary if it doesn't exist
             if (NodePackageDictionary == null)
             {
-                NodePackageDictionary = new Dictionary<string, List<PackageDependencyInfo>>();
+                NodePackageDictionary = new Dictionary<string, List<PackageInfo>>();
             }
             // Add new assemblies to NodePackageDictionary
             var nodeLibraries = package.LoadedAssemblies.Where(a => a.IsNodeLibrary);
@@ -253,15 +248,15 @@ namespace Dynamo.PackageManager
                 }
                 else
                 {
-                    NodePackageDictionary[assembly.FullName] = new List<PackageDependencyInfo>();
+                    NodePackageDictionary[assembly.FullName] = new List<PackageInfo>();
                 }
-                NodePackageDictionary[assembly.FullName].Add(new PackageDependencyInfo(package.Name, new Version(package.VersionName)));
+                NodePackageDictionary[assembly.FullName].Add(new PackageInfo(package.Name, new Version(package.VersionName)));
             }
 
             // Create CustomNodePackageDictionary if it doesn't exist
             if (CustomNodePackageDictionary == null)
             {
-                CustomNodePackageDictionary = new Dictionary<Guid, List<PackageDependencyInfo>>();
+                CustomNodePackageDictionary = new Dictionary<Guid, List<PackageInfo>>();
             }
             // Add new custom nodes to CustomNodePackageDictionary
             foreach (var cn in package.LoadedCustomNodes)
@@ -276,15 +271,15 @@ namespace Dynamo.PackageManager
                 }
                 else
                 {
-                    CustomNodePackageDictionary[cn.FunctionId] = new List<PackageDependencyInfo>();
+                    CustomNodePackageDictionary[cn.FunctionId] = new List<PackageInfo>();
                 }
-                CustomNodePackageDictionary[cn.FunctionId].Add(new PackageDependencyInfo(package.Name, new Version(package.VersionName)));
+                CustomNodePackageDictionary[cn.FunctionId].Add(new PackageInfo(package.Name, new Version(package.VersionName)));
             }
         }
 
         private void OnPackageRemoved(Package package)
         {
-            var pInfo = new PackageDependencyInfo(package.Name, new Version(package.VersionName));
+            var pInfo = new PackageInfo(package.Name, new Version(package.VersionName));
 
             // Remove package references from NodePackageDictionary
             var nodeLibraries = package.LoadedAssemblies.Where(a => a.IsNodeLibrary);

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
@@ -65,26 +65,18 @@ namespace Dynamo.PackageDependency
             table.Columns.Clear();
             foreach (var package in ws.PackageDependencies)
             {
-                bool matchFound = false;
-                // Check if the target package is installed and loaded.
-                foreach (var loadedPackage in ws.LoadedPackageDependencies)
+                if (package.IsLoaded)
                 {
-                    if (package.Equals(loadedPackage))
+                    table.Columns.Add(new Column()
                     {
-                        table.Columns.Add(new Column()
-                        {
-                            ColumnsData = new ObservableCollection<ColumnData>()
+                        ColumnsData = new ObservableCollection<ColumnData>()
                             {
                                 new ColumnData(package.Name),
                                 new ColumnData(package.Version.ToString(), 100)
                             }
-                        });
-                        matchFound = true;
-                        continue;
-                    }
+                    });
                 }
-                // TODO: Not ideal! O(N * M) complexicty, would like LoadedPackageDependencies to be a dictionary or something with constant package name search time
-                if (!matchFound)
+                else
                 {
                     table.Columns.Add(new Column()
                     {

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -93,6 +93,7 @@ namespace Dynamo.Tests
             var package = packageDependencies.First();
             Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), package);
             Assert.AreEqual(1, package.Nodes.Count);
+            Assert.IsTrue(package.IsLoaded);
 
             // Assert package dependency is serialized
             var ToJson = CurrentDynamoModel.CurrentWorkspace.ToJson(CurrentDynamoModel.EngineController);
@@ -128,6 +129,7 @@ namespace Dynamo.Tests
             var package = packageDependencies.First();
             Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), package);
             Assert.AreEqual(1, package.Nodes.Count);
+            Assert.IsTrue(package.IsLoaded);
         }
 
         [Test]
@@ -144,6 +146,7 @@ namespace Dynamo.Tests
             var package = packageDependencies.First();
             Assert.AreEqual(new PackageDependencyInfo("Custom Rounding", new Version("0.1.4")), package);
             Assert.AreEqual(1, package.Nodes.Count);
+            Assert.IsTrue(package.IsLoaded);
         }
 
         [Test]
@@ -160,6 +163,7 @@ namespace Dynamo.Tests
             var package = packageDependencies.First();
             Assert.AreEqual(pi, package);
             Assert.AreEqual(1, package.Nodes.Count);
+            Assert.IsTrue(package.IsLoaded);
         }
         
         [Test]
@@ -195,6 +199,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(2, packageDependencies.Count);
             foreach(var package in packageDependencies)
             {
+                Assert.IsTrue(package.IsLoaded);
                 if (package.Equals(package1))
                 {
                     // Package 1 should have two nodes
@@ -231,6 +236,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(1, packageDependencies.First().Nodes.Count);
             Assert.True(!packageDependencies.First().Nodes.Contains(node1.GUID));
+            Assert.IsTrue(packageDependencies.First().IsLoaded);
 
             // Remove te second node and assert package dependencies is now empty
             CurrentDynamoModel.CurrentWorkspace.RemoveAndDisposeNode(node2);
@@ -268,6 +274,7 @@ namespace Dynamo.Tests
             // Assert new package dependency is collected
             var packageDependencies = CurrentDynamoModel.CurrentWorkspace.PackageDependencies;
             Assert.Contains(pi, packageDependencies);
+            Assert.IsTrue(packageDependencies.First().IsLoaded);
         }
 
         [Test]
@@ -311,6 +318,7 @@ namespace Dynamo.Tests
             // Assert ZTTestPackage is still a package dependency
             var packageDependencies = CurrentDynamoModel.CurrentWorkspace.PackageDependencies;
             Assert.Contains(new PackageDependencyInfo("ZTTestPackage", new Version("0.0.1")), packageDependencies);
+            Assert.IsTrue(packageDependencies.First().IsLoaded == false);
         }
     }
 }

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -343,13 +343,12 @@ namespace Dynamo.Tests
             OpenModel(path);
 
             // Assert clockwork is still the only dependency returned
-            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
             var packageDependencies = CurrentDynamoModel.CurrentWorkspace.PackageDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(clockworkInfo, packageDependencies.First());
 
             // Void package dependency for node
-            CurrentDynamoModel.CurrentWorkspace.VoidNodeDependency(CurrentDynamoModel.CurrentWorkspace.Nodes.First().GUID);
+            CurrentDynamoModel.CurrentWorkspace.VoidNodeDependency(Guid.Parse("d87512f7f69e433d86c729bac18bcfef"));
 
             // Assert local package dependency overrides deserialized package dependency
             var pi = GetPackageInfo("Custom Rounding");

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -328,6 +328,7 @@ namespace Dynamo.Tests
             string path = Path.Combine(TestDirectory, @"core\packageDependencyTests\CustomNodeContainedInMultiplePackages.dyn");
 
             // Assert serialized package dependency is Clockwork
+            var clockworkInfo = new PackageDependencyInfo("Clockwork for Dynamo 2.x", new Version("2.1.2"));
             using (StreamReader file = new StreamReader(path))
             {
                 var data = file.ReadToEnd();
@@ -336,18 +337,24 @@ namespace Dynamo.Tests
                 var deserializedPDs = JsonConvert.DeserializeObject<List<PackageDependencyInfo>>(pd.ToString(), new PackageDependencyConverter(CurrentDynamoModel.Logger));
                 Assert.AreEqual(1, deserializedPDs.Count);
                 var package = deserializedPDs.First();
-                Assert.AreEqual(new PackageDependencyInfo("Clockwork for Dynamo 2.x", new Version("2.1.2")), package);
+                Assert.AreEqual(clockworkInfo, package);
             }
 
             OpenModel(path);
 
-            // Assert only one package dependency is returned for one node
+            // Assert clockwork is still the only dependency returned
             Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
             var packageDependencies = CurrentDynamoModel.CurrentWorkspace.PackageDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
+            Assert.AreEqual(clockworkInfo, packageDependencies.First());
+
+            // Void package dependency for node
+            CurrentDynamoModel.CurrentWorkspace.VoidNodeDependency(CurrentDynamoModel.CurrentWorkspace.Nodes.First().GUID);
 
             // Assert local package dependency overrides deserialized package dependency
             var pi = GetPackageInfo("Custom Rounding");
+            packageDependencies = CurrentDynamoModel.CurrentWorkspace.PackageDependencies;
+            Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(pi, packageDependencies.First());
         }
     }

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -320,5 +320,35 @@ namespace Dynamo.Tests
             Assert.Contains(new PackageDependencyInfo("ZTTestPackage", new Version("0.0.1")), packageDependencies);
             Assert.IsTrue(packageDependencies.First().IsLoaded == false);
         }
+
+        [Test]
+        public void PackageDependenciesUpdatedWhenCustomNodeResolvedByNewPackage()
+        {
+            // Load JSON file graph
+            string path = Path.Combine(TestDirectory, @"core\packageDependencyTests\CustomNodeContainedInMultiplePackages.dyn");
+
+            // Assert serialized package dependency is Clockwork
+            using (StreamReader file = new StreamReader(path))
+            {
+                var data = file.ReadToEnd();
+                var json = (JObject)JsonConvert.DeserializeObject(data);
+                var pd = json["PackageDependencies"];
+                var deserializedPDs = JsonConvert.DeserializeObject<List<PackageDependencyInfo>>(pd.ToString(), new PackageDependencyConverter(CurrentDynamoModel.Logger));
+                Assert.AreEqual(1, deserializedPDs.Count);
+                var package = deserializedPDs.First();
+                Assert.AreEqual(new PackageDependencyInfo("Clockwork for Dynamo 2.x", new Version("2.1.2")), package);
+            }
+
+            OpenModel(path);
+
+            // Assert only one package dependency is returned for one node
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.PackageDependencies;
+            Assert.AreEqual(1, packageDependencies.Count);
+
+            // Assert local package dependency overrides deserialized package dependency
+            var pi = GetPackageInfo("Custom Rounding");
+            Assert.AreEqual(pi, packageDependencies.First());
+        }
     }
 }

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -648,9 +648,7 @@ namespace Dynamo.Tests
         {
             var di = new DirectoryInfo(TestDirectory);
             var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
-            var dyn = fis.Select(fi => fi.FullName).ToList();
-            dyn.Remove("CustomNodeContainedInMultiplePackages.dyn");
-            return dyn.ToArray();
+            return fis.Select(fi => fi.FullName).ToArray();
         }
 
         /// <summary>
@@ -736,7 +734,8 @@ namespace Dynamo.Tests
                 "packageTest",
                 "reduce-example",
                 "TestFrozen",
-                "TestImperativeInCBN"
+                "TestImperativeInCBN",
+                "CustomNodeContainedInMultiplePackages"
             };
 
         private void DoWorkspaceOpenAndCompare(string filePath, string dirName,

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -648,7 +648,9 @@ namespace Dynamo.Tests
         {
             var di = new DirectoryInfo(TestDirectory);
             var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
-            return fis.Select(fi => fi.FullName).ToArray();
+            var dyn = fis.Select(fi => fi.FullName).ToList();
+            dyn.Remove("CustomNodeContainedInMultiplePackages.dyn");
+            return dyn.ToArray();
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1005,7 +1005,9 @@ namespace DynamoCoreWpfTests
             var di = new DirectoryInfo(TestDirectory);
             var fis = new string[] { "*.dyn", "*.dyf" }
             .SelectMany(i => di.GetFiles(i, SearchOption.AllDirectories));
-            return fis.Select(fi => fi.FullName).ToArray();
+            var dyn = fis.Select(fi => fi.FullName).ToList();
+            dyn.Remove("CustomNodeContainedInMultiplePackages.dyn");
+            return dyn.ToArray();
         }
 
 

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1005,9 +1005,7 @@ namespace DynamoCoreWpfTests
             var di = new DirectoryInfo(TestDirectory);
             var fis = new string[] { "*.dyn", "*.dyf" }
             .SelectMany(i => di.GetFiles(i, SearchOption.AllDirectories));
-            var dyn = fis.Select(fi => fi.FullName).ToList();
-            dyn.Remove("CustomNodeContainedInMultiplePackages.dyn");
-            return dyn.ToArray();
+            return fis.Select(fi => fi.FullName).ToArray();
         }
 
 

--- a/test/core/packageDependencyTests/CustomNodeContainedInMultiplePackages.dyn
+++ b/test/core/packageDependencyTests/CustomNodeContainedInMultiplePackages.dyn
@@ -1,0 +1,105 @@
+{
+  "Uuid": "d790c1df-1de2-4169-8ba6-f94aba302d00",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "CustomNodeContainedInMultiplePackages",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "6d1e3caa-780d-40fd-a045-766b3170235d",
+      "FunctionType": "Graph",
+      "NodeType": "FunctionNode",
+      "Id": "d87512f7f69e433d86c729bac18bcfef",
+      "Inputs": [
+        {
+          "Id": "3c91c143924b4674a8ec69cd2a5abbe0",
+          "Name": "dbl",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f57c76bb48284d04b23691a2ab331ff2",
+          "Name": "precision",
+          "Description": "double\nDefault value : 1 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8e4f0e26cb42499cbef595a15fe3d93d",
+          "Name": "dbl",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Rounds a number *down* to a specified precision"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [
+    "6d1e3caa-780d-40fd-a045-766b3170235d"
+  ],
+  "PackageDependencies": [
+    {
+      "Name": "Clockwork for Dynamo 2.x",
+      "Version": "2.1.2",
+      "Nodes": [
+        "d87512f7f69e433d86c729bac18bcfef"
+      ]
+    }
+  ],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.3.0.5345",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Rounding.Floor+",
+        "Id": "d87512f7f69e433d86c729bac18bcfef",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 226.0,
+        "Y": 160.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/packageDependencyTests/CustomNodeContainedInMultiplePackages.dyn
+++ b/test/core/packageDependencyTests/CustomNodeContainedInMultiplePackages.dyn
@@ -48,9 +48,40 @@
       ],
       "Replication": "Auto",
       "Description": "Rounds a number *down* to a specified precision"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;",
+      "Id": "afea8607558642f2814af462fac7f302",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "76a96f87412c4cfeb0ab28913843ad18",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
     }
   ],
-  "Connectors": [],
+  "Connectors": [
+    {
+      "Start": "76a96f87412c4cfeb0ab28913843ad18",
+      "End": "3c91c143924b4674a8ec69cd2a5abbe0",
+      "Id": "ccec16c48557422ab7b5e4c7616ca38d"
+    },
+    {
+      "Start": "76a96f87412c4cfeb0ab28913843ad18",
+      "End": "f57c76bb48284d04b23691a2ab331ff2",
+      "Id": "61598895a0e84a6283cdca0c64faaad4"
+    }
+  ],
   "Dependencies": [
     "6d1e3caa-780d-40fd-a045-766b3170235d"
   ],
@@ -69,7 +100,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.3.0.5345",
+      "Version": "2.3.0.5367",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -93,8 +124,18 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 226.0,
-        "Y": 160.0
+        "X": 262.0,
+        "Y": 203.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "afea8607558642f2814af462fac7f302",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 147.0,
+        "Y": 217.0
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose
This PR addresses https://jira.autodesk.com/browse/DYN-1997 and also simplifies the package dependency collection process. 
This PR removes `LoadedPackageDependencies` property and refactors `PackageDependencies` property/collection and `PackageDependencyInfo` object.

- Only one package should be listed as a dependency for a node
- By default, the original deserialized package dependency should be maintained
- API to override the original dependency with the local dependency
- Unit test
- Adds new `PackageInfo` type.
- Adds `IsLoaded` property to `PackageDependencyInfo`
- Simplifies package dependency collection process

This should fix the case found by @QilongTang where a node can have two package dependencies when multiple packages are loaded with the same custom node. Previously, both the deserialized package dependency and the collected package dependency of a single node could be contained in the `PackageDependencies` property of a workspace. Now, the *original* package dependency is maintained until it is voided using `VoidNodeDependency()`. After the original dependency has been voided, the local package dependency will be used for serialization.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @aparajit-pratap @QilongTang @ColinDayOrg 
