### PR TITLE
AGD-1300 Add mechanism for common package directory similar to common definition directory

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -72,6 +72,7 @@ namespace Dynamo.Core
         private readonly string commonDataDir;
 
         private readonly string commonDefinitions;
+        private readonly string commonPackages;
         private readonly string logDirectory;
         private readonly string samplesDirectory;
         private readonly string backupDirectory;
@@ -93,6 +94,11 @@ namespace Dynamo.Core
         private IEnumerable<string> RootDirectories
         {
             get { return Preferences != null ? Preferences.CustomPackageFolders : rootDirectories; }
+        }
+
+        internal string CommonPackageDirectory
+        {
+            get { return commonPackages; }
         }
 
         #region IPathManager Interface Implementation
@@ -344,6 +350,7 @@ namespace Dynamo.Core
             commonDataDir = GetCommonDataFolder(pathResolver);
 
             commonDefinitions = Path.Combine(commonDataDir, DefinitionsDirectoryName);
+            commonPackages = Path.Combine(commonDataDir, PackagesDirectoryName);
             samplesDirectory = GetSamplesFolder(commonDataDir);
             var galleryDirectory = GetGalleryDirectory(commonDataDir);
             galleryFilePath = Path.Combine(galleryDirectory, GalleryContentsFileName);
@@ -390,6 +397,7 @@ namespace Dynamo.Core
             // Common data folders for all users.
             exceptions.Add(PathHelper.CreateFolderIfNotExist(commonDataDir));
             exceptions.Add(PathHelper.CreateFolderIfNotExist(commonDefinitions));
+            exceptions.Add(PathHelper.CreateFolderIfNotExist(commonPackages));
 
             exceptions.RemoveAll(x => x == null); // Remove all null entries.
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -636,6 +636,10 @@ namespace Dynamo.Models
             var userDataFolder = pathManager.GetUserDataFolder(); // Get the default user data path
             AddPackagePath(userDataFolder);
 
+            // Make sure that the global package folder is added in the list
+            var userCommonPackageFolder = pathManager.CommonPackageDirectory;
+            AddPackagePath(userCommonPackageFolder);
+
             // Load Python Template
             // The loading pattern is conducted in the following order
             // 1) Set from DynamoSettings.XML

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -91,7 +91,7 @@ namespace Dynamo.PackageManager
         {
             InitializePackageDirectories(packagesDirectories);
 
-            if (packagesDirectories == null)
+            if (packageDirectoriesToVerify == null)
                 throw new ArgumentNullException("packageDirectoriesToVerify");
 
             this.packagesDirectoriesToVerifyCertificates.AddRange(packageDirectoriesToVerify);

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -370,7 +370,8 @@ namespace Dynamo.PackageManager
                     Directory.EnumerateDirectories(root, "*", SearchOption.TopDirectoryOnly))
                 {
                     
-                    //
+                    // verify if the package directory requires certificate verifications
+                    // This is done by default for the package directory defined in PathManager common directory location.
                     var checkCertificates = false;
                     foreach (var pathToVerifyCert in packagesDirectoriesToVerifyCertificates)
                     {
@@ -416,7 +417,7 @@ namespace Dynamo.PackageManager
                     throw new LibraryLoadFailedException(directory, String.Format(Properties.Resources.NoHeaderPackage, headerPath));
                 }
 
-                // prevent unsigned packages
+                // prevent loading unsigned packages if the certificates are required on package dlls
                 if (checkCertificates)
                 {
                     foreach (var assemFile in (new System.IO.DirectoryInfo(discoveredPkg.BinaryDirectory)).EnumerateFiles("*.dll"))

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -130,7 +130,7 @@ namespace Dynamo.PackageManager
                 throw new ArgumentException("Incorrectly formatted URL provided for Package Manager address.", "url");
             }
 
-            PackageLoader = new PackageLoader(startupParams.PathManager.PackagesDirectories);
+            PackageLoader = new PackageLoader(startupParams.PathManager.PackagesDirectories, new [] {startupParams.PathManager.CommonDataDirectory});
             PackageLoader.MessageLogged += OnMessageLogged;
             PackageLoader.PackgeLoaded += OnPackageLoaded;
             PackageLoader.PackageRemoved += OnPackageRemoved;


### PR DESCRIPTION
### Purpose

The purpose of this PR is to add a mechanism to allow a common package installation directory similar to the common custom node directly already supported in the PathManager.  The common package directly will allow for the installation of packages that are available to all users on a specific machine. This common directory will supplement the current default user package and definitions directories located in user/appdata/...  

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@sm6srw @Dewb 
