### PR TITLE
Correct package install error dialog messages

### DIFF
--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -875,7 +875,7 @@ namespace Dynamo.Properties {
         ///   Looks up a localized string similar to {1} cannot be loaded. 
         ///Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 
         ///To install {1}, Dynamo needs to first uninstall {0}. 
-        ///Restart Dynamo to complete the uninstall, then try and download {1} again..
+        ///Restart Dynamo to complete the uninstall..
         /// </summary>
         public static string MessageCustomNodePackageFailedToLoad {
             get {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -704,6 +704,6 @@ The input name should be a valid variable name, without spaces. An input type an
     <value>{1} cannot be loaded. 
 Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 
 To install {1}, Dynamo needs to first uninstall {0}. 
-Restart Dynamo to complete the uninstall, then try and download {1} again.</value>
+Restart Dynamo to complete the uninstall.</value>
   </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -704,6 +704,6 @@ The input name should be a valid variable name, without spaces. An input type an
     <value>{1} cannot be loaded. 
 Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 
 To install {1}, Dynamo needs to first uninstall {0}. 
-Restart Dynamo to complete the uninstall, then try and download {1} again.</value>
+Restart Dynamo to complete the uninstall.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3308,7 +3308,7 @@ namespace Dynamo.Wpf.Properties {
         ///   Looks up a localized string similar to {1} cannot be loaded.
         ///Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 
         ///To install {1}, Dynamo needs to first uninstall {0}. 
-        ///Restart Dynamo to complete the uninstall, then try and download {1} again.
+        ///Restart Dynamo to complete the uninstall.
         ///
         ///Uninstall the following packages: {0}?.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2203,7 +2203,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>{1} cannot be loaded.
 Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 
 To install {1}, Dynamo needs to first uninstall {0}. 
-Restart Dynamo to complete the uninstall, then try and download {1} again.
+Restart Dynamo to complete the uninstall.
 
 Uninstall the following packages: {0}?</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2206,7 +2206,7 @@ Want to publish a different package?</value>
     <value>{1} cannot be loaded.
 Installing it will conflict with one or more node definitions that already exist in {0}, which is currently loaded. 
 To install {1}, Dynamo needs to first uninstall {0}. 
-Restart Dynamo to complete the uninstall, then try and download {1} again.
+Restart Dynamo to complete the uninstall.
 
 Uninstall the following packages: {0}?</value>
   </data>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -468,7 +468,7 @@ namespace Dynamo.PackageManager
         
         private string JoinPackageNames(IEnumerable<Package> pkgs)
         {
-            return String.Join(", ", pkgs.Select(x => x.Name));
+            return String.Join(", ", pkgs.Select(x => x.Name + " " + x.VersionName));
         } 
 
         private void PackageOnExecuted(PackageManagerSearchElement element, PackageVersion version, string downloadPath)


### PR DESCRIPTION
### Purpose

JIRA issue: https://jira.autodesk.com/browse/DYN-2026

In the case of a conflicting custom node package being installed, the "Cannot Download Package" dialog said that the already loaded package first needs to be uninstalled by Dynamo and Dynamo restarted. _Then the user would need to try installing the package again._ However, in this case the conflicting package is still **downloaded** even though it isn't **loaded** in the current Dynamo session. If the user selects "Yes" in the dialog, the already loaded package is deleted when Dynamo is restarted and he/she is not expected to reinstall the second package as it was already downloaded previously. When Dynamo is restarted the second package loads successfully after the original conflicting package is deleted.

The dialog message is updated to reflect this behavior more clearly: 
Before:
![image](https://user-images.githubusercontent.com/5710686/60838678-461ec280-a199-11e9-8745-10571af8634f.png)

After:
![image](https://user-images.githubusercontent.com/5710686/60838602-153e8d80-a199-11e9-9688-5c952ad8c072.png)

In addition this fixes an issue in a similar dialog where the package version wasn't explicit in the error message:
Before:
![image](https://user-images.githubusercontent.com/5710686/60838883-c6ddbe80-a199-11e9-8636-1e7a78167c6c.png)

After:
![image](https://user-images.githubusercontent.com/5710686/60838936-f1c81280-a199-11e9-9376-ff351bcce74e.png)

TODO: 
- [ ] Cherry-pick into RC2.3.0 branch.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI. [WIP]
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @reddyashish 

### FYIs

@mjkkirschner 
