### PR TITLE
Adding back the width for the splitter between workspace and extensions side bar

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1866,7 +1866,7 @@
                       Name="extensionSplitter"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      Margin="-2"
+                      Margin="0"
                       Background="Transparent"
                       Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur" />
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1862,11 +1862,11 @@
                       Grid.Row="2"
                       Grid.RowSpan="2"
                       Height="Auto"
-                      Width="0"
+                      Width="3"
                       Name="extensionSplitter"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      Margin="0"
+                      Margin="-2"
                       Background="Transparent"
                       Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur" />
 


### PR DESCRIPTION
### Purpose

This PR is to add back the width for the Grid Splitter that is between the canvas and the extensions side bar. It was removed in this PR: https://github.com/DynamoDS/Dynamo/pull/9822.

In addition, I have decreased the margin as well as there is no extra padding. 

When the margin is set to -2:
![1](https://user-images.githubusercontent.com/43763136/61077904-5e871b00-a3ed-11e9-9fa4-a73d4061b010.PNG)
The splitter element can be dragged easily now. 

When the margin is set to 0:
![2](https://user-images.githubusercontent.com/43763136/61078519-c853f480-a3ee-11e9-8f3b-ac11b1bab354.PNG)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 
