### PR TITLE
DYN-2002 Localize the node description tooltip.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -692,6 +692,7 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
+        [JsonConverter(typeof(DescriptionConverter))]
         /// <summary>
         ///     Description of this Node.
         /// </summary>

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -376,7 +376,9 @@ namespace Dynamo.Graph.Workspaces
         }
     }
 
-    // Converter for description property. 
+    ///<Summary>
+    ///  Converter for Description property in the NodeModel class.
+    ///</Summary>
     public class DescriptionConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
@@ -384,11 +386,15 @@ namespace Dynamo.Graph.Workspaces
             return (objectType == typeof(String));
         }
 
+        /// When deserializing, we do not want to read this property from the file
+        /// so null is being returned. This is to convert the Description property
+        /// to the localized language. 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             return null;
         }
 
+        /// Serializing the description property. 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             serializer.Serialize(writer, value);

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -376,6 +376,25 @@ namespace Dynamo.Graph.Workspaces
         }
     }
 
+    // Converter for description property. 
+    public class DescriptionConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(String));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+    }
+
     /// <summary>
     /// The WorkspaceConverter is used to serialize and deserialize WorkspaceModels.
     /// Construction of a WorkspaceModel requires things like an EngineController,

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -617,6 +617,20 @@ namespace Dynamo.Tests
                 serializationTestUtils.SaveWorkspaceComparisonData);
         }
 
+        [Test]
+        public void NodeDescriptionDeserilizationTest()
+        {
+            // This test is in reference to this task: https://jira.autodesk.com/browse/DYN-2002
+            // The description of the node in the below graph has been updated to a different value. 
+            // We continue to serilize the description property to the json file but we do not want to
+            // read this value back while deserializing. This test will make sure that the description is
+            // not read from the json file and it gets the value from the node's config.
+            var testFile = Path.Combine(TestDirectory, @"core\serialization\NodeDescriptionDeserilizationTest.dyn");
+            OpenModel(testFile);
+            var node = this.CurrentDynamoModel.CurrentWorkspace.Nodes.First();
+            Assert.AreEqual(node.Description, "Makes a new list out of the given inputs");
+        }
+
         [Test, Category("JsonTestExclude")]
         public void FunctionNodeLoadsWhenSignatureChanges()
         {

--- a/test/core/serialization/NodeDescriptionDeserilizationTest.dyn
+++ b/test/core/serialization/NodeDescriptionDeserilizationTest.dyn
@@ -1,0 +1,85 @@
+{
+  "Uuid": "8e90cdd6-77c5-4d3a-82e9-272711e2c498",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "NodeDescriptionDeserilizationTest",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.CreateList, CoreNodeModels",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "5b193e6856cf440a9d31bd85d16545aa",
+      "Inputs": [
+        {
+          "Id": "39685ea9b6154feb952bd8e23338861a",
+          "Name": "item0",
+          "Description": "Item Index #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "893da7592d6e49a1857de969eaea3088",
+          "Name": "list",
+          "Description": "A list",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Bad Description. This value should not be read."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.0.5896",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "List Create",
+        "Id": "5b193e6856cf440a9d31bd85d16545aa",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 281.0,
+        "Y": 258.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

This PR is in reference to this task: https://jira.autodesk.com/browse/DYN-2002. 

In short after this fix, the description tooltip (for the nodes in the workspace) will be converted to the localized language. We will still be serializing this property but when deserializing we do not read this value from the JSON file. The value will be picked up from node's xml config and will be converted to the localized language. 

<img width="1040" alt="Screen Shot 2019-08-13 at 12 24 21 PM" src="https://user-images.githubusercontent.com/43763136/63062059-7444a000-bec5-11e9-84d3-804ec20e2a9c.png">


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang @aparajit-pratap 

