### PR TITLE
[DYN-2349] Close workspace references extension tab by user action and API

### DIFF
--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -147,7 +147,6 @@ namespace Dynamo.Wpf.Extensions
             }
         }
 
-
         private void AddItemToMenu(MenuBarType type, Control itemToAdd, int index)
         {
             if (dynamoMenu == null) return;

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -83,7 +83,6 @@ namespace Dynamo.Wpf.Extensions
             dynamoMenu = dynamoView.titleBar.ChildOfType<Menu>();
             ViewStartupParams = new ViewStartupParams(dynamoVM);
             DynamoSelection.Instance.Selection.CollectionChanged += OnSelectionCollectionChanged;
-            DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
         }
 
         public void AddMenuItem(MenuBarType type, MenuItem menuItem, int index = -1)
@@ -148,18 +147,6 @@ namespace Dynamo.Wpf.Extensions
             }
         }
 
-        /// <summary>
-        /// This event is raised when an extension tab is closed and this event 
-        /// is subscired by the Workspace dependency view extension
-        /// </summary>
-        internal event Action OnExtensionTabClosed;
-        private void OnExtensionTabClosedHandler()
-        {
-            if (OnExtensionTabClosed != null)
-            {
-                OnExtensionTabClosed();
-            }
-        }
 
         private void AddItemToMenu(MenuBarType type, Control itemToAdd, int index)
         {

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -152,7 +152,7 @@ namespace Dynamo.Wpf.Extensions
         /// This event is raised when an extension tab is closed and this event 
         /// is subscired by the Workspace dependency view extension
         /// </summary>
-        public event Action OnExtensionTabClosed;
+        internal event Action OnExtensionTabClosed;
         private void OnExtensionTabClosedHandler()
         {
             if (OnExtensionTabClosed != null)

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -9,7 +9,6 @@ using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Visualization;
-using Dynamo.Wpf.ViewModels;
 using Dynamo.Wpf.ViewModels.Watch3D;
 
 namespace Dynamo.Wpf.Extensions
@@ -84,6 +83,7 @@ namespace Dynamo.Wpf.Extensions
             dynamoMenu = dynamoView.titleBar.ChildOfType<Menu>();
             ViewStartupParams = new ViewStartupParams(dynamoVM);
             DynamoSelection.Instance.Selection.CollectionChanged += OnSelectionCollectionChanged;
+            DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
         }
 
         public void AddMenuItem(MenuBarType type, MenuItem menuItem, int index = -1)
@@ -145,6 +145,19 @@ namespace Dynamo.Wpf.Extensions
             if (SelectionCollectionChanged != null)
             {
                 SelectionCollectionChanged(notifyCollectionChangedEventArgs);
+            }
+        }
+
+        /// <summary>
+        /// This event is raised when an extension tab is closed and this event 
+        /// is subscired by the Workspace dependency view extension
+        /// </summary>
+        public event Action OnExtensionTabClosed;
+        private void OnExtensionTabClosedHandler()
+        {
+            if (OnExtensionTabClosed != null)
+            {
+                OnExtensionTabClosed();
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -69,7 +69,7 @@ namespace Dynamo.Controls
         private ShortcutToolbar shortcutBar;
         private bool loaded = false;
         // This event is raised on the dynamo view when an extension tab is closed.
-        internal static event Action CloseExtension;
+        internal static event Action<String> CloseExtension;
 
         internal ObservableCollection<TabItem> TabItems { set; get; } = new ObservableCollection<TabItem>();
 
@@ -260,7 +260,7 @@ namespace Dynamo.Controls
         {
             string tabName = (sender as Button).DataContext.ToString();
 
-            CloseExtension?.Invoke();
+            CloseExtension?.Invoke(tabName);
 
             TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
             CloseTab(tabitem);

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -203,14 +203,16 @@ namespace Dynamo.Controls
         }
 
         /// <summary>
-        /// This method close a tab item in the right side bar based on passed extension
+        /// This method will close a tab item in the right side bar based on passed extension
         /// </summary>
         /// <param name="viewExtension">Extension to be closed</param>
         /// <returns></returns>
         internal void CloseTabItem(IViewExtension viewExtension)
         {
             string tabName = viewExtension.Name;
-            CloseTab(tabName);
+
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Name == tabName);
+            CloseTab(tabitem);
         }
 
         // This method adds a tab item to the right side bar and 
@@ -227,6 +229,7 @@ namespace Dynamo.Controls
                 TabItem tab = new TabItem();
                 tab.Header = viewExtension.Name;
                 tab.Tag = viewExtension.GetType();
+                tab.Uid = viewExtension.UniqueId;
                 tab.HeaderTemplate = tabDynamic.FindResource("TabHeader") as DataTemplate;
 
                 // setting the extension UI to the current tab content 
@@ -256,38 +259,37 @@ namespace Dynamo.Controls
         private void CloseTab(object sender, RoutedEventArgs e)
         {
             string tabName = (sender as Button).CommandParameter.ToString();
-            CloseTab(tabName);
+
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Name == tabName);
+            CloseTab(tabitem);
         }
 
         /// <summary>
         /// Close tab by its name
         /// </summary>
