### PR TITLE
Cherry pick #9861: Fix warning message for indexing into lists, display fully qualified …

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -355,6 +355,7 @@ namespace ProtoFFI
                 {
                     dsi.LogSemanticError(ex.InnerException.Message);
                 }
+
                 dsi.LogSemanticError(ex.Message);
             }
             catch (System.Reflection.TargetException ex)
@@ -363,6 +364,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.Reflection.TargetInvocationException ex)
@@ -374,9 +376,9 @@ namespace ProtoFFI
                     if (exception != null)
                     {
                         var innerMessage = string.Format(Resources.ArgumentNullException, exception.ParamName);
-                        var msg = string.Format(Resources.OperationFailType2, 
-                            ReflectionInfo.DeclaringType.Name, 
-                            ReflectionInfo.Name, 
+                        var msg = string.Format(Resources.OperationFailType2,
+                            ReflectionInfo.DeclaringType.Name,
+                            ReflectionInfo.Name,
                             innerMessage);
 
                         dsi.LogWarning(ProtoCore.Runtime.WarningID.InvalidArguments, msg);
@@ -391,7 +393,11 @@ namespace ProtoFFI
                     }
                     else if (exc is System.NullReferenceException)
                     {
-                        dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ErrorString(null));
+                        dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ErrorString(exc));
+                    }
+                    else if (exc is BuiltinNullReferenceException)
+                    {
+                        dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ErrorString(exc));
                     }
                     else if (exc is StringOverIndexingException)
                     {
@@ -417,6 +423,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.MethodAccessException ex)
@@ -425,6 +432,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.InvalidOperationException ex)
@@ -433,6 +441,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (System.NotSupportedException ex)
@@ -441,6 +450,7 @@ namespace ProtoFFI
                 {
                     dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.InnerException.Message);
                 }
+
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.AccessViolation, ex.Message);
             }
             catch (ArgumentNullException ex)
