### PR TITLE
DYN-2289: Fix crash with NodeToCode

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -536,7 +536,7 @@ namespace Dynamo.Graph.Nodes
             if (statement == null)
                 return type;
 
-            BinaryExpressionNode expr = statement.AstNode as BinaryExpressionNode;
+            var expr = statement.AstNode as BinaryExpressionNode;
             if (expr == null || expr.Optr != Operator.assign)
                 return type;
 
@@ -554,15 +554,21 @@ namespace Dynamo.Graph.Nodes
                     return type;
 
                 var classIndex = core.ClassTable.IndexOf(fullyQualifiedName);
-                if (classIndex == ProtoCore.DSASM.Constants.kInvalidIndex)
+                if (classIndex == Constants.kInvalidIndex)
                     return type;
 
                 var targetClass = core.ClassTable.ClassNodes[classIndex];
-                var func = targetClass.GetFirstMemberFunctionBy(funcNode.Function.Name);
+                var funcName = funcNode.Function.Name;
+                var func = targetClass.GetFirstMemberFunctionBy(funcName);
+                if (func == null)
+                {
+                    func = targetClass.ProcTable.GetPropertyGetterByName(funcName);
+                }
                 type = func.ReturnType;
                 return type;
             }
-            else if (expr.RightNode is FunctionCallNode)
+
+            if (expr.RightNode is FunctionCallNode)
             {
                 var functionCallNode = expr.RightNode as FunctionCallNode;
                 ProtoCore.FunctionGroup funcGroup;

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -514,9 +514,9 @@ namespace ProtoFFI
 
             string name = m.Name;
             int nParams = 0;
-            if (name.StartsWith("get_"))
+            if (name.StartsWith(Constants.kGetterPrefix))
                 name.Remove(0, 4);
-            else if (name.StartsWith("set_"))
+            else if (name.StartsWith(Constants.kSetterPrefix))
             {
                 name.Remove(0, 4);
                 nParams = 1;

--- a/src/Engine/ProtoCore/ProcedureTable.cs
+++ b/src/Engine/ProtoCore/ProcedureTable.cs
@@ -299,6 +299,12 @@ namespace ProtoCore.DSASM
             return Procedures.Where(p => p.Name.Equals(name));
         }
 
+        /// <summary>
+        /// Returns getter function for given property name.
+        /// Ex: for X property of Point, this method returns get_X(Point p).
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public ProcedureNode GetPropertyGetterByName(string name)
         {
             var getterMethodName = Constants.kGetterPrefix + name;

--- a/src/Engine/ProtoCore/ProcedureTable.cs
+++ b/src/Engine/ProtoCore/ProcedureTable.cs
@@ -299,6 +299,13 @@ namespace ProtoCore.DSASM
             return Procedures.Where(p => p.Name.Equals(name));
         }
 
+        public ProcedureNode GetPropertyGetterByName(string name)
+        {
+            var getterMethodName = Constants.kGetterPrefix + name;
+            return Procedures.FirstOrDefault(p => p.Name == getterMethodName &&
+                                                  p.IsStatic && p.ArgumentTypes.Count == 1);
+        }
+
         /// <summary>
         /// Returns all functions with specified name and the number of argument.
         ///

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1342,6 +1342,22 @@ namespace Dynamo.Tests
             Assert.IsNotNull(cbn);
             Assert.IsTrue(cbn.GetAstIdentifierForOutputIndex(0).Value.StartsWith("num"));
         }
+
+        [Test]
+        public void TestNodeToCodeWithPropertyInCodeBlock()
+        {
+            OpenModel(@"core\node2code\NodeToCode_CodeBlock.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            SelectAll(nodes);
+
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            AssertPreviewValue(cbn.GUID.ToString(), false);
+        }
     }
 
     [Category("NodeToCode")]

--- a/test/core/node2code/NodeToCode_CodeBlock.dyn
+++ b/test/core/node2code/NodeToCode_CodeBlock.dyn
@@ -1,0 +1,135 @@
+{
+  "Uuid": "815297e0-a634-4ca1-a1e3-35e16774573a",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "point1 = Point.ByCoordinates(10, 0, 0);\nnum1 = Point.X(point1);",
+      "Id": "459b7a03967e47edad45109fa1c02996",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "7cacc376e22a442c8efead26169377ce",
+          "Name": "",
+          "Description": "point1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "193144eee6fc4eb0b842bee205a194fb",
+          "Name": "",
+          "Description": "num1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.IsEmpty@var[]..[]",
+      "Id": "19099719248c4d3ab5c336dd40243ddf",
+      "Inputs": [
+        {
+          "Id": "8266ff53c9e34ac1a5599779cc677f34",
+          "Name": "list",
+          "Description": "List to check for items.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d4b15af56c4348c5bd67e5ba6832af59",
+          "Name": "bool",
+          "Description": "Whether the list is empty.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if the given list is empty.\n\nList.IsEmpty (list: var[]..[]): bool"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "193144eee6fc4eb0b842bee205a194fb",
+      "End": "8266ff53c9e34ac1a5599779cc677f34",
+      "Id": "7a56817a34c7477f80197cc168946b9a"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7474",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "459b7a03967e47edad45109fa1c02996",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 282.5,
+        "Y": 247.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.IsEmpty",
+        "Id": "19099719248c4d3ab5c336dd40243ddf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 723.0,
+        "Y": 262.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/DYN-2289
GH Issue: https://github.com/DynamoDS/Dynamo/issues/9227

This fix prevents a crash when converting nodes to code in which at least one upstream node is a CBN that has static property invocations such as:
```
p = Point.ByCoordinates(0, 0, 0);
x = Point.X(p);
```
The reason for the crash was that the property was not found in the procedure table for the class. Since property getters internally compile to `get_propertyname(object)`, a method has been added that additionally checks for a static getter that accepts one argument (namely the class object), which in this example would be searching explicitly for `get_X(p)` instead of just `X`.  

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