-        /// <param name="tabName">tab name</param>
-        private void CloseTab(string tabName)
+        /// <param name="tabitem">tab item</param>
+        private void CloseTab(TabItem tabitem)
         {
-            TabItem tab = tabDynamic.SelectedItem as TabItem;
+            TabItem tabToBeRemoved = tabitem;
 
-            if (tab != null)
+            // get the selected tab
+            TabItem selectedTab = tabDynamic.SelectedItem as TabItem;
+
+            // clear tab control binding and bind to the new tab-list. 
+            tabDynamic.DataContext = null;
+            TabItems.Remove(tabToBeRemoved);
+            TabItems = TabItems;
+            tabDynamic.DataContext = TabItems;
+
+            // Highlight previously selected tab. if that is removed then Highlight the first tab
+            if (selectedTab.Equals(tabToBeRemoved))
             {
-                // get the selected tab
-                TabItem selectedTab = tabDynamic.SelectedItem as TabItem;
-
-                // clear tab control binding and bind to the new tab-list. 
-                tabDynamic.DataContext = null;
-                TabItems.Remove(tab);
-                TabItems = TabItems;
-                tabDynamic.DataContext = TabItems;
-
-                // Highlight previously selected tab. if that is removed then Highlight the first tab
-                if (selectedTab == null || selectedTab.Equals(tab))
+                if (TabItems.Count > 0)
                 {
-                    if (TabItems.Count > 0)
-                    {
-                        selectedTab = TabItems[0];
-                    }
+                    selectedTab = TabItems[0];
                 }
-                tabDynamic.SelectedItem = selectedTab;
             }
+            tabDynamic.SelectedItem = selectedTab;
         }
 
         // This event is triggered when the tabitems list is changed and will show/hide the right side bar accordingly.

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -174,14 +174,15 @@ namespace Dynamo.WorkspaceDependency
 
         /// <summary>
         /// This event is raised when an extension tab is closed and this event 
-        /// is subscired by the Workspace dependency view extension
+        /// is subscribed by the Workspace dependency view extension.
+        /// <param name="extensionTabName"></param>
         /// </summary>
