### PR TITLE
Fix crash when opening second script in French C3D

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -256,7 +256,7 @@
                                 <Condition Value="True">
                                     <Condition.Binding>
                                         <MultiBinding Converter="{StaticResource GroupFontSizeToEditorEnabledConverter }">
-                                            <Binding Path ="DataContext.Zoom" FallbackValue="1.0" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
+                                            <Binding Path ="DataContext.Zoom" FallbackValue="1" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
                                             <Binding ElementName="GroupTextBlock" Path="FontSize"/>
                                             <Binding ElementName="GroupTextBlock" Path="Visibility"/>
                                         </MultiBinding>


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose
Fix crash when opening second script in French C3D

Steps to reproduce:
- Launch Dynamo in French OS and French Civil 3D.
- Open from `Help` menu: `Help>Samples>Core>Core_ListAtLevel.dyn`
- Without close the dyn, open from `Help` menu: `Help>Samples>Core>Core_ListLacing.dyn`.
- Exception dialog comes and C3D will crash.

The exception arises when converting `1.0` to double under `fr-FR` culture,
in `GroupFontSizeToEditorEnabledConverter.Convert()` on `values[0]`.

Questions:
- Where does this `1.0` come from?
  It is from `AnnotationView.xaml`, where `FallbackValue` of the `Visibility`
property is set to `1.0`. When we switch from first dyn to the second, the
current workspace will be removed, triggered WPF binding updates.

- Why it doesn't crash when we do the same operation in DynamoSandbox?
  WPF actually doesn't follow `CurrentCulture` or `CurrentUICulture`
when resolving the binding (https://weblog.west-wind.com/posts/2009/Jun/14/WPF-Bindings-and-CurrentCulture-Formattings.
  So by default, the `culture` passed to the `Convert` method is always `en-US`.
  So it is OK.

- How to reproduce with DynamoSandbox?
  You have to manually add several lines of code to `DynamoSandbox` entry fuction, it will crash
although no exception dialog (interestingly, it pops up IE on my side).
```
CultureInfo.DefaultThreadCurrentCulture = CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
FrameworkElement.LanguageProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag)));
```

- Why does Civil 3D have `fr-FR` culture?
  People buying Civil 3D will get Map 3D for free. The Map 3D dll, `Autodesk.Map.IM.Loader.dll`,
  will override the Culture to be used by all WPF bindings, with the very similar code as above.
  When I rename it, the crash goes away.

- So how to fix?
  At this stage, the safest fix would be simply changing `1.0` to `1`.
  Later we should evaluate whether we really need to simply use the InvariantCulture
  in all our binding coverters. We have unit tests for those converters, so also
  need to remove/change them if decided to go that way.
  Another way, we might should catch all the exception and `Converter.ToDouble()` and use invariant culture if failed..

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

Michael Kirschner
Aaran Tang

### FYIs

