### PR TITLE
Fix the library view display issues introduced by MS WebBrowser

### DIFF
--- a/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
@@ -69,7 +69,6 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
 
         private void scriptNotifyHandler(string dataFromjs)
         {
-
             if (string.IsNullOrEmpty(dataFromjs))
             {
                 return;
@@ -231,6 +230,7 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 dynamoViewModel.ImportLibraryCommand.Execute(null)
             ));
         }
+
         /// <summary>
         /// This function logs events to instrumentation if it matches a set of known events
         /// </summary>
@@ -243,16 +243,16 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 Analytics.LogPiiInfo(eventName, data);
             }
         }
+
         internal void RefreshLibraryView(WebBrowser browser)
         {
             dynamoWindow.Dispatcher.BeginInvoke(
             new Action(() =>
             {
-
                 var ext1 = string.Empty;
                 var ext2 = string.Empty;
-            //read the full loadedTypes and LayoutSpec json strings.
-            var reader = new StreamReader(nodeProvider.GetResource(null, out ext1));
+                //read the full loadedTypes and LayoutSpec json strings.
+                var reader = new StreamReader(nodeProvider.GetResource(null, out ext1));
                 var loadedTypes = reader.ReadToEnd();
 
                 var reader2 = new StreamReader(layoutProvider.GetResource(null, out ext2));
@@ -260,8 +260,7 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
 
                 try
                 {
-                    browser.InvokeScript
-                         ("refreshLibViewFromData", loadedTypes, layoutSpec);
+                    browser.InvokeScript("refreshLibViewFromData", loadedTypes, layoutSpec);
                 }
                 catch (Exception e)
                 {
@@ -269,9 +268,7 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 }
                 reader.Dispose();
                 reader2.Dispose();
-
             }));
-
         }
 
         #endregion
@@ -344,7 +341,6 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
             var libminstring = "LIBJS";
             var libraryHTMLPage = "LIBRARY HTML WAS NOT FOUND";
 
-
             using (var reader = new StreamReader(libminstream))
             {
                 libminstring = reader.ReadToEnd();
@@ -354,7 +350,6 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 {
                     libminstring = ReplaceUrlWithBase64Image(libminstring, path.Item1, path.Item2);
                 });
-
             }
 
             using (var reader = new StreamReader(stream))
@@ -373,9 +368,14 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
             browser.Loaded += Browser_Loaded;
             browser.SizeChanged += Browser_SizeChanged;
             LibraryViewController.SetupSearchModelEventsObserver(browser, dynamoViewModel.Model.SearchModel, this, this.customization);
+
+            browser.DpiChanged += Browser_DpiChanged;
         }
 
-
+        private void Browser_DpiChanged(object sender, DpiChangedEventArgs e)
+        {
+            browser.InvokeScript("adaptDPI");
+        }
 
         private void Browser_Loaded(object sender, RoutedEventArgs e)
         {
@@ -473,7 +473,6 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 controller.CloseNodeTooltip(true);
             };
 
-
             var observer = new EventObserver<NodeSearchElement, IEnumerable<NodeSearchElement>>(
                                 elements => NotifySearchModelUpdate(customization, elements), CollectToList
                             ).Throttle(TimeSpan.FromMilliseconds(throttleTime));
@@ -539,7 +538,6 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                .Select(p => new LayoutIncludeInfo() { path = p });
 
                 customization.AddIncludeInfo(includes, "Add-ons");
-
             }
         }
 

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -177,8 +177,17 @@
 
         function adaptDPI() {
             document.body.style.overflowX = 'hidden';
+
+            var dpiScale = getDPIScale();
+
+            var libraryHeader = document.getElementsByClassName("LibraryHeader")[0];
+            libraryHeader.style.zoom = dpiScale;
+            
+            var widthPercentage = (100.0 / dpiScale).toString() + '%';
+            libraryHeader.style.width = widthPercentage;
+
             var libraryItemsContainer = document.getElementsByClassName("LibraryItemContainer")[0];
-            libraryItemsContainer.style.zoom = getDPIScale();
+            libraryItemsContainer.style.zoom = dpiScale;
         }
 
     </script>

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -49,7 +49,6 @@
                 window.external.GetBase64StringFromPath(src);
                
             });
