### PR TITLE
[DNM] Draft approach to add clickable links to error bubbles

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -80,6 +80,13 @@ namespace Dynamo.ViewModels
             set { content = value; RaisePropertyChanged("Content"); }
         }
 
+        private Uri errorMessagesLink;
+        public Uri ErrorMessagesLink
+        {
+            get { return errorMessagesLink; }
+            set { errorMessagesLink = value; RaisePropertyChanged(nameof(ErrorMessagesLink)); }
+        }
+
         public Point targetTopLeft;
         public Point TargetTopLeft
         {
@@ -141,6 +148,7 @@ namespace Dynamo.ViewModels
             limitedDirection = Direction.None;
             ConnectingDirection = Direction.None;
             Content = string.Empty;
+            ErrorMessagesLink = null;
             ZIndex = 3;
             InfoBubbleStyle = Style.None;
             InfoBubbleState = State.Minimized;
@@ -159,6 +167,7 @@ namespace Dynamo.ViewModels
             UpdateContent(data.Text);
             TargetTopLeft = data.TopLeft;
             TargetBotRight = data.BotRight;
+            ErrorMessagesLink = data.Link;
         }
 
         private bool CanUpdateInfoBubbleCommand(object parameter)
@@ -271,27 +280,49 @@ namespace Dynamo.ViewModels
                     Content = FullContent;
                     break;
             }
-        }        
-
+        }    
         #endregion
     }
 
     public struct InfoBubbleDataPacket
     {
+        private const string externalLinkIdentifier = "href=";
         public InfoBubbleViewModel.Style Style;
         public Point TopLeft;
         public Point BotRight;
         public string Text;
+        public Uri Link;
         public InfoBubbleViewModel.Direction ConnectingDirection;
 
-        public InfoBubbleDataPacket(InfoBubbleViewModel.Style style, Point topLeft, Point botRight,
-            string text, InfoBubbleViewModel.Direction connectingDirection)
+        public InfoBubbleDataPacket(
+            InfoBubbleViewModel.Style style,
+            Point topLeft,
+            Point botRight,
+            string text,
+            InfoBubbleViewModel.Direction connectingDirection)
         {
             Style = style;
             TopLeft = topLeft;
             BotRight = botRight;
+            Link = CheckIfMessageHasHrefLinkAndExtract(ref text);
             Text = text;
             ConnectingDirection = connectingDirection;
+        }
+
+
+        //Check if has link
+        private static Uri CheckIfMessageHasHrefLinkAndExtract(ref string text)
+        {
+            // if there is no link, we do nothing
+            if (!text.Contains(externalLinkIdentifier)) return null;
+
+            string[] split = text.Split(new string[] { externalLinkIdentifier }, StringSplitOptions.None);
+            if (split.Length <= 1) return null;
+
+            var link = string.IsNullOrWhiteSpace(split[1]) ? null : new Uri(split[1]);
+            text = split[0]; // works ?
+
+            return link;
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
+using System.Windows.Navigation;
 using System.Windows.Shapes;
 using Dynamo.Configuration;
 using Dynamo.UI;
@@ -437,9 +440,22 @@ namespace Dynamo.Controls
                 {
                     content = Wpf.Properties.Resources.InfoBubbleError + content;
                 }
+
                 TextBox textBox = GetNewTextBox(content);
                 ContentContainer.Children.Add(textBox);
+
+                if (viewModel.ErrorMessagesLink != null)
+                {
+                    TextBlock linkBlock = GetNewHyperlinkTextBlock(viewModel.ErrorMessagesLink);
+                    ContentContainer.Children.Add(linkBlock);
+                }
             }
+        }
+
+        private void Link_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            e.Handled = true;
         }
 
         private TextBox GetNewTextBox(string text)
@@ -471,6 +487,34 @@ namespace Dynamo.Controls
             return textBox;
         }
 
