### PR TITLE
DYN-2226: Graphs with large node quantities cause long delays when setting element bound Revit nodes to update

### DIFF
--- a/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
+++ b/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
@@ -12,4 +12,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ProtoTest")]
 [assembly: InternalsVisibleTo("ProtoTestFx")]
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
+[assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
 

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -49,7 +49,7 @@ namespace ProtoCore
         /// <summary>		
         /// Map from a graph UI node to callsite identifiers. 		
         /// </summary>
-        public Dictionary<Guid, List<CallSite>> NodeToCallsiteObjectMap { get; }
+        internal Dictionary<Guid, List<CallSite>> NodeToCallsiteObjectMap { get; }
         
 #endregion
 
@@ -60,14 +60,11 @@ namespace ProtoCore
             NodeToCallsiteObjectMap = new Dictionary<Guid, List<CallSite>>();
         }
 
-      
 
         /// <summary>
         /// Retrieves an existing instance of a callsite associated with a UID
         /// It creates a new callsite if non was found
         /// </summary>
-        /// <param name="core"></param>
-        /// <param name="uid"></param>
         /// <returns></returns>
         public CallSite GetCallSite(int classScope, string methodName, Executable executable, RuntimeCore runtimeCore)
         {

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -125,7 +125,8 @@ namespace ProtoCore
 
                 CallsiteCache[callsiteID] = csInstance;
                 CallSiteToNodeMap[csInstance.CallSiteID] = topGraphNode.guid;
-                if (NodeToCallsiteIdentifiersMap.TryGetValue(topGraphNode.guid, out var callsiteIDs))
+                List<string> callsiteIDs;
+                if (NodeToCallsiteIdentifiersMap.TryGetValue(topGraphNode.guid, out callsiteIDs))
                 {
                     callsiteIDs.Add(callsiteID);
                 }
@@ -177,14 +178,16 @@ namespace ProtoCore
                     return nodeMap;
             }
 
+            List<string> callsiteIDs;
             foreach (Guid nodeGuid in nodeGuids)
             {
-                if (NodeToCallsiteIdentifiersMap.TryGetValue(nodeGuid, out var callsiteIDs))
+                if (NodeToCallsiteIdentifiersMap.TryGetValue(nodeGuid, out callsiteIDs))
                 {
                     var matchingCallSites = new List<CallSite>();
                     foreach (var id in callsiteIDs)
                     {
-                        if (CallsiteCache.TryGetValue(id, out var callsite))
+                        CallSite callsite;
+                        if (CallsiteCache.TryGetValue(id, out callsite))
                             matchingCallSites.Add(callsite);
                     }
                     nodeMap[nodeGuid] = matchingCallSites;

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -125,6 +125,14 @@ namespace ProtoCore
 
                 CallsiteCache[callsiteID] = csInstance;
                 CallSiteToNodeMap[csInstance.CallSiteID] = topGraphNode.guid;
+                if (NodeToCallsiteIdentifiersMap.TryGetValue(topGraphNode.guid, out var callsiteIDs))
+                {
+                    callsiteIDs.Add(callsiteID);
+                }
+                else
+                {
+                    NodeToCallsiteIdentifiersMap[topGraphNode.guid] = new List<string>() { callsiteID };
+                }
             }
 
             if (graphNode != null && !CoreUtils.IsDisposeMethod(methodName))

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -46,13 +46,18 @@ namespace ProtoCore
         /// Map from a callsite's guid to a graph UI node. 		
         /// </summary>
         public Dictionary<Guid, Guid> CallSiteToNodeMap { get; }
- 		 
- #endregion
+        /// <summary>		
+        /// Map from a graph UI node to callsite identifiers. 		
+        /// </summary>
+        public Dictionary<Guid, List<string>> NodeToCallsiteIdentifiersMap { get; }
+        
+#endregion
 
         public RuntimeData()
         {
             CallsiteCache = new Dictionary<string, CallSite>();
             CallSiteToNodeMap = new Dictionary<Guid, Guid>();
+            NodeToCallsiteIdentifiersMap = new Dictionary<Guid, List<string>>();
         }
 
       

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -145,8 +145,15 @@ namespace ProtoCore
             return csInstance;
         }
 
