### PR TITLE
[DNM] perform library reload after superfluous package load/custom node executions.

### DIFF
--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -132,10 +132,10 @@ namespace Dynamo.Engine
         /// <param name="libraryServices"> LibraryServices manages builtin libraries and imported libraries.</param>
         /// <param name="geometryFactoryFileName">Path to LibG</param>
         /// <param name="verboseLogging">Bool value, if set to true, enables verbose logging</param>
-        public EngineController(LibraryServices libraryServices, string geometryFactoryFileName, bool verboseLogging)
+        public EngineController(LibraryServices libraryServices, string geometryFactoryFileName, bool verboseLogging, DynamoScheduler scheduler)
         {
             this.libraryServices = libraryServices;
-            libraryServices.LibraryLoaded += LibraryLoaded;
+            libraryServices.LibraryLoaded += (s,e)=> { scheduler.ScheduleForExecution(new DelegateBasedAsyncTask(scheduler, () => { LibraryLoaded(s, e); })); };
             CompilationServices = new CompilationServices(libraryServices);
 
             liveRunnerServices = new LiveRunnerServices(this, geometryFactoryFileName);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1436,7 +1436,8 @@ namespace Dynamo.Models
             EngineController = new EngineController(
                 LibraryServices,
                 geometryFactoryPath,
-                DebugSettings.VerboseLogging);
+                DebugSettings.VerboseLogging,
+                this.Scheduler);
 
             EngineController.MessageLogged += LogMessage;
             EngineController.TraceReconcliationComplete += EngineController_TraceReconcliationComplete;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1429,6 +1429,7 @@ namespace Dynamo.Models
             {
                 EngineController.TraceReconcliationComplete -= EngineController_TraceReconcliationComplete;
                 EngineController.MessageLogged -= LogMessage;
+                EngineController.dumpedLibrary -= EngineController_dumpedLibrary;
                 EngineController.Dispose();
                 EngineController = null;
             }
@@ -1436,15 +1437,24 @@ namespace Dynamo.Models
             EngineController = new EngineController(
                 LibraryServices,
                 geometryFactoryPath,
-                DebugSettings.VerboseLogging,
-                this.Scheduler);
+                DebugSettings.VerboseLogging
+                );
 
+            EngineController.dumpedLibrary += EngineController_dumpedLibrary;
             EngineController.MessageLogged += LogMessage;
             EngineController.TraceReconcliationComplete += EngineController_TraceReconcliationComplete;
 
             foreach (var def in CustomNodeManager.LoadedDefinitions)
                 RegisterCustomNodeDefinitionWithEngine(def);
         }
+
+        private void EngineController_dumpedLibrary()
+        {
+
+            foreach (var def in CustomNodeManager.LoadedDefinitions)
+                RegisterCustomNodeDefinitionWithEngine(def);
+        }              
+    
 
         /// <summary>
         ///     Forces an evaluation of the current workspace by resetting the DesignScript VM.


### PR DESCRIPTION
### Purpose

@aparajit-pratap @reddyashish -

update:
current commit uses a pre-existing lock in the engine, to block reloading the library while the engine is inside a few important functions. One of these functions is `generateGraphSyncDataForCustomNode` https://github.com/DynamoDS/Dynamo/blob/dfb938bba667e9a4ddf54df1c983f3d4a48fdc1f/src/DynamoCore/Engine/EngineController.cs#L327

which is triggered when the customNode definition is updated. - this seems to stop the crash at least. But diagramming the execution flow - doesn't really explain why it works -  as I thought the graphSync generation would occur on the same thread as the library reload. (main thread)

`getMirror` also uses this lock
https://github.com/DynamoDS/Dynamo/blob/dfb938bba667e9a4ddf54df1c983f3d4a48fdc1f/src/DynamoCore/Engine/EngineController.cs#L212
and this might be a more likely explanation, as the graph executes getMirror maybe called from the scheduler thread and a race condition is prevented. - But I have not confirmed this.


In any case the reason this code works is not easy to confirm - and it could be that getting the lock simply changes timing enough to make avoid a race condition in debug mode. 😕 .

 But -  then we need to resync the custom node definitions with the engine, though I still don't understand exactly why this is case. My assumption is that reloading the library has dumped the loaded functions and they need to be re-registered - and usually this occurs after the library load as part of the node being loaded or placed. It's still not clear though or what consequences these changes have but they might be a potential refactor for later.

#### TLDR:

I'm not confident in this change at this time.

I found these two very interesting PRs:
https://github.com/DynamoDS/Dynamo/pull/2745
https://github.com/DynamoDS/Dynamo/pull/4235

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of