### PR TITLE
Fix for adding duplicate ZT search entries for packages already loaded

### DIFF
--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -263,7 +263,7 @@ namespace Dynamo.PackageManager
             }
 
             var assemblies =
-                LocalPackages.SelectMany(x => x.EnumerateAssembliesInBinDirectory().Where(y => y.IsNodeLibrary));
+                packages.SelectMany(x => x.EnumerateAssembliesInBinDirectory().Where(y => y.IsNodeLibrary));
             OnPackagesLoaded(assemblies.Select(x => x.Assembly));
         }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -257,13 +257,14 @@ namespace Dynamo.PackageManager
         /// <param name="packages"></param>
         public void LoadPackages(IEnumerable<Package> packages)
         {
-            foreach (var pkg in packages)
+            var enumerable = packages.ToList();
+            foreach (var pkg in enumerable)
             {
                 TryLoadPackageIntoLibrary(pkg);
             }
 
             var assemblies =
-                packages.SelectMany(x => x.EnumerateAssembliesInBinDirectory().Where(y => y.IsNodeLibrary));
+                enumerable.SelectMany(x => x.EnumerateAssembliesInBinDirectory().Where(y => y.IsNodeLibrary));
             OnPackagesLoaded(assemblies.Select(x => x.Assembly));
         }
 

--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.Scheduler;
+using Dynamo.Search.SearchElements;
 using Dynamo.Selection;
 using Dynamo.Tests;
 using Dynamo.Utilities;
@@ -178,6 +180,19 @@ namespace Dynamo
                 return extensions.First().PackageLoader;
             }
 
+            return null;
+        }
+
+        protected NodeModel GetNodeInstance(string creationName)
+        {
+            var searchElementList = CurrentDynamoModel.SearchModel.SearchEntries.OfType<NodeSearchElement>();
+            foreach (var element in searchElementList)
+            {
+                if (element.CreationName == creationName)
+                {
+                    return ((NodeSearchElement) element).CreateNode();
+                }
+            }
             return null;
         }
     }

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -47,19 +47,6 @@ namespace Dynamo.Tests
             return null;
         }
 
-        private NodeModel GetNodeInstance(string creationName)
-        {
-            var searchElementList = CurrentDynamoModel.SearchModel.SearchEntries.OfType<NodeSearchElement>();
-            foreach (var element in searchElementList)
-            {
-                if (element.CreationName == creationName)
-                {
-                    return (element as NodeSearchElement).CreateNode();
-                }
-            }
-            return null;
-        }
-
         protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPreferences settings)
         {
             return new DynamoModel.DefaultStartConfiguration()

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -163,12 +163,16 @@ namespace Dynamo.PackageManager.Tests
             // There are 11 packages in "GitHub\Dynamo\test\pkgs"
             Assert.AreEqual(11, loader.LocalPackages.Count());
 
+            // Simulate loading new package from PM
             string packageDirectory = Path.Combine(TestDirectory, @"core\packageDependencyTests\ZTTestPackage");
             var pkg = loader.ScanPackageDirectory(packageDirectory);
             loader.LoadPackages(new List<Package> {pkg});
+
+            // Assert that node belonging to new package is imported
             var node = GetNodeInstance("ZTTestPackage.RRTestClass.RRTestClass");
             Assert.IsNotNull(node);
 
+            // Check that node belonging to one of the preloaded packages exists and is unique
             var entries = CurrentDynamoModel.SearchModel.SearchEntries.ToList();
             Assert.IsTrue(entries.Count(x => x.FullName == "AnotherPackage.AnotherPackage.AnotherPackage.HelloAnotherWorld") == 1);
         }


### PR DESCRIPTION
### Purpose

Fix for this:
![image](https://user-images.githubusercontent.com/5710686/59889203-45b0ba00-9399-11e9-85d5-0f61a7b79ac4.png)

Regression caused by #9736 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

