### PR TITLE
Renamed node suffix label

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Autodesk.DesignScript.Interfaces;
 using Dynamo.Engine;
+using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using ProtoCore.Mirror;
 
@@ -104,6 +105,15 @@ namespace Dynamo.Graph.Nodes
                 return elNameAttrib.Name;
 
             return nodeType.FullName;
+        }
+
+        internal static string GetCustomNodeOriginalName(this NodeModel node)
+        {
+            if (node == null) 
+                return string.Empty;
+
+            var customNodeFunction = node as Function;
+            return customNodeFunction.Definition.DisplayName;
         }
 
         private static void GetGraphicItemsFromMirrorData(MirrorData mirrorData, List<IGraphicItem> graphicItems)

--- a/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
@@ -94,6 +94,8 @@ namespace Dynamo.Graph.Nodes
         internal static string GetOriginalName(this NodeModel node)
         {
             if (node == null) return string.Empty;
+            if (node.IsCustomFunction)
+                return GetCustomNodeOriginalName(node);
 
             var function = node as DSFunctionBase;
             if (function != null)
@@ -107,11 +109,8 @@ namespace Dynamo.Graph.Nodes
             return nodeType.FullName;
         }
 
-        internal static string GetCustomNodeOriginalName(this NodeModel node)
+        private static string GetCustomNodeOriginalName(NodeModel node)
         {
-            if (node == null) 
-                return string.Empty;
-
             var customNodeFunction = node as Function;
             return customNodeFunction.Definition.DisplayName;
         }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -61,6 +61,10 @@
     <!-- Node colors in selected state -->
     <SolidColorBrush x:Key="outerBorderSelection" Color="#4192d9" />
 
+    <!-- NodeLabel colors -->
+    <SolidColorBrush x:Key="renamedLabelBackground"
+                     Color="#FCDC95" />
+
     <!--Update Manager-->
     <SolidColorBrush x:Key="UpdateManagerUpdateAvailableBrush" Color="OrangeRed"/>
     <SolidColorBrush x:Key="UpdateManagerUpToDateBrush" Color="Green"/>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -208,19 +208,9 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// The original name of the node.
-        /// This is the name of the node as it is when first added to the canvas.
         /// </summary>
         [JsonIgnore]
