### PR TITLE
DYN-2375 - Event to handle the close operation of the workspace references extension 

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -32,11 +32,8 @@ namespace Dynamo.Graph.Workspaces
         private readonly bool verboseLogging;
         private bool graphExecuted;
 
-        // Event to handle closing of the extension when the workspace is closed. 
-        internal static event Action<String> CloseExtension;
-
-        private String workspaceReferencesExtensionName = "Workspace References";
-
+        // Event to handle closing of the workspace references extension when the workspace is closed. 
+        internal static event Action WorkspaceCleared;
 
         // To check whether task is completed or not. 
         private bool executingTask;
@@ -425,7 +422,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public override void Clear()
         {
-            CloseExtension?.Invoke(workspaceReferencesExtensionName);
+            WorkspaceCleared?.Invoke();
             base.Clear();
             PreloadedTraceData = null;
             RunSettings.Reset();

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -32,6 +32,12 @@ namespace Dynamo.Graph.Workspaces
         private readonly bool verboseLogging;
         private bool graphExecuted;
 
+        // Event to handle closing of the extension when the workspace is closed. 
+        internal static event Action<String> CloseExtension;
+
+        private String workspaceReferencesExtensionName = "Workspace References";
+
+
         // To check whether task is completed or not. 
         private bool executingTask;
 
@@ -419,6 +425,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public override void Clear()
         {
+            CloseExtension?.Invoke(workspaceReferencesExtensionName);
             base.Clear();
             PreloadedTraceData = null;
             RunSettings.Reset();

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Graph.Workspaces
         private bool graphExecuted;
 
         // Event to handle closing of the workspace references extension when the workspace is closed. 
-        internal static event Action WorkspaceCleared;
+        internal static event Action WorkspaceClosed;
 
         // To check whether task is completed or not. 
         private bool executingTask;
@@ -422,7 +422,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public override void Clear()
         {
-            WorkspaceCleared?.Invoke();
+            WorkspaceClosed?.Invoke();
             base.Clear();
             PreloadedTraceData = null;
             RunSettings.Reset();

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -201,11 +201,25 @@ namespace Dynamo.Controls
             // Add an event handler to check if the collection is modified.   
             ExtensionTabItems.CollectionChanged += this.OnCollectionChanged;
 
+            HomeWorkspaceModel.CloseExtension += this.CloseExtensionTab;
+
             this.HideOrShowRightSideBar();
 
             this.dynamoViewModel.RequestPaste += OnRequestPaste;
             this.dynamoViewModel.RequestReturnFocusToView += OnRequestReturnFocusToView;
             FocusableGrid.InputBindings.Clear();
+        }
+
+        /// <summary>
+        /// This method is called when the home workspace is closed. This will inturn close the workspace references extension.
+        /// </summary>
+        /// <param name="extensionTabName">Extension name</param>
+        /// <returns></returns>
+        internal void CloseExtensionTab(String extensionTabName)
+        {
+            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == extensionTabName);
+            CloseExtension?.Invoke(extensionTabName);
+            CloseTab(tabitem);
         }
 
         /// <summary>
@@ -2048,6 +2062,8 @@ namespace Dynamo.Controls
 
             // Removing the tab items list handler
             ExtensionTabItems.CollectionChanged -= this.OnCollectionChanged;
+            HomeWorkspaceModel.CloseExtension -= this.CloseExtensionTab;
+
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -201,37 +201,11 @@ namespace Dynamo.Controls
             // Add an event handler to check if the collection is modified.   
             ExtensionTabItems.CollectionChanged += this.OnCollectionChanged;
 
-            HomeWorkspaceModel.CloseExtension += this.CloseExtensionTab;
-
             this.HideOrShowRightSideBar();
 
             this.dynamoViewModel.RequestPaste += OnRequestPaste;
             this.dynamoViewModel.RequestReturnFocusToView += OnRequestReturnFocusToView;
             FocusableGrid.InputBindings.Clear();
-        }
-
-        /// <summary>
-        /// This method is called when the home workspace is closed. This will inturn close the workspace references extension.
-        /// </summary>
-        /// <param name="extensionTabName">Extension name</param>
-        /// <returns></returns>
-        internal void CloseExtensionTab(String extensionTabName)
-        {
-            TabItem tabitem = TabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == extensionTabName);
-            CloseExtension?.Invoke(extensionTabName);
-            CloseTab(tabitem);
-        }
-
-        /// <summary>
-        /// This method will close a tab item in the right side bar based on passed extension
-        /// </summary>
-        /// <param name="viewExtension">Extension to be closed</param>
-        /// <returns></returns>
-        internal void CloseExtensionTabItem(IViewExtension viewExtension)
-        {
-            string tabName = viewExtension.Name;
-            TabItem tabitem = ExtensionTabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
-            CloseExtensionTab(tabitem);
         }
 
         // This method adds a tab item to the right side bar and 
