### PR TITLE
Type identifier in previews

### DIFF
--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -75,7 +75,7 @@ namespace Dynamo.Interfaces
                     values = dict.Values.Cast<object>();
                 }
 
-                var node = new WatchViewModel(keys.Any() ? WatchViewModel.DICTIONARY : WatchViewModel.EMPTY_DICTIONARY, tag, RequestSelectGeometry, true);
+                var node = new WatchViewModel(keys.Any() ? WatchViewModel.DICTIONARY : WatchViewModel.EMPTY_DICTIONARY, tag, RequestSelectGeometry, TypeCode.Empty, true);
 
                 foreach (var e in keys.Zip(values, (key, val) => new { key, val }))
                 {
@@ -89,7 +89,7 @@ namespace Dynamo.Interfaces
             {
                 var list = (value as IEnumerable).Cast<dynamic>().ToList();
 
-                var node = new WatchViewModel(list.Count == 0 ? WatchViewModel.EMPTY_LIST : WatchViewModel.LIST, tag, RequestSelectGeometry, true);
+                var node = new WatchViewModel(list.Count == 0 ? WatchViewModel.EMPTY_LIST : WatchViewModel.LIST, tag, RequestSelectGeometry, TypeCode.Empty, true);
                 foreach (var e in list.Select((element, idx) => new { element, idx }))
                 {
                     node.Children.Add(callback(e.element, null, runtimeCore, tag + ":" + e.idx, showRawData));
@@ -112,15 +112,15 @@ namespace Dynamo.Interfaces
                     int typeId = runtimeCore.DSExecutable.TypeSystem.GetType(stackValue);
                     stringValue = runtimeCore.DSExecutable.classTable.ClassNodes[typeId].Name;
                 }
-                return new WatchViewModel(stringValue, tag, RequestSelectGeometry);
+                return new WatchViewModel(stringValue, tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
             }
 
             if (value is Enum)
             {
-                return new WatchViewModel(((Enum)value).GetDescription(), tag, RequestSelectGeometry);
+                return new WatchViewModel(((Enum)value).GetDescription(), tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
             }
 
-            return new WatchViewModel(ToString(value), tag, RequestSelectGeometry);
+            return new WatchViewModel(ToString(value), tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
         }
 
         private WatchViewModel ProcessThing(SIUnit unit, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
@@ -128,28 +128,28 @@ namespace Dynamo.Interfaces
             return showRawData
                 ? new WatchViewModel(
                     unit.Value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture),
-                    tag, RequestSelectGeometry)
-                : new WatchViewModel(unit.ToString(), tag, RequestSelectGeometry);
+                    tag, RequestSelectGeometry, Type.GetTypeCode(unit.GetType()))
+                : new WatchViewModel(unit.ToString(), tag, RequestSelectGeometry, Type.GetTypeCode(unit.GetType()));
         }
 
         private WatchViewModel ProcessThing(double value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
+            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
         }
 
         private WatchViewModel ProcessThing(System.DateTime value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
+            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
         }
 
         private WatchViewModel ProcessThing(long value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
+            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
         }
 
         private WatchViewModel ProcessThing(string value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value, tag, RequestSelectGeometry);
+            return new WatchViewModel(value, tag, RequestSelectGeometry, Type.GetTypeCode(value.GetType()));
         }
 
         private WatchViewModel ProcessThing(MirrorData data, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback, List<string> preferredDictionaryOrdering = null)
