### PR TITLE
try adding more fuzz time based on test runtime

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
+++ b/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
@@ -30,8 +30,15 @@ namespace DynamoPerformanceTests
 
         internal static ComparisonResultState DefaultBenchmarkComparison(BenchmarkComparison comparisonData)
         {
-            //if the change in mean time
-            if (comparisonData.MeanDelta > 10)
+            //assumes times are in ms
+            //if the mean delta is greater than 10 + (scaled and inverted baseMean)
+            //then fail.
+            //This adds a larger fuzz factor for those tests with small run times.
+            //EX. test with runtime of 100ms will yeild fuzz factor of 10 + 1000/100 = 20%
+            //EX. test with runtime of 1000ms will yeild fuzz factor of 10 + 1000/1000 = 11%
+            //This attempts to deal with test failures that have very small runtimes which are 
+            //more susceptible to uncontrollable operating system or machine workloads.
+            if (comparisonData.MeanDelta > (10 + (1000/comparisonData.BaseResult.Mean)))
             {
                 return ComparisonResultState.FAIL;
             }


### PR DESCRIPTION
### Purpose
This PR adds a fuzz factor the performance tests based on their mean time in the baseline data - smaller runtimes translate to larger fuzz times. This is to handle the case where very small fluctuations in actual time (ms) cause large percentage changes, and the tests fail.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@smangarole 
@reddyashish 
