### PR TITLE
[Cherry-pick #9840] Adding back the width for the splitter between workspace and extensions side bar

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1862,7 +1862,7 @@
                       Grid.Row="2"
                       Grid.RowSpan="2"
                       Height="Auto"
-                      Width="0"
+                      Width="3"
                       Name="extensionSplitter"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"


### PR DESCRIPTION
### Purpose
This PR is to cherrypick the commit in here: https://github.com/DynamoDS/Dynamo/pull/9840

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@mjkkirschner @QilongTang 
