### PR TITLE
restore libraryViewContainer and LibrarySearchView - option1

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -345,6 +345,12 @@
     <Compile Include="Views\Preview\Watch3DSettingsControl.xaml.cs">
       <DependentUpon>Watch3DSettingsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\Search\LibraryContainerView.xaml.cs">
+      <DependentUpon>LibraryContainerView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Search\LibrarySearchView.xaml.cs">
+      <DependentUpon>LibrarySearchView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Windows\BrowserWindow.xaml.cs">
       <DependentUpon>BrowserWindow.xaml</DependentUpon>
     </Compile>
@@ -1125,6 +1131,14 @@
     <Page Include="Views\Preview\Watch3DSettingsControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Search\LibraryContainerView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>XamlIntelliSenseFileGenerator</Generator>
+    </Page>
+    <Page Include="Views\Search\LibrarySearchView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
     <Page Include="Windows\BrowserWindow.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -536,7 +536,7 @@ namespace Dynamo.ViewModels
             this.WatchHandler = startConfiguration.WatchHandler;
             var pmExtension = model.GetPackageManagerExtension();
             this.PackageManagerClientViewModel = new PackageManagerClientViewModel(this, pmExtension.PackageManagerClient);
-            this.SearchViewModel = null;
+            this.SearchViewModel = new SearchViewModel(this);
 
             // Start page should not show up during test mode.
             this.ShowStartPage = !DynamoModel.IsTestMode;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -27,6 +27,7 @@ using Dynamo.Nodes;
 using Dynamo.Nodes.Prompts;
 using Dynamo.PackageManager;
 using Dynamo.PackageManager.UI;
+using Dynamo.Search;
 using Dynamo.Search.SearchElements;
 using Dynamo.Selection;
 using Dynamo.Services;
@@ -632,6 +633,16 @@ namespace Dynamo.Controls
             InitializeLogin();
             InitializeShortcutBar();
             InitializeStartPage(isFirstRun);
