### PR TITLE
fix exception being thrown during shutdown of workspace dep viewer

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -83,6 +83,7 @@ namespace Dynamo.WorkspaceDependency
 
         public void Loaded(ViewLoadedParams viewLoadedParams)
         {
+            LoadedParams = viewLoadedParams;
             DependencyView = new WorkspaceDependencyView(this, viewLoadedParams);
             // when a package is loaded update the DependencyView 
             // as we may have installed a missing package.


### PR DESCRIPTION


### Purpose

`LoadedParams` was never set but was being referenced during shutdown - 
shutdown calls for view extensions are wrapped in a try catch so it doesn't crash.
It's possible this causes some leaks during the test runs as the events in the shutdown handler were not unsubscribed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@reddyashish 
@ColinDayOrg 