-        public string OriginalName
-        {
-            get 
-            {
-                if (nodeLogic.IsCustomFunction)
-                    return nodeLogic.GetCustomNodeOriginalName();
-
-                return nodeLogic.GetOriginalName(); 
-            }
-        }
+        public string OriginalName => nodeLogic.GetOriginalName();
 
         /// <summary>
         /// If a node has been renamed.

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -200,9 +200,7 @@ namespace Dynamo.ViewModels
         {
             get 
             {
-                if (OriginalName != nodeLogic.Name)
-                    IsRenamed = true;
-
+                IsRenamed = OriginalName != nodeLogic.Name;
                 return nodeLogic.Name; 
             }
             set { nodeLogic.Name = value; }
@@ -212,25 +210,22 @@ namespace Dynamo.ViewModels
         /// The original name of the node.
         /// This is the name of the node as it is when first added to the canvas.
         /// </summary>
+        [JsonIgnore]
         public string OriginalName
         {
-            get { return OriginalNameFromCreationName(); }
+            get 
+            {
+                if (nodeLogic.IsCustomFunction)
+                    return nodeLogic.GetCustomNodeOriginalName();
+
+                return nodeLogic.GetOriginalName(); 
+            }
         }
 
         /// <summary>
-        /// Construct the original name from the creation name
-        /// by removing the unwanted part of the creation name.
-        /// ex Autodesk.Designscript.Geometry.Point.ByCoordinate@double,double,double
-        /// would remove everyting after the "@" and the take the last two words from Autodesk.Designscript.Geometry.Point.ByCoordinate
+        /// If a node has been renamed.
         /// </summary>
-        /// <returns></returns>
-        private string OriginalNameFromCreationName()
-        {
-            string[] longName = nodeLogic.CreationName.Split('@')[0].Split('.');
-            string[] typeAndMethodName = longName.Skip(Math.Max(0, longName.Count() - 2)).ToArray();
-            return String.Join(".", typeAndMethodName);
-        }
-
+        [JsonIgnore]
         public bool IsRenamed
         {
             get { return isRenamed; }
@@ -249,6 +244,9 @@ namespace Dynamo.ViewModels
             get { return nodeLogic.Description; }
         }
 
+        /// <summary>
+        /// The node description part of the nodes description
+        /// </summary>
         [JsonIgnore]
         public string NodeDescription
         {
@@ -258,6 +256,9 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// The DesignScript syntax part of the nodes description
+        /// </summary>
         [JsonIgnore]
         public string DesignScriptSyntaxDescription
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -210,7 +210,11 @@ namespace Dynamo.ViewModels
         /// The original name of the node.
         /// </summary>
         [JsonIgnore]
-        public string OriginalName => nodeLogic.GetOriginalName();
+        public string OriginalName
+        {
+            get { return nodeLogic.GetOriginalName(); }
+        }
+               
 
         /// <summary>
         /// If a node has been renamed.

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -49,6 +49,7 @@ namespace Dynamo.ViewModels
         private string astText = string.Empty;
         private bool isexplictFrozen;
         private bool canToggleFrozen = true;
+        private bool isRenamed = false;
         #endregion
 
         #region public members
@@ -197,8 +198,43 @@ namespace Dynamo.ViewModels
         /// </summary>
         public string Name
         {
-            get { return nodeLogic.Name; }
+            get 
+            {
+                if (OriginalName != nodeLogic.Name)
+                    IsRenamed = true;
+
+                return nodeLogic.Name; 
+            }
             set { nodeLogic.Name = value; }
+        }
+
+        /// <summary>
+        /// The original name of the node.
+        /// This is the name of the node as it is when first added to the canvas.
+        /// </summary>
+        public string OriginalName
+        {
+            get { return OriginalNameFromCreationName(); }
+        }
+
+        /// <summary>
+        /// Construct the original name from the creation name
+        /// by removing the unwanted part of the creation name.
+        /// ex Autodesk.Designscript.Geometry.Point.ByCoordinate@double,double,double
+        /// would remove everyting after the "@" and the take the last two words from Autodesk.Designscript.Geometry.Point.ByCoordinate
+        /// </summary>
+        /// <returns></returns>
+        private string OriginalNameFromCreationName()
+        {
+            string[] longName = nodeLogic.CreationName.Split('@')[0].Split('.');
+            string[] typeAndMethodName = longName.Skip(Math.Max(0, longName.Count() - 2)).ToArray();
+            return String.Join(".", typeAndMethodName);
+        }
+
+        public bool IsRenamed
+        {
+            get { return isRenamed; }
+            set { isRenamed = value; RaisePropertyChanged(nameof(IsRenamed)); }
         }
 
         [JsonIgnore]
@@ -211,6 +247,24 @@ namespace Dynamo.ViewModels
         public string Description
         {
             get { return nodeLogic.Description; }
+        }
+
+        [JsonIgnore]
+        public string NodeDescription
+        {
+            get
+            {
+                return Description.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)[0];
+            }
+        }
+
+        [JsonIgnore]
+        public string DesignScriptSyntaxDescription
+        {
+            get
+            {
+                return Description.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)[2];
+            }
         }
 
         [JsonIgnore]

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -14,14 +14,15 @@
              MouseLeave="OnNodeViewMouseLeave"
              PreviewMouseMove="OnNodeViewMouseMove"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown">
-    
+
     <Grid Name="grid"
           x:FieldModifier="public"
           HorizontalAlignment="Left">
-
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="Auto" MaxHeight="{StaticResource NodeNameHeight}"></RowDefinition>
+            <RowDefinition Height="Auto"
+                           MaxHeight="{StaticResource NodeNameHeight}">
+            </RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -50,7 +51,7 @@
                           Command="{Binding Path=UngroupCommand}" />
                 <MenuItem Name="addtoGroup"
                           Header="{x:Static p:Resources.ContextAddGroupFromSelection}"
-                          Command="{Binding Path=AddToGroupCommand}" />               
+                          Command="{Binding Path=AddToGroupCommand}" />
                 <MenuItem Header="{x:Static p:Resources.ContextMenuLacing}"
                           Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter},Mode=OneWay}">
                     <MenuItem IsCheckable="True"