+        private TextBlock GetNewHyperlinkTextBlock(Uri uri)
+        {
+            TextBlock linkBlock = new TextBlock();
+            linkBlock.TextWrapping = TextWrapping.Wrap;
+
+            linkBlock.Margin = ContentMargin;
+            linkBlock.MaxHeight = ContentMaxHeight;
+            linkBlock.MaxWidth = ContentMaxWidth;
+
+            linkBlock.Foreground = ContentForeground;
+            linkBlock.FontWeight = ContentFontWeight;
+            linkBlock.FontSize = ContentFontSize;
+
+            var font = SharedDictionaryManager.DynamoModernDictionary["OpenSansRegular"];
+            linkBlock.FontFamily = font as FontFamily;
+
+            linkBlock.Background = Brushes.Transparent;
+            linkBlock.HorizontalAlignment = HorizontalAlignment.Center;
+            linkBlock.VerticalAlignment = VerticalAlignment.Center;
+
+            Hyperlink link = new Hyperlink();
+            link.NavigateUri = uri;
+            link.RequestNavigate += Link_RequestNavigate;
+            link.Inlines.Add("Read more...");
+            linkBlock.Inlines.Add(link);
+
+            return linkBlock;
+        }
         #endregion
 
         #region Update Shape

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace ProtoCore.Properties
-{
-
-
+namespace ProtoCore.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,7 +19,7 @@ namespace ProtoCore.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -971,7 +971,7 @@ namespace ProtoCore.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List indices must be numeric..
+        ///   Looks up a localized string similar to List indices must be numeric. href=https://dictionary.dynamobim.com/#/Revit/Schedules/ScheduleFilter/Create/ByFieldTypeAndValue.
         /// </summary>
         public static string InvalidArrayIndexType {
             get {
@@ -1970,7 +1970,7 @@ namespace ProtoCore.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} expects argument type(s) ({1}), but was called with ({2})..
+        ///   Looks up a localized string similar to {0} expects argument type(s) ({1}), but was called with ({2}). href=https://dictionary.dynamobim.com/#/BuiltIn/Action/AllFalse.
         /// </summary>
         public static string NonOverloadMethodResolutionError {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -927,13 +927,13 @@ Parameter name: {0}</value>
     <value>Variable {0} is used in the same statement that you defined it. Recursive dependency is not allowed.</value>
   </data>
   <data name="InvalidArrayIndexType" xml:space="preserve">
-    <value>List indices must be numeric.</value>
+    <value>List indices must be numeric. href=https://dictionary.dynamobim.com/#/Revit/Schedules/ScheduleFilter/Create/ByFieldTypeAndValue</value>
   </data>
   <data name="FailedToConvertArrayToDictionary" xml:space="preserve">
     <value>Cannot convert List to Dictionary type.</value>
   </data>
   <data name="NonOverloadMethodResolutionError" xml:space="preserve">
-    <value>{0} expects argument type(s) ({1}), but was called with ({2}).</value>
+    <value>{0} expects argument type(s) ({1}), but was called with ({2}). href=https://dictionary.dynamobim.com/#/BuiltIn/Action/AllFalse</value>
   </data>
   <data name="DeprecatedListInitializationSyntax" xml:space="preserve">
     <value>Curly braces are no longer used for list creation. Use square brackets instead, like [] or [1,2,3].</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -930,13 +930,13 @@ Parameter name: {0}</value>
     <value>Variable {0} is used in the same statement that you defined it. Recursive dependency is not allowed.</value>
   </data>
   <data name="InvalidArrayIndexType" xml:space="preserve">
-    <value>List indices must be numeric.</value>
+    <value>List indices must be numeric. href=https://dictionary.dynamobim.com/#/Revit/Schedules/ScheduleFilter/Create/ByFieldTypeAndValue</value>
   </data>
   <data name="FailedToConvertArrayToDictionary" xml:space="preserve">
     <value>Cannot convert List to Dictionary type.</value>
   </data>
   <data name="NonOverloadMethodResolutionError" xml:space="preserve">
-    <value>{0} expects argument type(s) ({1}), but was called with ({2}).</value>
+    <value>{0} expects argument type(s) ({1}), but was called with ({2}). href=https://dictionary.dynamobim.com/#/BuiltIn/Action/AllFalse</value>
   </data>
   <data name="DeprecatedListInitializationSyntax" xml:space="preserve">
     <value>Curly braces are no longer used for list creation. Use square brackets instead, like [] or [1,2,3].</value>


### PR DESCRIPTION
### Purpose

Showcases a prototype approach to add clickable links to error bubbles

![errorbubble_link](https://user-images.githubusercontent.com/13732445/67765976-51964200-fa45-11e9-99e3-a5715f8b413b.gif)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@radumg 

### FYIs

@alvpickmans