### PR TITLE
restore behavior of extension loadNodeLibrary method

### DIFF
--- a/src/DynamoCLI/CommandLineRunner.cs
+++ b/src/DynamoCLI/CommandLineRunner.cs
@@ -103,7 +103,7 @@ namespace DynamoCLI
                 {
                     Console.WriteLine($"attempting to import assembly {path}");
                     var assembly = System.Reflection.Assembly.LoadFile(path);
-                    model.LoadNodeLibrary(assembly);
+                    model.LoadNodeLibrary(assembly,true);
                 }
             }
             catch (Exception e)

--- a/src/DynamoCore/Extensions/ExtensionLibraryLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLibraryLoader.cs
@@ -24,14 +24,28 @@ namespace Dynamo.Extensions
         }
 
         /// <summary>
-        /// Loads the node library.
+        /// Loads a zZeroTouch or NodeModel based node into the VM and search.
+        /// To guarantee the node is correctly added to the LibraryUI this method should not
+        /// be called while LibraryExtension is loading.
         /// </summary>
         /// <param name="library">The library.</param>
         public void LoadNodeLibrary(Assembly library)
         {
-            model.LoadNodeLibrary(library);
+            model.LoadNodeLibrary(library,false);
         }
 
+        //TODO add to ILibraryLoader in 3.0 OR refactor package/zeroTouch import code path.
+        /// <summary>
+        /// Loads a zeroTouch or explicit NodeModel based node into the VM.
+        /// Does not add zeroTouch libraries to Search. Currently only used by package manager extension.
+        /// </summary>
+        /// <param name="library">The library.</param>
+        internal void LoadLibraryAndSuppressZTSearchImport(Assembly library)
+        {
+            model.LoadNodeLibrary(library, true);
+        }
+
+        //TODO add to ILibraryLoader in 3.0
         /// <summary>
         /// Loads packages for import into VM and for node search.
         /// </summary>

--- a/src/DynamoCore/Extensions/ExtensionLibraryLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLibraryLoader.cs
@@ -24,7 +24,7 @@ namespace Dynamo.Extensions
         }
 
         /// <summary>
-        /// Loads a zZeroTouch or NodeModel based node into the VM and search.
+        /// Loads a ZeroTouch or NodeModel based node into the VM and search.
         /// To guarantee the node is correctly added to the LibraryUI this method should not
         /// be called while LibraryExtension is loading.
         /// </summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1252,11 +1252,27 @@ namespace Dynamo.Models
             CustomNodeManager.AddUninitializedCustomNodesInPath(pathManager.CommonDefinitions, IsTestMode);
         }
 
