### PR TITLE
Visual Identifier on Optional Inputs

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -136,7 +136,7 @@
                 </Rectangle>
 
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-                <TextBlock Name="portNameTb"
+                    <TextBlock Name="portNameTb"
                        Width="Auto"
                        HorizontalAlignment="Stretch"
                        Style="{StaticResource SZoomFadeText}"
@@ -148,6 +148,20 @@
                        IsHitTestVisible="False"
                        Background="{x:Null}"
                        Foreground="#555555">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding UsingDefaultValue}" Value="True">
+                                        <Setter Property="FontStyle" Value="Italic"/>
+                                        <Setter Property="FontWeight" Value="Normal"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding UsingDefaultValue}" Value="False">
+                                        <Setter Property="FontStyle" Value="Normal"/>
+                                        <Setter Property="FontWeight" Value="Normal"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
                 </TextBlock>
                 <!-- We wrap the text block in a grid so that it wont be displayed on output port-->
                 <Grid Visibility="{Binding Path=UseLevelVisibility}" HorizontalAlignment="Right"> 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -152,12 +152,12 @@
                             <Style TargetType="TextBlock">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding UsingDefaultValue}" Value="True">
-                                        <Setter Property="FontStyle" Value="Italic"/>
-                                        <Setter Property="FontWeight" Value="Normal"/>
+                                        <Setter Property="FontStyle"
+                                                Value="Italic" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding UsingDefaultValue}" Value="False">
-                                        <Setter Property="FontStyle" Value="Normal"/>
-                                        <Setter Property="FontWeight" Value="Normal"/>
+                                        <Setter Property="FontStyle"
+                                                Value="Normal" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>


### PR DESCRIPTION
### Purpose

This PR adds a visual identifier to optional input ports.
When inputs are using default values, the font on port will be displayed in _Italic_

![optionalInputs](https://user-images.githubusercontent.com/13732445/73956953-94499f00-48fd-11ea-99de-b06b088523fb.gif)

![image](https://user-images.githubusercontent.com/13732445/73957014-a7f50580-48fd-11ea-95a5-52689be368ab.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@radumg 

### FYIs

@mjkkirschner will wait for your comments before doing tests