+
+            #region Search initialization
+
+            var search = new SearchView(
+                dynamoViewModel.SearchViewModel,
+                dynamoViewModel);
+            sidebarGrid.Children.Add(search);
+            dynamoViewModel.SearchViewModel.Visible = true;
+
+            #endregion
 
 #if !__NO_SAMPLES_MENU
             LoadSamplesMenu();

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml
@@ -1,0 +1,448 @@
+﻿<UserControl x:Class="Dynamo.Search.SearchView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ViewModels="clr-namespace:Dynamo.ViewModels"
+             xmlns:views="clr-namespace:Dynamo.UI.Views"
+             xmlns:ui="clr-namespace:Dynamo.UI"
+             xmlns:fa="http://schemas.fontawesome.io/icons/"
+             xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
+             d:DataContext="{d:DesignInstance ViewModels:SearchViewModel, IsDesignTimeCreatable=False}"
+             mc:Ignorable="d"
+             Visibility="Visible"
+             d:DesignWidth="300"
+             d:DesignHeight="300"
+             x:Name="SearchControl"
+             GiveFeedback="OnLibraryContainerViewGiveFeedback">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+                <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+                <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid Background="{StaticResource DynamoWindowBrush}">
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid Name="buttonGrid"
+              Background="{StaticResource WorkspaceBackgroundBrush}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Label Grid.Column="0"
+                   FontWeight="Normal"
+                   Padding="16,0,0,0"
+                   Foreground="{StaticResource MemberButtonText}"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Stretch"
+                   Content="{x:Static p:Resources.LibraryViewTitle}" />
+            <Border Grid.Column="1"
+                    BorderBrush="{StaticResource FilterIconColor}"
+                    BorderThickness="1,0,1,0"
+                    Margin="0,5,0,5">
+                <fa:ImageAwesome Name="Filter"
+                                 Icon="filter"
+                                 IsHitTestVisible="{Binding IsAnySearchResult}"
+                                 MouseLeftButtonUp="OnFilterMouseLeftButtonUp"
+                                 Margin="5,0,5,0"
+                                 Height="10"
+                                 Width="10">
+                    <fa:ImageAwesome.ToolTip>
+                        <TextBlock Text="{x:Static p:Resources.FilterIconTooltip}" />
+                    </fa:ImageAwesome.ToolTip>
+                    <fa:ImageAwesome.Style>
+                        <Style TargetType="{x:Type fa:ImageAwesome}"
+                               BasedOn="{StaticResource LibraryIconsStyle}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsOpen, ElementName=FilterPopup}"
+                                             Value="True">
+                                    <Setter Property="Foreground"
+                                            Value="White" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </fa:ImageAwesome.Style>
+                </fa:ImageAwesome>
+            </Border>
+            <Border Grid.Column="2"
+                    BorderBrush="{StaticResource FilterIconColor}"
+                    BorderThickness="0,0,1,0"
+                    Margin="0,5,0,5">
+                <fa:ImageAwesome Name="ViewLayoutSelector"
+                                 Icon="list"
+                                 IsHitTestVisible="{Binding IsAnySearchResult}"
+                                 MouseLeftButtonUp="OnViewLayoutSelectorMouseLeftButtonUp"
+                                 Margin="5,0,5,0"
+                                 Height="10"
+                                 Width="10">
+                    <fa:ImageAwesome.ToolTip>
+                        <TextBlock Text="{x:Static p:Resources.LayoutIconTooltip}" />
+                    </fa:ImageAwesome.ToolTip>
+                    <fa:ImageAwesome.Style>
+                        <Style TargetType="{x:Type fa:ImageAwesome}"
+                               BasedOn="{StaticResource LibraryIconsStyle}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsOpen, ElementName=LayoutPopup}"
+                                             Value="True">
+                                    <Setter Property="Foreground"
+                                            Value="White" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </fa:ImageAwesome.Style>
+                </fa:ImageAwesome>
+            </Border>
+            <Button Mouse.MouseEnter="OnLibraryExpanderMouseEnter"
+                    Mouse.MouseLeave="OnLibraryExpanderMouseLeave"
+                    Click="OnLibraryExpanderClick"
+                    Template="{DynamicResource BackgroundButton}"
+                    Grid.Column="3"
+                    VerticalAlignment="Center">
+                <Button.Resources>
+                    <ControlTemplate x:Key="BackgroundButton"
+                                     TargetType="Button">
+                        <Border Name="border"
+                                BorderThickness="0"
+                                BorderBrush="Black"
+                                Background="{StaticResource WorkspaceBackgroundBrush}"
+                                Height="20"
+                                Margin="0,0,-1,0">
+                            <ContentPresenter HorizontalAlignment="Stretch"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </Button.Resources>
+                <Button.Content>
+                    <Image Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
+                           Width="20"
+                           Height="20"
+                           RenderTransformOrigin="0.5, 0.5">
+                        <Image.RenderTransform>
+                            <RotateTransform Angle="180" />
+                        </Image.RenderTransform>
+                        <Image.ToolTip>
+                            <TextBlock Text="{x:Static p:Resources.ShowHideLibraryIconTooltip}" />
+                        </Image.ToolTip>
+                    </Image>
+                </Button.Content>
+            </Button>
+        </Grid>
+
+        <Border BorderThickness="0"
+                Background="{StaticResource SearchTextBoxBackground}"
+                CornerRadius="8"
+                Margin="5"
+                Grid.Row="1">
+            <Grid Name="SearchTextBoxGrid"
+                  Height="28"
+                  VerticalAlignment="Center"
+                  MouseEnter="OnSearchTextBoxGridMouseEnter"
+                  MouseLeave="OnSearchTextBoxGridMouseLeave">
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Name="SearchIconAndTextBlockGrid"
+                            Width="Auto"
+                            Orientation="Horizontal">
+                    <StackPanel.HorizontalAlignment>
+                        <Binding Path="SearchIconAlignment" />
+                    </StackPanel.HorizontalAlignment>
+
+
+                    <Image x:Name="SearchIcon"
+                           Source="/DynamoCoreWpf;component/UI/Images/search_normal.png"
+                           Width="16"
+                           Height="16"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Left"
+                           Margin="5,0,0,0" />
+
+                    <TextBlock Name="SearchTextBlock"
+                               FontSize="14"
+                               IsHitTestVisible="False"
+                               Foreground="{StaticResource DeafultSearchTextBlockText}"
+                               VerticalAlignment="Center"
+                               Visibility="{Binding Path=SearchText, 
+                                                    Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
+                               HorizontalAlignment="Center"
+                               Height="18"
+                               Margin="6,0,0,0">
+
+                    </TextBlock>
+                </StackPanel>
+
+                <TextBox Name="SearchTextBox"
+                         KeyboardNavigation.TabIndex="0"
+                         Foreground="{StaticResource SearchBoxBackgroundColor}"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         FontSize="14"
+                         IsEnabled="True"
+                         TextChanged="OnSearchTextBoxTextChanged"
+                         GotKeyboardFocus="TextBoxGotKeyboardFocus"
+                         LostKeyboardFocus="TextBoxLostKeyboardFocus"
+                         VerticalAlignment="Center"
+                         Text="{Binding Path=SearchText,Mode=TwoWay}"
+                         MinWidth="280"
+                         CaretBrush="{StaticResource CommonSidebarTextColor}"
+                         Margin="26,0,0,-1"
+                         Grid.ColumnSpan="2" />
+
+                <Button Name="SearchCancelButton"
+                        Grid.Column="1"
+                        Click="OnSearchCancelButtonClick"
+                        VerticalAlignment="Center">
+                    <Button.Visibility>
+                        <Binding Path="SearchText"
+                                 Converter="{StaticResource EmptyStringToCollapsedConverter}" />
+                    </Button.Visibility>
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="Button">
+                                        <Image Name="SearchCancelImage"
+                                               Source="/DynamoCoreWpf;component/UI/Images/searchcancel_normal.png"
+                                               Width="16"
+                                               Height="16"
+                                               Margin="0,0,5,0" />
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver"
+                                                     Value="True">
+                                                <Setter TargetName="SearchCancelImage"
+                                                        Property="Source"
+                                                        Value="/DynamoCoreWpf;component/UI/Images/searchcancel_hover.png" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver"
+                                                     Value="False">
+                                                <Setter TargetName="SearchCancelImage"
+                                                        Property="Source"
+                                                        Value="/DynamoCoreWpf;component/UI/Images/searchcancel_normal.png" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </Grid>
+        </Border>
+
+        <!-- LIBRARY VIEW -->
+        <views:LibraryView x:Name="libraryView"
+                           Grid.Row="2"
+                           VerticalAlignment="Stretch"
+                           HorizontalAlignment="Stretch"
+                           DataContext="{Binding}"
+                           PreviewKeyDown="OnLibraryViewPreviewKeyDown">
+            <views:LibraryView.Visibility>
+                <Binding Path="CurrentMode"
+                         Converter="{StaticResource ViewModeToVisibilityConverter}"
+                         ConverterParameter="LibraryView" />
+            </views:LibraryView.Visibility>
+        </views:LibraryView>
+
+        <!-- LIBRARYSEARCH VIEW -->
+        <views:LibrarySearchView Grid.Row="2"
+                                 DataContext="{Binding}"
+                                 PreviewKeyDown="OnLibraryViewPreviewKeyDown"
+                                 x:Name="librarySearchView">
+            <views:LibrarySearchView.Visibility>
+                <Binding Path="CurrentMode"
+                         Converter="{StaticResource ViewModeToVisibilityConverter}"
+                         ConverterParameter="LibrarySearchView" />
+            </views:LibrarySearchView.Visibility>
+        </views:LibrarySearchView>
+
+        <!--Filter popup-->
+        <Popup Name="FilterPopup"
+               StaysOpen="False"
+               AllowsTransparency="True"
+               Placement="Bottom"
+               PlacementTarget="{Binding ElementName=Filter}"
+               VerticalOffset="3"
+               HorizontalOffset="-10">
+            <ContentControl Style="{StaticResource LibraryPopupContentStyle}">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="{x:Static p:Resources.SelectAllTitle}"
+                               HorizontalAlignment="Right"
+                               Style="{StaticResource FilterTextBlockStyle}"
+                               Margin="0,5,5,5">
+                        <TextBlock.InputBindings>
+                            <MouseBinding Command="{Binding SelectAllCategoriesCommand}"
+                                          MouseAction="LeftClick" />
+                        </TextBlock.InputBindings>
+                    </TextBlock>
+
+                    <ItemsControl ItemsSource="{Binding SearchCategories}"
+                                  Margin="3,0,3,5">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button Name="CategoryButton"
+                                        Command="{Binding ClickCommand}">
+
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <ContentPresenter />
+                                        </ControlTemplate>
+                                    </Button.Template>
+
+                                    <Border Style="{StaticResource LayoutButtonStyle}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <!-- We didn't use checkbox, because the whole button should be clickable. -->
+                                            <!-- "CheckBox" background-->
+                                            <Border Grid.Column="0"
+                                                    Height="10"
+                                                    Width="10"
+                                                    Margin="3,0,3,0"
+                                                    CornerRadius="1"
+                                                    Background="White">
+
+                                                <!-- "CheckBox" mark -->
+
+                                                <Path Width="7"
+                                                      Height="7"
+                                                      x:Name="CheckMark"
+                                                      SnapsToDevicePixels="False"
+                                                      Stroke="{StaticResource SelectedFilterButtonTextColor}"
+                                                      StrokeThickness="2"
+                                                      Data="M 0 3 L 3 6 M 3 6 L 7 0"
+                                                      Visibility="{Binding IsSelected, 
+                                                                       Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                            </Border>
+
+                                            <TextBlock Name="CategoryName"
+                                                       Grid.Column="1"
+                                                       Text="{Binding Name}"
+                                                       Foreground="{Binding IsSelected, 
+                                                                        Converter={StaticResource FilterIsSelertedCategoryForegroundConverter}}"
+                                                       FontStyle="Italic"
+                                                       Margin="0,0,5,0" />
+
+                                            <TextBlock Name="OnlyTextBlock"
+                                                       Grid.Column="2"
+                                                       Text="{x:Static p:Resources.OnlyTitle}"
+                                                       Style="{StaticResource FilterTextBlockStyle}"
+                                                       HorizontalAlignment="Right"
+                                                       Margin="0,0,2,0"
+                                                       PreviewMouseLeftButtonDown="OnOnlyTextBlockMouseDown"
+                                                       Visibility="{Binding RelativeSource={
+                                                                            RelativeSource FindAncestor, 
+                                                                            AncestorType={x:Type Border}}, 
+                                                                            Path=IsMouseOver,
+                                                                            Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <TextBlock.InputBindings>
+                                                    <MouseBinding Command="{Binding OnlyClickCommand}"
+                                                                  MouseAction="LeftClick" />
+                                                </TextBlock.InputBindings>
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ContentControl>
+        </Popup>
+
+        <!-- View layout popup-->
+        <Popup Name="LayoutPopup"
+               StaysOpen="False"
+               AllowsTransparency="True"
+               Placement="Bottom"
+               PlacementTarget="{Binding ElementName=ViewLayoutSelector}"
+               VerticalOffset="3"
+               HorizontalOffset="-10">
+            <ContentControl Style="{StaticResource LibraryPopupContentStyle}">
+                <WrapPanel>
+                    <!-- Compact layout button -->
+                    <Button Name="CompactButton"
+                            Command="{Binding ToggleLayoutCommand}">
+                        <Button.CommandParameter>
+                            <system:Boolean>False</system:Boolean>
+                        </Button.CommandParameter>
+                        <Button.Template>
+                            <ControlTemplate>
+                                <Border BorderThickness="0,0,1,0"
+                                        BorderBrush="{StaticResource SearchDarkGreyTextColor}"
+                                        Style="{StaticResource LayoutButtonStyle}">
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="5,5,5,5">
+                                        <fa:ImageAwesome Name="CompactLayoutIcon"
+                                                         Icon="list"
+                                                         Foreground="{Binding IsDetailedMode, 
+                                                                              Converter={StaticResource CompactLayoutForegroundConverter}}"
+                                                         Margin="5,0,5,0"
+                                                         Height="13"
+                                                         Width="13" />
+                                        <TextBlock Foreground="{Binding IsDetailedMode, 
+                                                                              Converter={StaticResource CompactLayoutForegroundConverter}}"
+                                                   Text="{x:Static p:Resources.CompactLayoutTitle}"
+                                                   FontSize="13" />
+                                    </StackPanel>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+
+                    <!-- Detailed layout button -->
+
+                    <Button Name="DetailedButton"
+                            Command="{Binding ToggleLayoutCommand}">
+                        <Button.CommandParameter>
+                            <system:Boolean>True</system:Boolean>
+                        </Button.CommandParameter>
+                        <Button.Template>
+                            <ControlTemplate>
+                                <Border Style="{StaticResource LayoutButtonStyle}">
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="5,5,5,5">
+                                        <fa:ImageAwesome  Name="DetailedLayoutIcon"
+                                                          Foreground="{Binding IsDetailedMode, 
+                                                                              Converter={StaticResource DetailedLayoutForegroundConverter}}"
+                                                          Icon="ThList"
+                                                          Margin="5,0,5,0"
+                                                          Height="13"
+                                                          Width="13" />
+                                        <TextBlock Foreground="{Binding IsDetailedMode, 
+                                                                              Converter={StaticResource DetailedLayoutForegroundConverter}}"
+                                                   Text="{x:Static p:Resources.DetailedLayoutTitle}"
+                                                   FontSize="13" />
+                                    </StackPanel>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+
+                </WrapPanel>
+            </ContentControl>
+        </Popup>
+    </Grid>
+
+</UserControl>

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+using Dynamo.Controls;
+using Dynamo.Logging;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Utilities;
+
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace Dynamo.Search
+{
+    /// <summary>
+    ///     Interaction logic for SearchView.xaml
+    /// </summary>
+    public partial class SearchView
+    {
+        private readonly SearchViewModel viewModel;
+        private readonly DynamoViewModel dynamoViewModel;
+
+        private const string baseUrl = @"pack://application:,,,/DynamoCoreWpf;component/UI/Images/";
+
+        private BitmapImage searchIconBitmapNormal =
+            new BitmapImage(new Uri(baseUrl + "search_normal.png"));
+        private BitmapImage searchIconBitmapHover =
+            new BitmapImage(new Uri(baseUrl + "search_hover.png"));
+
+        public SearchView(SearchViewModel searchViewModel, DynamoViewModel dynamoViewModel)
+        {
+            viewModel = searchViewModel;
+            this.dynamoViewModel = dynamoViewModel;
+
+            DataContext = viewModel;
+            InitializeComponent();
+            Loaded += OnSearchViewLoaded;
+            Unloaded += OnSearchViewUnloaded;
+
+            SearchTextBox.IsVisibleChanged += delegate
+            {
+                if (!SearchTextBox.IsVisible) return;
+
+                this.viewModel.SearchCommand.Execute(null);
+                Keyboard.Focus(SearchTextBox);
+                SearchTextBlock.Text = Properties.Resources.SearchTextBlockText;
+            };
+        }
+
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+        {
+            if (e.ClickCount == 1)
+            {
+                SearchTextBox.Focus();
+            }
+        }
+
+        private void OnSearchViewUnloaded(object sender, EventArgs e)
+        {
+            viewModel.RequestFocusSearch -= OnSearchViewModelRequestFocusSearch;
+        }
+
+        private void OnSearchViewLoaded(object sender, RoutedEventArgs e)
+        {
+            MouseEnter += OnSearchViewMouseEnter;
+            MouseLeave += OnSearchViewMouseLeave;
+
+            SearchTextBox.PreviewKeyDown += KeyHandler;
+
+            viewModel.RequestFocusSearch += OnSearchViewModelRequestFocusSearch;
+        }
+
+        private void OnSearchViewMouseLeave(object sender, MouseEventArgs e)
+        {
+            viewModel.SearchScrollBarVisibility = false;
+        }
+
+        private void OnSearchViewMouseEnter(object sender, MouseEventArgs e)
+        {
+            viewModel.SearchScrollBarVisibility = true;
+        }
+
+        /// <summary>
+        ///     A KeyHandler method used by SearchView, increments decrements and executes based on input.
+        /// </summary>
+        /// <param name="sender">Originating object for the KeyHandler </param>
+        /// <param name="e">Parameters describing the key push</param>
+        public void KeyHandler(object sender, KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.Escape:
+                    {
+                        ClearSearchBox();
+                        e.Handled = true;
+                        break;
+                    }
+
+                case Key.Enter:
+                    {
+                        e.Handled = true;
+                        if (IsAnySearchResult())
+                        {
+                            viewModel.ExecuteSelectedItem();
+                            Keyboard.Focus(SearchTextBox);
+                        }
+
+                        break;
+                    }
+
+                case Key.Down:
+                    {
+                        e.Handled = true;
+                        if (IsAnySearchResult())
+                        {
+                            viewModel.MoveSelection(SearchViewModel.Direction.Down);
+                        }
+                        
+                        break;
+                    }
+
+                case Key.Up:
+                    {
+                        e.Handled = true;
+                        if (IsAnySearchResult())
+                        {
+                            viewModel.MoveSelection(SearchViewModel.Direction.Up);
+                        }
+                        
+                        break;
+                    }
+            }
+        }
+
+        private bool IsAnySearchResult()
+        {
+            return viewModel.CurrentMode == SearchViewModel.ViewMode.LibrarySearchView
+                   && viewModel.IsAnySearchResult;
+        }
+
+        private void OnSearchViewModelRequestFocusSearch(object sender, EventArgs e)
+        {
+            SearchTextBox.Focus();
+        }
+
+        public void OnSearchTextBoxTextChanged(object sender, TextChangedEventArgs e)
+        {
+            var binding = ((TextBox)sender).GetBindingExpression(TextBox.TextProperty);
+            if (binding != null)
+                binding.UpdateSource();
+
+            viewModel.SearchCommand.Execute(null);
+        }
+
+        // Not used anywhere.
+        public void ListBoxItem_Click(object sender, RoutedEventArgs e)
+        {
+            ((ListBoxItem)sender).IsSelected = true;
+            Keyboard.Focus(SearchTextBox);
+        }
+
+        private void OnLibraryExpanderClick(object sender, RoutedEventArgs e)
+        {
+            dynamoViewModel.OnSidebarClosed(this, EventArgs.Empty);
+        }
+
+        private void OnLibraryExpanderMouseEnter(object sender, MouseEventArgs e)
+        {
+            var b = (Button)sender;
+            var g = (Grid)b.Parent;
+            var lb = (Label)(g.Children[0]);
+            var bc = new BrushConverter();
+            lb.Foreground = (Brush)bc.ConvertFromString("#cccccc");
+            var collapsestate = (Image)(b).Content;
+            var collapsestateSource = new Uri(baseUrl + "expand_hover.png");
+            collapsestate.Source = new BitmapImage(collapsestateSource);
+
+            Cursor = CursorLibrary.GetCursor(CursorSet.LinkSelect);
+        }
+
+        private void OnLibraryExpanderMouseLeave(object sender, MouseEventArgs e)
+        {
+            var b = (Button)sender;
+            var g = (Grid)b.Parent;
+            var lb = (Label)(g.Children[0]);
+            var bc = new BrushConverter();
+            lb.Foreground = (Brush)bc.ConvertFromString("#aaaaaa");
+            var collapsestate = (Image)(b).Content;
+            var collapsestateSource = new Uri(baseUrl + "expand_normal.png");
+            collapsestate.Source = new BitmapImage(collapsestateSource);
+
+            Cursor = null;
+        }
+
+        private void OnSearchTextBoxGridMouseEnter(object sender, MouseEventArgs e)
+        {
+            SearchIcon.Source = searchIconBitmapHover;
+            SearchTextBlock.Text = Properties.Resources.SearchTextBlockText;
+        }
+
+        private void OnSearchTextBoxGridMouseLeave(object sender, MouseEventArgs e)
+        {
+            SearchIcon.Source = searchIconBitmapNormal;
+            SearchTextBlock.Text = Properties.Resources.SearchTextBlockText;
+        }
+
+        private void OnSearchCancelButtonClick(object sender, RoutedEventArgs e)
+        {
+            ClearSearchBox();
+        }
+
+        private void ClearSearchBox()
+        {
+            SearchTextBox.Text = "";
+            Keyboard.Focus(SearchTextBox);
+        }
+
+        private void TextBoxGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            if (viewModel != null)
+                viewModel.SearchIconAlignment = HorizontalAlignment.Left;
+        }
+
+        private void TextBoxLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            if (viewModel == null) return;
+
+            viewModel.SearchIconAlignment = string.IsNullOrEmpty(viewModel.SearchText)
+                ? HorizontalAlignment.Center
+                : HorizontalAlignment.Left;
+        }
+
+        private void OnLibraryViewPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape) return;
+
+            SearchTextBox.Text = "";
+        }
+
+
+        /// <summary>
+        /// On drag&drop starts change cursor to cursor, that is shown when the user is hovering over the workspace.
+        /// </summary>
+        private void OnLibraryContainerViewGiveFeedback(object sender, GiveFeedbackEventArgs e)
+        {
+            e.UseDefaultCursors = e.Effects.HasFlag(DragDropEffects.Copy) || e.Effects.HasFlag(DragDropEffects.Move);
+
+            if (!e.UseDefaultCursors)
+            {
+                Mouse.SetCursor(CursorLibrary.GetCursor(CursorSet.DragMove));
+            }
+
+            e.Handled = true;
+        }
+
+        private void OnFilterMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            FilterPopup.IsOpen = true;
+
+            Analytics.TrackEvent(Actions.FilterButtonClicked, Categories.SearchUX);
+        }
+
+        private void OnViewLayoutSelectorMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            LayoutPopup.IsOpen = true;
+        }
+
+        private void OnOnlyTextBlockMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            viewModel.UnSelectAllCategories();
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -1,0 +1,183 @@
+﻿<UserControl x:Class="Dynamo.UI.Views.LibrarySearchView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
+             xmlns:ui="clr-namespace:Dynamo.UI"
+             xmlns:vm="clr-namespace:Dynamo.Wpf.ViewModels"
+             xmlns:views="clr-namespace:Dynamo.UI.Views"
+             xmlns:fa="http://schemas.fontawesome.io/icons/"
+             xmlns:search="clr-namespace:Dynamo.Search"
+             mc:Ignorable="d"
+             d:DesignHeight="525"
+             d:DesignWidth="350">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.SidebarGridDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate x:Key="SearchItemTemplate"
+                          DataType="{x:Type vm:NodeSearchElementViewModel}">
+                <Button Command="{Binding ClickedCommand}"
+                        Margin="15,9,15,9">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+
+                            <!-- Transparent, yet clickable background -->
+                            <Grid Background="#01000000">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <!-- Node icon -->
+                                <Image Grid.Column="0"
+                                       Source="{Binding SmallIcon}"
+                                       Height="32"
+                                       Width="32"
+                                       VerticalAlignment="Top"
+                                       HorizontalAlignment="Left"
+                                       Margin="0,0,10,0" />
+
+                                <StackPanel Grid.Column="1"
+                                            Orientation="Vertical">
+
+                                    <!-- Node name -->
+                                    <TextBlock Name="memberName"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Top"
+                                               FontSize="13">
+                                                <Run Text="{Binding Name, Mode=OneWay}"
+                                                     Foreground="{StaticResource NodeNameForeground}" />
+                                                <Run Text="{Binding Parameters, Mode=OneWay}"
+                                                     Foreground="{StaticResource CommonSidebarTextColor}" />
+                                    </TextBlock>
+
+                                    <!-- Node description -->
+                                    <TextBlock Name="memberDescription"
+                                               FontSize="11"
+                                               MaxHeight="50"
+                                               Text="{Binding Description}"
+                                               Foreground="{StaticResource SearchDarkGreyTextColor}"
+                                               TextWrapping="Wrap"
+                                               TextTrimming="CharacterEllipsis"
+                                               Visibility="{Binding DataContext.IsDetailedMode, 
+                                                                        RelativeSource={RelativeSource FindAncestor, 
+                                                                        AncestorType={x:Type search:SearchView}},
+                                                                        Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                                    <!-- Node class, group icon, node category -->
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding Class}"
+                                                   PreviewMouseDown="OnClassNamePreviewMouseDown"
+                                                   TextDecorations="Underline">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground"
+                                                            Value="{StaticResource NodeCategoryForeground}" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver"
+                                                                 Value="True">
+                                                            <Setter Property="Foreground"
+                                                                    Value="#42adff" />
+                                                            <Setter Property="Cursor"
+                                                                    Value="Hand" />
+                                                            <Setter Property="TextBlock.TextDecorations"
+                                                                    Value="Underline" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <fa:ImageAwesome Icon="{Binding GroupIconName}"
+                                                         Foreground="{Binding Group, 
+                                                                              Converter={StaticResource ElementGroupToColorConverter}}"
+                                                         VerticalAlignment="Center"
+                                                         HorizontalAlignment="Center"
+                                                         Height="10"
+                                                         Width="10"
+                                                         Margin="4,4,4,4" />
+                                        <TextBlock Text="{Binding Category}"
+                                                   Foreground="{StaticResource NodeCategoryForeground}"
+                                                   FontStyle="Italic" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Grid>
+                        </ControlTemplate>
+                    </Button.Template>
+                </Button>
+            </DataTemplate>
+
+            <!-- Remove default listbox blue highlight. Disable item selection -->
+            <Style x:Key="SearchItemStyle"
+                   TargetType="ListBoxItem">
+                <Setter Property="IsSelected"
+                        Value="{Binding IsSelected, Mode=OneWay}" />
+                <Setter Property="Visibility"
+                        Value="{Binding Visibility, Mode=OneWay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListBoxItem">
+                            <Border Background="{TemplateBinding Background}"
+                                    Margin="0,2,0,0"
+                                    Width="{Binding ActualWidth, 
+                                        RelativeSource={RelativeSource Mode=FindAncestor, 
+                                        AncestorType={x:Type views:LibrarySearchView }}}">
+                                <ContentPresenter />
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+
+                <EventSetter Event="PreviewMouseLeftButtonDown"
+                             Handler="OnButtonMouseLeftButtonDown" />
+                <EventSetter Event="PreviewMouseMove"
+                             Handler="OnButtonPreviewMouseMove" />
+                <EventSetter Event="MouseLeave"
+                             Handler="OnPopupMouseLeave" />
+                <EventSetter Event="MouseEnter"
+                             Handler="OnMemberMouseEnter" />
+
+                <Setter Property="Background"
+                        Value="Transparent" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver"
+                             Value="True">
+                        <Setter Property="Background"
+                                Value="{StaticResource LibraryMemberOnHover}" />
+                    </Trigger>
+                    <Trigger Property="IsSelected"
+                             Value="True">
+                        <Setter Property="Background"
+                                Value="{StaticResource LibraryMemberOnHover}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style BasedOn="{StaticResource LibraryScrollViewerStyle}"
+                   TargetType="{x:Type ScrollViewer}">
+                <Setter Property="Template"
+                        Value="{StaticResource LibraryScrollViewerControlTemplate}" />
+            </Style>
+
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <ListBox  Name="SearchResults"
+                  Background="{StaticResource LibraryItemHostBackground}"
+                  BorderThickness="0"
+                  ItemsSource="{Binding FilteredResults}"
+                  ItemTemplate="{StaticResource SearchItemTemplate}"
+                  ItemContainerStyle="{StaticResource SearchItemStyle}"
+                  VirtualizingStackPanel.VirtualizationMode="Recycling" />
+        <uicontrols:LibraryToolTipPopup x:Name="libraryToolTipPopup"
+                                        StaysOpen="True"
+                                        AllowsTransparency="True"
+                                        MouseLeave="OnPopupMouseLeave" />
+    </Grid>
+</UserControl>

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Threading;
+using Dynamo.Search;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.ViewModels;
+using Dynamo.Search.SearchElements;
+using Dynamo.Wpf.Utilities;
+
+namespace Dynamo.UI.Views
+{
+    /// <summary>
+    /// Interaction logic for LibrarySearchView.xaml
+    /// </summary>
+    public partial class LibrarySearchView : UserControl
+    {
+        private SearchViewModel viewModel;
+        private LibraryDragAndDrop dragDropHelper = new LibraryDragAndDrop();
+
+        public LibrarySearchView()
+        {
+            InitializeComponent();
+
+            // Invalidate the DataContext here because it will be set at a later 
+            // time through data binding expression. This way debugger will not 
+            // display warnings for missing properties.
+            this.DataContext = null;
+
+            Loaded += OnLibrarySearchViewLoaded;
+        }
+
+        private void OnLibrarySearchViewLoaded(object sender, RoutedEventArgs e)
+        {
+            viewModel = DataContext as SearchViewModel;
+            viewModel.SearchTextChanged +=viewModel_SearchTextChanged;
+        }
+
+        private void viewModel_SearchTextChanged(object sender, EventArgs e)
+        {
+            //Get the scrollview and scroll to top on every text entered
+            var scroll = SearchResults.ChildOfType<ScrollViewer>();
+            if (scroll != null)
+            {               
+                scroll.ScrollToTop();
+            }
+        }
+
+        private void OnNoMatchFoundButtonClick(object sender, RoutedEventArgs e)
+        {
+            // Clear SearchText in ViewModel, as result search textbox clears as well.
+            viewModel.SearchText = "";
+        }
+
+        #region ToolTip methods
+
+        private void OnMemberMouseEnter(object sender, RoutedEventArgs e)
+        {
+            ShowTooltip(sender);
+        }
+
+        private void OnPopupMouseLeave(object sender, MouseEventArgs e)
+        {
+            CloseToolTipInternal();
+        }
+
+        private void ShowTooltip(object sender)
+        {
+            FrameworkElement fromSender = sender as FrameworkElement;
+            if (fromSender == null) return;
+            var nodeVM = fromSender.DataContext as NodeSearchElementViewModel;
+
+            var senderVM = fromSender.DataContext as NodeSearchElementViewModel;
+
+            if (senderVM != null && senderVM.Visibility)
+            {
+                libraryToolTipPopup.PlacementTarget = fromSender;
+                libraryToolTipPopup.SetDataContext(fromSender.DataContext);
+            }
+        }
+
+        private void CloseToolTipInternal(bool closeImmediately = false)
+        {
+            libraryToolTipPopup.SetDataContext(null, closeImmediately);
+        }
+
+        #endregion
+
+        #region Drag&Drop
+
+        private void OnButtonMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var senderButton = e.OriginalSource as FrameworkElement;
+            if (senderButton != null)
+            {
+                HelperHandleMouseDown(e.GetPosition(null), senderButton.DataContext);
+            }
+            else
+            {
+                var senderRunButton = e.OriginalSource as Run;
+                if (senderRunButton != null)
+                {
+                    HelperHandleMouseDown(e.GetPosition(null), senderRunButton.DataContext);
+                }
+            }
+        }
+
+        private void HelperHandleMouseDown(Point position, object dataContext)
+        {
+            var searchElementVM = dataContext as NodeSearchElementViewModel;
+
+            if (searchElementVM != null)
+            {
+                dragDropHelper.HandleMouseDown(position, searchElementVM);
+            }
+        }
+
+        private void OnButtonPreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton != MouseButtonState.Pressed)
+                return;
+
+            var senderButton = e.OriginalSource as FrameworkElement;
+
+            if (senderButton == null)
+                return;
+
+            var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            if (searchElementVM != null)
+                dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null));
+            else
+                dragDropHelper.Clear();
+
+        }
+
+        #endregion
+
+        private void OnClassNamePreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var senderButton = e.OriginalSource as FrameworkElement;
+            if (senderButton == null)
+            {
+                return;
+            }
+
+            var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            if (searchElementVM == null)
+            {
+                return;
+            }
+
+            int lastIndex =
+                searchElementVM.FullName.LastIndexOf(
+                Configuration.Configurations.CategoryDelimiterString + searchElementVM.Name,
+                    StringComparison.Ordinal);
+
+            var selectedClassWithCategory = lastIndex == -1
+                ? searchElementVM.FullName
+                : searchElementVM.FullName.Substring(0,
+                    lastIndex);
+            viewModel.OpenSelectedClass(selectedClassWithCategory);
+        }
+    }
+}


### PR DESCRIPTION
this displays when the library extension is removed
still work to do:
- [ ] remove library extension container code (arrow)
- [ ] hide builtins in dsbuiltin.dll
- [ ] split packages and OOTB nodes
- [ ] verify search returns same results
- [ ] verify custom nodes load correctly when created
- [ ] verify installing packages from package manager.
- [ ] decide how this change is bundled/controlled - a separate extension, a config option to enable it, an automatic fallback if cef fails to load or the webUI view fails to load?





### Purpose

restore the wpf based library

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
![Screen Shot 2019-12-05 at 5 02 31 PM](https://user-images.githubusercontent.com/508936/70345558-590def80-182a-11ea-8736-7d7e53b66878.png)
![Screen Shot 2019-12-05 at 5 02 41 PM](https://user-images.githubusercontent.com/508936/70345559-590def80-182a-11ea-93bb-2f93ae4b21ac.png)
