### PR TITLE
[DYN-2341] Labels on helix-update branch cause slow down

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -21,13 +22,14 @@ using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.Selection;
+using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Visualization;
 using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.Rendering;
 using DynamoUtilities;
 using HelixToolkit.Wpf.SharpDX;
-using HelixToolkit.Wpf.SharpDX.Core;
+using HelixToolkit.Wpf.SharpDX.Shaders;
 using Newtonsoft.Json;
 using SharpDX;
 using Color = SharpDX.Color;
@@ -37,10 +39,6 @@ using MeshBuilder = HelixToolkit.Wpf.SharpDX.MeshBuilder;
 using MeshGeometry3D = HelixToolkit.Wpf.SharpDX.MeshGeometry3D;
 using PerspectiveCamera = HelixToolkit.Wpf.SharpDX.PerspectiveCamera;
 using TextInfo = HelixToolkit.Wpf.SharpDX.TextInfo;
-using Newtonsoft.Json;
-using HelixToolkit.Wpf.SharpDX.Shaders;
-using System.Windows.Data;
-using Dynamo.Utilities;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
 {
@@ -2428,7 +2426,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <returns>A <see cref="BoundingBox"/> object encapsulating the geometry.</returns>
         internal static BoundingBox Bounds(this GeometryModel3D geom, float defaultBoundsSize = 5.0f)
         {
-            if (geom.Geometry.Positions.Count == 0)
+            if (geom.Geometry.Positions == null || geom.Geometry.Positions.Count == 0)
             {
                 return new BoundingBox();
             }

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -823,6 +823,7 @@ namespace WpfVisualizationTests
         // Before the fix, this test would take around 5 mins to finish but now this test finishes in just 20 secs. 
         public void PerformanceTestOnLabelsAfterHelixUpgrade()
         {
+            System.DateTime startTime = System.DateTime.Now;
             OpenVisualizationTest("PerformanceTestOnLabelsAfterHelixUpgrade.dyn");
             var ws = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
 
@@ -861,6 +862,9 @@ namespace WpfVisualizationTests
                 Assert.AreEqual(1, geometry.TextInfo.Count);
                 Assert.AreEqual("["+ itemIndex  +"]", geometry.TextInfo[0].Text);
             }
+            System.DateTime endTime = System.DateTime.Now;
+            var totalExecutionTime = (endTime - startTime).TotalSeconds;
+            Assert.LessOrEqual(totalExecutionTime, 20);
         }
 
         [Test]

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -843,7 +843,7 @@ namespace WpfVisualizationTests
             var parentTreeViewItem = nodeView.ChildOfType<TreeViewItem>();
 
             // Selcting a sphere object 70 different times to render new labels again. 
-            for (int i = 0; i < 70; i++) {
+            for (int i = 0; i < 30; i++) {
 
                 var itemIndex = i % 10; 
                 var treeViewItem = parentTreeViewItem.ChildrenOfType<TreeViewItem>().ElementAt(itemIndex);

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -817,6 +817,53 @@ namespace WpfVisualizationTests
         }
 
         [Test]
+        // This test will select a sphere object 70 times from a list of sphere's, to display 
+        // the corresponding label for that sphere object. After the Helix update, this workflow was causing
+        // delays and would cause dynamo to hang. The fix was added in this PR: https://github.com/DynamoDS/Dynamo/pull/10399
+        // Before the fix, this test would take around 5 mins to finish but now this test finishes in just 20 secs. 
+        public void PerformanceTestOnLabelsAfterHelixUpgrade()
+        {
+            OpenVisualizationTest("PerformanceTestOnLabelsAfterHelixUpgrade.dyn");
+            var ws = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+
+            RunCurrentModel();
+
+            var codeBlockGUID = "07b8781c-8f73-4721-b0e5-d86b8484ca97";
+            NodeModel codeBlockNodeModel = ws.Nodes.Where(node => node.GUID.ToString() == codeBlockGUID).FirstOrDefault();
+
+            // The Key to identify the Label's geometry object from Model3DDictionary.
+            var labelKey = codeBlockNodeModel.AstIdentifierForPreview + ":text";
+
+            var helix = ViewModel.BackgroundPreviewViewModel as HelixWatch3DViewModel;
+
+            // Clicking on a single value from the output of the watch node
+            // should show only one label corresponding to that value.  
+            var nodeView = View.ChildrenOfType<NodeView>().First(nv => nv.ViewModel.Name == "Watch");
+            var parentTreeViewItem = nodeView.ChildOfType<TreeViewItem>();
+
+            // Selcting a sphere object 70 different times to render new labels again. 
+            for (int i = 0; i < 70; i++) {
+
+                var itemIndex = i % 10; 
+                var treeViewItem = parentTreeViewItem.ChildrenOfType<TreeViewItem>().ElementAt(itemIndex);
+
+                View.Dispatcher.Invoke(() =>
+                {
+                    treeViewItem.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+                    {
+                        RoutedEvent = Mouse.MouseUpEvent
+                    });
+                });
+
+                DispatcherUtil.DoEvents();
+
+                var geometry = (helix.Element3DDictionary[labelKey] as GeometryModel3D).Geometry as BillboardText3D;
+                Assert.AreEqual(1, geometry.TextInfo.Count);
+                Assert.AreEqual("["+ itemIndex  +"]", geometry.TextInfo[0].Text);
+            }
+        }
+
+        [Test]
         public void Display_BySurfaceColors_HasColoredMesh()
         {
             OpenVisualizationTest("Display.BySurfaceColors.dyn");

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -817,7 +817,7 @@ namespace WpfVisualizationTests
         }
 
         [Test]
-        // This test will select a sphere object 70 times from a list of sphere's, to display 
+        // This test will select a sphere object 30 times from a list of sphere's, to display 
         // the corresponding label for that sphere object. After the Helix update, this workflow was causing
         // delays and would cause dynamo to hang. The fix was added in this PR: https://github.com/DynamoDS/Dynamo/pull/10399
         // Before the fix, this test would take around 5 mins to finish but now this test finishes in just 20 secs. 

--- a/test/core/visualization/PerformanceTestOnLabelsAfterHelixUpgrade.dyn
+++ b/test/core/visualization/PerformanceTestOnLabelsAfterHelixUpgrade.dyn
@@ -1,0 +1,237 @@
+{
+  "Uuid": "5ca0c38e-e614-4513-b690-906014ed432b",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "spehere-labels",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "07b8781c8f734721b0e5d86b8484ca97",
+      "Inputs": [
+        {
+          "Id": "62644a8f8ec3449aad70ae2d7f8f2f85",
+          "Name": "centerPoint",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d8ea8befb0d94bc08035f347ed38981e",
+          "Name": "radius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6692355e49144f61a4c36caf1d07696a",
+          "Name": "Sphere",
+          "Description": "Sphere",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a Solid Sphere cetered at the input Point, with given radius.\n\nSphere.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Sphere"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "f7d2adc42daf4a4fa2e1f533c991d18b",
+      "Inputs": [
+        {
+          "Id": "984137ce54524d3f890870f9592052d6",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1597441220f44cb3820d471650757318",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f8649dcc8f50451ba8caa9da4ff48b31",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "82b0f21cf26749a78e8cd7a8534695dc",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..100;",
+      "Id": "8b4a5a677eee4333aaa16f50e0f70f99",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "26f538a35e304ae4bee3e884acf958b6",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "49a7d90cd214426dbd1b673caa4dbb12",
+      "Inputs": [
+        {
+          "Id": "bf0b09193fa64f7caae667f4e74ebfce",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1176e3043f7d4821b4647f674a99bdfa",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "6692355e49144f61a4c36caf1d07696a",
+      "End": "bf0b09193fa64f7caae667f4e74ebfce",
+      "Id": "e5002bd1a711446cb4da7c6d1f211ff0"
+    },
+    {
+      "Start": "82b0f21cf26749a78e8cd7a8534695dc",
+      "End": "62644a8f8ec3449aad70ae2d7f8f2f85",
+      "Id": "ded04598f5c84bcca35762407f1d2694"
+    },
+    {
+      "Start": "26f538a35e304ae4bee3e884acf958b6",
+      "End": "984137ce54524d3f890870f9592052d6",
+      "Id": "2e456c8f3b4a4c55afd46233edae51e6"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7787",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Sphere.ByCenterPointRadius",
+        "Id": "07b8781c8f734721b0e5d86b8484ca97",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 387.87774726744556,
+        "Y": 143.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Point.ByCoordinates",
+        "Id": "f7d2adc42daf4a4fa2e1f533c991d18b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 139.0,
+        "Y": 139.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "8b4a5a677eee4333aaa16f50e0f70f99",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 36.0,
+        "Y": 29.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "49a7d90cd214426dbd1b673caa4dbb12",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 852.588869249369,
+        "Y": 266.97073058440185
+      }
+    ],
+    "Annotations": [],
+    "X": 42.074791980970872,
+    "Y": 65.94391697627816,
+    "Zoom": 0.8467448192874274
+  }
+}


### PR DESCRIPTION
### Purpose

Fix the null pointer exception. After this fix, the labels on the workspace will render without any lags. Dynamo used to hang after being used for sometime as multiple exceptions were being thrown on the geom.Geometry.Positions object. 

JIRA: https://jira.autodesk.com/browse/DYN-2341

Before the change:
![without fix](https://user-images.githubusercontent.com/43763136/74758779-cfc16300-5245-11ea-8116-7d7ac9e63b79.gif)
The exception is shown on the dynamo console. 

After the change:
![after fix](https://user-images.githubusercontent.com/43763136/74758801-d5b74400-5245-11ea-84a2-0fab47decac0.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang @aparajit-pratap 