### PR TITLE
[WIP] AGD-1239: Sync filename and workspace name on file open

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1686,6 +1686,7 @@ namespace Dynamo.Models
                 CustomNodeManager);
 
             workspace.FileName = filePath;
+            workspace.Name = Path.GetFileNameWithoutExtension(filePath);
             workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
 
             // NOTE: This is to handle the case of opening a JSON file that does not have a version string


### PR DESCRIPTION
### Purpose

The purpose of this PR is to sync the filename with the DYN json `Name` property on file open operations.  Currently this occurs on initial save and saveas operations.  This can get out of sync if the DYN file is renamed in the file system.  

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang

### FYIs

@varvaratou @mjkkirschner 