-        public Dictionary<Guid, List<CallSite>>
-        GetCallsitesForNodes(IEnumerable<Guid> nodeGuids, Executable executable)
+        /// <summary>
+        /// This API is used by host integrations such as for Revit and C3D.
+        /// It is used to gets the trace data list for all nodes binding to elements in the host.
+        /// </summary>
+        /// <param name="nodeGuids"></param>
+        /// <param name="executable"></param>
+        /// <returns></returns>
+        public Dictionary<Guid, List<CallSite>> GetCallsitesForNodes(
+            IEnumerable<Guid> nodeGuids, Executable executable)
         {
             if (nodeGuids == null)
                 throw new ArgumentNullException("nodeGuids");

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -159,25 +159,6 @@ namespace ProtoCore
             if (!nodeGuids.Any()) // Nothing to persist now.
                 return nodeMap;
 
-            // Attempt to get the list of graph node if one exists.
-            IEnumerable<GraphNode> graphNodes = null;
-            {
-                if (executable != null)
-                {
-                    var stream = executable.instrStreamList;
-                    if (stream != null && (stream.Length > 0))
-                    {
-                        var graph = stream[0].dependencyGraph;
-                        if (graph != null)
-                            graphNodes = graph.GraphList;
-                    }
-                }
-
-
-                if (graphNodes == null) // No execution has taken place.
-                    return nodeMap;
-            }
-
             List<string> callsiteIDs;
             foreach (Guid nodeGuid in nodeGuids)
             {

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -179,20 +179,20 @@ namespace ProtoCore
 
             foreach (Guid nodeGuid in nodeGuids)
             {
-                // Get a list of GraphNode objects that correspond to this node.
-                var matchingGraphNodes = graphNodes.Where(gn => gn.guid == nodeGuid);
-
-                if (!matchingGraphNodes.Any())
-                    continue;
-
-                // Get all callsites that match the graph node ids.
-                var matchingCallSites = (from cs in CallsiteCache
-                                         from gn in matchingGraphNodes
-                                         where string.Equals(cs.Key, gn.CallsiteIdentifier)
-                                         select cs.Value);
-
-                // Append each callsite element under node element.
-                nodeMap[nodeGuid] = matchingCallSites.ToList();
+                if (NodeToCallsiteIdentifiersMap.TryGetValue(nodeGuid, out var callsiteIDs))
+                {
+                    var matchingCallSites = new List<CallSite>();
+                    foreach (var id in callsiteIDs)
+                    {
+                        if (CallsiteCache.TryGetValue(id, out var callsite))
+                            matchingCallSites.Add(callsite);
+                    }
+                    nodeMap[nodeGuid] = matchingCallSites;
+                }
+                else
+                {
+                    nodeMap[nodeGuid] = new List<CallSite>();
+                }
             }
 
             return nodeMap;

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -49,7 +49,7 @@ namespace ProtoCore
         /// <summary>		
         /// Map from a graph UI node to callsite identifiers. 		
         /// </summary>
-        public Dictionary<Guid, List<string>> NodeToCallsiteIdentifiersMap { get; }
+        public Dictionary<Guid, List<CallSite>> NodeToCallsiteObjectMap { get; }
         
 #endregion
 
@@ -57,7 +57,7 @@ namespace ProtoCore
         {
             CallsiteCache = new Dictionary<string, CallSite>();
             CallSiteToNodeMap = new Dictionary<Guid, Guid>();
-            NodeToCallsiteIdentifiersMap = new Dictionary<Guid, List<string>>();
+            NodeToCallsiteObjectMap = new Dictionary<Guid, List<CallSite>>();
         }
 
       
@@ -125,14 +125,14 @@ namespace ProtoCore
 
                 CallsiteCache[callsiteID] = csInstance;
                 CallSiteToNodeMap[csInstance.CallSiteID] = topGraphNode.guid;
-                List<string> callsiteIDs;
-                if (NodeToCallsiteIdentifiersMap.TryGetValue(topGraphNode.guid, out callsiteIDs))
+                List<CallSite> callsites;
+                if (NodeToCallsiteObjectMap.TryGetValue(topGraphNode.guid, out callsites))
                 {
-                    callsiteIDs.Add(callsiteID);
+                    callsites.Add(csInstance);
                 }
                 else
                 {
-                    NodeToCallsiteIdentifiersMap[topGraphNode.guid] = new List<string>() { callsiteID };
+                    NodeToCallsiteObjectMap[topGraphNode.guid] = new List<CallSite>() { csInstance };
                 }
             }
 
@@ -159,19 +159,12 @@ namespace ProtoCore
             if (!nodeGuids.Any()) // Nothing to persist now.
                 return nodeMap;
 
-            List<string> callsiteIDs;
+            List<CallSite> callsites;
             foreach (Guid nodeGuid in nodeGuids)
             {
-                if (NodeToCallsiteIdentifiersMap.TryGetValue(nodeGuid, out callsiteIDs))
+                if (NodeToCallsiteObjectMap.TryGetValue(nodeGuid, out callsites))
                 {
-                    var matchingCallSites = new List<CallSite>();
-                    foreach (var id in callsiteIDs)
-                    {
-                        CallSite callsite;
-                        if (CallsiteCache.TryGetValue(id, out callsite))
-                            matchingCallSites.Add(callsite);
-                    }
-                    nodeMap[nodeGuid] = matchingCallSites;
+                    nodeMap[nodeGuid] = callsites;
                 }
                 else
                 {

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2774,8 +2774,8 @@ namespace DynamoCoreWpfTests
         [Test, RequiresSTA]
         public void TestNodeToCallsitesObjMapModifyInputConnection()
         {
-            Guid callsiteIdentifierFirstCall = new Guid();
-            Guid callsiteIdentifierSecondCall = new Guid();
+            Guid callsiteIdFirstCall = new Guid();
+            Guid callsiteIdSecondCall = new Guid();
             Guid functionCallNodeGuid = new Guid("16e960e5-8a24-44e7-ac81-3759aaf11d25");
 
             preloadGeometry = true;
@@ -2795,10 +2795,10 @@ namespace DynamoCoreWpfTests
                     // There must only be 1 callsite at this point
                     Assert.AreEqual(1, callSites.Count);
 
-                    // Get the callsite identifier string
+                    // Get the callsite id
                     foreach (var cs in callSites)
                     {
-                        callsiteIdentifierFirstCall = cs.CallSiteID;
+                        callsiteIdFirstCall = cs.CallSiteID;
                     }
                 }
                 else if (commandTag == "ModifyX_SecondTime")
@@ -2811,18 +2811,18 @@ namespace DynamoCoreWpfTests
                     bool containsNodeGuid = core.RuntimeData.NodeToCallsiteObjectMap.TryGetValue(functionCallNodeGuid, out callSites);
                     Assert.AreEqual(true, containsNodeGuid);
 
-                    // There must only be 1 callsite at this point
+                    // There must still only be 1 callsite at this point
                     Assert.AreEqual(1, callSites.Count);
 
-                    // Get the callsite identifier string
+                    // Get the callsite id
                     foreach (var cs in callSites)
                     {
-                        callsiteIdentifierSecondCall = cs.CallSiteID;
+                        callsiteIdSecondCall = cs.CallSiteID;
                     }
 
                     // The callsite guid must match 
                     // This means that that the callsite was cached and reused
-                    Assert.AreEqual(callsiteIdentifierFirstCall, callsiteIdentifierSecondCall);
+                    Assert.AreEqual(callsiteIdFirstCall, callsiteIdSecondCall);
                 }
 
             });

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2771,6 +2771,61 @@ namespace DynamoCoreWpfTests
         }
 
         [Test, RequiresSTA]