@@ -478,7 +488,7 @@ namespace ProtoFFI
 
         private string ErrorString(System.Exception ex)
         {
-            if (ex is System.InvalidOperationException)
+            if (ex is System.InvalidOperationException || ex is BuiltinNullReferenceException)
                 return ex.Message;
 
             string msg = (ex == null) ? "" : ex.Message;

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -356,8 +356,6 @@ namespace ProtoCore
                                                List<StackValue> arguments = null)
         {
             string message;
-            string propertyName;
-            Operator op;
 
             var qualifiedMethodName = methodName;
 
@@ -366,12 +364,22 @@ namespace ProtoCore
 
             if (classScope != Constants.kGlobalScope)
             {
+                if (methodName == nameof(DesignScript.Builtin.Get.ValueAtIndex))
+                {
+                    if (arguments.Count == 2 && arguments[0].IsInteger && arguments[1].IsInteger)
+                    {
+                        LogWarning(WarningID.IndexOutOfRange, Resources.IndexIntoNonArrayObject);
+                        return;
+                    }
+                }
                 var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
                 className = classNode.Name;
                 classNameSimple = className.Split('.').Last();
                 qualifiedMethodName = classNameSimple + "." + methodName;
             }
 
+            Operator op;
+            string propertyName;
             if (CoreUtils.TryGetPropertyName(methodName, out propertyName))
             {
                 if (classScope != Constants.kGlobalScope)
@@ -408,7 +416,7 @@ namespace ProtoCore
                 var argsJoined = string.Join(", ", arguments.Select(GetTypeName));
                 
                 var fep = funcGroup.FunctionEndPoints[0];
-                var formalParamsJoined = string.Join(", ", fep.FormalParams.Select(x => x.ToShortString()));
+                var formalParamsJoined = string.Join(", ", fep.FormalParams);
 
                 message = string.Format(Resources.NonOverloadMethodResolutionError, qualifiedMethodName, formalParamsJoined, argsJoined);
             }

--- a/src/Libraries/DesignScriptBuiltin/Builtin.cs
+++ b/src/Libraries/DesignScriptBuiltin/Builtin.cs
@@ -14,6 +14,11 @@ namespace DesignScript
 
             public static object ValueAtIndex(Dictionary dictionary, string key)
             {
+                if (dictionary == null)
+                {
+                    throw new BuiltinNullReferenceException(DesignScriptBuiltin.NullReferenceExceptionMessage);
+                }
+
                 try
                 {
                     return dictionary.ValueAtKey(key);
@@ -56,6 +61,10 @@ namespace DesignScript
 
             public static object ValueAtIndex(string stringList, int index)
             {
+                if (stringList == null)
+                {
+                    throw new BuiltinNullReferenceException(DesignScriptBuiltin.NullReferenceExceptionMessage);
+                }
                 while (index < 0)
                 {
                     var count = stringList.Length;

--- a/src/Libraries/DesignScriptBuiltin/IndexingExceptions.cs
+++ b/src/Libraries/DesignScriptBuiltin/IndexingExceptions.cs
@@ -25,4 +25,16 @@ namespace DesignScript.Builtin
         {
         }
     }
+
+    /// <summary>
+    /// Null reference exception thrown with null DS builtin types:
+    /// lists, dictionaries and strings.
+    /// </summary>
+    public class BuiltinNullReferenceException : NullReferenceException
+    {
+        public BuiltinNullReferenceException(string message)
+            : base(message)
+        {
+        }
+    }
 }

--- a/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.Designer.cs
+++ b/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Builtin.Properties
-{
-
-
+namespace Builtin.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -66,6 +66,15 @@ namespace Builtin.Properties
         internal static string IndexOutOfRangeExceptionMessage {
             get {
                 return ResourceManager.GetString("IndexOutOfRangeExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot index into a null list, dictionary or string..
+        /// </summary>
+        internal static string NullReferenceExceptionMessage {
+            get {
+                return ResourceManager.GetString("NullReferenceExceptionMessage", resourceCulture);
             }
         }
         

--- a/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.en-US.resx
+++ b/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.en-US.resx
@@ -123,4 +123,7 @@
   <data name="StringOverIndexingExceptionMessage" xml:space="preserve">
     <value>Index was out of range. If non-negative must be less than the size of the string.</value>
   </data>
+  <data name="NullReferenceExceptionMessage" xml:space="preserve">
+    <value>Cannot index into a null list, dictionary or string.</value>
+  </data>
 </root>

--- a/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.resx
+++ b/src/Libraries/DesignScriptBuiltin/Properties/DesignScriptBuiltin.resx
@@ -123,4 +123,7 @@
   <data name="StringOverIndexingExceptionMessage" xml:space="preserve">
     <value>Index was out of range. If non-negative must be less than the size of the string.</value>
   </data>
+  <data name="NullReferenceExceptionMessage" xml:space="preserve">
+    <value>Cannot index into a null list, dictionary or string.</value>
+  </data>
 </root>

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -656,14 +656,12 @@ y = foo()[1];
             string code = @"
 [Imperative]
 {
-    arr1 = [true, false];
-    arr2 = [1, 2, 3];
-    arr3 = [false, true];
-    t = arr2[1][0];
+    arr = [1, 2, 3];
+    t = arr[1][0];
 }
 ";
             thisTest.RunScriptSource(code);
-            TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.MethodResolutionFailure);
+            TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.IndexOutOfRange);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
@@ -1321,7 +1321,7 @@ a = [Imperative]
 }
 ";
             thisTest.RunScriptSource(code);
-            TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.MethodResolutionFailure);
+            TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.IndexOutOfRange);
         }
 
         [Test]


### PR DESCRIPTION
…classname in warnings (#9861)

* fix warning message for indexing into lists, display fully qualified classname in warnings

* display fully qualified class names in type mismatch and method resolution warnings

* add resource strings for null reference exceptions with lists, strings and dictionaries

* add comments

Cherry pick #9861 as JIRA tasks were tagged as `Dynamo2.4`

FYI: @mjkkirschner @QilongTang 