-        internal void LoadNodeLibrary(Assembly assem)
+        /// <summary>
+        /// Imports a node library (zero touch or nodeModel) into the VM.
+        /// Does not necessarily add those imported functions to search.
+        /// </summary>
+        /// <param name="assem">The assembly to load which contains the types to import.</param>
+        /// <param name="suppressZeroTouchLibraryLoad">If True, zero touch types will not be added to search.
+        /// This is used by packageManager extension to defer adding ZT libraries to search until all libraries are loaded.
+        /// </param>
+        internal void LoadNodeLibrary(Assembly assem, bool suppressZeroTouchLibraryLoad)
         {
             if (!NodeModelAssemblyLoader.ContainsNodeModelSubType(assem))
             {
-                LibraryServices.ImportLibrary(assem.Location);
+                if (suppressZeroTouchLibraryLoad)
+                {
+                    LibraryServices.LoadNodeLibrary(assem.Location,false);
+                }
+                else
+                {
+                    LibraryServices.ImportLibrary(assem.Location);
+                }
+               
                 return;
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1257,6 +1257,8 @@ namespace Dynamo.Models
             if (!NodeModelAssemblyLoader.ContainsNodeModelSubType(assem))
             {
                 LibraryServices.LoadNodeLibrary(assem.Location, false);
+                LibraryServices.OnLibrariesImported(new LibraryServices.LibraryLoadedEventArgs(new List<string> { assem.Location }));
+
                 return;
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1256,9 +1256,7 @@ namespace Dynamo.Models
         {
             if (!NodeModelAssemblyLoader.ContainsNodeModelSubType(assem))
             {
-                LibraryServices.LoadNodeLibrary(assem.Location, false);
-                LibraryServices.OnLibrariesImported(new LibraryServices.LibraryLoadedEventArgs(new List<string> { assem.Location }));
-
+                LibraryServices.ImportLibrary(assem.Location);
                 return;
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1260,7 +1260,7 @@ namespace Dynamo.Models
         /// <param name="suppressZeroTouchLibraryLoad">If True, zero touch types will not be added to search.
         /// This is used by packageManager extension to defer adding ZT libraries to search until all libraries are loaded.
         /// </param>
-        internal void LoadNodeLibrary(Assembly assem, bool suppressZeroTouchLibraryLoad)
+        internal void LoadNodeLibrary(Assembly assem, bool suppressZeroTouchLibraryLoad = true)
         {
             if (!NodeModelAssemblyLoader.ContainsNodeModelSubType(assem))
             {

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -281,30 +281,6 @@ namespace Dynamo.Search.SearchElements
             inputParameters.Add(Tuple.Create(String.Empty, Properties.Resources.NoneString));
             return inputParameters;
         }
-
-        // The following methods are overridden so that duplicate nodeSearchElements cannot be added to the 
-        // node library. Even when creating new searchElements if properties of those elements match they are considered
-        // the same entry.
-
-        public override bool Equals(object obj)
-        {
-            if (!(obj is NodeSearchElement)) return false;
-
-            NodeSearchElement nse = (NodeSearchElement)obj;
-            return FullName == nse.FullName 
-                && CreationName == nse.CreationName
-                && Assembly == nse.Assembly
-                && Parameters == nse.Parameters;
-        }
-
-        public override int GetHashCode()
-        {
-            return (FullName?? String.Empty).GetHashCode() ^ 
-                (CreationName?? String.Empty).GetHashCode() ^
-                (Assembly ?? String.Empty).GetHashCode() ^
-                (Parameters ?? String.Empty).GetHashCode();
-        }
-
     }
 
     /// <summary>

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -281,6 +281,20 @@ namespace Dynamo.Search.SearchElements
             inputParameters.Add(Tuple.Create(String.Empty, Properties.Resources.NoneString));
             return inputParameters;
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is NodeSearchElement)) return false;
+
+            NodeSearchElement nse = (NodeSearchElement)obj;
+            return CreationName == nse.CreationName && Assembly == nse.Assembly;
+        }
+
+        public override int GetHashCode()
+        {
+            return CreationName.GetHashCode() ^ Assembly.GetHashCode();
+        }
+
     }
 
     /// <summary>

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -282,17 +282,27 @@ namespace Dynamo.Search.SearchElements
             return inputParameters;
         }
 
+        // The following methods are overridden so that duplicate nodeSearchElements cannot be added to the 
+        // node library. Even when creating new searchElements if properties of those elements match they are considered
+        // the same entry.
+
         public override bool Equals(object obj)
         {
             if (!(obj is NodeSearchElement)) return false;
 
             NodeSearchElement nse = (NodeSearchElement)obj;
-            return CreationName == nse.CreationName && Assembly == nse.Assembly;
+            return FullName == nse.FullName 
+                && CreationName == nse.CreationName
+                && Assembly == nse.Assembly
+                && Parameters == nse.Parameters;
         }
 
         public override int GetHashCode()
         {
-            return CreationName.GetHashCode() ^ Assembly.GetHashCode();
+            return (FullName?? String.Empty).GetHashCode() ^ 
+                (CreationName?? String.Empty).GetHashCode() ^
+                (Assembly ?? String.Empty).GetHashCode() ^
+                (Parameters ?? String.Empty).GetHashCode();
         }
 
     }

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -134,7 +134,7 @@ namespace Dynamo.PackageManager
             PackageLoader.MessageLogged += OnMessageLogged;
             PackageLoader.PackgeLoaded += OnPackageLoaded;
             PackageLoader.PackageRemoved += OnPackageRemoved;