-
         }
 
         function completeReplaceImages(base64String) {
@@ -60,10 +59,8 @@
                 // we'll break out later instead of trying to reload it.
                 //TODO don't cache the string if it is the default icon.
                 // currentImage.orgSrc = base64String;
-            }
-        
+            }        
         }
-
 
         function refreshLibViewFromData(loadedTypes,layoutSpec){
             var append = false; // Replace existing contents instead of appending.
@@ -71,12 +68,13 @@
             libController.setLayoutSpecsJson(JSON.parse(layoutSpec) , append);
             libController.refreshLibraryView(); // Refresh library view.
 
+            adaptDPI();
+
             //update image src properties after dom is updated.
             setTimeout(function () {
                 replaceImages();
             }, replaceImageDelayTime);
         }
-
 
         //Create library controller
         var libController = LibraryEntryPoint.CreateLibraryController();
@@ -87,6 +85,7 @@
         function completeSearch(searchLoadedTypes){
             searchCallback(JSON.parse(searchLoadedTypes));
         }
+
         //set a custom search handler
         libController.searchLibraryItemsHandler = function (text, callback) {
             var encodedText = encodeURIComponent(text);
@@ -133,6 +132,29 @@
 
         //Update the view with contents the first time.
         window.external.notify("requestUpdateLibrary");
+
+        function getDPIScale() {
+            var dpi = 96.0;
+            if (window.screen.deviceXDPI != undefined) {
+                dpi = window.screen.deviceXDPI;
+            }
+            else {
+                var tmpNode = document.createElement("DIV");
+                tmpNode.style.cssText = "width:1in;height:1in;position:absolute;left:0px;top:0px;z-index:99;visibility:hidden";
+                document.body.appendChild(tmpNode);
+                dpi = parseInt(tmpNode.offsetWidth);
+                tmpNode.parentNode.removeChild(tmpNode);   
+            }
+
+            return dpi / 96.0;
+        }
+
+        function adaptDPI() {
+            //document.body.style.overflow = 'hidden';
+            var libraryItemsContainer = document.getElementsByClassName("LibraryItemContainer")[0];
+            //libraryItemsContainer.style.overflow = 'hidden';
+            libraryItemsContainer.style.zoom = getDPIScale();
+        }
 
     </script>
 

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -150,9 +150,8 @@
         }
 
         function adaptDPI() {
-            //document.body.style.overflow = 'hidden';
+            document.body.style.overflowX = 'hidden';
             var libraryItemsContainer = document.getElementsByClassName("LibraryItemContainer")[0];
-            //libraryItemsContainer.style.overflow = 'hidden';
             libraryItemsContainer.style.zoom = getDPIScale();
         }
 

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -32,6 +32,32 @@
             return false;
         }
 
+        // Disable zoom by keyboard
+        document.addEventListener("keydown",
+            function(event) {
+                if ((event.ctrlKey === true || event.metaKey === true) &&
+                    (event.which === 61 ||
+                    event.which === 107 ||
+                    event.which === 173 ||
+                    event.which === 109 ||
+                    event.which === 187 ||
+                    event.which === 189)) {
+                        event.preventDefault();
+                    }
+            },
+            false
+        );
+
+        // Disable zoom by mouse wheel
+        document.addEventListener("mousewheel",
+            function(event) {
+                if (event.ctrlKey === true || event.metaKey) {
+                    event.preventDefault();
+                }
+            },
+            false
+        );
+
         function replaceImages() {
             var allimages = document.getElementsByTagName("img");
 

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -27,6 +27,11 @@
         var replaceImageDelayTime = 100;
         var currentImage;
 
+        // Disable the context menu
+        document.oncontextmenu = function () {
+            return false;
+        }
+
         function replaceImages() {
             var allimages = document.getElementsByTagName("img");
 

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -12,6 +12,9 @@
             margin: 0;
             background-color: #353535;
         }
+        input::-ms-clear {
+            display: none;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
### Purpose

The following library view display issues introduced by MS WebBrowser are fixed:

1. Disable the context menu on library view.
2. Zoom the library view to adapt the current DPI scale.
3. Disable the ability about zooming library view by keyboard or mouse wheel.
4. Hidden the extra close button on search bar.

Add CSS and JS code to Library.html to solve the above issues.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@DynamoDS/dynamo