### PR TITLE
NodeProfilingData start time should update when node is re-executed

### DIFF
--- a/src/DynamoCore/Engine/Profiling/IProfilingExecutionTimeData.cs
+++ b/src/DynamoCore/Engine/Profiling/IProfilingExecutionTimeData.cs
@@ -9,12 +9,13 @@ namespace Dynamo.Engine.Profiling
     public interface IProfilingExecutionTimeData
     {
         /// <summary>
-        /// Returns the total amount of time spent compiling and executing nodes.
+        /// Returns the total amount of time spent compiling and executing nodes during the most recent graph run.
         /// </summary>
         TimeSpan? TotalExecutionTime { get; }
 
         /// <summary>
         /// Returns the amount of time spent compiling and executing a specific node.
+        /// Returns null if the node was not executed during the most recent graph run.
         /// </summary>
         TimeSpan? NodeExecutionTime(NodeModel node);
     }

--- a/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
@@ -11,8 +11,6 @@ namespace Dynamo.Engine.Profiling
         private DateTime? startTime = null;
         private DateTime? endTime = null;
 
-        internal bool profilingStarted;
-
         internal NodeProfilingData(NodeModel node)
         {
             this.node = node;
@@ -32,10 +30,9 @@ namespace Dynamo.Engine.Profiling
 
         private void RecordEvaluationState(object data)
         {
-            if (!profilingStarted)
+            if (!startTime.HasValue)
             {
                 startTime = DateTime.Now;
-                profilingStarted = true;
                 node.OnNodeExecutionBegin();
                 return;
             }

--- a/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
@@ -11,6 +11,8 @@ namespace Dynamo.Engine.Profiling
         private DateTime? startTime = null;
         private DateTime? endTime = null;
 
+        private bool profilingInProcess;
+
         internal NodeProfilingData(NodeModel node)
         {
             this.node = node;
@@ -30,14 +32,16 @@ namespace Dynamo.Engine.Profiling
 
         private void RecordEvaluationState(object data)
         {
-            if (!startTime.HasValue)
+            if (!profilingInProcess)
             {
                 startTime = DateTime.Now;
+                profilingInProcess = true;
                 node.OnNodeExecutionBegin();
                 return;
             }
 
             endTime = DateTime.Now;
+            profilingInProcess = false;
             node.OnNodeExecutionEnd();
         }
 

--- a/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/NodeProfilingData.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Engine.Profiling
         private DateTime? startTime = null;
         private DateTime? endTime = null;
 
-        private bool profilingInProcess;
+        internal bool profilingStarted;
 
         internal NodeProfilingData(NodeModel node)
         {
@@ -32,16 +32,15 @@ namespace Dynamo.Engine.Profiling
 
         private void RecordEvaluationState(object data)
         {
-            if (!profilingInProcess)
+            if (!profilingStarted)
             {
                 startTime = DateTime.Now;
-                profilingInProcess = true;
+                profilingStarted = true;
                 node.OnNodeExecutionBegin();
                 return;
             }
 
             endTime = DateTime.Now;
-            profilingInProcess = false;
             node.OnNodeExecutionEnd();
         }
 

--- a/src/DynamoCore/Engine/Profiling/ProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingData.cs
@@ -114,11 +114,11 @@ namespace Dynamo.Engine.Profiling
             nodeProfilingData = remainingNodes;
         }
 
-        internal void ResetProfilingDataState()
+        internal void Reset()
         {
             foreach(var node in nodeProfilingData.Values)
             {
-                node.profilingStarted = false;
+                node.Reset();
             }
         }
     }

--- a/src/DynamoCore/Engine/Profiling/ProfilingData.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingData.cs
@@ -113,5 +113,13 @@ namespace Dynamo.Engine.Profiling
 
             nodeProfilingData = remainingNodes;
         }
+
+        internal void ResetProfilingDataState()
+        {
+            foreach(var node in nodeProfilingData.Values)
+            {
+                node.profilingStarted = false;
+            }
+        }
     }
 }

--- a/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
@@ -46,12 +46,12 @@ namespace Dynamo.Engine.Profiling
         private void OnGraphPreExecution(Session.IExecutionSession session)
         {
             profilingData.StartTime = DateTime.Now;
+            profilingData.Reset();
         }
 
         private void OnGraphPostExecution(Session.IExecutionSession session)
         {
             profilingData.EndTime = DateTime.Now;
-            profilingData.ResetProfilingDataState();
         }
 
         internal void RegisterNode(NodeModel node)

--- a/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
@@ -45,8 +45,8 @@ namespace Dynamo.Engine.Profiling
 
         private void OnGraphPreExecution(Session.IExecutionSession session)
         {
-            profilingData.StartTime = DateTime.Now;
             profilingData.Reset();
+            profilingData.StartTime = DateTime.Now;
         }
 
         private void OnGraphPostExecution(Session.IExecutionSession session)