@@ -76,12 +77,12 @@
                 </MenuItem>
                 <MenuItem Name="nodeIsFrozen"
                           Header="{x:Static p:Resources.NodesRunStatus}"
-                          IsChecked="{Binding IsFrozenExplicitly,Mode=OneWay}"   
+                          IsChecked="{Binding IsFrozenExplicitly,Mode=OneWay}"
                           IsEnabled="{Binding CanToggleFrozen, Mode=OneWay}"
                           Command="{Binding Path=ToggleIsFrozenCommand}" />
                 <MenuItem Name="isVisible_cm"
                           Header="{x:Static p:Resources.NodeContextMenuPreview}"
-                          IsChecked="{Binding Path=IsVisible,Mode=OneWay}"                          
+                          IsChecked="{Binding Path=IsVisible,Mode=OneWay}"
                           Command="{Binding Path=ToggleIsVisibleCommand}"
                           Visibility="{Binding Path=ShowsVisibilityToggles, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <MenuItem Name="isDisplayLabelsEnabled_cm"
@@ -115,21 +116,24 @@
         </Grid.ContextMenu>
 
         <Rectangle Name="frozenBorder"
-                Grid.Row="1"
-                Grid.ColumnSpan="3"
-                Grid.RowSpan="3"
-                Canvas.ZIndex="1"
-                Margin="-5,-5,-5,-5"
-                StrokeDashArray="2"
-                StrokeThickness="3"
-                Opacity=".5"
-                Stroke="#444">
+                   Grid.Row="1"
+                   Grid.ColumnSpan="3"
+                   Grid.RowSpan="3"
+                   Canvas.ZIndex="1"
+                   Margin="-5,-5,-5,-5"
+                   StrokeDashArray="2"
+                   StrokeThickness="3"
+                   Opacity=".5"
+                   Stroke="#444">
             <Rectangle.Style>
                 <Style TargetType="{x:Type Rectangle}">
-                    <Setter Property="Visibility" Value="Hidden"/>
+                    <Setter Property="Visibility"
+                            Value="Hidden" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsFrozen}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
+                        <DataTrigger Binding="{Binding IsFrozen}"
+                                     Value="True">
+                            <Setter Property="Visibility"
+                                    Value="Visible" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
@@ -182,20 +186,22 @@
             <Rectangle.Style>
                 <Style TargetType="{x:Type Rectangle}">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsFrozen}" Value="True">
-                            <Setter Property="Opacity" Value ="0.5"/>
+                        <DataTrigger Binding="{Binding IsFrozen}"
+                                     Value="True">
+                            <Setter Property="Opacity"
+                                    Value="0.5" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </Rectangle.Style>
-            <Rectangle.Fill>                
+            <Rectangle.Fill>
                 <Binding Path="State"
                          UpdateSourceTrigger="PropertyChanged"
                          Mode="OneWay"
                          ConverterParameter="BodyBackground"
-                         Converter="{StaticResource StateToColorConverter}">                     
-                </Binding>      
-                
+                         Converter="{StaticResource StateToColorConverter}">
+                </Binding>
+
             </Rectangle.Fill>
         </Rectangle>
 
@@ -218,8 +224,10 @@
             <Rectangle.Style>
                 <Style TargetType="{x:Type Rectangle}">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsFrozen}" Value="True">
-                            <Setter Property="Opacity" Value ="0.5"/>
+                        <DataTrigger Binding="{Binding IsFrozen}"
+                                     Value="True">
+                            <Setter Property="Opacity"
+                                    Value="0.5" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
@@ -236,9 +244,30 @@
                 <dynui:DynamoToolTip AttachmentSide="Top"
                                      Style="{DynamicResource ResourceKey=SLightToolTip}">
                     <Grid>
