### PR TITLE
this test fails when run alone

### DIFF
--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -48,6 +48,9 @@ namespace DynamoCoreWpfTests
         [Test, Category("DisplayHardwareDependent")]
         public void Watch3DHasViewer()
         {
+            var path = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Process) + ";" + Model.PathManager.DynamoCoreDirectory;
+            Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
+
             var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
             if (renderingTier < 2)
             {


### PR DESCRIPTION
set the path to include core directory
## Purpose

This test requires sharpdx dlls at runtime, but the path has not been set to find them. This code was copied from the startup sequence of the helixWatch3dViewModel tests.

![Screen Shot 2019-07-23 at 6 10 59 PM](https://user-images.githubusercontent.com/508936/61751117-3eecdc80-ad75-11e9-9351-93b4764eef30.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
