### PR TITLE
Change mechanism to retrieve the certificate from assembly

### DIFF
--- a/src/DynamoUtilities/CertificateVerification.cs
+++ b/src/DynamoUtilities/CertificateVerification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -37,7 +38,17 @@ namespace DynamoUtilities
             }
 
             //Verify the node library has a verified signed certificate
-            var cert = asm.Modules.FirstOrDefault()?.GetSignerCertificate();
+            X509Certificate cert;
+            try
+            {
+                cert = X509Certificate.CreateFromSignedFile(assemblyPath);
+            }
+            catch
+            {
+                throw new Exception(String.Format(
+                    "A dll file found at {0} did not have a certificate attached.", assemblyPath));
+            }
+
             if (cert != null)
             {
                 var cert2 = new System.Security.Cryptography.X509Certificates.X509Certificate2(cert);


### PR DESCRIPTION
### Purpose

This PR update the mechanism the CertificateVerification code uses to extract a certificate from an assembly during the verification process

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@sm6srw
