### PR TITLE
DYN-2273 - Fix crash by compiling null input to null AST node

### DIFF
--- a/src/DynamoCore/Engine/CodeGeneration/AstBuilder.cs
+++ b/src/DynamoCore/Engine/CodeGeneration/AstBuilder.cs
@@ -191,11 +191,7 @@ namespace Dynamo.Engine.CodeGeneration
                     NodeModel inputModel = inputTuple.Item2;
                     AssociativeNode inputNode = inputModel.GetAstIdentifierForOutputIndex(outputIndexOfInput);
 
-                    // If there are any null AST's (for e.g. if there's an error in the input node),
-                    // graph update for the given node is skipped.
-                    Validity.Assert(inputNode != null, "Shouldn't have null nodes in the AST list");
-
-                    inputAstNodes.Add(inputNode);
+                    inputAstNodes.Add(inputNode ?? new NullNode());
                 }
                 else
                 {
@@ -237,7 +233,7 @@ namespace Dynamo.Engine.CodeGeneration
             }
 
 #if DEBUG
-            Validity.Assert(inputAstNodes.All(n => n != null), 
+            Validity.Assert(inputAstNodes.All(n => n != null),
                 "Shouldn't have null nodes in the AST list");
 #endif
 

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -998,6 +998,39 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void UpdateCBNInCustomNodeDef_DoesNotCrash()
+        {
+            var basePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
+
+            OpenModel(Path.Combine(basePath, "cbn_customnode_crash.dyn"));
+
+            // Assert custom node instance executes successfully
+            AssertPreviewValue("12d33f2a354a4e65ac06a3c783a7e679", "this is a custom node");
+
+            var customWorkspace = CurrentDynamoModel.CustomNodeManager.LoadedWorkspaces.FirstOrDefault(x => x != null);
+
+            // Navigate to custom node workspace
+            CurrentDynamoModel.AddWorkspace(customWorkspace);
+
+            // Extract cbn from custom node WS
+            var cbn = customWorkspace.Nodes.FirstOrDefault(x => x is CodeBlockNodeModel) as CodeBlockNodeModel;
+
+            // Edit CBN in custom node definition to introduce syntax error,
+            // update custom node definition and re-execute 
+            Assert.DoesNotThrow(() =>
+            {
+                CurrentDynamoModel.ExecuteCommand(
+                    new DynamoModel.UpdateModelValueCommand(
+                        customWorkspace.Guid,
+                        cbn.GUID,
+                        "Code",
+                        "1...10"));
+            });
+
+            AssertPreviewValue("12d33f2a-354a-4e65-ac06-a3c783a7e679", null);
+        }
+
+        [Test]
         public void TestGroupsOnCustomNodes()
         {
             string openPath = Path.Combine(TestDirectory, @"core\collapse\collapse.dyn");

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -23,7 +23,6 @@ using DynamoShapeManager;
 using NUnit.Framework;
 using PythonNodeModels;
 using SystemTestServices;
-using CoreNodeModels;
 using TestServices;
 using IntegerSlider = CoreNodeModels.Input.IntegerSlider;
 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -23,6 +23,7 @@ using DynamoShapeManager;
 using NUnit.Framework;
 using PythonNodeModels;
 using SystemTestServices;
+using CoreNodeModels;
 using TestServices;
 using IntegerSlider = CoreNodeModels.Input.IntegerSlider;
 
@@ -5614,6 +5615,8 @@ namespace DynamoCoreWpfTests
                     Assert.IsNotNull(node);
                     Assert.IsTrue(node.IsInErrorState);
                     Assert.AreEqual(1, node.AllConnectors.Count());
+
+                    AssertPreviewValue("44115db6-bf0b-478a-90f6-2719eb65b70d", null);
                 }
             });
         }

--- a/test/core/CustomNodes/cbn_customnode_crash.dyf
+++ b/test/core/CustomNodes/cbn_customnode_crash.dyf
@@ -1,0 +1,113 @@
+{
+  "Uuid": "02464870-e36f-4b00-b9c5-390b72339821",
+  "IsCustomNode": true,
+  "Category": "Test",
+  "Description": "",
+  "Name": "cbn_customnode_crash",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"this is a custom node\";",
+      "Id": "7cd8efe791994faa9f54ab308421df12",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "85973fe62ed0483da3c8181c85299050",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "",
+      "Id": "54eec7da789b4e8db824e0a829c62c85",
+      "Inputs": [
+        {
+          "Id": "e7a8c6bc05aa413297514da41776ae34",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "85973fe62ed0483da3c8181c85299050",
+      "End": "e7a8c6bc05aa413297514da41776ae34",
+      "Id": "cd9ca725bd2b405fb92b78a02a655dd3"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.0.6797",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "7cd8efe791994faa9f54ab308421df12",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 250.0,
+        "Y": 0.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "54eec7da789b4e8db824e0a829c62c85",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 553.0,
+        "Y": 0.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/CustomNodes/cbn_customnode_crash.dyn
+++ b/test/core/CustomNodes/cbn_customnode_crash.dyn
@@ -1,0 +1,78 @@
+{
+  "Uuid": "55c196e1-8972-4a4d-907e-608fd66455a8",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "cbn_customnode_crash",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "02464870-e36f-4b00-b9c5-390b72339821",
+      "FunctionType": "Graph",
+      "NodeType": "FunctionNode",
+      "Id": "12d33f2a354a4e65ac06a3c783a7e679",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d3f9c2bcdeff4edca78420fe1397bc7e",
+          "Name": "",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": ""
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [
+    "02464870-e36f-4b00-b9c5-390b72339821"
+  ],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.0.6797",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "cbn_customnode_crash",
+        "Id": "12d33f2a354a4e65ac06a3c783a7e679",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 326.0,
+        "Y": 252.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/DYN-2273

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
