### PR TITLE
use invariant culture to parse inputs to converters -

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1414,7 +1414,7 @@ namespace Dynamo.Controls
         }
     }
 
-    //TODO remove(this is not used anywhere)
+    //TODO remove(this is not used anywhere) in Dynamo 3.0
     public class ZoomToVisibilityConverter : IValueConverter
     {
         /// <summary>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2322,7 +2322,7 @@ namespace Dynamo.Controls
             //just use defaults, this will enable the text editor.
             catch(Exception e)
             {
-                Console.WriteLine($"problem attempting to parse fontsize or zoom {values[0]} {values[1]} { e.Message}");
+                Console.WriteLine($"problem attempting to parse fontsize or zoom {values[1]} {values[0]}. { e.Message}");
             }
 
             var factor = zoom*fontsize;

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1414,15 +1414,29 @@ namespace Dynamo.Controls
         }
     }
 
+    //TODO remove(this is not used anywhere)
     public class ZoomToVisibilityConverter : IValueConverter
     {
+        /// <summary>
+        /// Returns hidden for small zoom sizes - appears unused.
+        /// </summary>
+        /// <param name="value">zoom size</param>
+        /// <param name="targetType">unused</param>
+        /// <param name="parameter">unused</param>
+        /// <param name="culture">unused</param>
+        /// <returns></returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            double zoom = System.Convert.ToDouble(value, culture);
-
-            if (zoom < .5)
-                return Visibility.Hidden;
-
+            try
+            {
+                double zoom = System.Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                if (zoom < .5)
+                    return Visibility.Hidden;
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine($"problem attempting to parse zoomsize or param {value}{ e.Message}");
+            }
             return Visibility.Visible;
         }
 
