### PR TITLE
DYN-1999 Adding a section for users to provide feedback.

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4309,6 +4309,33 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to  This Feature is in Preview! .
+        /// </summary>
+        public static string PreviewText {
+            get {
+                return ResourceManager.GetString("PreviewText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  Provide Feedback.
+        /// </summary>
+        public static string ProvideFeedbackButton {
+            get {
+                return ResourceManager.GetString("ProvideFeedbackButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not re-direct to the Dynamo forum page for feedback:.
+        /// </summary>
+        public static string ProvideFeedbackError {
+            get {
+                return ResourceManager.GetString("ProvideFeedbackError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Publish Online.
         /// </summary>
         public static string PublishPackage {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2199,4 +2199,13 @@ Do you want to install the latest Dynamo update?</value>
   <data name="ExtensionAlreadyPresent" xml:space="preserve">
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
+  <data name="ProvideFeedbackButton" xml:space="preserve">
+    <value> Provide Feedback</value>
+  </data>
+  <data name="PreviewText" xml:space="preserve">
+    <value> This Feature is in Preview! </value>
+  </data>
+  <data name="ProvideFeedbackError" xml:space="preserve">
+    <value>Could not re-direct to the Dynamo forum page for feedback:</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2202,4 +2202,13 @@ Want to publish a different package?</value>
   <data name="ExtensionAlreadyPresent" xml:space="preserve">
     <value>No new tab is added, as the extension is already present in the extensions side bar.</value>
   </data>
+  <data name="ProvideFeedbackButton" xml:space="preserve">
+    <value> Provide Feedback</value>
+  </data>
+  <data name="PreviewText" xml:space="preserve">
+    <value> This Feature is in Preview! </value>
+  </data>
+  <data name="ProvideFeedbackError" xml:space="preserve">
+    <value>Could not re-direct to the Dynamo forum page for feedback:</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -68,8 +68,9 @@
     <Color x:Key="SelectionColor">#009EFF</Color>
     <Color x:Key="MaterialColor">#efede4</Color>
 
-    <!--Sidebar-->
+    <!--Extensions Sidebar-->
     <SolidColorBrush x:Key="BorderBrushWhite" Color="#FF3F4040" />
+    <SolidColorBrush x:Key="FeedbackSectionBackground" Color="CornflowerBlue" />
     
     <!-- Library background-->
     <SolidColorBrush x:Key="SearchTextBoxBackground" Color="#F1F2F2" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -70,7 +70,7 @@
 
     <!--Extensions Sidebar-->
     <SolidColorBrush x:Key="BorderBrushWhite" Color="#FF3F4040" />
-    <SolidColorBrush x:Key="FeedbackSectionBackground" Color="CornflowerBlue" />
+    <SolidColorBrush x:Key="FeedbackSectionBackground" Color="#4192D9" />
     
     <!-- Library background-->
     <SolidColorBrush x:Key="SearchTextBoxBackground" Color="#F1F2F2" />

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1711,7 +1711,7 @@
                         </Setter>
                     </Style>
                     
-                    <!--Template for each tab item in the extensions side bar-->
+                    <!--Template for tab header in the extensions side bar-->
                     <DataTemplate x:Key="TabHeader" DataType="TabItem">
                         <DockPanel HorizontalAlignment="Stretch" MinWidth="{Binding Source={x:Static configuration:Configurations.ExtensionsSideBarTabMinWidth}}">
                             <TextBlock Text="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Header}" HorizontalAlignment="Stretch"/>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1677,7 +1677,7 @@
               Grid.Row="2"
               Grid.Column="4"
               Grid.RowSpan="2">
-            <TabControl Name="tabDynamic" ItemsSource="{Binding}">
+            <TabControl Name="tabDynamic" Background="#353535" BorderThickness="0" ItemsSource="{Binding}">
                 <TabControl.Resources>
                     <!--Styling for the close button in the tab-->
                     <Style TargetType="{x:Type Button}"
@@ -1862,7 +1862,7 @@
                       Grid.Row="2"
                       Grid.RowSpan="2"
                       Height="Auto"
-                      Width="3"
+                      Width="0"
                       Name="extensionSplitter"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml
@@ -89,7 +89,7 @@
 
         <!-- Template for the feedback banner -->
         <DockPanel Name="Feedback" Margin="0,800,0,40" Grid.Row="1">
-            <StatusBar Background="CornflowerBlue" DockPanel.Dock="Bottom"  Height="55">
+            <StatusBar Background="CornflowerBlue" DockPanel.Dock="Bottom" Height="55">
                 <!-- Preview text -->
                 <StatusBarItem>
                     <Border Height="50">

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml
@@ -96,7 +96,7 @@
                         <TextBlock TextWrapping="Wrap" Padding="10,0,10,0" FontSize="15" Foreground="White" Text="This Feature is in Preview!" VerticalAlignment="Center"/>
                     </Border>
                 </StatusBarItem>
-                <StatusBarItem Width="193" Padding="0,0,0,0" Margin="100,0,0,0" Height="40">
+                <StatusBarItem Width="193" Margin="100,0,0,0" Height="40">
                     <Border Name="FeedbackBorder" BorderThickness="1">
                         <Border.Style>
                             <Style>
@@ -113,7 +113,7 @@
                         <!-- Feedback button -->
                         <Button HorizontalAlignment="Right"
                             Width="150" Click="ProvideFeedback" Background="#373737" Height="30">
-                            <TextBlock TextWrapping="Wrap" FontSize="15" Padding="0,0,0,0" Foreground="White" Height="20" Text="Provide Feedback" VerticalAlignment="Center"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="15" Foreground="White" Height="20" Text="Provide Feedback" VerticalAlignment="Center"/>
                             <Button.Style>
                                 <Style TargetType="{x:Type Button}">
                                     <Setter Property="Template">

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml
@@ -3,9 +3,18 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+             xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
              mc:Ignorable="d" 
              VerticalAlignment="Top"
              HorizontalAlignment="Left">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid Background= "#353535" Height="860">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -89,11 +98,11 @@
 
         <!-- Template for the feedback banner -->
         <DockPanel Name="Feedback" Margin="0,800,0,40" Grid.Row="1">
-            <StatusBar Background="CornflowerBlue" DockPanel.Dock="Bottom" Height="55">
+            <StatusBar Background="{StaticResource FeedbackSectionBackground}" DockPanel.Dock="Bottom" Height="55">
                 <!-- Preview text -->
                 <StatusBarItem>
                     <Border Height="50">
-                        <TextBlock TextWrapping="Wrap" Padding="10,0,10,0" FontSize="15" Foreground="White" Text="This Feature is in Preview!" VerticalAlignment="Center"/>
+                        <TextBlock TextWrapping="Wrap" Padding="10,0,10,0" FontSize="15" Foreground="White" Text="{x:Static p:Resources.PreviewText}" VerticalAlignment="Center"/>
                     </Border>
                 </StatusBarItem>
                 <StatusBarItem Width="193" Margin="100,0,0,0" Height="40">
@@ -113,7 +122,7 @@
                         <!-- Feedback button -->
                         <Button HorizontalAlignment="Right"
                             Width="150" Click="ProvideFeedback" Background="#373737" Height="30">
-                            <TextBlock TextWrapping="Wrap" FontSize="15" Foreground="White" Height="20" Text="Provide Feedback" VerticalAlignment="Center"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="15" Foreground="White" Height="20" Text="{x:Static p:Resources.ProvideFeedbackButton}" VerticalAlignment="Center"/>
                             <Button.Style>
                                 <Style TargetType="{x:Type Button}">
                                     <Setter Property="Template">

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml
@@ -6,7 +6,7 @@
              mc:Ignorable="d" 
              VerticalAlignment="Top"
              HorizontalAlignment="Left">
-    <Grid Background= "#353535" Height="800">
+    <Grid Background= "#353535" Height="860">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -26,7 +26,7 @@
             RowBackground="Transparent"
             FontSize="14"
             IsHitTestVisible="False"
-            Grid.Row="0">
+            Grid.Row="1">
             <DataGrid.Columns>
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.HeaderTemplate>
@@ -86,5 +86,51 @@
                 </TextBlock>
             </Button>
         </Grid>-->
+
+        <!-- Template for the feedback banner -->
+        <DockPanel Name="Feedback" Margin="0,800,0,40" Grid.Row="1">
+            <StatusBar Background="CornflowerBlue" DockPanel.Dock="Bottom"  Height="55">
+                <!-- Preview text -->
+                <StatusBarItem>
+                    <Border Height="50">
+                        <TextBlock TextWrapping="Wrap" Padding="10,0,10,0" FontSize="15" Foreground="White" Text="This Feature is in Preview!" VerticalAlignment="Center"/>
+                    </Border>
+                </StatusBarItem>
+                <StatusBarItem Width="193" Padding="0,0,0,0" Margin="100,0,0,0" Height="40">
+                    <Border Name="FeedbackBorder" BorderThickness="1">
+                        <Border.Style>
+                            <Style>
+                                <Style.Triggers>
+                                    <Trigger Property="Border.IsMouseOver" Value="True">
+                                        <Setter Property="Border.BorderBrush" Value="White" />
+                                    </Trigger>
+                                    <Trigger Property="Border.IsMouseOver" Value="False">
+                                        <Setter Property="Border.BorderBrush" Value="#373737" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <!-- Feedback button -->
+                        <Button HorizontalAlignment="Right"
+                            Width="150" Click="ProvideFeedback" Background="#373737" Height="30">
+                            <TextBlock TextWrapping="Wrap" FontSize="15" Padding="0,0,0,0" Foreground="White" Height="20" Text="Provide Feedback" VerticalAlignment="Center"/>
+                            <Button.Style>
+                                <Style TargetType="{x:Type Button}">
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="{x:Type Button}">
+                                                <Border Background="{TemplateBinding Background}">
+                                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                </Border>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+                    </Border>
+                </StatusBarItem>
+            </StatusBar>
+        </DockPanel>
     </Grid>
 </UserControl>

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml
@@ -35,7 +35,7 @@
             RowBackground="Transparent"
             FontSize="14"
             IsHitTestVisible="False"
-            Grid.Row="1">
+            Grid.Row="0">
             <DataGrid.Columns>
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.HeaderTemplate>
@@ -97,7 +97,7 @@
         </Grid>-->
 
         <!-- Template for the feedback banner -->
-        <DockPanel Name="Feedback" Margin="0,800,0,40" Grid.Row="1">
+        <DockPanel Name="Feedback" Margin="0,800,0,40" Grid.Row="0">
             <StatusBar Background="{StaticResource FeedbackSectionBackground}" DockPanel.Dock="Bottom" Height="55">
                 <!-- Preview text -->
                 <StatusBarItem>

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
@@ -1,9 +1,9 @@
 ﻿using Dynamo.Graph.Workspaces;
-using Dynamo.Logging;
 using Dynamo.Wpf.Extensions;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 
@@ -50,7 +50,8 @@ namespace Dynamo.PackageDependency
                 System.Diagnostics.Process.Start(FeedbackLink);
             }
             catch (Exception ex) {
-                LogMessage.Info("Could not re-direct to the Dynamo forum page for feedback: "+ ex.Message);
+                String message = Dynamo.Wpf.Properties.Resources.ProvideFeedbackError + "\n\n" + ex.Message;
+                MessageBox.Show(message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
@@ -17,6 +17,8 @@ namespace Dynamo.PackageDependency
 
         private WorkspaceModel currentWorkspace;
 
+        private String FeedbackLink = "https://forum.dynamobim.com/t/call-for-feedback-on-dynamo-graph-package-dependency-display/37229";
+
         private ViewLoadedParams loadedParams;
         private PackageDependencyViewExtension dependencyViewExtension;
 
@@ -38,6 +40,13 @@ namespace Dynamo.PackageDependency
             }
         }
 
+        /// <summary>
+        /// Re-directs to a web link to get the feedback from the user. 
+        /// </summary>
+        private void ProvideFeedback(object sender, EventArgs e)
+        {
+            System.Diagnostics.Process.Start(FeedbackLink);
+        }
 
         /// <summary>
         /// Event handler for workspaceAdded event

--- a/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
+++ b/src/PackageDependencyViewExtension/PackageDependencyView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Dynamo.Graph.Workspaces;
+using Dynamo.Logging;
 using Dynamo.Wpf.Extensions;
 using System;
 using System.Collections.ObjectModel;
@@ -45,7 +46,12 @@ namespace Dynamo.PackageDependency
         /// </summary>
         private void ProvideFeedback(object sender, EventArgs e)
         {
-            System.Diagnostics.Process.Start(FeedbackLink);
+            try {
+                System.Diagnostics.Process.Start(FeedbackLink);
+            }
+            catch (Exception ex) {
+                LogMessage.Info("Could not re-direct to the Dynamo forum page for feedback: "+ ex.Message);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This PR is to add a footer section to get feedback from the user regarding the package dependency view extension feature. 

JIRA: https://jira.autodesk.com/browse/DYN-1999

The LightBlue color for the section was making it hard to read the text inside, so I used another shade of blue. Let me know your thoughts on these. 

![1](https://user-images.githubusercontent.com/43763136/60412321-aa8cc100-9b9e-11e9-89fd-ec0a39a1fee9.PNG)

![2](https://user-images.githubusercontent.com/43763136/60412278-7fa26d00-9b9e-11e9-9fdb-ca3b6864d0bd.PNG)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 