-                        <TextBlock MaxWidth="320"
-                                   TextWrapping="Wrap"
-                                   Text="{Binding Path=Description}"></TextBlock>
+                        <StackPanel Orientation="Vertical"
+                                    MaxWidth="320">
+                            <StackPanel>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="Original node name: ">
+                                </TextBlock>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{Binding Path=OriginalName}"
+                                           FontWeight="SemiBold">
+                                </TextBlock>
+                            </StackPanel>
+                            <StackPanel>
+                                <TextBlock Text="&#xD;" />
+                            </StackPanel>
+                            <StackPanel>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="Description: ">
+                                </TextBlock>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{Binding Path=Description}"
+                                           FontWeight="Normal">
+                                </TextBlock>
+                            </StackPanel>
+                        </StackPanel>
                     </Grid>
                 </dynui:DynamoToolTip>
             </Rectangle.ToolTip>
@@ -262,32 +291,83 @@
             </Border.Visibility>
         </Border>
 
+        <StackPanel Orientation="Horizontal"
+                    Grid.Row="1"
+                    Grid.ColumnSpan="3"
+                    Panel.ZIndex="12"
+                    HorizontalAlignment="Center"
+                    Margin="3 0 3 0">
+            <TextBlock Name="NameBlock"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Stretch"
+                       Grid.ColumnSpan="3"
+                       Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
+                       Padding="5"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       FontFamily="{StaticResource OpenSansSemibold}"
+                       TextAlignment="Center"
+                       IsHitTestVisible="False"
+                       Background="{x:Null}"
+                       Style="{StaticResource SZoomFadeText}">
+                <TextBlock.Foreground>
+                    <Binding Path="State"
+                             UpdateSourceTrigger="PropertyChanged"
+                             Mode="OneWay"
+                             ConverterParameter="HeaderForeground"
+                             Converter="{StaticResource StateToColorConverter}">
+                    </Binding>
+                </TextBlock.Foreground>
+            </TextBlock>
 
-        <TextBlock Name="NameBlock"
-                   Grid.Row="1"
-                   Grid.ColumnSpan="3"
-                   VerticalAlignment="Center"
-                   HorizontalAlignment="Stretch"
-                   Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
-                   Padding="5"
-                   FontSize="13"
-                   FontWeight="SemiBold"
-                   FontFamily="{StaticResource OpenSansSemibold}"
-                   TextAlignment="Center"
-                   IsHitTestVisible="False"
-                   Canvas.ZIndex="12"
-                   Height="{StaticResource NodeNameHeight}"
-                   Background="{x:Null}"
-                   Style="{StaticResource SZoomFadeText}">
-            <TextBlock.Foreground>
-                <Binding Path="State"
-                         UpdateSourceTrigger="PropertyChanged"
-                         Mode="OneWay"
-                         ConverterParameter="HeaderForeground"
-                         Converter="{StaticResource StateToColorConverter}">
-                </Binding>
-            </TextBlock.Foreground>
-        </TextBlock>
+            <Border CornerRadius="3,3,3,3"
+                    Height="12"
+                    Width="Auto"
+                    Background="{StaticResource renamedLabelBackground}"
+                    Margin="3 0 0 0">
+                <Border.Style>
+                    <Style TargetType="{x:Type Border}">
+                        <Setter Property="Visibility"
+                                Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsRenamed}"
+                                         Value="True">
+                                <Setter Property="Visibility"
+                                        Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Text="Renamed"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           FontStyle="Italic"
+                           FontSize="8"
+                           Width="Auto"
+                           FontFamily="Consolas"
+                           Margin="2 0 2 0">
+                    <TextBlock.Style>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="Visibility"
+                                    Value="Hidden" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsRenamed}"
+                                             Value="True">
+                                    <Setter Property="Visibility"
+                                            Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Border>
+
+        </StackPanel>
+
+        
+
+
+
 
         <!-- INPUT PORTS -->
         <ItemsControl Name="inputPortControl"
@@ -345,16 +425,16 @@
 
             <Grid>
                 <TextBlock Name="lacingOptionTextBlock"
-                       Text="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToAbbreviationConverter}}"
-                       ToolTip="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToTooltipConverter}}"
-                       Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter}}"
-                       FontFamily="Tahoma"
-                       FontSize="8"
-                       Margin="5"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center"
-                       Foreground="#99000000"
-                       FontWeight="Bold" />
+                           Text="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToAbbreviationConverter}}"
+                           ToolTip="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToTooltipConverter}}"
+                           Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter}}"
+                           FontFamily="Tahoma"
+                           FontSize="8"
+                           Margin="5"
+                           HorizontalAlignment="Right"
+                           VerticalAlignment="Center"
+                           Foreground="#99000000"
+                           FontWeight="Bold" />
             </Grid>
         </StackPanel>
 
