### PR TITLE
Limit the tooltip width of Ports

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -67,7 +67,7 @@
                 <Grid.ToolTip>
                     <dynui:DynamoToolTip AttachmentSide="{Binding Path=PortType, Converter={StaticResource PortToAttachmentConverter}}" Style="{DynamicResource ResourceKey=SLightToolTip}">
                         <Grid>
-                            <TextBlock Text="{Binding Path=ToolTipContent}"></TextBlock>
+                            <TextBlock MaxWidth="320" TextWrapping="Wrap" Text="{Binding Path=ToolTipContent}"></TextBlock>
                         </Grid>
                     </dynui:DynamoToolTip>
                 </Grid.ToolTip>


### PR DESCRIPTION
### Purpose

Limit the tooltip width of Ports so that the bubble will not be very long.
![LongToolTipBubble](https://user-images.githubusercontent.com/33445445/59989728-045b2b80-9673-11e9-8150-b564d47b2938.png)
![ShortToolTipBubble](https://user-images.githubusercontent.com/33445445/59989738-0a510c80-9673-11e9-9ca2-a8dca305bcba.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@AndyDu1985 
