### PR TITLE
[Cherry-pick][DYN-2349] Close workspace references extension tab by user action an…

### DIFF
--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -9,7 +9,6 @@ using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Visualization;
-using Dynamo.Wpf.ViewModels;
 using Dynamo.Wpf.ViewModels.Watch3D;
 
 namespace Dynamo.Wpf.Extensions

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -68,6 +68,8 @@ namespace Dynamo.Controls
         internal ViewExtensionManager viewExtensionManager;
         private ShortcutToolbar shortcutBar;
         private bool loaded = false;
+        // This event is raised on the dynamo view when an extension tab is closed.
+        internal static event Action<String> CloseExtension;
 
         internal ObservableCollection<TabItem> TabItems { set; get; } = new ObservableCollection<TabItem>();
 
@@ -203,14 +205,15 @@ namespace Dynamo.Controls
         }
 
         /// <summary>
-        /// This method close a tab item in the right side bar based on passed extension
+        /// This method will close a tab item in the right side bar based on passed extension
         /// </summary>
         /// <param name="viewExtension">Extension to be closed</param>
         /// <returns></returns>
         internal void CloseTabItem(IViewExtension viewExtension)
         {
             string tabName = viewExtension.Name;
-            CloseTab(tabName);
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
+            CloseTab(tabitem);
         }
 
         // This method adds a tab item to the right side bar and 
@@ -227,6 +230,7 @@ namespace Dynamo.Controls
                 TabItem tab = new TabItem();
                 tab.Header = viewExtension.Name;
                 tab.Tag = viewExtension.GetType();
+                tab.Uid = viewExtension.UniqueId;
                 tab.HeaderTemplate = tabDynamic.FindResource("TabHeader") as DataTemplate;
 
                 // setting the extension UI to the current tab content 
@@ -242,7 +246,6 @@ namespace Dynamo.Controls
 
                 //Insert the tab at the end
                 TabItems.Insert(count, tab);
-                TabItems = TabItems;
 
                 tabDynamic.DataContext = TabItems;
                 tabDynamic.SelectedItem = tab;
@@ -255,31 +258,35 @@ namespace Dynamo.Controls
         // This method triggers the close operation on the selected tab. 
         private void CloseTab(object sender, RoutedEventArgs e)
         {
-            string tabName = (sender as Button).CommandParameter.ToString();
-            CloseTab(tabName);
+            string tabName = (sender as Button).DataContext.ToString();
+
+            CloseExtension?.Invoke(tabName);
+
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
+            CloseTab(tabitem);
         }
 
         /// <summary>
         /// Close tab by its name
         /// </summary>