+        public void TestNodeToCallsiteIdentifierMapModifyInputConnection()
+        {
+            string callsiteIdentifierFirstCall = "";
+            string callsiteIdentifierSecondCall = "";
+            Guid functionCallNodeGuid = new Guid("16e960e5-8a24-44e7-ac81-3759aaf11d25");
+
+            preloadGeometry = true;
+            RunCommandsFromFile("TestCallsiteMapModifyModifyInputConnection.xml", (commandTag) =>
+            {
+                ProtoCore.RuntimeCore core = ViewModel.Model.EngineController.LiveRunnerRuntimeCore;
+                if (commandTag == "ModifyX_FirstTime")
+                {
+                    // There must only be 1 node at this point
+                    Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteIdentifiersMap.Count);
+
+                    // Verify that the nodemap contains the node guid
+                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out List<string> indentifiers);
+                    Assert.AreEqual(true, containsNodeGuid);
+
+                    // There must only be 1 callsite at this point
+                    Assert.AreEqual(1, indentifiers.Count);
+
+                    // Get the callsite identifier string
+                    foreach (var id in indentifiers)
+                    {
+                        callsiteIdentifierFirstCall = id;
+                    }
+                }
+                else if (commandTag == "ModifyX_SecondTime")
+                {
+                    // There must only be 1 callsite at this point
+                    Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteIdentifiersMap.Count);
+
+                    // Verify that the nodemap contains the node guid
+                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out List<string> indentifiers);
+                    Assert.AreEqual(true, containsNodeGuid);
+
+                    // There must only be 1 callsite at this point
+                    Assert.AreEqual(1, indentifiers.Count);
+
+                    // Get the callsite identifier string
+                    foreach (var id in indentifiers)
+                    {
+                        callsiteIdentifierSecondCall = id;
+                    }
+
+                    // The callsite guid must match 
+                    // This means that that the callsite was cached and reused
+                    Assert.AreEqual(callsiteIdentifierFirstCall, callsiteIdentifierSecondCall);
+                }
+
+            });
+        }
+
+        [Test, RequiresSTA]
         [Category("RegressionTests")]
 
         //Details for steps can be found in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2521

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -21,6 +21,7 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using DynamoShapeManager;
 using NUnit.Framework;
