### PR TITLE
show line numbers in codeblock nodes

### DIFF
--- a/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
@@ -184,7 +184,10 @@ namespace Dynamo.UI.Controls
         private void OnTextChanged(object sender, EventArgs e)
         {
             if (WatermarkLabel.Visibility == Visibility.Visible)
+            {
                 WatermarkLabel.Visibility = Visibility.Collapsed;
+                InnerTextEditor.ShowLineNumbers = true;
+            }
         }
 
         private void OnTextAreaTextEntering(object sender, TextCompositionEventArgs e)


### PR DESCRIPTION
### Purpose

This PR adds line numbers to `Code Blocks` using AvalonEdit, same as the Line numbers in the Python Editior.

![LineNumbers](https://user-images.githubusercontent.com/13732445/73958224-8268fb80-48ff-11ea-855c-e1980eca20c0.gif)

![image](https://user-images.githubusercontent.com/13732445/73958269-93197180-48ff-11ea-9964-e3d150cb0327.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@radumg 

### FYIs

@mjkkirschner will wait for your comments before doing the tests
