### PR TITLE
[WIP] do not crash when libG objects are garbage collected.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -600,6 +600,7 @@ namespace Dynamo.Models
                 {
                     this.Scheduler.ScheduleForExecution(new DelegateBasedAsyncTask(this.Scheduler, combined as Action));
                 }
+                requestedDisposalCalls.Clear();
             };
 
             geometryFactoryPath = config.GeometryFactoryPath;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -585,6 +585,12 @@ namespace Dynamo.Models
             var thread = config.SchedulerThread ?? new DynamoSchedulerThread();
             Scheduler = new DynamoScheduler(thread, config.ProcessMode);
             Scheduler.TaskStateChanged += OnAsyncTaskStateChanged;
+            //TODO dispose this.
+            ExecutionEvents.RequestRunOnDynamoScheduler += (actionToSchedule) =>
+            {
+                var task = new DelegateBasedAsyncTask(this.Scheduler, actionToSchedule);
+                Scheduler.ScheduleForExecution(task);
+            };
 
             geometryFactoryPath = config.GeometryFactoryPath;
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -596,7 +596,10 @@ namespace Dynamo.Models
             this.EvaluationCompleted += (s,e) => {
 
                 var combined = Delegate.Combine(requestedDisposalCalls.ToArray());
-                this.Scheduler.ScheduleForExecution(new DelegateBasedAsyncTask(this.Scheduler, combined as Action));
+                if(combined != null)
+                {
+                    this.Scheduler.ScheduleForExecution(new DelegateBasedAsyncTask(this.Scheduler, combined as Action));
+                }
             };
 
             geometryFactoryPath = config.GeometryFactoryPath;

--- a/src/NodeServices/ExecutionEvents.cs
+++ b/src/NodeServices/ExecutionEvents.cs
@@ -1,4 +1,6 @@
 ﻿using Dynamo.Session;
+using System;
+
 namespace Dynamo.Events
 {
     public delegate void ExecutionStateHandler(IExecutionSession session);
@@ -24,6 +26,21 @@ namespace Dynamo.Events
         /// This property is set to null if graph is not executing.
         /// </summary>
         public static IExecutionSession ActiveSession { get; private set; }
+
+        /// <summary>
+        /// An event that is triggered when a client has requested that an action be run
+        /// on the Dynamo Scheduler.
+        /// </summary>
+        public static event Action<Action> RequestRunOnDynamoScheduler;
+
+        /// <summary>
+        /// Use this method to request that an action be run on the Dynamo scheduler.
+        /// </summary>
+        /// <param name="action"></param>
+        public static void OnRequestRunOnDynamoScheduler(Action action)
+        {
+            RequestRunOnDynamoScheduler?.Invoke(action);
+        }
 
         /// <summary>
         /// Notify observers that the graph is about to evaluate

--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.DynamoSamples.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.DynamoSamples.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright Autodesk 2019</copyright>
   </metadata>
   <files>
-    <file src="..\..\..\bin\AnyCPU\Release\samples\**" target="Samples" />
-    <file src="..\..\..\bin\AnyCPU\Release\gallery\**" target="gallery" />
+    <file src="samples\**" target="Samples" />
+    <file src="gallery\**" target="gallery" />
   </files>
 </package>

--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.Tests.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.Tests.nuspec
@@ -21,8 +21,8 @@
   </metadata>
   <files>
     <!--These assemblies are referenced from the bin directory since they are not harvested for the installer-->
-    <file src="..\..\..\bin\AnyCPU\Release\DynamoCoreTests.dll" target="lib\net47" />
-    <file src="..\..\..\bin\AnyCPU\Release\SystemTestServices.dll" target="lib\net47" />
-    <file src="..\..\..\bin\AnyCPU\Release\TestServices.dll" target="lib\net47" />
+    <file src="DynamoCoreTests.dll" target="lib\net47" />
+    <file src="SystemTestServices.dll" target="lib\net47" />
+    <file src="TestServices.dll" target="lib\net47" />
   </files>
 </package>


### PR DESCRIPTION
### Purpose

This PR exposes a new API on `DynamoServices` to request an `action` be scheduled on the dynamo scheduler thread.

It also subscribes to that event and adds all requested actions to a list - when the graph raises an `EvaluationCompleted` event - the actions are scheduled to execute on the scheduler thread. 

Theres likely something better than this - but as a POC - this works.

This enables us to create 100,000 cuboids which immediately go out of scope - this throws or crashes on master within a few seconds.


### TODO
Look into native locking mechanism suggested by @aparajit-pratap - if that turns out to be successful this PR may not be needed.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap

### FYI

@Dewb 