### PR TITLE
update dev view UI when package installed.

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -1,12 +1,12 @@
-﻿using Dynamo.Extensions;
+﻿using System;
+using System.Linq;
+using System.Windows.Controls;
+using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.PackageManager;
 using Dynamo.WorkspaceDependency.Properties;
 using Dynamo.Wpf.Extensions;
-using System;
-using System.Linq;
-using System.Windows.Controls;
 
 namespace Dynamo.WorkspaceDependency
 {
@@ -86,6 +86,7 @@ namespace Dynamo.WorkspaceDependency
             DependencyView = new WorkspaceDependencyView(this, viewLoadedParams);
             // when a package is loaded update the DependencyView 
             // as we may have installed a missing package.
+
             pmExtension.PackageLoader.PackgeLoaded += (package) =>
             {
                 DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Windows.Controls;
-using Dynamo.Extensions;
+﻿using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.PackageManager;
 using Dynamo.WorkspaceDependency.Properties;
 using Dynamo.Wpf.Extensions;
+using System;
+using System.Linq;
+using System.Windows.Controls;
 
 namespace Dynamo.WorkspaceDependency
 {
@@ -18,7 +18,7 @@ namespace Dynamo.WorkspaceDependency
     public class WorkspaceDependencyViewExtension : IViewExtension, ILogSource
     {
         private MenuItem packageDependencyMenuItem;
-        private ReadyParams ReadyParams;
+        private ViewLoadedParams LoadedParams;
 
         internal WorkspaceDependencyView DependencyView
         {
@@ -57,16 +57,16 @@ namespace Dynamo.WorkspaceDependency
         {
         }
 
-       
+
+        [Obsolete("This method is not implemented and will be removed.")]
         public void Ready(ReadyParams readyParams)
         {
-            ReadyParams = readyParams;
         }
 
         public void Shutdown()
         {
-            ReadyParams.CurrentWorkspaceChanged -= DependencyView.OnWorkspaceChanged;
-            ReadyParams.CurrentWorkspaceCleared -= DependencyView.OnWorkspaceCleared;
+            LoadedParams.CurrentWorkspaceChanged -= DependencyView.OnWorkspaceChanged;
+            LoadedParams.CurrentWorkspaceCleared -= DependencyView.OnWorkspaceCleared;
             this.Dispose();
         }
 
@@ -84,6 +84,12 @@ namespace Dynamo.WorkspaceDependency
         public void Loaded(ViewLoadedParams viewLoadedParams)
         {
             DependencyView = new WorkspaceDependencyView(this, viewLoadedParams);
+            // when a package is loaded update the DependencyView 
+            // as we may have installed a missing package.
+            pmExtension.PackageLoader.PackgeLoaded += (package) =>
+            {
+                DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
+            };
 
             // Adding a button in view menu to refresh and show manually
             packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString };
@@ -95,5 +101,6 @@ namespace Dynamo.WorkspaceDependency
             };
             viewLoadedParams.AddMenuItem(MenuBarType.View, packageDependencyMenuItem);
         }
+
     }
 }


### PR DESCRIPTION
set package loader to update dep UI
add this outisde the view to make it clear this is intended to be a singleton view
get rid of properties that were not set

### Purpose

update dep UI when package is loaded to catch new installations.
also gets rid of ready params from extension - those are only set on model extensions...

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang 
### FYIs

@scottmitchell 