@@ -2208,12 +2222,31 @@ namespace Dynamo.Controls
 
     public class MenuItemCheckConverter : IValueConverter
     {
+        /// <summary>
+        /// Converts from a fontsize and param to determine if the two numbers are equal.(ie what is the font set to)
+        /// </summary>
+        /// <param name="value">fontSize</param>
+        /// <param name="targetType">unusued</param>
+        /// <param name="parameter">target font size</param>
+        /// <param name="culture">unusued</param>
+        /// <returns></returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var fontsize = System.Convert.ToDouble(value, culture);
-            var param = System.Convert.ToDouble(parameter, culture);
-
-            return fontsize == param;            
+         
+            //use invariant culture, these strings should always be set via our code.
+            try
+            {
+                var fontsize = System.Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                var param = System.Convert.ToDouble(parameter, CultureInfo.InvariantCulture);
+                return fontsize == param;
+            }
+            
+            catch(Exception e)
+            {
+                Console.WriteLine($"problem attempting to parse fontsize or param {value} {parameter} { e.Message}");
+                return false;
+            }
+          
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -2265,10 +2298,32 @@ namespace Dynamo.Controls
     {
         private const double MinFontFactor = 7.0;
 
+        /// <summary>
+        /// converts a zoom and fontsize to a bool used to determine if group title editor should be enabled.
+        /// </summary>
+        /// <param name="values">[0] zoom [1] fontSize - could be strings or doubles</param>
+        /// <param name="targetType">unused</param>
+        /// <param name="parameter">unused</param>
+        /// <param name="culture">unused</param>
+        /// <returns></returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            var zoom = System.Convert.ToDouble(values[0], culture);
-            var fontsize = System.Convert.ToDouble(values[1], culture);
+            //defaults
+            var zoom = 1.0;
+            var fontsize = 36.0;
+            try
+            {
+                //use invariantCulture - 
+                //fontSize should only be serialized in invariant culture
+                // and zoom should either come from fallback value or runtime value.
+                zoom = System.Convert.ToDouble(values[0], CultureInfo.InvariantCulture);
+                fontsize = System.Convert.ToDouble(values[1], CultureInfo.InvariantCulture);
+            }
+            //just use defaults, this will enable the text editor.
+            catch(Exception e)
+            {
+                Console.WriteLine($"problem attempting to parse fontsize or zoom {values[0]} {values[1]} { e.Message}");
+            }
 
             var factor = zoom*fontsize;
             if (factor < MinFontFactor)

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -636,45 +636,72 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void MenuItemCheckConverterTest()
         {
-            object equal;
+            object result;
             MenuItemCheckConverter converter = new MenuItemCheckConverter();
 
-            equal = converter.Convert("1.0", typeof(string), "1.0", new CultureInfo("en-US"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert("1.0", typeof(string), "1.0", new CultureInfo("en-US"));
+            Assert.AreEqual(result, true);
 
-            equal = converter.Convert("1,0", typeof(string), "1,0", new CultureInfo("de-DE"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert("1,0", typeof(string), "1,0", new CultureInfo("de-DE"));
+            Assert.AreEqual(result, true);
 
-            equal = converter.Convert(1.0, typeof(double), 1.0, new CultureInfo("en-US"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert(1.0, typeof(double), 1.0, new CultureInfo("en-US"));
+            Assert.AreEqual(result, true);
 
-            equal = converter.Convert(1.0, typeof(double), 1.0, new CultureInfo("de-DE"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert(1.0, typeof(double), 1.0, new CultureInfo("de-DE"));
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(1.0, null, 1.0, null);
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(1.0, null, 100, null);
+            Assert.AreEqual(result, false);
         }
 
         [Test]
         [Category("UnitTests")]
         public void GroupFontSizeToEditorEnabledConverterTest()
         {
-            object equal;
+            object result;
             GroupFontSizeToEditorEnabledConverter converter = new GroupFontSizeToEditorEnabledConverter();
+            //obj [1] = zoom, obj [2]= fontsize
+            string[] stringsUsDefault = { "1.0", "36.0" };
+            string[] stringsUsDefaultResultInFalse = { "1.0", "2.0" };
             string[] stringsUs = { "2.0", "4.0" };
             string[] stringsDe = { "2,0", "4,0" };
             double[] doubles = { 2.0, 4.0 };
             object[] objects = new object[2];
             doubles.CopyTo(objects, 0);
 
-            equal = converter.Convert(stringsUs , typeof(string), null, new CultureInfo("en-US"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert(stringsUs , typeof(string), null, new CultureInfo("en-US"));
+            Assert.AreEqual(result, true);
 
-            equal = converter.Convert(stringsDe, typeof(string), null, new CultureInfo("de-DE"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert(stringsDe, typeof(string), null, new CultureInfo("de-DE"));
+            Assert.AreEqual(result, true);
 
-            equal = converter.Convert(objects, typeof(float), null, new CultureInfo("en-US"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert(objects, typeof(float), null, new CultureInfo("en-US"));
+            Assert.AreEqual(result, true);
 
-            equal = converter.Convert(objects, typeof(float), null, new CultureInfo("de-DE"));
-            Assert.AreEqual(equal, true);
+            result = converter.Convert(objects, typeof(float), null, new CultureInfo("de-DE"));
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(stringsDe, typeof(float), null, new CultureInfo("de-DE"));
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(stringsUsDefault, typeof(float), null, new CultureInfo("de-DE"));
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(stringsUsDefault, typeof(float), null, new CultureInfo("fr-FR"));
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(stringsDe, typeof(float), null, new CultureInfo("fr-FR"));
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(stringsUsDefault, null, null, null);
+            Assert.AreEqual(result, true);
+
+            result = converter.Convert(stringsUsDefaultResultInFalse, null, null, null);
+            Assert.AreEqual(result, false);
         }
     }
 }


### PR DESCRIPTION
we were passing the culture before but this was usually set to en-us EVEN in localized environments
unless something set it explicitly
wrap with try catch and return some default conversion

### Purpose

This one has a bit of a history.
issue from user:
https://github.com/DynamoDS/Dynamo/issues/6261
fix:
https://github.com/DynamoDS/Dynamo/pull/6724
fix:
https://github.com/DynamoDS/Dynamo/pull/9994

When this was fixed originally by @sm6srw it appears that unlike what it implies in his PR - unintentionally the culture might have always been set to `en-us` as @angelowang points out WPF passes en-us culture to the converters EVEN if the environment is localized. (I tried both localizing dynamo and localizing windows and got en-us everytime!)

SO - this means that the original fix three years ago, was close, but in certain situations it lets the host change the culture - we don't want that.

Our strings are hardcoded in en-us format in our xaml, and I think that is okay, these converters are not really for public consumption. SO this pr does the following.

* switches to using invariant culture
* documents that the culture parameter is unusued on the convert method
* adds some more test cases (the fr-FR cases failed before this PR)
* wraps the conversions in try catch blocks which logs the exception - incase something fails or someone uses these converters from an extension or in an unanticipated way.
* adds a TODO to remove a converter I cannot find used anywhere.

I've added similar logic to two other converters that @sm6srw added culture to. It appears to me the only time strings are used on these converters is from hardcoded xaml values, or the tests.

I still need to run the self serve tests.
- [x] cherry pick to 2.4.1 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@sm6srw 
### FYIs

@angelowang 