@@ -273,6 +247,19 @@ namespace Dynamo.Controls
             return null;
         }
 
+        /// <summary>
+        /// This method will close a tab item in the right side bar based on passed extension
+        /// </summary>
+        /// <param name="viewExtension">Extension to be closed</param>
+        /// <returns></returns>
+        internal void CloseExtensionTabItem(IViewExtension viewExtension)
+        {
+            string tabName = viewExtension.Name;
+            TabItem tabitem = ExtensionTabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == tabName);
+            CloseExtension?.Invoke(tabName);
+            CloseExtensionTab(tabitem);
+        }
+ 
         /// <summary>
         /// Event handler for the CloseButton.
         /// This method triggers the close operation on the selected tab.
@@ -2062,8 +2049,6 @@ namespace Dynamo.Controls
 
             // Removing the tab items list handler
             ExtensionTabItems.CollectionChanged -= this.OnCollectionChanged;
-            HomeWorkspaceModel.CloseExtension -= this.CloseExtensionTab;
-
         }
     }
 }

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -173,7 +173,7 @@ namespace Dynamo.WorkspaceDependency
             dependencyViewExtension = viewExtension;
             DependencyRegen(currentWorkspace);
             DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
-            HomeWorkspaceModel.WorkspaceCleared += this.CloseExtensionTab;
+            HomeWorkspaceModel.WorkspaceClosed += this.CloseExtensionTab;
         }
 
         /// <summary>
@@ -277,7 +277,7 @@ namespace Dynamo.WorkspaceDependency
             loadedParams.CurrentWorkspaceCleared -= OnWorkspaceCleared;
             WorkspaceModel.DummyNodesReloaded -= TriggerDependencyRegen;
             DynamoView.CloseExtension -= this.OnExtensionTabClosedHandler;
-            HomeWorkspaceModel.WorkspaceCleared -= this.CloseExtensionTab;
+            HomeWorkspaceModel.WorkspaceClosed -= this.CloseExtensionTab;
         }
 
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -153,7 +153,7 @@ namespace Dynamo.WorkspaceDependency
         internal void TriggerDependencyRegen()
         {
             DependencyRegen(currentWorkspace);
-        } 
+        }
 
         /// <summary>
         /// Constructor
@@ -173,6 +173,15 @@ namespace Dynamo.WorkspaceDependency
             dependencyViewExtension = viewExtension;
             DependencyRegen(currentWorkspace);
             DynamoView.CloseExtension += this.OnExtensionTabClosedHandler;
+            HomeWorkspaceModel.WorkspaceCleared += this.CloseExtensionTab;
+        }
+
+        /// <summary>
+        /// This method will call the close API on the workspace references extension. 
+        /// </summary>
+        internal void CloseExtensionTab()
+        {
+            loadedParams.CloseExtensioninInSideBar(dependencyViewExtension);
         }
 
         /// <summary>
@@ -268,6 +277,7 @@ namespace Dynamo.WorkspaceDependency
             loadedParams.CurrentWorkspaceCleared -= OnWorkspaceCleared;
             WorkspaceModel.DummyNodesReloaded -= TriggerDependencyRegen;
             DynamoView.CloseExtension -= this.OnExtensionTabClosedHandler;
+            HomeWorkspaceModel.WorkspaceCleared -= this.CloseExtensionTab;
         }
 
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -129,6 +129,23 @@ namespace DynamoCoreWpfTests
         }
 
         /// <summary>
+        /// This test will make sure that the extension tab is closed upon closing the home workspace.
+        /// </summary>
+        [Test]
+        public void CloseViewExtensionTabOnClosingWorkspace()
+        {
+            RaiseLoadedEvent(this.View);
+            var extensionManager = View.viewExtensionManager;
+            extensionManager.Add(viewExtension);
+            // Open a graph which should bring up the Workspace References view extension window with one tab
+            Open(@"pkgs\Dynamo Samples\extra\CustomRenderExample.dyn");
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            var homeSpace = Model.Workspaces.First(ws => ws is HomeWorkspaceModel) as HomeWorkspaceModel;
+            homeSpace.Clear();
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+        }
+
+        /// <summary>
         /// This test is created to guard a crash happened that while dep viewer is loaded,
         /// opening a dyf directly and closing it to switch to an empty homeworkspace causing a crash
         /// </summary>


### PR DESCRIPTION
### Purpose

This PR is to close the workspace references extension tab when the workspace is closed so that when the user reopens the graph with no missing dependencies, the extension is hidden. It will only be shown when the workspace has missing dependencies.

This PR is a replica of this PR: https://github.com/DynamoDS/Dynamo/pull/10271

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang @mjkkirschner @aparajit-pratap 