@@ -158,7 +158,7 @@ namespace Dynamo.Interfaces
             {
                 var list = data.GetElements();
 
-                var node = new WatchViewModel(!list.Any() ? WatchViewModel.EMPTY_LIST : WatchViewModel.LIST, tag, RequestSelectGeometry, true);
+                var node = new WatchViewModel(!list.Any() ? WatchViewModel.EMPTY_LIST : WatchViewModel.LIST, tag, RequestSelectGeometry, TypeCode.Empty, true);
                 foreach (var e in list.Select((element, idx) => new { element, idx }))
                 {
                     node.Children.Add(ProcessThing(e.element, runtimeCore, tag + ":" + e.idx, showRawData, callback));
@@ -179,7 +179,7 @@ namespace Dynamo.Interfaces
                     values = keys.Select(k => dict.ValueAtKey(k));
                 }
 
-                var node = new WatchViewModel(keys.Any() ? WatchViewModel.DICTIONARY : WatchViewModel.EMPTY_DICTIONARY, tag, RequestSelectGeometry, true);
+                var node = new WatchViewModel(keys.Any() ? WatchViewModel.DICTIONARY : WatchViewModel.EMPTY_DICTIONARY, tag, RequestSelectGeometry, TypeCode.Empty, true);
 
                 foreach (var e in keys.Zip(values, (key, value) => new { key, value }))
                 {

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -61,6 +61,14 @@
     <!-- Node colors in selected state -->
     <SolidColorBrush x:Key="outerBorderSelection" Color="#4192d9" />
 
+    <!-- NodeLabel colors -->
+    <SolidColorBrush x:Key="stringLabelBackground"
+                     Color="#c3ae9d" />
+    <SolidColorBrush x:Key="numberLabelBackground"
+                     Color="#91c2f2" />
+    <SolidColorBrush x:Key="objectLabelBackground"
+                     Color="#a1a1a1" />
+
     <!--Update Manager-->
     <SolidColorBrush x:Key="UpdateManagerUpdateAvailableBrush" Color="OrangeRed"/>
     <SolidColorBrush x:Key="UpdateManagerUpToDateBrush" Color="Green"/>

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -36,6 +36,7 @@ namespace Dynamo.ViewModels
         private bool _isOneRowContent;
         private readonly Action<string> tagGeometry;
         private bool isCollection;
+        private string _outputType;
 
         // Instance variable for the number of items in the list 
         private int numberOfItems;
@@ -197,11 +198,17 @@ namespace Dynamo.ViewModels
         /// </summary>
         public bool IsTopLevel { get; set; }
 
+        public string ValueType
+        {
+            get { return _outputType; }
+            set { _outputType = value; RaisePropertyChanged(nameof(ValueType)); }
+        }
+
         #endregion
 
-        public WatchViewModel(Action<string> tagGeometry) : this(null, null, tagGeometry, true) { }
+        public WatchViewModel(Action<string> tagGeometry) : this(null, null, tagGeometry, TypeCode.Empty, true) { }
 
-        public WatchViewModel(string label, string path, Action<string> tagGeometry, bool expanded = false)
+        public WatchViewModel(string label, string path, Action<string> tagGeometry, TypeCode? outputType = TypeCode.Empty, bool expanded = false)
         {
             FindNodeForPathCommand = new DelegateCommand(FindNodeForPath, CanFindNodeForPath);
             _path = path;
@@ -211,6 +218,37 @@ namespace Dynamo.ViewModels
             numberOfItems = 0;
             maxListLevel = 0;
             isCollection = label == WatchViewModel.LIST || label == WatchViewModel.DICTIONARY;
+            ValueType = GetDisplayType(outputType);
+        }
+
+        private string GetDisplayType(TypeCode? typecode)
+        {
+            switch (typecode)
+            {
+                case TypeCode.Boolean:
+                    return "bool";
+
+                case TypeCode.Double:
+                    return "double";
+
+                case TypeCode.Int64:
+                    return "int";
+
+                case TypeCode.Int32:
+                    return "int";
+
+                case TypeCode.Object:
+                    return "object";
+
+                case TypeCode.String:
+                    return "string";
+
+                case TypeCode.Empty:
+                    return "";
+
+                default:
+                    return "";
+            }
         }
 
         private bool CanFindNodeForPath(object obj)

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -313,6 +313,42 @@
                                    Width="Auto"
                                    FontFamily="Consolas"
                                    Margin="{Binding Path =IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}" />
+
+                        <Grid Margin="4 0 0 0">
+                            <Border CornerRadius="3,3,3,3">
+                                <Border.Style>
+                                    <Style>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="string">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource stringLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="int">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource numberLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="double">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource numberLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="object">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource objectLabelBackground}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
+                            <TextBlock Text="{Binding ValueType}"
+                                       FontStyle="Italic"
+                                       FontSize="8"
+                                       VerticalAlignment="Center"
+                                       Width="Auto"
+                                       FontFamily="Consolas"
+                                       Margin="2 0 2 0">
+                            </TextBlock>
+                        </Grid>
+                  
                         <Button Content="{Binding Path=Link}"
                                 RenderTransformOrigin="0.5,0.5"
                                 Margin="10,2,2,2"


### PR DESCRIPTION
### Purpose

This PR adds a `Value Type` label to all node previews (watch nodes and the expandable node preview).

Currently the value labels are 

- `string`
- `int`
- `double`
- `object` 

Object is generic and will display on all that is not of type string, integer or double.

The label colors all follow the DesignScript type colors as they are displayed in code blocks.

Nested `List` or `Dictionary` wont have a label.

![TypeIdentifier](https://user-images.githubusercontent.com/13732445/73959626-83029180-4901-11ea-8b9d-4cd0695ac9c4.gif)

![image](https://user-images.githubusercontent.com/13732445/73959658-8e55bd00-4901-11ea-8aa0-d5dc7768d0e7.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@radumg 

### FYIs

@mjkkirschner will wait for your comments before doing the tests
