### PR TITLE
Remove Down Vote Button and Obsolete UI command

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -4031,15 +4031,6 @@ namespace Dynamo.Wpf.Properties {
         public static string PackageSearchViewDescription {
             get {
                 return ResourceManager.GetString("PackageSearchViewDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Downvote to voice lack of support for this package.
-        /// </summary>
-        public static string PackageSearchViewDownvoteButtonTooltip {
-            get {
-                return ResourceManager.GetString("PackageSearchViewDownvoteButtonTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1667,9 +1667,6 @@ Next assemblies were loaded several times:
     <value>Description</value>
     <comment>Package description</comment>
   </data>
-  <data name="PackageSearchViewDownvoteButtonTooltip" xml:space="preserve">
-    <value>Downvote to voice lack of support for this package</value>
-  </data>
   <data name="PackageSearchViewInstallButton" xml:space="preserve">
     <value>⇓ Install</value>
     <comment>To install package</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1308,9 +1308,6 @@ You will get a chance to save your work.</value>
     <value>Description</value>
     <comment>Package description</comment>
   </data>
-  <data name="PackageSearchViewDownvoteButtonTooltip" xml:space="preserve">
-    <value>Downvote to voice lack of support for this package</value>
-  </data>
   <data name="PackageSearchViewInstallButton" xml:space="preserve">
     <value>⇓ Install</value>
     <comment>To install package</comment>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -435,8 +435,6 @@ namespace Dynamo.ViewModels
                 var ele = new PackageManagerSearchElement(header);
 
                 ele.UpvoteRequested += this.Model.Upvote;
-                ele.DownvoteRequested += this.Model.Downvote;
-
                 CachedPackageList.Add( ele );
             }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -14,6 +14,8 @@ namespace Dynamo.PackageManager.ViewModels
     {
         public ICommand DownloadLatestCommand { get; set; }
         public ICommand UpvoteCommand { get; set; }
+
+        [Obsolete("This UI command will no longer decrease package votes and will be removed in Dynamo 3.0")]
         public ICommand DownvoteCommand { get; set; }
         public ICommand VisitSiteCommand { get; set; }
         public ICommand VisitRepositoryCommand { get; set; }
@@ -31,6 +33,8 @@ namespace Dynamo.PackageManager.ViewModels
             this.DownloadLatestToCustomPathCommand = new DelegateCommand(() => OnRequestDownload(Model.Header.versions.Last(), true));
 
             this.UpvoteCommand = new DelegateCommand(Model.Upvote, () => canLogin);
+
+            // TODO: Remove the initialization of the UI command in Dynamo 3.0
             this.DownvoteCommand = new DelegateCommand(Model.Downvote, () => canLogin);
 
             this.VisitSiteCommand =

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -323,25 +323,18 @@
                                                 </StackPanel>
                                             </Button>
 
-                                            <StackPanel Width="55"  Orientation="Vertical" Margin="3,0,0,0">
-                                                <StackPanel Orientation="Horizontal">
+                                            <StackPanel Width="80"  Orientation="Vertical" Margin="3,0,0,0">
+                                                <StackPanel Orientation="Vertical">
                                                     <Button Name="UpvoteButton" 
                                                         FontSize="15" 
                                                         ToolTip="{x:Static p:Resources.PackageSearchViewUpvoteButtonTooltip}"  
                                                         Content="👍"
-                                                        Margin="0,0,8,0"
+                                                        Margin="0,0,0,0"
                                                         Foreground="Gray" 
                                                         Command="{Binding Path=UpvoteCommand}" 
                                                         Style="{StaticResource FlatButton}" />
-                                                    <Button Name="DownvoteButton" 
-                                                        FontSize="15" 
-                                                        ToolTip="{x:Static p:Resources.PackageSearchViewDownvoteButtonTooltip}" 
-                                                        Foreground="Gray" 
-                                                        Content="👎"  
-                                                        Command="{Binding Path=DownvoteCommand}" 
-                                                        Style="{StaticResource FlatButton}" />
+                                                    <TextBlock FontSize="10" TextAlignment="Center" Margin="0,0,0,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
                                                 </StackPanel>
-                                                <TextBlock FontSize="10" TextAlignment="Center" Margin="0,0,0,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
                                             </StackPanel>
                                         </StackPanel>
 

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -57,15 +57,6 @@ namespace Dynamo.PackageManager
             }, false);
         }
 
-        internal bool Downvote(string packageId)
-        {
-            return FailFunc.TryExecute(() =>
-            {
-                var pkgResponse = this.client.ExecuteAndDeserialize(new Downvote(packageId));
-                return pkgResponse.success;
-            }, false);
-        }
-
         internal PackageManagerResult DownloadPackage(string packageId, string version, out string pathToPackage)
         {
             try

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -26,6 +26,7 @@ namespace Dynamo.PackageManager
         ///     An event that's invoked when the user has attempted to downvote this
         ///     package.
         /// </summary>
+        [Obsolete("This event will be removed in Dynamo 3.0")]
         public event Func<string, bool> DownvoteRequested;
 
         public string Maintainers { get { return String.Join(", ", this.Header.maintainers.Select(x => x.username)); } }
@@ -155,6 +156,7 @@ namespace Dynamo.PackageManager
                 , TaskScheduler.FromCurrentSynchronizationContext());
         }
 
+        [Obsolete("This API will no longer decrease package votes and will be removed in Dynamo 3.0")]
         public void Downvote()
         {
             Task<bool>.Factory.StartNew(() => DownvoteRequested(this.Id))

--- a/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
@@ -173,39 +173,6 @@ namespace Dynamo.PackageManager.Tests
 
         #endregion
 
-        #region Downvote
-
-        [Test]
-        public void Downvote_ReturnsTrueWhenRequestSucceeds()
-        {
-            var gc = new Mock<IGregClient>();
-            gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<Downvote>())).Returns(new ResponseBody()
-            {
-                success = true
-            });
-
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
-
-            var res = pc.Downvote("id");
-
-            Assert.IsTrue(res);
-        }
-
-        [Test]
-        public void Downvote_ReturnsFalseWhenRequestThrowsException()
-        {
-            var gc = new Mock<IGregClient>();
-            gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<Downvote>())).Throws<Exception>();
-
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
-
-            var res = pc.Downvote("id");
-
-            Assert.IsFalse(res);
-        }
-
-        #endregion
-
         #region GetTermsOfUseAcceptanceStatus
 
         [Test]


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[DYN-1990](https://jira.autodesk.com/browse/DYN-1990)
As a Dynamo dev, I want to clean up package down vote info to push positive reinforcement.	

Before:
![image](https://user-images.githubusercontent.com/3942418/63974054-0f1eac00-ca7a-11e9-9e5c-4c476cb514ff.png)

After:
![image](https://user-images.githubusercontent.com/3942418/63974044-0a59f800-ca7a-11e9-9da2-696f35d287b0.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
Running Self CI
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Dewb @johnpierson @Amoursol 