### PR TITLE
harden assembly resolve during deserialization

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -97,7 +97,15 @@ namespace Dynamo.Graph.Workspaces
             NodeModel node = null;
 
             var obj = JObject.Load(reader);
-            var type = Type.GetType(obj["$type"].Value<string>());
+            Type type = null;
+            try
+            {
+               type = Type.GetType(obj["$type"].Value<string>());
+            }
+            catch(Exception e)
+            {
+                nodeFactory?.AsLogger().Log(e);
+            }
             // If we can't find this type - try to look in our load from assemblies,
             // but only during testing - this is required during testing because some dlls are loaded
             // using Assembly.LoadFrom using the assemblyHelper - which loads dlls into loadFrom context - 

--- a/test/DynamoCoreTests/DummyNodeTests.cs
+++ b/test/DynamoCoreTests/DummyNodeTests.cs
@@ -108,7 +108,6 @@ namespace Dynamo.Tests
             });
             //attach our handler that will throw
             AppDomain.CurrentDomain.AssemblyResolve += handler;
-            System.Threading.Thread.Sleep(5000);
 
             string openPath = Path.Combine(TestDirectory, testFileWithUknownAssembly);
             OpenModel(openPath);

--- a/test/core/dummy_node/unknownAssemblyName.dyn
+++ b/test/core/dummy_node/unknownAssemblyName.dyn
@@ -1,0 +1,105 @@
+{
+  "Uuid": "edd9e95c-26a5-4ec2-cd1c-ca2a80bc827b",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "unknownAssemblyName",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.UNKNOWNTYPE, UNKNOWNASSEMBLY",
+      "NodeType": "CodeBlockNode",
+      "Code": "4;",
+      "Id": "158f8f25ddb746c88323ae262e87611e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cddfa508b4a246fd94f79792d303cbf5",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "5;",
+      "Id": "6cbd0760736f4235a03b38fb359e9957",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8234ec6cc018433da0605ddfb17cdc2b",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.3.0.5184",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "158f8f25ddb746c88323ae262e87611e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 179.8,
+        "Y": 160.39999999999992
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6cbd0760736f4235a03b38fb359e9957",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 76.8,
+        "Y": 162.4
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-2160

This PR hardens graph deserialization when searching for a node type/assembly. Previously assembly load could throw an exception, we would not handle it and a dummy node would not be created.

Now we catch the exception, log it to Dynamo console, and in some cases even recover and create the node correctly if the assembly can be found by the `nodeFactory` when it calls `ResolveType` later in the `nodeReader` 

The main cause of this failure is when some other code attaches an AssemblyResolve handler and then throws from inside that handler - these handlers should not throw - they should either return null or return the assembly, but we cannot control other handlers in any host so we should harden the loading code.

 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ColinDayOrg 
@reddyashish 
### FYIs