-            RequestLoadNodeLibraryHandler = startupParams.LibraryLoader.LoadNodeLibrary;
+            RequestLoadNodeLibraryHandler = (startupParams.LibraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
             //TODO: Add LoadPackages to ILibraryLoader interface in 3.0
             LoadPackagesHandler = (startupParams.LibraryLoader as ExtensionLibraryLoader).LoadPackages;
             customNodeManager = (startupParams.CustomNodeManager as Core.CustomNodeManager);

--- a/test/DynamoCoreTests/SearchModelTests.cs
+++ b/test/DynamoCoreTests/SearchModelTests.cs
@@ -112,9 +112,14 @@ namespace Dynamo.Tests
             const string descr = "TheCat";
             const string path = @"C:\turtle\graphics.dyn";
             var guid1 = Guid.NewGuid();
+            var guid2 = Guid.NewGuid();
+
+            //all properties are the same except guid.
             var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var dummyInfo2 = new CustomNodeInfo(guid2, nodeName, catName, descr, path);
+
             var dummySearch1 = new CustomNodeSearchElement(null, dummyInfo1);
-            var dummySearch2 = new CustomNodeSearchElement(null, dummyInfo1);
+            var dummySearch2 = new CustomNodeSearchElement(null, dummyInfo2);
 
             search.Add(dummySearch1);
             search.Add(dummySearch2);

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -126,7 +126,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             loader.LoadAll(new LoadPackageParams
             {
@@ -157,7 +157,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             loader.LoadAll(new LoadPackageParams
             {
@@ -189,7 +189,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             // This test needs the "isTestMode" flag to be turned off as an exception to be able 
             // to test duplicate custom node def loading.
@@ -216,7 +216,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
             var package1 = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);
@@ -245,7 +245,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             // This test needs the "isTestMode" flag to be turned off as an exception to be able 
             // to test duplicate custom node def loading.
@@ -276,9 +276,9 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
-          
+
             var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
             var packageDirectory2 = Path.Combine(TestDirectory, "pkgs", "EvenOdd2");
             var package1 = Package.FromDirectory(packageDirectory,CurrentDynamoModel.Logger);
@@ -319,7 +319,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
             var package1 = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);
@@ -381,7 +381,7 @@ namespace Dynamo.PackageManager.Tests
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
-            loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
+            loader.RequestLoadNodeLibrary += (libraryLoader as ExtensionLibraryLoader).LoadLibraryAndSuppressZTSearchImport;
 
             var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
             var package1 = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/DYN-2325
previously the method `LoadNodeLibrary` on dynamoModel - accessed via the extensionLibraryLoader had the behavior that it would successfully load zerotouch OR NodeModel assemblies and add them to the library.

after this pr:
https://github.com/DynamoDS/Dynamo/pull/9736

this no longer works for zerotouch assemblies as the call is redirected to `LibraryServices.LoadNodeLibrary` instead of `ImportLibrary` - which no longer raises a `LibraryLoaded` event .

~~to remedy this I simply added the event raise back to the branch of code where a zero touch assembly is encountered. The libraryLoaded event, among other things, adds the zero touch nodes to search which updates the library view.~~

~~@aparajit-pratap does this have a negative impact on the work you did here? If thats the case we can isolate this by only adding the event raise to the `ExtensionLibraryLoader` class and keep it out of `DynamoModel` - but it does seem like a significant change in behavior and cause of confusion (zero touch functions are in the VM, but none of them are loaded into the library)~~

I would like to get this or the alternative (or something better) into 2.5 to avoid breaking integrations which rely on this functionality.

we will also need to add a test that ensures the searchModel is updated when this function is called. ✔️ 

![Screen Shot 2019-12-02 at 6 58 41 PM](https://user-images.githubusercontent.com/508936/70005281-fcaf8500-1536-11ea-9c2e-8a63030542ac.png)

### Update:

~~This PR now implements `equals` and `getHashCode()` for the `NodeSearchElement` base class - so that duplicate searchElements cannot be added to search if they contain matching properties. This was not a problem for builtin nodes, but for nodeModels and zeroTouch where we construct new `nodeSearchElements` whenever the importLibrary or loadNodeLibrary methods are called, this could lead to extra search entries being created if those apis were called from extensions.~~

The reason that we have this duplication problem when reverting back to `ImportLibrary` is that the method `AddZeroTouchNodeToSearch` is called when `ImportLibrary` is done importing, as it raises the event OnLibrariesImported for each library - then later, after all packages are loaded - the packageLoader raises the same handler via the `PackageLoaded` event. - calling `AddZeroTouchNodeToSearch` again.

~~so this solution works, but it leaves something to be desired, why do this extra work of scanning the zt functions again. I think other solutions might be~~

~~1.  to remove the additional call in the packageLoader which re-raises the `LibraryLoaded` events - I believe @aparajit-pratap added this to finish importing all libraries into search only after all packages were loaded for a small speedup benefit, but it seems this may be the root of some of our issues. What do you think about removing this?~~

2. We can add a new method like ImportLibrary - which does not raise the LoadedEvent and does not add anything to search - package manager extension can use this method instead of the public one. I find this odd because it just seems strange to me to have a method which imports a library but does not finish adding it to search, but we can make this method very explicitly named and documented - perhaps its a parameter added to an overload of  `LoadNodeLibrary` to control adding to search. ie `LoadNodeLibrary(Assembly assem, addToSearch = true)`

~~3. whats in this PR currently - overriding equals and getHashcode - so that when the zt packages are added again to the search we end up just resetting the search element tags - but don't add a new element - it's some wasted cycles per zt function imported per package.~~

~~In any case we can leave these overrides in `NodeSearchModel` if the team thinks this is the correct behavior - thats my opinion.~~

### update2: 

went with solution 2. Removed equality overrides as we would need to add them for each class and carefully test the assumptions each class makes. For now this PR restores the old behavior of the API for extensions authors and keeps the new behavior for package manager using an internal method.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@reddyashish @aparajit-pratap 

### FYIs

@jhauswirth
