### PR TITLE
Adjusting the width of the preview section.

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -174,7 +174,7 @@
         </Grid>
 
         <!-- Template for the feedback banner -->
-        <DockPanel Name="Feedback" VerticalAlignment="Bottom" Grid.Row="2" Width="Auto">
+        <DockPanel Name="Feedback" VerticalAlignment="Bottom" Grid.Row="2" Width="600">
             <StatusBar Background="{StaticResource FeedbackSectionBackground}" DockPanel.Dock="Bottom" Height="55">
                 <!-- Preview text -->
                 <StatusBarItem>


### PR DESCRIPTION
### Purpose

This PR is to fix the width of the preview section after this . 
Task: https://jira.autodesk.com/browse/DYN-2039

The strange thing is on @scottmitchell 's system, the width of the bar is filling up the whole space but on my system it is showing up like in the 1st screenshot below. @aparajit-pratap also confirmed the same thing on his system. So I changed the value of the width from Auto to 600. 

Before:
<img width="359" alt="Screen Shot 2019-08-07 at 1 08 16 PM" src="https://user-images.githubusercontent.com/43763136/62642828-8d24e280-b914-11e9-94b1-50a326fc10ac.png">

After:
<img width="314" alt="Screen Shot 2019-08-07 at 12 59 33 PM" src="https://user-images.githubusercontent.com/43763136/62642845-96ae4a80-b914-11e9-9093-a6b93482ab48.png">

@mjkkirschner and @QilongTang Can you guys test it on your machine too?


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