@@ -434,7 +514,7 @@
                 Grid.ColumnSpan="3"
                 Margin="0,4,0,0"
                 HorizontalAlignment="Left"
-                Background="Blue"/>
+                Background="Blue" />
 
         <Canvas ClipToBounds="False"
                 Grid.Row="4"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -324,7 +324,7 @@
                     Height="12"
                     Width="Auto"
                     Background="{StaticResource renamedLabelBackground}"
-                    Margin="3 0 0 0">
+                    Margin="3 0 3 0">
                 <Border.Style>
                     <Style TargetType="{x:Type Border}">
                         <Setter Property="Visibility"

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -229,5 +229,51 @@ namespace DynamoCoreWpfTests
             // Delete temp file
             File.Delete(tempPath);
         }
+
+        [Test]
+        public void SettingOriginalNodeName()
+        {
+            Open(@"core\originalNodeNameTests\originalNodeName.dyn");
+
+            // Get the node view for a specific node in the graph
+            NodeView nodeView = NodeViewWithGuid("37749b95-916a-4dfe-b69b-b516b2ccafe9");
+
+            // Get a reference to the current workspace
+            NodeViewModel nodeViewModel = (nodeView.DataContext as NodeViewModel);
+
+            string expectedOriginalName = "List Create";
+
+            Assert.AreEqual(false, nodeViewModel.IsRenamed);
+            Assert.AreEqual(nodeViewModel.OriginalName, expectedOriginalName);
+
+            string newName = "NewName";
+            nodeViewModel.Name = newName;
+            Assert.AreEqual(nodeViewModel.IsRenamed, true);
+            Assert.AreEqual(nodeViewModel.Name, newName);
+            Assert.AreEqual(nodeViewModel.OriginalName, expectedOriginalName);
+        }
+
+        [Test]
+        public void SettingOriginalNodeNameOnCustomNode()
+        {
+            Open(@"core\originalNodeNameTests\originalNodeNameCustomNode.dyn");
+
+            // Get the node view for a specific node in the graph
+            NodeView nodeView = NodeViewWithGuid(Guid.Parse("d0b81747d16f48cfbc9992182783d229").ToString());
+
+            // Get a reference to the current workspace
+            NodeViewModel nodeViewModel = (nodeView.DataContext as NodeViewModel);
+
+            string expectedOriginalName = "NestedNode";
+
+            Assert.AreEqual(nodeViewModel.IsRenamed, false);
+            Assert.AreEqual(nodeViewModel.OriginalName, expectedOriginalName);
+
+            string newName = "NewName";
+            nodeViewModel.Name = newName;
+            Assert.AreEqual(nodeViewModel.IsRenamed, true);
+            Assert.AreEqual(nodeViewModel.Name, newName);
+            Assert.AreEqual(nodeViewModel.OriginalName, expectedOriginalName);
+        }
     }
 }