+using ProtoCore;
 using PythonNodeModels;
 using SystemTestServices;
 using TestServices;
@@ -2771,10 +2772,10 @@ namespace DynamoCoreWpfTests
         }
 
         [Test, RequiresSTA]
-        public void TestNodeToCallsiteIdentifierMapModifyInputConnection()
+        public void TestNodeToCallsitesObjMapModifyInputConnection()
         {
-            string callsiteIdentifierFirstCall = "";
-            string callsiteIdentifierSecondCall = "";
+            Guid callsiteIdentifierFirstCall = new Guid();
+            Guid callsiteIdentifierSecondCall = new Guid();
             Guid functionCallNodeGuid = new Guid("16e960e5-8a24-44e7-ac81-3759aaf11d25");
 
             preloadGeometry = true;
@@ -2784,39 +2785,39 @@ namespace DynamoCoreWpfTests
                 if (commandTag == "ModifyX_FirstTime")
                 {
                     // There must only be 1 node at this point
-                    Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteIdentifiersMap.Count);
+                    Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteObjectMap.Count);
 
                     // Verify that the map contains the node guid
-                    List<string> indentifiers;
-                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out indentifiers);
+                    List<CallSite> callSites;
+                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteObjectMap.TryGetValue(functionCallNodeGuid, out callSites);
                     Assert.AreEqual(true, containsNodeGuid);
 
                     // There must only be 1 callsite at this point