--- a/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
+++ b/src/DynamoCore/Engine/Profiling/ProfilingSession.cs
@@ -51,6 +51,7 @@ namespace Dynamo.Engine.Profiling
         private void OnGraphPostExecution(Session.IExecutionSession session)
         {
             profilingData.EndTime = DateTime.Now;
+            profilingData.ResetProfilingDataState();
         }
 
         internal void RegisterNode(NodeModel node)

--- a/test/DynamoCoreTests/ProfilingTest.cs
+++ b/test/DynamoCoreTests/ProfilingTest.cs
@@ -185,8 +185,8 @@ namespace Dynamo.Tests
             }
 
             // Wait a few seconds so we can later confirm that the start time gets reset after this pause
-            var pauseTime = new TimeSpan(0, 0, 0, 5);
-            Thread.Sleep(5000);
+            var pauseTime = new TimeSpan(0, 0, 0, 5); // 5 seconds
+            Thread.Sleep(pauseTime);
 
             // Mark ONLY the most upstream node as modified
             var codeBlockGuid = "87794137f78d4d809814e73d977e46fb";
@@ -198,7 +198,7 @@ namespace Dynamo.Tests
                 }
             }
 
-            // Second run
+            // Second run / Re-execute
             BeginRun();
 
             // Gather second run data

--- a/test/DynamoCoreTests/ProfilingTest.cs
+++ b/test/DynamoCoreTests/ProfilingTest.cs
@@ -7,6 +7,7 @@ using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Graph.Nodes;
 using NUnit.Framework;
+using System.Threading;
 
 namespace Dynamo.Tests
 {
@@ -147,6 +148,69 @@ namespace Dynamo.Tests
             {
                 node.NodeExecutionBegin -= onNodeExectuionBegin;
                 node.NodeExecutionEnd -= onNodeExectuionEnd;
+            }
+        }
+
+        [Test]
+        public void StartTimeResetsWhenNodeIsReExecuted()
+        {
+            // Note: This test file is saved in manual run mode
+            string openPath = Path.Combine(TestDirectory, @"core\profiling\createSomePoints.dyn");
+            OpenModel(openPath);
+
+            // Enable profiling
+            var engineController = CurrentDynamoModel.EngineController;
+            var homeWorkspace = CurrentDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().FirstOrDefault();
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            engineController.EnableProfiling(true, homeWorkspace, nodes);
+            var profilingData = engineController.ProfilingSession.ProfilingData;
+
+            // Assert no profiling data has been created for any node yet
+            foreach (var node in nodes)
+            {
+                var time = profilingData.NodeExecutionTime(node);
+                Assert.IsNull(time);
+            }
+
+            // First run
+            BeginRun();
+
+            // Gather first run data and assert it is not null
+            var firstRunTimes = new List<TimeSpan>();
+            foreach (var node in nodes)
+            {
+                var time = profilingData.NodeExecutionTime(node);
+                Assert.IsNotNull(time);
+                firstRunTimes.Add((TimeSpan)time);
+            }
+
+            // Wait a few seconds so we can later confirm that the start time gets reset after this pause
+            var pauseTime = new TimeSpan(0, 0, 0, 5);
+            Thread.Sleep(5000);
+
+            // Mark ONLY the most upstream node as modified
+            var codeBlockGuid = "87794137f78d4d809814e73d977e46fb";
+            foreach (var node in nodes)
+            {
+                if (node.GUID == Guid.Parse(codeBlockGuid))
+                {
+                    node.MarkNodeAsModified();
+                }
+            }
+
+            // Second run
+            BeginRun();
+
+            // Gather second run data
+            var secondRunTimes = new List<TimeSpan>();
+            foreach (var node in nodes)
+            {
+                var executionTime = (TimeSpan)profilingData.NodeExecutionTime(node);
+                Assert.IsNotNull(executionTime);
+                secondRunTimes.Add(executionTime);
+                // Assert the execution time is less than the 5 second pause time
+                // i.e. The start time has been reset since before we paused for 5 seconds
+                Assert.Less(executionTime.TotalMilliseconds, pauseTime.TotalMilliseconds);
             }
         }
     }


### PR DESCRIPTION
### Purpose

Previously, the `startTime` for a `nodeProfilingData` could never be updated. When a node was re-executed, its `endTime` would be updated, but not its `startTime`. 

This caused the `executionTime` property of a `nodeProfilingData` to return the timespan from the **start of its first execution** to the **end of its most recent execution**. 

It should instead return the timespan from the **start of its most recent execution** to the **end of its most recent execution**.

An existing workaround is to re-enable profiling on all nodes between profiling graph runs. However, this forces all nodes to re-execute, making it difficult to collect profiling data on partial graph runs (delta compute). This PR makes it easy to gather profiling data on partial graph runs, and also makes it unnecessary for extension developers to re-enable profiling between runs (unless they want to re-execute all nodes). 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ColinDayOrg @mjkkirschner @QilongTang 

### FYI

@alvpickmans
