### PR TITLE
DYN-2149 DummyNode unresolved node messages are confusing

### DIFF
--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -45,6 +45,7 @@ namespace Dynamo.Graph.Nodes
             LegacyNodeName = "Dynamo.Graph.Nodes.DummyNode";
             LegacyFullName = LegacyNodeName;
             LegacyAssembly = string.Empty;
+            FunctionName = string.Empty;
             NodeNature = Nature.Unresolved;
             Description = GetDescription();
             ShouldDisplayPreviewCore = false;
@@ -123,6 +124,52 @@ namespace Dynamo.Graph.Nodes
             LegacyNodeName = legacyName;
             LegacyFullName = legacyName;
             Name = legacyName;
+
+            OriginalNodeContent = originalElement;
+
+            LegacyAssembly = legacyAssembly;
+            NodeNature = DummyNode.Nature.Unresolved;
+
+            Description = GetDescription();
+            ShouldDisplayPreviewCore = false;
+
+            if (originalElement != null)
+            {
+                var legacyFullName = originalElement["FunctionSignature"];
+                if (legacyFullName != null)
+                    LegacyFullName = legacyFullName.ToString();
+            }
+
+            UpdatePorts();
+        }
+
+        /// <summary>
+        /// This function creates DummyNode with specified number of ports.
+        /// </summary>
+        /// <param name="id">Id of the original node</param>
+        /// <param name="inputCount">Number of input ports</param>
+        /// <param name="outputCount">Number of output ports</param>
+        /// <param name="legacyAssembly">Assembly of the node</param>
+        /// <param name="functionName">Function name of the node</param>
+        /// <param name="originalElement">Original JSON description of the node</param>
+        public DummyNode(
+           string id,
+           int inputCount,
+           int outputCount,
+           string legacyAssembly,
+           string functionName,
+           JObject originalElement)
+        {
+            GUID = new Guid(id);
+
+            InputCount = inputCount;
+            OutputCount = outputCount;
+
+            string legacyName = "Unresolved";
+            LegacyNodeName = legacyName;
+            LegacyFullName = legacyName;
+            Name = legacyName;
+            FunctionName = functionName;
 
             OriginalNodeContent = originalElement;
 
@@ -320,29 +367,29 @@ namespace Dynamo.Graph.Nodes
         {
             if (NodeNature == Nature.Deprecated)
             {
-                if (string.IsNullOrEmpty(LegacyAssembly))
+                if (string.IsNullOrEmpty(FunctionName))
                 {
-                    const string format = "Node of type '{0}' is now deprecated";
-                    return string.Format(format, LegacyNodeName);
+                    const string description = "Node is now deprecated";
+                    return description;
                 }
                 else
                 {
-                    const string format = "Node of type '{0}' ({1}) is now deprecated";
-                    return string.Format(format, LegacyNodeName, LegacyAssembly);
+                    const string format = "Node '{0}' is now deprecated";
+                    return string.Format(format, FunctionName);
                 }
             }
 
             if (NodeNature == Nature.Unresolved)
             {
-                if (string.IsNullOrEmpty(LegacyAssembly))
+                if (string.IsNullOrEmpty(FunctionName))
                 {
-                    const string format = "Node of type '{0}' cannot be resolved";
-                    return string.Format(format, LegacyNodeName);
+                    const string description = "Node cannot be resolved";
+                    return description;
                 }
                 else
                 {
-                    const string format = "Node of type '{0}' ({1}) cannot be resolved";
-                    return string.Format(format, LegacyNodeName, LegacyAssembly);
+                    const string format = "Node '{0}' cannot be resolved.";
+                    return string.Format(format, FunctionName);
                 }
             }
 
@@ -369,6 +416,11 @@ namespace Dynamo.Graph.Nodes
         /// Returns the node assembly
         /// </summary>
         public string LegacyAssembly { get; private set; }
+
+        /// <summary>
+        /// Returns the node's function name
+        /// </summary>
+        public string FunctionName { get; private set; }
 
         /// <summary>
         /// Returns the original node DSFunction description or UI node type

--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Xml;
-using Autodesk.DesignScript.Runtime;
+﻿using Autodesk.DesignScript.Runtime;
 using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Graph.Nodes.NodeLoaders;
@@ -11,6 +7,10 @@ using Dynamo.Logging;
 using Dynamo.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
 
 namespace Dynamo.Graph.Nodes
 {
@@ -467,12 +467,12 @@ namespace Dynamo.Graph.Nodes
         public string LegacyAssembly { get; private set; }
 
         /// <summary>
-        /// Type name of the node.
+        /// Type name of the node. This is property is only valid for NodeModel dummy nodes
         /// </summary>
         public string TypeName { get; private set; }
 
         /// <summary>
-        /// Returns the node's function name
+        /// Returns the node's function name. This property is only valid for ZeroTouch dummy nodes
         /// </summary>
         public string FunctionName { get; private set; }
 

--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -189,6 +189,55 @@ namespace Dynamo.Graph.Nodes
             UpdatePorts();
         }
 
+        /// <summary>
+        /// This function creates DummyNode with specified number of ports.
+        /// </summary>
+        /// <param name="id">Id of the original node</param>
+        /// <param name="inputCount">Number of input ports</param>
+        /// <param name="outputCount">Number of output ports</param>
+        /// <param name="legacyAssembly">Assembly of the node</param>
+        /// <param name="functionName">Function name of the node</param>
+        /// <param name="typeName">Type of the node</param>
+        /// <param name="originalElement">Original JSON description of the node</param>
+        public DummyNode(
+           string id,
+           int inputCount,
+           int outputCount,
+           string legacyAssembly,
+           string functionName,
+           string typeName,
+           JObject originalElement)
+        {
+            GUID = new Guid(id);
+
+            InputCount = inputCount;
+            OutputCount = outputCount;
+
+            string legacyName = "Unresolved";
+            LegacyNodeName = legacyName;
+            LegacyFullName = legacyName;
+            Name = legacyName;
+            FunctionName = functionName;
+
+            OriginalNodeContent = originalElement;
+
+            LegacyAssembly = legacyAssembly;
+            TypeName = typeName;
+            NodeNature = DummyNode.Nature.Unresolved;
+
+            Description = GetDescription();
+            ShouldDisplayPreviewCore = false;
+
+            if (originalElement != null)
+            {
+                var legacyFullName = originalElement["FunctionSignature"];
+                if (legacyFullName != null)
+                    LegacyFullName = legacyFullName.ToString();
+            }
+
+            UpdatePorts();
+        }
+
         private void LoadNode(XmlNode nodeElement)
         {
             XmlElement originalElement = OriginalXmlNodeContent;
@@ -369,8 +418,8 @@ namespace Dynamo.Graph.Nodes
             {
                 if (string.IsNullOrEmpty(FunctionName))
                 {
-                    const string format = "Node from assembly '{0}' is now deprecated.";
-                    return string.Format(format, LegacyAssembly);
+                    const string format = "Node of type '{0}',from assembly '{1}', is now deprecated.";
+                    return string.Format(format, TypeName, LegacyAssembly);
                 }
                 else
                 {
@@ -383,8 +432,8 @@ namespace Dynamo.Graph.Nodes
             {
                 if (string.IsNullOrEmpty(FunctionName))
                 {
-                    const string format = "Node from assembly '{0}' cannot be resolved.";
-                    return string.Format(format, LegacyAssembly);
+                    const string format = "Node of type '{0}', from assembly '{1}', cannot be resolved.";
+                    return string.Format(format, TypeName, LegacyAssembly);
                 }
                 else
                 {
@@ -416,6 +465,11 @@ namespace Dynamo.Graph.Nodes
         /// Returns the node assembly
         /// </summary>
         public string LegacyAssembly { get; private set; }
+
+        /// <summary>
+        /// Type name of the node.
+        /// </summary>
+        public string TypeName { get; private set; }
 
         /// <summary>
         /// Returns the node's function name

--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -369,8 +369,8 @@ namespace Dynamo.Graph.Nodes
             {
                 if (string.IsNullOrEmpty(FunctionName))
                 {
-                    const string description = "Node is now deprecated";
-                    return description;
+                    const string format = "Node from assembly '{0}' is now deprecated.";
+                    return string.Format(format, LegacyAssembly);
                 }
                 else
                 {
@@ -383,8 +383,8 @@ namespace Dynamo.Graph.Nodes
             {
                 if (string.IsNullOrEmpty(FunctionName))
                 {
-                    const string description = "Node cannot be resolved";
-                    return description;
+                    const string format = "Node from assembly '{0}' cannot be resolved.";
+                    return string.Format(format, LegacyAssembly);
                 }
                 else
                 {

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -96,11 +96,22 @@ namespace Dynamo.Graph.Workspaces
         {
             NodeModel node = null;
 
+            String typeName = null;
+            String functionName = null;
+
             var obj = JObject.Load(reader);
             Type type = null;
+
             try
             {
                type = Type.GetType(obj["$type"].Value<string>());
+               typeName = obj["$type"].Value<string>().Split(',').FirstOrDefault();
+
+               if (typeName.Contains("ZeroTouch"))
+               {
+                    // This assemblyName does not usually contain version information...
+                    functionName = obj["FunctionSignature"].Value<string>().Split('@').FirstOrDefault().Trim();
+               }
             }
             catch(Exception e)
             {
@@ -115,7 +126,6 @@ namespace Dynamo.Graph.Workspaces
             {
                 List<Assembly> resultList;
 
-                var typeName = obj["$type"].Value<string>().Split(',').FirstOrDefault();
                 // This assemblyName does not usually contain version information...
                 var assemblyName = obj["$type"].Value<string>().Split(',').Skip(1).FirstOrDefault().Trim();
                 if (assemblyName != null)
@@ -159,7 +169,7 @@ namespace Dynamo.Graph.Workspaces
             // If type is still null at this point return a dummy node
             if (type == null)
             {
-                node = CreateDummyNode(obj, assemblyLocation, inPorts, outPorts);
+                node = CreateDummyNode(obj, assemblyLocation, functionName, inPorts, outPorts);
             }
             // Attempt to create a valid node using the type
             else if (type == typeof(Function))
@@ -223,7 +233,7 @@ namespace Dynamo.Graph.Workspaces
                 // Use the functionDescriptor to try and restore the proper node if possible
                 if (functionDescriptor == null)
                 {
-                    node = CreateDummyNode(obj, assemblyLocation, inPorts, outPorts);
+                    node = CreateDummyNode(obj, assemblyLocation, functionName, inPorts, outPorts);
                 }
                 else
                 {
@@ -286,7 +296,7 @@ namespace Dynamo.Graph.Workspaces
             return node;
         }
 
-        private DummyNode CreateDummyNode(JObject obj, string assemblyLocation, PortModel[] inPorts, PortModel[] outPorts)
+        private DummyNode CreateDummyNode(JObject obj, string assemblyLocation, string functionName, PortModel[] inPorts, PortModel[] outPorts)
         {
             var inputcount = inPorts.Count();
             var outputcount = outPorts.Count();
@@ -296,6 +306,7 @@ namespace Dynamo.Graph.Workspaces
                 inputcount,
                 outputcount,
                 assemblyLocation,
+                functionName,
                 obj);
         }
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -175,7 +175,7 @@ namespace Dynamo.Graph.Workspaces
             // If type is still null at this point return a dummy node
             if (type == null)
             {
-                node = CreateDummyNode(obj, assemblyName, functionName, inPorts, outPorts);
+                node = CreateDummyNode(obj, typeName, assemblyName, functionName, inPorts, outPorts);
             }
             // Attempt to create a valid node using the type
             else if (type == typeof(Function))
@@ -313,6 +313,21 @@ namespace Dynamo.Graph.Workspaces
                 outputcount,
                 legacyAssembly,
                 functionName,
+                obj);
+        }
+
+        private DummyNode CreateDummyNode(JObject obj, string typeName, string legacyAssembly, string functionName, PortModel[] inPorts, PortModel[] outPorts)
+        {
+            var inputcount = inPorts.Count();
+            var outputcount = outPorts.Count();
+
+            return new DummyNode(
+                obj["Id"].ToString(),
+                inputcount,
+                outputcount,
+                legacyAssembly,
+                functionName,
+                typeName,
                 obj);
         }
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -108,7 +108,7 @@ namespace Dynamo.Graph.Workspaces
                type = Type.GetType(obj["$type"].Value<string>());
                typeName = obj["$type"].Value<string>().Split(',').FirstOrDefault();
 
-                if (typeName.Contains("ZeroTouch"))
+                if (typeName.Equals("Dynamo.Graph.Nodes.ZeroTouch.DSFunction"))
                 {
                     // If it is a zero touch node, then get the whole function name including the namespace.
                     functionName = obj["FunctionSignature"].Value<string>().Split('@').FirstOrDefault().Trim();

--- a/test/DynamoCoreTests/DummyNodeTests.cs
+++ b/test/DynamoCoreTests/DummyNodeTests.cs
@@ -160,5 +160,26 @@ namespace Dynamo.Tests
             Assert.AreEqual(0, dummyNodes.Count());
             Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.HasUnsavedChanges, false);
         }
+
+        [Test]
+        public void DummyNodesWarningMessageTest()
+        {
+            String path = Path.Combine(TestDirectory, @"core\dummy_node\DummyNodesWarningMessageTest.dyn");
+            OpenModel(path);
+
+            var dummyNodes = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>();
+            Assert.AreEqual(2, dummyNodes.Count());
+
+            // Asserting the warning message that is displayed for zerotouch and nodemodel dummy nodes.
+            var zeroTouchDummyNode = dummyNodes.First();
+            Assert.AreEqual(zeroTouchDummyNode.NodeNature, DummyNode.Nature.Unresolved);
+            Assert.AreEqual(zeroTouchDummyNode.FunctionName, "HowickMaker.hMember.ByLineVector");
+            Assert.AreEqual(zeroTouchDummyNode.GetDescription(), "Node 'HowickMaker.hMember.ByLineVector' cannot be resolved.");
+
+            var nodeModelDummyNode = dummyNodes.Last();
+            Assert.AreEqual(nodeModelDummyNode.NodeNature, DummyNode.Nature.Unresolved);
+            Assert.AreEqual(nodeModelDummyNode.LegacyAssembly, "SampleLibraryUI");
+            Assert.AreEqual(nodeModelDummyNode.GetDescription(), "Node of type 'SampleLibraryUI.Examples.DropDownExample', from assembly 'SampleLibraryUI', cannot be resolved.");
+        }
     }
 }

--- a/test/core/dummy_node/DummyNodesWarningMessageTest.dyn
+++ b/test/core/dummy_node/DummyNodesWarningMessageTest.dyn
@@ -1,0 +1,156 @@
+{
+  "Uuid": "8ac993b7-6516-45c6-8bac-9ff985fbb0ad",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Dummy node message",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "HowickMaker.hMember.ByLineVector@Autodesk.DesignScript.Geometry.Line,Autodesk.DesignScript.Geometry.Vector,string",
+      "Id": "aeb3e5df26cc4f16af55bf0baef46ae1",
+      "Inputs": [
+        {
+          "Id": "2cda30bf385741c3ad5d4b290d8452c1",
+          "Name": "webAxis",
+          "Description": "Line",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "76a24bab17214e1697ab78692268bc77",
+          "Name": "webNormal",
+          "Description": "Vector",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5cdd38339cef4f09a61f60abd6095076",
+          "Name": "name",
+          "Description": "string\nDefault value : \"0\"",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e45e1d20e89b422698798660461602e6",
+          "Name": "hMember",
+          "Description": "hMember",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates an hMember with its web lying along the webAxis, facing webNormal\n\nhMember.ByLineVector (webAxis: Line, webNormal: Vector, name: string = \"0\"): hMember"
+    },
+    {
+      "ConcreteType": "SampleLibraryUI.Examples.DropDownExample, SampleLibraryUI",
+      "SelectedIndex": 0,
+      "SelectedString": "Tywin",
+      "NodeType": "ExtensionNode",
+      "Id": "5de408d41309424ea9ab0a9a57011168",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "6c8499495f5d4beeb7e3ca58b861a297",
+          "Name": "item",
+          "Description": "The selected item",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "An example drop down node."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [
+    {
+      "Name": "HowickMaker",
+      "Version": "0.4.1",
+      "ReferenceType": "Package",
+      "Nodes": [
+        "aeb3e5df26cc4f16af55bf0baef46ae1"
+      ]
+    },
+    {
+      "Name": "Dynamo Samples",
+      "Version": "2.0.0",
+      "ReferenceType": "Package",
+      "Nodes": [
+        "5de408d41309424ea9ab0a9a57011168"
+      ]
+    }
+  ],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.0.6521",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "hMember.ByLineVector",
+        "Id": "aeb3e5df26cc4f16af55bf0baef46ae1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 39.256060510822806,
+        "Y": 268.69482120487669
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Drop Down Example",
+        "Id": "5de408d41309424ea9ab0a9a57011168",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 493.04874262470372,
+        "Y": 283.18790496760249
+      }
+    ],
+    "Annotations": [],
+    "X": 82.818344906128914,
+    "Y": 51.13140818532122,
+    "Zoom": 0.82346504096947037
+  }
+}


### PR DESCRIPTION
### Purpose

This PR is to improve the warning message shown on the unresolved dummy nodes. 
Task: https://jira.autodesk.com/browse/DYN-2149

The description of the node is shown when the user hovers on the node. When the node is of type 'unresolved', a warning message is shown that specifies the function name. 

Before this change, the message was:

![previous](https://user-images.githubusercontent.com/43763136/66630091-8135f500-ebd1-11e9-826e-03032f71acb4.png)

After this change, 

<img width="348" alt="Screen Shot 2019-10-11 at 2 48 16 AM" src="https://user-images.githubusercontent.com/43763136/66630154-9d399680-ebd1-11e9-8e18-cab7e01cea2c.png">

The assembly name is not stored in the object so instead we show the whole function name(along with the namespace).

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@DynamoDS/dynamo 



