### PR TITLE
Removed passing tests from failure category

### DIFF
--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -986,7 +986,7 @@ test = cs.Y;";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ported"), Category("Failure")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Replication")]
         public void T035_Defect_1467317_Replication_Guide_On_Instances()
         {
@@ -1004,7 +1004,7 @@ test = a.X<1> + b.X<2>;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ported"), Category("Failure")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Replication")]
         public void T035_Defect_1467317_Replication_Guide_On_Instances_2()
         {
@@ -1027,7 +1027,7 @@ test = foo();
         }
 
         [Test]
-        [Category("DSDefinedClass_Ported"), Category("Failure")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Replication")]
         public void T035_Defect_1467317_Replication_Guide_On_Instances_3()
         {
@@ -1121,7 +1121,7 @@ r = sum(1, [ 1, 2]<1>, y<2>);";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ported"), Category("Failure")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_3()
         {
@@ -1136,7 +1136,7 @@ x = (TestObjectA.TestObjectA(1..3))[0..2].a<1> +(TestObjectA.TestObjectA(1..3))[
         }
 
         [Test]
-        [Category("DSDefinedClass_Ported"), Category("Failure")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_4()
         {

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests_Imperative.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests_Imperative.cs
@@ -2387,7 +2387,7 @@ myRangeExpressionResult = [Imperative]
         }
 
         [Test]
-        [Category("Type System"), Category("Failure")]
+        [Category("Type System")]
         public void TS0194_TypeConversion_nested_block_1467568()
         {
             string code =


### PR DESCRIPTION
### Purpose

Removed passing tests from "failure" category after found to be passing in "Dynamo_failure_category" BRE job.

I'm not exactly sure since when did these tests start passing since the earliest I can see this is April 15th and before that the job was failing completely. @reddyashish can you trace this to a PR that could have potentially fixed these tests?

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@mjkkirschner @reddyashish 
