### PR TITLE
Event to handle the close operation of the workspace references extension

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Graph.Workspaces
         private bool graphExecuted;
 
         // Event to handle closing of the extension when the workspace is closed. 
-        internal static event Action<String> CloseExtension;
+        internal static event Action WorkspaceCleared;
 
         private String workspaceReferencesExtensionName = "Workspace References";
 
@@ -425,7 +425,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public override void Clear()
         {
-            CloseExtension?.Invoke(workspaceReferencesExtensionName);
+            WorkspaceCleared?.Invoke();
             base.Clear();
             PreloadedTraceData = null;
             RunSettings.Reset();

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -32,6 +32,12 @@ namespace Dynamo.Graph.Workspaces
         private readonly bool verboseLogging;
         private bool graphExecuted;
 
+        // Event to handle closing of the extension when the workspace is closed. 
+        internal static event Action<String> CloseExtension;
+
+        private String workspaceReferencesExtensionName = "Workspace References";
+
+
         // To check whether task is completed or not. 
         private bool executingTask;
 
@@ -419,6 +425,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public override void Clear()
         {
+            CloseExtension?.Invoke(workspaceReferencesExtensionName);
             base.Clear();
             PreloadedTraceData = null;
             RunSettings.Reset();

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -32,11 +32,8 @@ namespace Dynamo.Graph.Workspaces
         private readonly bool verboseLogging;
         private bool graphExecuted;
 
-        // Event to handle closing of the extension when the workspace is closed. 
+        // Event to handle closing of the workspace references extension when the workspace is closed. 
         internal static event Action WorkspaceCleared;
-
-        private String workspaceReferencesExtensionName = "Workspace References";
-
 
         // To check whether task is completed or not. 
         private bool executingTask;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -197,11 +197,25 @@ namespace Dynamo.Controls
             // Add an event handler to check if the collection is modified.   
             TabItems.CollectionChanged += this.OnCollectionChanged;
 
+            HomeWorkspaceModel.CloseExtension += this.CloseExtensionTab;
+
             this.HideOrShowRightSideBar();
 
             this.dynamoViewModel.RequestPaste += OnRequestPaste;
             this.dynamoViewModel.RequestReturnFocusToView += OnRequestReturnFocusToView;
             FocusableGrid.InputBindings.Clear();
+        }
+
+        /// <summary>
+        /// This method is called when the home workspace is closed. This will inturn close the workspace references extension.
+        /// </summary>
+        /// <param name="extensionTabName">Extension name</param>
+        /// <returns></returns>
+        internal void CloseExtensionTab(String extensionTabName)
+        {
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == extensionTabName);
+            CloseExtension?.Invoke(extensionTabName);
+            CloseTab(tabitem);
         }
 
         /// <summary>
@@ -2039,6 +2053,7 @@ namespace Dynamo.Controls
 
             // Removing the tab items list handler
             TabItems.CollectionChanged -= this.OnCollectionChanged;
+            HomeWorkspaceModel.CloseExtension -= this.CloseExtensionTab;
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -197,37 +197,11 @@ namespace Dynamo.Controls
             // Add an event handler to check if the collection is modified.   
             TabItems.CollectionChanged += this.OnCollectionChanged;
 
-            HomeWorkspaceModel.CloseExtension += this.CloseExtensionTab;
-
             this.HideOrShowRightSideBar();
 
             this.dynamoViewModel.RequestPaste += OnRequestPaste;
             this.dynamoViewModel.RequestReturnFocusToView += OnRequestReturnFocusToView;
             FocusableGrid.InputBindings.Clear();
-        }
-
-        /// <summary>
-        /// This method is called when the home workspace is closed. This will inturn close the workspace references extension.
-        /// </summary>
-        /// <param name="extensionTabName">Extension name</param>
-        /// <returns></returns>
-        internal void CloseExtensionTab(String extensionTabName)
-        {
-            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == extensionTabName);
-            CloseExtension?.Invoke(extensionTabName);
-            CloseTab(tabitem);
-        }
-
-        /// <summary>
-        /// This method will close a tab item in the right side bar based on passed extension
-        /// </summary>
-        /// <param name="viewExtension">Extension to be closed</param>
-        /// <returns></returns>
-        internal void CloseTabItem(IViewExtension viewExtension)
-        {
-            string tabName = viewExtension.Name;
-            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
-            CloseTab(tabitem);
         }
 
         // This method adds a tab item to the right side bar and 
@@ -267,6 +241,19 @@ namespace Dynamo.Controls
                 return tab;
             }
             return null;
+        }
+
+        /// <summary>
+        /// This method will close a tab item in the right side bar based on passed extension
+        /// </summary>
+        /// <param name="viewExtension">Extension to be closed</param>
+        /// <returns></returns>
+        internal void CloseTabItem(IViewExtension viewExtension)
+        {
+            string tabName = viewExtension.Name;
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
+            CloseExtension?.Invoke(tabName);
+            CloseTab(tabitem);
         }
 
         // This method triggers the close operation on the selected tab. 
@@ -2053,7 +2040,6 @@ namespace Dynamo.Controls
 
             // Removing the tab items list handler
             TabItems.CollectionChanged -= this.OnCollectionChanged;
-            HomeWorkspaceModel.CloseExtension -= this.CloseExtensionTab;
         }
     }
 }

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -176,6 +176,9 @@ namespace Dynamo.WorkspaceDependency
             HomeWorkspaceModel.WorkspaceCleared += this.CloseExtensionTab;
         }
 
+        /// <summary>
+        /// This method will call the close API on the workspace references extension. 
+        /// </summary>
         internal void CloseExtensionTab()
         {
             loadedParams.CloseExtensioninInSideBar(dependencyViewExtension);

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -153,7 +153,7 @@ namespace Dynamo.WorkspaceDependency
         internal void TriggerDependencyRegen()
         {
             DependencyRegen(currentWorkspace);
-        } 
+        }
 
         /// <summary>
         /// Constructor
@@ -173,6 +173,12 @@ namespace Dynamo.WorkspaceDependency
             dependencyViewExtension = viewExtension;
             DependencyRegen(currentWorkspace);
             DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
+            HomeWorkspaceModel.WorkspaceCleared += this.CloseExtensionTab;
+        }
+
+        internal void CloseExtensionTab()
+        {
+            loadedParams.CloseExtensioninInSideBar(dependencyViewExtension);
         }
 
         /// <summary>
@@ -268,6 +274,7 @@ namespace Dynamo.WorkspaceDependency
             loadedParams.CurrentWorkspaceCleared -= OnWorkspaceCleared;
             WorkspaceModel.DummyNodesReloaded -= TriggerDependencyRegen;
             DynamoView.CloseExtension -= this.OnExtensionTabClosedHandler;
+            HomeWorkspaceModel.WorkspaceCleared -= this.CloseExtensionTab;
         }
 
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)


### PR DESCRIPTION
# Purpose

This PR is to close the workspace references extension tab when the workspace is closed so that when the user reopens the graph with no missing dependencies, the extension is hidden. It will only be shown when the workspace has missing dependencies. 

![Closing](https://user-images.githubusercontent.com/43763136/71904667-8f71be00-318c-11ea-86a0-766373e6a8ae.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang @aparajit-pratap 