-                    Assert.AreEqual(1, indentifiers.Count);
+                    Assert.AreEqual(1, callSites.Count);
 
                     // Get the callsite identifier string
-                    foreach (var id in indentifiers)
+                    foreach (var cs in callSites)
                     {
-                        callsiteIdentifierFirstCall = id;
+                        callsiteIdentifierFirstCall = cs.CallSiteID;
                     }
                 }
                 else if (commandTag == "ModifyX_SecondTime")
                 {
                     // There must only be 1 callsite at this point
-                    Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteIdentifiersMap.Count);
+                    Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteObjectMap.Count);
 
                     // Verify that the map contains the node guid
-                    List<string> indentifiers;
-                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out indentifiers);
+                    List<CallSite> callSites;
+                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteObjectMap.TryGetValue(functionCallNodeGuid, out callSites);
                     Assert.AreEqual(true, containsNodeGuid);
 
                     // There must only be 1 callsite at this point
-                    Assert.AreEqual(1, indentifiers.Count);
+                    Assert.AreEqual(1, callSites.Count);
 
                     // Get the callsite identifier string
-                    foreach (var id in indentifiers)
+                    foreach (var cs in callSites)
                     {
-                        callsiteIdentifierSecondCall = id;
+                        callsiteIdentifierSecondCall = cs.CallSiteID;
                     }
 
                     // The callsite guid must match 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2786,8 +2786,9 @@ namespace DynamoCoreWpfTests
                     // There must only be 1 node at this point
                     Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteIdentifiersMap.Count);
 
-                    // Verify that the nodemap contains the node guid
-                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out List<string> indentifiers);
+                    // Verify that the map contains the node guid
+                    List<string> indentifiers;
+                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out indentifiers);
                     Assert.AreEqual(true, containsNodeGuid);
 
                     // There must only be 1 callsite at this point
@@ -2804,8 +2805,9 @@ namespace DynamoCoreWpfTests
                     // There must only be 1 callsite at this point
                     Assert.AreEqual(1, core.RuntimeData.NodeToCallsiteIdentifiersMap.Count);
 
-                    // Verify that the nodemap contains the node guid
-                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out List<string> indentifiers);
+                    // Verify that the map contains the node guid
+                    List<string> indentifiers;
+                    bool containsNodeGuid = core.RuntimeData.NodeToCallsiteIdentifiersMap.TryGetValue(functionCallNodeGuid, out indentifiers);
                     Assert.AreEqual(true, containsNodeGuid);
 
                     // There must only be 1 callsite at this point


### PR DESCRIPTION
### Purpose

The purpose of this PR is to address a slow down observed in Dynamo graphs with large node quantities when Dynamo4Revit is responding to Document Change events in Revit.  The specific flaw begins when the event handler [`RevitServicesUpdater_ElementsUpdated()`](https://github.com/DynamoDS/DynamoRevit/blob/4cc183fb6eb7db13e29cf2d04192df499961a8b9/src/DynamoRevit/Models/RevitDynamoModel.cs#L871) in D4R responds to the Document Change events.  It filters for transactions originating from Dynamo then passes the associated Element Id's to [`GetNodesFromElementIds()`](https://github.com/DynamoDS/DynamoRevit/blob/4cc183fb6eb7db13e29cf2d04192df499961a8b9/src/Libraries/RevitServices/Persistence/ElementBinder.cs#L464) in the `ElementBinder`.  This method calls `GetCallsitesForNodes()` in DynamoCore to find the associated Callsites for the nodes in the Graph.   This lookup can be **extremely** slow due to a series of nested loops.  This PR address the slowdown by processing the lookup with a pre-populated dictionary mapping the node Guids to Callsite Identifiers as the existing Callsite Cache dictionary.  The runtime difference for our sample graph with 456 nodes was 23sec to ~20ms.  

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner assign to whoever you want

### FYIs

@Dewb @QilongTang 
