### PR TITLE
Adding [Test] attribute to one of the tests that was missed.

### DIFF
--- a/test/DynamoCoreTests/DummyNodeTests.cs
+++ b/test/DynamoCoreTests/DummyNodeTests.cs
@@ -117,6 +117,8 @@ namespace Dynamo.Tests
             Assert.AreEqual(1, exceptionCount);
             AppDomain.CurrentDomain.AssemblyResolve -= handler;
         }
+
+        [Test]
         public void ResolveDummyNodesOnDownloadingPackage()
         {
             string path = Path.Combine(TestDirectory, @"core\packageDependencyTests\ResolveDummyNodesOnDownloadingPackage.dyn");


### PR DESCRIPTION
### Purpose

One of the tests was missing a [Test] attribute and added it now to the test fixture. This was passing before the https://github.com/DynamoDS/Dynamo/pull/10011 was merged. Triggered the self-serve again just to be sure. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