-        internal event Action OnExtensionTabClosed;
-        private void OnExtensionTabClosedHandler()
+        internal event Action<String> OnExtensionTabClosed;
+        private void OnExtensionTabClosedHandler(String extensionTabName)
         {
             if (OnExtensionTabClosed != null)
             {
-                OnExtensionTabClosed();
+                OnExtensionTabClosed(extensionTabName);
             }
         }
 

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -51,10 +51,13 @@ namespace Dynamo.WorkspaceDependency
             set
             {
                 hasDependencyIssue = value;
-                if (hasDependencyIssue && !dependencyViewExtension.packageDependencyMenuItem.IsChecked)
+                if (hasDependencyIssue)
                 {
                     loadedParams.AddToExtensionsSideBar(dependencyViewExtension, this);
-                    dependencyViewExtension.packageDependencyMenuItem.IsChecked = true;
+                    if (dependencyViewExtension.workspaceReferencesMenuItem != null && !dependencyViewExtension.workspaceReferencesMenuItem.IsChecked)
+                    {
+                        dependencyViewExtension.workspaceReferencesMenuItem.IsChecked = true;
+                    }
                 }
             }
         }

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -50,9 +50,10 @@ namespace Dynamo.WorkspaceDependency
             set
             {
                 hasDependencyIssue = value;
-                if (hasDependencyIssue)
+                if (hasDependencyIssue && !dependencyViewExtension.packageDependencyMenuItem.IsChecked)
                 {
                     loadedParams.AddToExtensionsSideBar(dependencyViewExtension, this);
+                    dependencyViewExtension.packageDependencyMenuItem.IsChecked = true;
                 }
             }
         }

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Dynamo.Controls;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.Utilities;
@@ -168,6 +169,20 @@ namespace Dynamo.WorkspaceDependency
             packageInstaller = p.PackageInstaller;
             dependencyViewExtension = viewExtension;
             DependencyRegen(currentWorkspace);
+            DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
+        }
+
+        /// <summary>
+        /// This event is raised when an extension tab is closed and this event 
+        /// is subscired by the Workspace dependency view extension
+        /// </summary>
+        internal event Action OnExtensionTabClosed;
+        private void OnExtensionTabClosedHandler()
+        {
+            if (OnExtensionTabClosed != null)
+            {
+                OnExtensionTabClosed();
+            }
         }
 
         /// <summary>
@@ -248,6 +263,7 @@ namespace Dynamo.WorkspaceDependency
             loadedParams.CurrentWorkspaceChanged -= OnWorkspaceChanged;
             loadedParams.CurrentWorkspaceCleared -= OnWorkspaceCleared;
             WorkspaceModel.DummyNodesReloaded -= TriggerDependencyRegen;
+            DynamoView.CloseExtension -= this.OnExtensionTabClosedHandler;
         }
 
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -17,7 +17,7 @@ namespace Dynamo.WorkspaceDependency
     /// </summary>
     public class WorkspaceDependencyViewExtension : IViewExtension, ILogSource
     {
-        internal MenuItem packageDependencyMenuItem;
+        internal MenuItem workspaceReferencesMenuItem;
         private String extensionName = "Workspace References";
 
         internal WorkspaceDependencyView DependencyView
@@ -86,7 +86,7 @@ namespace Dynamo.WorkspaceDependency
         {
             if (extensionTabName.Equals(extensionName))
             {
-                this.packageDependencyMenuItem.IsChecked = false;
+                this.workspaceReferencesMenuItem.IsChecked = false;
             }  
         }
 
@@ -104,24 +104,24 @@ namespace Dynamo.WorkspaceDependency
             DependencyView.OnExtensionTabClosed += OnCloseExtension;
 
             // Adding a button in view menu to refresh and show manually
-            packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString, IsCheckable = true, IsChecked = false };
-            packageDependencyMenuItem.Click += (sender, args) =>
+            workspaceReferencesMenuItem = new MenuItem { Header = Resources.MenuItemString, IsCheckable = true, IsChecked = false };
+            workspaceReferencesMenuItem.Click += (sender, args) =>
             {
-                if (packageDependencyMenuItem.IsChecked)
+                if (workspaceReferencesMenuItem.IsChecked)
                 {
                     // Refresh dependency data
                     DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
                     viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
-                    packageDependencyMenuItem.IsChecked = true;
+                    workspaceReferencesMenuItem.IsChecked = true;
                 }
                 else
                 {
                     viewLoadedParams.CloseExtensioninInSideBar(this);
-                    packageDependencyMenuItem.IsChecked = false;
+                    workspaceReferencesMenuItem.IsChecked = false;
                 }
 
             };