-        /// <param name="tabName">tab name</param>
-        private void CloseTab(string tabName)
+        /// <param name="tabitem">tab item</param>
+        private void CloseTab(TabItem tabitem)
         {
-            TabItem tab = tabDynamic.SelectedItem as TabItem;
+            TabItem tabToBeRemoved = tabitem;
 
-            if (tab != null)
+            // get the selected tab
+            TabItem selectedTab = tabDynamic.SelectedItem as TabItem;
+
+            if (tabToBeRemoved != null)
             {
-                // get the selected tab
-                TabItem selectedTab = tabDynamic.SelectedItem as TabItem;
-
                 // clear tab control binding and bind to the new tab-list. 
                 tabDynamic.DataContext = null;
-                TabItems.Remove(tab);
+                TabItems.Remove(tabToBeRemoved);
                 TabItems = TabItems;
                 tabDynamic.DataContext = TabItems;
 
                 // Highlight previously selected tab. if that is removed then Highlight the first tab
-                if (selectedTab == null || selectedTab.Equals(tab))
+                if (selectedTab.Equals(tabToBeRemoved))
                 {
                     if (TabItems.Count > 0)
                     {

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Dynamo.Controls;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.Utilities;
@@ -53,6 +54,10 @@ namespace Dynamo.WorkspaceDependency
                 if (hasDependencyIssue)
                 {
                     loadedParams.AddToExtensionsSideBar(dependencyViewExtension, this);
+                    if (dependencyViewExtension.workspaceReferencesMenuItem != null && !dependencyViewExtension.workspaceReferencesMenuItem.IsChecked)
+                    {
+                        dependencyViewExtension.workspaceReferencesMenuItem.IsChecked = true;
+                    }
                 }
             }
         }
@@ -167,6 +172,21 @@ namespace Dynamo.WorkspaceDependency
             packageInstaller = p.PackageInstaller;
             dependencyViewExtension = viewExtension;
             DependencyRegen(currentWorkspace);
+            DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
+        }
+
+        /// <summary>
+        /// This event is raised when an extension tab is closed and this event 
+        /// is subscribed by the Workspace dependency view extension.
+        /// <param name="extensionTabName"></param>
+        /// </summary>
+        internal event Action<String> OnExtensionTabClosed;
+        private void OnExtensionTabClosedHandler(String extensionTabName)
+        {
+            if (OnExtensionTabClosed != null)
+            {
+                OnExtensionTabClosed(extensionTabName);
+            }
         }
 
         /// <summary>
@@ -247,6 +267,7 @@ namespace Dynamo.WorkspaceDependency
             loadedParams.CurrentWorkspaceChanged -= OnWorkspaceChanged;
             loadedParams.CurrentWorkspaceCleared -= OnWorkspaceCleared;
             WorkspaceModel.DummyNodesReloaded -= TriggerDependencyRegen;
+            DynamoView.CloseExtension -= this.OnExtensionTabClosedHandler;
         }
 
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -17,7 +17,8 @@ namespace Dynamo.WorkspaceDependency
     /// </summary>
     public class WorkspaceDependencyViewExtension : IViewExtension, ILogSource
     {
-        private MenuItem packageDependencyMenuItem;
+        internal MenuItem workspaceReferencesMenuItem;
+        private const String extensionName = "Workspace References";
 
         internal WorkspaceDependencyView DependencyView
         {
@@ -34,7 +35,7 @@ namespace Dynamo.WorkspaceDependency
         {
             get
             {
-                return "Workspace References";
+                return extensionName;
             }
         }
 
@@ -54,6 +55,7 @@ namespace Dynamo.WorkspaceDependency
         /// </summary>
         public void Dispose()
         {
+            DependencyView.OnExtensionTabClosed -= OnCloseExtension;
         }
 
 
@@ -74,9 +76,18 @@ namespace Dynamo.WorkspaceDependency
         }
 
         public event Action<ILogMessage> MessageLogged;
+
         internal void OnMessageLogged(ILogMessage msg)
         {
             this.MessageLogged?.Invoke(msg);
+        }
+
+        internal void OnCloseExtension(String extensionTabName)
+        {
+            if (extensionTabName.Equals(extensionName))
+            {
+                this.workspaceReferencesMenuItem.IsChecked = false;
+            }  
         }
 
         public void Loaded(ViewLoadedParams viewLoadedParams)
@@ -90,23 +101,27 @@ namespace Dynamo.WorkspaceDependency
                 DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
             };
 
+            DependencyView.OnExtensionTabClosed += OnCloseExtension;
+
             // Adding a button in view menu to refresh and show manually
-            packageDependencyMenuItem = new MenuItem { Header = Resources.MenuItemString, IsCheckable = true, IsChecked = false };
-            packageDependencyMenuItem.Click += (sender, args) =>
+            workspaceReferencesMenuItem = new MenuItem { Header = Resources.MenuItemString, IsCheckable = true, IsChecked = false };
+            workspaceReferencesMenuItem.Click += (sender, args) =>
             {
-                if (packageDependencyMenuItem.IsChecked)
+                if (workspaceReferencesMenuItem.IsChecked)
                 {
                     // Refresh dependency data
                     DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
                     viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
+                    workspaceReferencesMenuItem.IsChecked = true;
                 }
                 else
                 {
                     viewLoadedParams.CloseExtensioninInSideBar(this);
+                    workspaceReferencesMenuItem.IsChecked = false;
                 }
 
             };
-            viewLoadedParams.AddMenuItem(MenuBarType.View, packageDependencyMenuItem);
+            viewLoadedParams.AddMenuItem(MenuBarType.View, workspaceReferencesMenuItem);
         }
 
     }


### PR DESCRIPTION
### Purpose

This PR is to cherry-pick https://github.com/DynamoDS/Dynamo/pull/10230 into RC2.5.0_master branch.  

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@mjkkirschner 
