### PR TITLE
Adding fix to show the dependency extension only when there is a missing package dependency

### DIFF
--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
@@ -1,9 +1,10 @@
-﻿using Dynamo.Graph.Workspaces;
-using Dynamo.Wpf.Extensions;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Wpf.Extensions;
 
 namespace Dynamo.PackageDependency
 {
@@ -15,6 +16,25 @@ namespace Dynamo.PackageDependency
         private DependencyTable table = new DependencyTable();
 
         private WorkspaceModel currentWorkspace;
+
+        private ViewLoadedParams loadedParams;
+        private PackageDependencyViewExtension dependencyViewExtension;
+
+        private Boolean missingPackage = false;
+
+        public Boolean MissingPackage
+        {
+            get { return missingPackage; }
+            set
+            {
+                missingPackage = value;
+                if (missingPackage)
+                {
+                    loadedParams.AddToExtensionsSideBar(dependencyViewExtension, this);
+                }
+            }
+        }
+
 
         /// <summary>
         /// Event handler for workspaceAdded event
@@ -86,6 +106,7 @@ namespace Dynamo.PackageDependency
                 // TODO: Not ideal! O(N * M) complexicty, would like LoadedPackageDependencies to be a dictionary or something with constant package name search time
                 if (!matchFound)
                 {
+                    MissingPackage = true;
                     table.Columns.Add(new Column()
                     {
                         ColumnsData = new ObservableCollection<ColumnData>()
@@ -102,7 +123,7 @@ namespace Dynamo.PackageDependency
         /// Constructor
         /// </summary>
         /// <param name="p">ViewLoadedParams</param>
-        public PackageDependencyView(ViewLoadedParams p)
+        public PackageDependencyView(PackageDependencyViewExtension viewExtension,ViewLoadedParams p)
         {
             InitializeComponent();
             DataContext = table;
@@ -110,6 +131,8 @@ namespace Dynamo.PackageDependency
             p.CurrentWorkspaceChanged += OnWorkspaceChanged;
             p.CurrentWorkspaceCleared += OnWorkspaceCleared;
             currentWorkspace.PropertyChanged += OnWorkspacePropertyChanged;
+            loadedParams = p;
+            dependencyViewExtension = viewExtension;
         }
     }
 

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Dynamo.Graph.Workspaces;
+using Dynamo.Wpf.Extensions;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Controls;
 using System.Windows.Media;
-using Dynamo.Graph.Workspaces;
-using Dynamo.Wpf.Extensions;
 
 namespace Dynamo.PackageDependency
 {
@@ -20,15 +20,18 @@ namespace Dynamo.PackageDependency
         private ViewLoadedParams loadedParams;
         private PackageDependencyViewExtension dependencyViewExtension;
 
-        private Boolean missingPackage = false;
+        private Boolean hasMissingPackage = false;
 
-        public Boolean MissingPackage
+        /// <summary>
+        /// Property to check if the current workspace has any missing package dependencies. 
+        /// </summary>
+        private Boolean HasMissingPackage
         {
-            get { return missingPackage; }
+            get { return hasMissingPackage; }
             set
             {
-                missingPackage = value;
-                if (missingPackage)
+                hasMissingPackage = value;
+                if (hasMissingPackage)
                 {
                     loadedParams.AddToExtensionsSideBar(dependencyViewExtension, this);
                 }
@@ -106,7 +109,7 @@ namespace Dynamo.PackageDependency
                 // TODO: Not ideal! O(N * M) complexicty, would like LoadedPackageDependencies to be a dictionary or something with constant package name search time
                 if (!matchFound)
                 {
-                    MissingPackage = true;
+                    HasMissingPackage = true;
                     table.Columns.Add(new Column()
                     {
                         ColumnsData = new ObservableCollection<ColumnData>()

--- a/src/PackageDependencyViewExtension/PackageDependencyViewExtension.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyViewExtension.cs
@@ -1,8 +1,8 @@
-﻿using Dynamo.Extensions;
+﻿using System.Windows.Controls;
+using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.PackageDependency.Properties;
 using Dynamo.Wpf.Extensions;
-using System.Windows.Controls;
 
 namespace Dynamo.PackageDependency
 {
@@ -78,8 +78,11 @@ namespace Dynamo.PackageDependency
 
         public void Loaded(ViewLoadedParams viewLoadedParams)
         {
-            DependencyView = new PackageDependencyView(viewLoadedParams);
-            viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
+            DependencyView = new PackageDependencyView(this, viewLoadedParams);
+
+            if (DependencyView.MissingPackage) {
+                viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
+            }
 
             // Adding a button in view menu to refresh and show manually
             packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString };

--- a/src/PackageDependencyViewExtension/PackageDependencyViewExtension.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyViewExtension.cs
@@ -1,8 +1,8 @@
-﻿using System.Windows.Controls;
-using Dynamo.Extensions;
+﻿using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.PackageDependency.Properties;
 using Dynamo.Wpf.Extensions;
+using System.Windows.Controls;
 
 namespace Dynamo.PackageDependency
 {
@@ -79,10 +79,6 @@ namespace Dynamo.PackageDependency
         public void Loaded(ViewLoadedParams viewLoadedParams)
         {
             DependencyView = new PackageDependencyView(this, viewLoadedParams);
-
-            if (DependencyView.MissingPackage) {
-                viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
-            }
 
             // Adding a button in view menu to refresh and show manually
             packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString };


### PR DESCRIPTION
### Purpose

This PR is to show the package dependency extension only when there is a missing package. 

1) When the user opens up a new workspace, the extension is not shown. 
2) When the user opens up a graph, that has all dependencies installed, the extension is not shown.  
3) When the user opens up a graph, that has missing dependencies, the extension is visible.

![right side bar](https://user-images.githubusercontent.com/43763136/59804442-54756f00-92bc-11e9-96c3-c9e5e6cbb36a.gif)

One thing to note here is that, when the user first opens up a graph(with missing dependencies), the extension side bar is shown. Now if the user closes the graph and opens a new graph that has all the dependencies installed, the extension side bar is still shown as we do not have an API to close the extension as of now. But if the user manually closes the extension tab at some point, then the dependencies extension is shown again only when the user opens a graph that has missing dependencies. 

This fixes the failing Recorded tests for now.  I am not sure how feasible this is, looking for suggestions. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 
