### PR TITLE
Cherry-pick #9899 - Allow ASM to be loaded from non-root product install directories

### DIFF
--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -127,6 +127,7 @@ namespace DynamoInstallDetective
         /// Product name for lookup
         /// </summary>
         public string ProductLookUpName { get; private set; }
+
         private readonly Func<string, string> fileLocator;
 
         static RegistryKey OpenKey(string key)
@@ -158,8 +159,9 @@ namespace DynamoInstallDetective
         /// <param name="fileLookup">file name pattern to lookup</param>
         public InstalledProductLookUp(string lookUpName, string fileLookup)
         {
-            this.ProductLookUpName = lookUpName;
-            this.fileLocator = (path) => Directory.GetFiles(path, fileLookup, SearchOption.AllDirectories).FirstOrDefault();
+            ProductLookUpName = lookUpName;
+            fileLocator = (path) => Directory.EnumerateFiles(path, fileLookup, SearchOption.AllDirectories)
+                .FirstOrDefault();
         }
 
         public InstalledProductLookUp(string lookUpName, Func<string, string> fileLocator)
@@ -255,7 +257,8 @@ namespace DynamoInstallDetective
         public InstalledProduct(string installLocation, InstalledProductLookUp lookUp)
         {
             var corePath = lookUp.GetCoreFilePathFromInstallation(installLocation);
-            InstallLocation = Path.GetDirectoryName(corePath);
+            InstallLocation = File.Exists(corePath) ? Path.GetDirectoryName(corePath) : installLocation;
+            
             VersionInfo = lookUp.GetVersionInfoFromFile(corePath);
             ProductName = string.Format("{0} {1}.{2}", lookUp.ProductLookUpName, VersionInfo.Item1, VersionInfo.Item2);
             VersionString = string.Format("{0}.{1}.{2}.{3}", VersionInfo.Item1, VersionInfo.Item2, VersionInfo.Item3, VersionInfo.Item4);

--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -159,7 +159,7 @@ namespace DynamoInstallDetective
         public InstalledProductLookUp(string lookUpName, string fileLookup)
         {
             this.ProductLookUpName = lookUpName;
-            this.fileLocator = (path) => Directory.GetFiles(path, fileLookup).FirstOrDefault();
+            this.fileLocator = (path) => Directory.GetFiles(path, fileLookup, SearchOption.AllDirectories).FirstOrDefault();
         }
 
         public InstalledProductLookUp(string lookUpName, Func<string, string> fileLocator)
@@ -254,8 +254,8 @@ namespace DynamoInstallDetective
 
         public InstalledProduct(string installLocation, InstalledProductLookUp lookUp)
         {
-            InstallLocation = installLocation;
-            var corePath = lookUp.GetCoreFilePathFromInstallation(InstallLocation);
+            var corePath = lookUp.GetCoreFilePathFromInstallation(installLocation);
+            InstallLocation = Path.GetDirectoryName(corePath);
             VersionInfo = lookUp.GetVersionInfoFromFile(corePath);
             ProductName = string.Format("{0} {1}.{2}", lookUp.ProductLookUpName, VersionInfo.Item1, VersionInfo.Item2);
             VersionString = string.Format("{0}.{1}.{2}.{3}", VersionInfo.Item1, VersionInfo.Item2, VersionInfo.Item3, VersionInfo.Item4);

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -14,7 +14,7 @@ namespace DynamoShapeManager
         /// <summary>
         /// Key words for Products containing ASM binaries
         /// </summary>
-        private static readonly List<string> ProductsWithASM = new List<string>() { "Revit", "Civil", "FormIt" };
+        private static readonly List<string> ProductsWithASM = new List<string>() { "Revit", "Civil", "Robot Structural Analysis", "FormIt" };
 
         #region public properties
         public static readonly string GeometryFactoryAssembly = "LibG.ProtoInterface.dll";

--- a/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
+++ b/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
@@ -39,9 +39,9 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\extern\NUnit\nunit.framework.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\extern\NUnit\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
### Purpose

Cherry-pick #9899. This also fixes regression caused by #9884 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@mjkkirschner @QilongTang 
