### PR TITLE
Save all workspaces after Dynamo crashes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1488,7 +1488,7 @@ namespace Dynamo.ViewModels
         /// <param name="isBackup">Indicates if an automated backup save has called this function.</param>
         /// <exception cref="IOException"></exception>
         /// <exception cref="UnauthorizedAccessException"></exception>
-        public void SaveAs(Guid id, string path, bool isBackup = false)
+        internal void SaveAs(Guid id, string path, bool isBackup = false)
         {
             try
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1465,9 +1465,7 @@ namespace Dynamo.ViewModels
             try
             {
                 Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
-
                 CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController);
-
                 if(!isBackup) AddToRecentFiles(path);
             }
             catch (Exception ex)
@@ -1480,7 +1478,34 @@ namespace Dynamo.ViewModels
             }
         }
 
-        
+        /// <summary>
+        /// Save the current workspace to a specific file path. If the file path is null or empty, an
+        /// exception is written to the console.
+        /// </summary>
+        /// <param name="id">Indicate the id of target workspace view model instead of defaulting to 
+        /// current workspace view model. This is critical in crash cases.</param>
+        /// <param name="path">The path to the file.</param>
+        /// <param name="isBackup">Indicates if an automated backup save has called this function.</param>
+        /// <exception cref="IOException"></exception>
+        /// <exception cref="UnauthorizedAccessException"></exception>
+        public void SaveAs(Guid id, string path, bool isBackup = false)
+        {
+            try
+            {
+                Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
+                Workspaces.Where(w => w.Model.Guid == id).FirstOrDefault().Save(path, isBackup, Model.EngineController);
+                if (!isBackup) AddToRecentFiles(path);
+            }
+            catch (Exception ex)
+            {
+                Model.Logger.Log(ex.Message);
+                Model.Logger.Log(ex.StackTrace);
+
+                if (ex is IOException || ex is UnauthorizedAccessException)
+                    System.Windows.MessageBox.Show(String.Format(ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Warning));
+            }
+        }
+
         /// <summary>
         ///     Attempts to save a given workspace.  Shows a save as dialog if the 
         ///     workspace does not already have a path associated with it
@@ -1492,21 +1517,18 @@ namespace Dynamo.ViewModels
             // crash should always allow save as
             if (!String.IsNullOrEmpty(workspace.FileName) && !DynamoModel.IsCrashing)
             {
-                SaveAs(workspace.FileName);
+                SaveAs(workspace.Guid, workspace.FileName);
                 return true;
             }
             else
             {
-                //TODO(ben): We still add a cancel button to the save dialog if we're crashing
-                // sadly it's not usually possible to cancel a crash
-
                 var fd = this.GetSaveDialog(workspace);
-                // since the workspace file directory is null, we set the initial directory
+                // Since the workspace file directory is null, we set the initial directory
                 // for the file to be MyDocument folder in the local computer. 
                 fd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                 if (fd.ShowDialog() == DialogResult.OK)
                 {
-                    SaveAs(fd.FileName);
+                    SaveAs(workspace.Guid, fd.FileName);
                     return true;
                 }
             }

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -576,6 +576,44 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void CanSaveDifferentTargetWorkspace()
+        {
+            // get empty workspace
+            var dynamoModel = ViewModel.Model;
+            Assert.IsNotNull(dynamoModel.CurrentWorkspace);
+            Assert.AreEqual("Home", ViewModel.Model.CurrentWorkspace.Name);
+
+            // get file path and name of file
+            var filePath = GetNewFileNameOnTempPath("dyn");
+            var fileName = Path.GetFileName(filePath);
+            string extension = Path.GetExtension(filePath);
+            if (extension == ".dyn" || extension == ".dyf")
+            {
+                fileName = Path.GetFileNameWithoutExtension(filePath);
+            }
+
+            // Open a dyf which making the current workspace become custom node workspace
+            var originalDyf = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
+            ViewModel.Model.OpenFileFromPath(originalDyf);
+
+            // save Home workspace
+            ViewModel.SaveAs(ViewModel.Workspaces[0].Model.Guid, filePath);
+
+            // save custom node workspace
+            var dyfFilePath = GetNewFileNameOnTempPath("dyf");
+            ViewModel.SaveAs(ViewModel.Workspaces[1].Model.Guid, dyfFilePath);
+
+            // Open the serialized files to verify
+            ViewModel.Model.OpenFileFromPath(filePath);
+            // Home workspace name should be file name
+            Assert.AreEqual(fileName, ViewModel.Model.CurrentWorkspace.Name);
+
+            ViewModel.Model.OpenFileFromPath(dyfFilePath);
+            Assert.AreEqual("Constant2", ViewModel.Model.CurrentWorkspace.Name);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void BackUpSaveDoesNotChangeName()
         {
             // get empty workspace


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per user report issue and internal report https://github.com/DynamoDS/Dynamo/issues/8913. Fixing the save workflow after Dynamo crashes. Before this PR, the **Save** and **SaveAs** function both default to the currentworkspace which is not always accurate, but is true in most other cases..

After:
User will have a chance to save each workspace with pending changes
![SaveWorkspacesAfterDynamoCrash](https://user-images.githubusercontent.com/3942418/68347373-b5171400-00c4-11ea-8f06-fd630fe3b485.gif)

Two files should be saved as a result of this crash:
![image](https://user-images.githubusercontent.com/3942418/68347909-636f8900-00c6-11ea-9618-18d5636afbf4.png)




### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Dewb 