--- a/test/core/originalNodeNameTests/NestedNodeCustomNode.dyf
+++ b/test/core/originalNodeNameTests/NestedNodeCustomNode.dyf
@@ -1,0 +1,164 @@
+{
+  "Uuid": "6f65de85-d71f-46e1-b995-dfdeba2adbe3",
+  "IsCustomNode": true,
+  "Category": "Test",
+  "Description": "Test nested node",
+  "Name": "NestedNode",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "x+10;",
+      "Id": "3496c67bf4d247bb890e803c9db6da98",
+      "Inputs": [
+        {
+          "Id": "d0fc7b791ec84b19849953813387fbf8",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ade1eaa57f854683a9db9a9c63185a25",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "out",
+      "Id": "7bc48859c6eb46ecb18ad28d036c2993",
+      "Inputs": [
+        {
+          "Id": "01864b0c19dc4788ac10b62ca298185a",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "num",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null,
+        "Description": ""
+      },
+      "Id": "f1cf99d1667f4693b6a39421b6878a48",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4209d0386cf1481bae30b2baf66c9036",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "ade1eaa57f854683a9db9a9c63185a25",
+      "End": "01864b0c19dc4788ac10b62ca298185a",
+      "Id": "a43adabcdcd64ad781466b05266fe7a6"
+    },
+    {
+      "Start": "4209d0386cf1481bae30b2baf66c9036",
+      "End": "d0fc7b791ec84b19849953813387fbf8",
+      "Id": "81022083777247ecbfd664fd87b79791"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7706",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "3496c67bf4d247bb890e803c9db6da98",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 255.33333333333326,
+        "Y": 35.333333333333343
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "7bc48859c6eb46ecb18ad28d036c2993",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 400.33333333333343,
+        "Y": 48.666666666666657
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Input",
+        "Id": "f1cf99d1667f4693b6a39421b6878a48",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 133.33333333333326,
+        "Y": 61.999999999999986
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/originalNodeNameTests/originalNodeName.dyn
+++ b/test/core/originalNodeNameTests/originalNodeName.dyn
@@ -1,0 +1,85 @@
+{
+  "Uuid": "c8afee00-b22d-4617-90ac-a6ae18848e19",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "originalNodeName",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.CreateList, CoreNodeModels",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "37749b95916a4dfeb69bb516b2ccafe9",
+      "Inputs": [
+        {
+          "Id": "933318af5fa4480fbd3e8c085a6c554a",
+          "Name": "item0",
+          "Description": "Item Index #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "851db4a97f014968af5ad1f23a0d6bce",
+          "Name": "list",
+          "Description": "A list",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Makes a new list out of the given inputs"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.4.0.6186",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Default Camera",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "List Create",
+        "Id": "37749b95916a4dfeb69bb516b2ccafe9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 315.33333333333326,
+        "Y": 217.99999999999994
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/originalNodeNameTests/originalNodeNameCustomNode.dyn
+++ b/test/core/originalNodeNameTests/originalNodeNameCustomNode.dyn
@@ -1,0 +1,124 @@
+{
+  "Uuid": "c8afee00-b22d-4617-90ac-a6ae18848e19",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "originalNodeNameCustomNode",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "6f65de85-d71f-46e1-b995-dfdeba2adbe3",
+      "FunctionType": "Graph",
+      "NodeType": "FunctionNode",
+      "Id": "d0b81747d16f48cfbc9992182783d229",
+      "Inputs": [
+        {
+          "Id": "2015b3fc037f4fbc92fea9ae666cb6da",
+          "Name": "num",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0d1fec0950bb4cf781a5d640c61f25b9",
+          "Name": "out",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Test nested node"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "12;",
+      "Id": "3ec35e031a54408e906bbfc1ecd31e35",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "218072b36cc64957a155de019f701a5f",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "218072b36cc64957a155de019f701a5f",
+      "End": "2015b3fc037f4fbc92fea9ae666cb6da",
+      "Id": "b9ec71009060440bbd1cdb0f6e2efee7"
+    }
+  ],
+  "Dependencies": [
+    "6f65de85-d71f-46e1-b995-dfdeba2adbe3"
+  ],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7706",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "NestedNode",
+        "Id": "d0b81747d16f48cfbc9992182783d229",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 232.66666666666674,
+        "Y": 257.66666666666669
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "3ec35e031a54408e906bbfc1ecd31e35",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 90.0,
+        "Y": 262.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

This PR adds a `Original Name` section to the tooltip of a node and divides the current tooltip description into 2 additional sections `Description` and `DesignScript Syntax`. The PR also adds a `Renamed` label to the Name block of the node, if the node has been renamed by the user.

The tooltip now displays the original name of the node, this makes it easy to identify nodes which has been renamed by users.

![image](https://user-images.githubusercontent.com/13732445/73960935-a3335000-4903-11ea-8d20-f902fcccf0f2.png)

To easily identify if a node has been renamed a label will appear on nodes that have been renamed
![image](https://user-images.githubusercontent.com/13732445/73961599-d4f8e680-4904-11ea-80af-8752d2c0c2d1.png)

![RenamedNode](https://user-images.githubusercontent.com/13732445/73961628-dcb88b00-4904-11ea-862b-3eed6bd71a47.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@radumg 

### FYIs

@mjkkirschner will wait for your comments before doing the tests