-            viewLoadedParams.AddMenuItem(MenuBarType.View, packageDependencyMenuItem);
+            viewLoadedParams.AddMenuItem(MenuBarType.View, workspaceReferencesMenuItem);
         }
 
     }

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -18,7 +18,7 @@ namespace Dynamo.WorkspaceDependency
     public class WorkspaceDependencyViewExtension : IViewExtension, ILogSource
     {
         internal MenuItem workspaceReferencesMenuItem;
-        private String extensionName = "Workspace References";
+        private const String extensionName = "Workspace References";
 
         internal WorkspaceDependencyView DependencyView
         {

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -54,6 +54,7 @@ namespace Dynamo.WorkspaceDependency
         /// </summary>
         public void Dispose()
         {
+            DependencyView.OnExtensionTabClosed -= OnCloseExtension;
         }
 
 
@@ -96,7 +97,7 @@ namespace Dynamo.WorkspaceDependency
                 DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
             };
 
-            viewLoadedParams.OnExtensionTabClosed += OnCloseExtension;
+            DependencyView.OnExtensionTabClosed += OnCloseExtension;
 
             // Adding a button in view menu to refresh and show manually
             packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString, IsCheckable = true, IsChecked = false };

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -18,6 +18,7 @@ namespace Dynamo.WorkspaceDependency
     public class WorkspaceDependencyViewExtension : IViewExtension, ILogSource
     {
         internal MenuItem packageDependencyMenuItem;
+        private String extensionName = "Workspace References";
 
         internal WorkspaceDependencyView DependencyView
         {
@@ -34,7 +35,7 @@ namespace Dynamo.WorkspaceDependency
         {
             get
             {
-                return "Workspace References";
+                return extensionName;
             }
         }
 
@@ -81,9 +82,12 @@ namespace Dynamo.WorkspaceDependency
             this.MessageLogged?.Invoke(msg);
         }
 
-        internal void OnCloseExtension()
+        internal void OnCloseExtension(String extensionTabName)
         {
-            this.packageDependencyMenuItem.IsChecked = false;
+            if (extensionTabName.Equals(extensionName))
+            {
+                this.packageDependencyMenuItem.IsChecked = false;
+            }  
         }
 
         public void Loaded(ViewLoadedParams viewLoadedParams)

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -17,7 +17,7 @@ namespace Dynamo.WorkspaceDependency
     /// </summary>
     public class WorkspaceDependencyViewExtension : IViewExtension, ILogSource
     {
-        private MenuItem packageDependencyMenuItem;
+        internal MenuItem packageDependencyMenuItem;
 
         internal WorkspaceDependencyView DependencyView
         {
@@ -74,9 +74,15 @@ namespace Dynamo.WorkspaceDependency
         }
 
         public event Action<ILogMessage> MessageLogged;
+
         internal void OnMessageLogged(ILogMessage msg)
         {
             this.MessageLogged?.Invoke(msg);
+        }
+
+        internal void OnCloseExtension()
+        {
+            this.packageDependencyMenuItem.IsChecked = false;
         }
 
         public void Loaded(ViewLoadedParams viewLoadedParams)
@@ -90,6 +96,8 @@ namespace Dynamo.WorkspaceDependency
                 DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
             };
 
+            viewLoadedParams.OnExtensionTabClosed += OnCloseExtension;
+
             // Adding a button in view menu to refresh and show manually
             packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString, IsCheckable = true, IsChecked = false };
             packageDependencyMenuItem.Click += (sender, args) =>
@@ -99,10 +107,12 @@ namespace Dynamo.WorkspaceDependency
                     // Refresh dependency data
                     DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
                     viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
+                    packageDependencyMenuItem.IsChecked = true;
                 }
                 else
                 {
                     viewLoadedParams.CloseExtensioninInSideBar(this);
+                    packageDependencyMenuItem.IsChecked = false;
                 }
 
             };


### PR DESCRIPTION
### Purpose

This PR is to address the bug related to the closing of the extension tab. 

Task: https://jira.autodesk.com/browse/DYN-2349

![close extension](https://user-images.githubusercontent.com/43763136/71009581-7c515e00-20b8-11ea-83a1-1749bb67dbf7.gif)

![close extension new](https://user-images.githubusercontent.com/43763136/71140816-5a52fb00-21e0-11ea-97b3-60e3c7ea55fd.gif)

TODO:
There is still one bug related to the check mark in the tab menu for the workspace references extension. Looking into that ----> Fixed

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang @aparajit-pratap 

