### PR TITLE
[WIP] Add better unresolved node error messages

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -98,6 +98,10 @@ namespace Dynamo.Graph.Workspaces
 
             var obj = JObject.Load(reader);
             var type = Type.GetType(obj["$type"].Value<string>());
+            var typeName = obj["$type"].Value<string>().Split(',').FirstOrDefault();
+            // This assemblyName does not usually contain version information...
+            var assemblyName = obj["$type"].Value<string>().Split(',').Skip(1).FirstOrDefault().Trim();
+            
             // If we can't find this type - try to look in our load from assemblies,
             // but only during testing - this is required during testing because some dlls are loaded
             // using Assembly.LoadFrom using the assemblyHelper - which loads dlls into loadFrom context - 
@@ -106,10 +110,7 @@ namespace Dynamo.Graph.Workspaces
             if(type == null && this.isTestMode == true)
             {
                 List<Assembly> resultList;
-
-                var typeName = obj["$type"].Value<string>().Split(',').FirstOrDefault();
-                // This assemblyName does not usually contain version information...
-                var assemblyName = obj["$type"].Value<string>().Split(',').Skip(1).FirstOrDefault().Trim();
+                
                 if (assemblyName != null)
                 {
                     if(this.loadedAssemblies.TryGetValue(assemblyName, out resultList))
@@ -144,8 +145,7 @@ namespace Dynamo.Graph.Workspaces
             var outPorts = obj["Outputs"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
 
             var resolver = (IdReferenceResolver)serializer.ReferenceResolver;
-            var assemblyName = obj["$type"].Value<string>().Split(',').Skip(1).FirstOrDefault().Trim();
-
+           
             bool remapPorts = true;
 
             // If type is still null at this point return a dummy node

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -144,14 +144,14 @@ namespace Dynamo.Graph.Workspaces
             var outPorts = obj["Outputs"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
 
             var resolver = (IdReferenceResolver)serializer.ReferenceResolver;
-            string assemblyLocation = objectType.Assembly.Location;
+            var assemblyName = obj["$type"].Value<string>().Split(',').Skip(1).FirstOrDefault().Trim();
 
             bool remapPorts = true;
 
             // If type is still null at this point return a dummy node
             if (type == null)
             {
-                node = CreateDummyNode(obj, assemblyLocation, inPorts, outPorts);
+                node = CreateDummyNode(obj, assemblyName, inPorts, outPorts);
             }
             // Attempt to create a valid node using the type
             else if (type == typeof(Function))
@@ -215,7 +215,7 @@ namespace Dynamo.Graph.Workspaces
                 // Use the functionDescriptor to try and restore the proper node if possible
                 if (functionDescriptor == null)
                 {
-                    node = CreateDummyNode(obj, assemblyLocation, inPorts, outPorts);
+                    node = CreateDummyNode(obj, assemblyName, inPorts, outPorts);
                 }
                 else
                 {
@@ -278,7 +278,7 @@ namespace Dynamo.Graph.Workspaces
             return node;
         }
 
-        private DummyNode CreateDummyNode(JObject obj, string assemblyLocation, PortModel[] inPorts, PortModel[] outPorts)
+        private DummyNode CreateDummyNode(JObject obj, string assemblyName, PortModel[] inPorts, PortModel[] outPorts)
         {
             var inputcount = inPorts.Count();
             var outputcount = outPorts.Count();
@@ -287,7 +287,7 @@ namespace Dynamo.Graph.Workspaces
                 obj["Id"].ToString(),
                 inputcount,
                 outputcount,
-                assemblyLocation,
+                assemblyName,
                 obj);
         }
 


### PR DESCRIPTION
### Purpose

The error message when creating a dummy node does not make sense:
see this thread:
https://forum.dynamobim.com/t/standard-nodes-are-unresolved/40307/10

these are not coreNodes and yet they imply that the types are defined in dynamoCore - I think this is because the baseType is always a NodeModel or DSFunction which is defined in DynamoCore.dll


![](https://aws1.discourse-cdn.com/business6/uploads/dynamobim/original/3X/a/7/a7df77862d2c02995b8106b07967dfcea897cafb.png)


instead use the concrete type assembly, which we have, to set a more logical error message. Alternatively we could use the entire type name if that is more useful...

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of