### PR TITLE
Fix warning message for indexing into lists, display fully qualified classname in warnings

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -355,6 +355,7 @@ namespace ProtoFFI
                 {
                     dsi.LogSemanticError(ex.InnerException.Message);
                 }
+
                 dsi.LogSemanticError(ex.Message);
             }
             catch (System.Reflection.TargetException ex)
@@ -363,6 +364,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.Reflection.TargetInvocationException ex)
@@ -374,9 +376,9 @@ namespace ProtoFFI
                     if (exception != null)
                     {
                         var innerMessage = string.Format(Resources.ArgumentNullException, exception.ParamName);
-                        var msg = string.Format(Resources.OperationFailType2, 
-                            ReflectionInfo.DeclaringType.Name, 
-                            ReflectionInfo.Name, 
+                        var msg = string.Format(Resources.OperationFailType2,
+                            ReflectionInfo.DeclaringType.Name,
+                            ReflectionInfo.Name,
                             innerMessage);
 
                         dsi.LogWarning(ProtoCore.Runtime.WarningID.InvalidArguments, msg);
@@ -391,7 +393,11 @@ namespace ProtoFFI
                     }
                     else if (exc is System.NullReferenceException)
                     {
-                        dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ErrorString(null));
+                        dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ErrorString(exc));
+                    }
+                    else if (exc is BuiltinNullReferenceException)
+                    {
+                        dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ErrorString(exc));
                     }
                     else if (exc is StringOverIndexingException)
                     {
@@ -417,6 +423,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.MethodAccessException ex)
@@ -425,6 +432,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.InvalidOperationException ex)
@@ -433,6 +441,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.NotSupportedException ex)
@@ -441,6 +450,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (ArgumentNullException ex)
@@ -478,7 +488,7 @@ namespace ProtoFFI
 
         private string ErrorString(System.Exception ex)
         {
-            if (ex is System.InvalidOperationException)
+            if (ex is System.InvalidOperationException || ex is BuiltinNullReferenceException)
                 return ex.Message;
 
             string msg = (ex == null) ? "" : ex.Message;

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -360,7 +360,8 @@ namespace ProtoCore
             var qualifiedMethodName = methodName;
 
             var className = string.Empty;
-            
+            var classNameSimple = string.Empty;
+
             if (classScope != Constants.kGlobalScope)
             {
                 if (methodName == nameof(DesignScript.Builtin.Get.ValueAtIndex))
@@ -371,12 +372,10 @@ namespace ProtoCore
                         return;
                     }
                 }
-                else
-                {
-                    var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
-                    className = classNode.Name;
-                    qualifiedMethodName = className + "." + methodName;
-                }
+                var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
+                className = classNode.Name;
+                classNameSimple = className.Split('.').Last();
+                qualifiedMethodName = classNameSimple + "." + methodName;
             }
 
             Operator op;
