### PR TITLE
Run all excel tests in non-visible mode

### DIFF
--- a/src/Libraries/DSOffice/Properties/AssemblyInfo.cs
+++ b/src/Libraries/DSOffice/Properties/AssemblyInfo.cs
@@ -10,4 +10,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4b9906ad-ac4d-469c-9f6e-0373b8c7a12a")]
+[assembly: InternalsVisibleTo("DynamoCoreTests")]
 [assembly: InternalsVisibleTo("DynamoMSOfficeTests")]

--- a/src/Libraries/DSOffice/Properties/AssemblyInfo.cs
+++ b/src/Libraries/DSOffice/Properties/AssemblyInfo.cs
@@ -11,3 +11,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4b9906ad-ac4d-469c-9f6e-0373b8c7a12a")]
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
+[assembly: InternalsVisibleTo("DynamoMSOfficeTests")]

--- a/src/Libraries/DSOffice/Properties/AssemblyInfo.cs
+++ b/src/Libraries/DSOffice/Properties/AssemblyInfo.cs
@@ -11,4 +11,3 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4b9906ad-ac4d-469c-9f6e-0373b8c7a12a")]
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
-[assembly: InternalsVisibleTo("DynamoMSOfficeTests")]

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -184,6 +184,10 @@
       <Name>CoreNodeModels</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Libraries\DSOffice\DSOffice.csproj">
+      <Project>{9b4fdc96-e2f9-4b8f-894a-4294405d50e7}</Project>
+      <Name>DSOffice</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Libraries\DynamoUnits\Units.csproj">
       <Project>{6e0a079e-85f1-45a1-ad5b-9855e4344809}</Project>
       <Name>Units</Name>

--- a/test/DynamoCoreTests/MigrationTestFramework.cs
+++ b/test/DynamoCoreTests/MigrationTestFramework.cs
@@ -67,10 +67,6 @@ namespace Dynamo.Tests
 
             return testParameters;
         }
-
-        #region Private Helper Methods
-
-
-        #endregion
+        
     }
 }

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -64,6 +64,7 @@ namespace Dynamo
         public virtual void Setup()
         {
             SetupDirectories();
+            DSOffice.ExcelInterop.ShowOnStartup = false;
         }
 
         [TearDown]

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -38,8 +38,6 @@ namespace Dynamo.Tests
             // not get persisted across to the subsequent test case.
             // 
             PreferenceSettings.DynamoTestPath = Path.Combine(TempFolder, "UserPreferenceTest.xml");
-
-            ExcelInterop.ShowOnStartup = false;
         }
 
         public override void Cleanup()


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/DYN-2060
This PR tries to run all excel tests in the repo with the setting set to non-interactive so that Excel windows do not show up while running them.

I have made that setting on the base class for all test fixtures. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 


