### PR TITLE
Fix localization for Spanish Civil 3D

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -543,7 +543,7 @@ namespace Dynamo.Core
                 dataRootDirectory = Directory.GetParent(versionedDirectory).FullName;
             }
 
-            var uiCulture = CultureInfo.CurrentUICulture.ToString();
+            var uiCulture = CultureInfo.CurrentUICulture.Name;
             var sampleDirectory = Path.Combine(dataRootDirectory, SamplesDirectoryName, uiCulture);
 
             // If the localized samples directory does not exist then fall back 
@@ -582,7 +582,7 @@ namespace Dynamo.Core
                 commonDataDir = Directory.GetParent(versionedDirectory).FullName;
             }
 
-            var uiCulture = CultureInfo.CurrentUICulture.ToString();
+            var uiCulture = CultureInfo.CurrentUICulture.Name;
             var galleryDirectory = Path.Combine(commonDataDir, GalleryDirectoryName, uiCulture);
 
             // If the localized gallery directory does not exist then fall back 

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -67,7 +67,7 @@ namespace Dynamo.Engine
                 baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
             }
 
-            var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();
+            var language = System.Threading.Thread.CurrentThread.CurrentUICulture.Name;
             //try with the system culture
             var localizedDocPath = Path.Combine(baseDir, language);
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1373,7 +1373,7 @@ namespace Dynamo.ViewModels
             {
                 Assembly dynamoAssembly = Assembly.GetExecutingAssembly();
                 string location = Path.GetDirectoryName(dynamoAssembly.Location);
-                string UICulture = CultureInfo.CurrentUICulture.ToString();
+                string UICulture = CultureInfo.CurrentUICulture.Name;
                 string path = Path.Combine(location, "samples", UICulture);
 
                 if (Directory.Exists(path))


### PR DESCRIPTION
In AutoCAD/Civil3D, `CurrentUICulture.ToString()` will return traditional `es-ES_tradnl`,
instead of plain `es-ES`. This will fail the finding of xml document, gallery, and sample folders later.

This change uses `CurrentUICulture.Name` instead.
From MS DOC for `CultureInfo.Name`:
> Gets the culture name in the format languagecode2-country/regioncode2.

Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

### FYIs