@@ -387,7 +386,7 @@ namespace ProtoCore
                 {
                     if (arguments != null && arguments.Any())
                     {
-                        qualifiedMethodName = className + "." + propertyName;
+                        qualifiedMethodName = classNameSimple + "." + propertyName;
 
                         // if the property is found on the class, it must be a static getter being called on 
                         // an instance argument type not matching the property
@@ -417,7 +416,7 @@ namespace ProtoCore
                 var argsJoined = string.Join(", ", arguments.Select(GetTypeName));
                 
                 var fep = funcGroup.FunctionEndPoints[0];
-                var formalParamsJoined = string.Join(", ", fep.FormalParams.Select(x => x.ToShortString()));
+                var formalParamsJoined = string.Join(", ", fep.FormalParams);
 
                 message = string.Format(Resources.NonOverloadMethodResolutionError, qualifiedMethodName, formalParamsJoined, argsJoined);
             }

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -356,29 +356,38 @@ namespace ProtoCore
                                                List<StackValue> arguments = null)
         {
             string message;
-            string propertyName;
-            Operator op;
 
             var qualifiedMethodName = methodName;
 
             var className = string.Empty;
-            var classNameSimple = string.Empty;
-
+            
             if (classScope != Constants.kGlobalScope)
             {
-                var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
-                className = classNode.Name;
-                classNameSimple = className.Split('.').Last();
-                qualifiedMethodName = classNameSimple + "." + methodName;
+                if (methodName == nameof(DesignScript.Builtin.Get.ValueAtIndex))
+                {
+                    if (arguments.Count == 2 && arguments[0].IsInteger && arguments[1].IsInteger)
+                    {
+                        LogWarning(WarningID.IndexOutOfRange, Resources.IndexIntoNonArrayObject);
+                        return;
+                    }
+                }
+                else
+                {
+                    var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
+                    className = classNode.Name;
+                    qualifiedMethodName = className + "." + methodName;
+                }
             }
 
+            Operator op;
+            string propertyName;
             if (CoreUtils.TryGetPropertyName(methodName, out propertyName))
             {
                 if (classScope != Constants.kGlobalScope)
                 {
                     if (arguments != null && arguments.Any())
                     {
-                        qualifiedMethodName = classNameSimple + "." + propertyName;
+                        qualifiedMethodName = className + "." + propertyName;
 
                         // if the property is found on the class, it must be a static getter being called on 
                         // an instance argument type not matching the property

--- a/src/Libraries/DesignScriptBuiltin/Builtin.cs
+++ b/src/Libraries/DesignScriptBuiltin/Builtin.cs
@@ -14,6 +14,11 @@ namespace DesignScript
 
             public static object ValueAtIndex(Dictionary dictionary, string key)
             {
+                if (dictionary == null)
+                {
+                    throw new BuiltinNullReferenceException(DesignScriptBuiltin.NullReferenceExceptionMessage);
+                }
+
                 try
                 {
                     return dictionary.ValueAtKey(key);
@@ -56,6 +61,10 @@ namespace DesignScript
 
             public static object ValueAtIndex(string stringList, int index)
             {
+                if (stringList == null)
+                {
+                    throw new BuiltinNullReferenceException(DesignScriptBuiltin.NullReferenceExceptionMessage);
+                }
                 while (index < 0)
                 {
                     var count = stringList.Length;

--- a/src/Libraries/DesignScriptBuiltin/IndexingExceptions.cs
+++ b/src/Libraries/DesignScriptBuiltin/IndexingExceptions.cs
@@ -25,4 +25,12 @@ namespace DesignScript.Builtin
         {
         }
     }
+
+    public class BuiltinNullReferenceException : Exception
+    {
+        public BuiltinNullReferenceException(string message)
+            : base(message)
+        {
+        }
+    }
 }

--- a/src/Libraries/DesignScriptBuiltin/IndexingExceptions.cs
+++ b/src/Libraries/DesignScriptBuiltin/IndexingExceptions.cs
@@ -26,7 +26,11 @@ namespace DesignScript.Builtin
         }
     }
 
-    public class BuiltinNullReferenceException : Exception
+    /// <summary>
+    /// Null reference exception thrown with null DS builtin types:
+    /// lists, dictionaries and strings.
+    /// </summary>
+    public class BuiltinNullReferenceException : NullReferenceException
     {
         public BuiltinNullReferenceException(string message)
             : base(message)

--- a/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.Designer.cs
+++ b/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Builtin.Properties
-{
-
-
+namespace Builtin.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -66,6 +66,15 @@ namespace Builtin.Properties
         internal static string IndexOutOfRangeExceptionMessage {
             get {
                 return ResourceManager.GetString("IndexOutOfRangeExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot index into a null list, dictionary or string..
+        /// </summary>
+        internal static string NullReferenceExceptionMessage {
+            get {
+                return ResourceManager.GetString("NullReferenceExceptionMessage", resourceCulture);
             }
         }
         

--- a/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.en-US.resx
+++ b/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.en-US.resx
@@ -123,4 +123,7 @@
   <data name="StringOverIndexingExceptionMessage" xml:space="preserve">
     <value>Index was out of range. If non-negative must be less than the size of the string.</value>
   </data>
+  <data name="NullReferenceExceptionMessage" xml:space="preserve">
+    <value>Cannot index into a null list, dictionary or string.</value>
+  </data>
 </root>

--- a/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.resx
+++ b/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.resx
@@ -123,4 +123,7 @@
   <data name="StringOverIndexingExceptionMessage" xml:space="preserve">
     <value>Index was out of range. If non-negative must be less than the size of the string.</value>
   </data>
+  <data name="NullReferenceExceptionMessage" xml:space="preserve">
+    <value>Cannot index into a null list, dictionary or string.</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/DYN-1487, https://jira.autodesk.com/browse/DYN-1044

The warning on the node no longer mentions `Get.ValueAtIndex` and displays the appropriate error message:
![image](https://user-images.githubusercontent.com/5710686/61979834-f296dc00-afc2-11e9-8d33-04197f00f9fd.png)


![image](https://user-images.githubusercontent.com/5710686/61979859-04787f00-afc3-11e9-9221-c9da6c57a2fd.png)

![image](https://user-images.githubusercontent.com/5710686/61989502-57235c80-affe-11e9-9ea0-d616932d7576.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
