### PR TITLE
Added a couple of asserts for the properties.

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -20,11 +20,8 @@ namespace Dynamo.WorkspaceDependency
         internal MenuItem workspaceReferencesMenuItem;
         private const String extensionName = "Workspace References";
 
-        internal WorkspaceDependencyView DependencyView
-        {
-            get;
-            set;
-        }
+        internal WorkspaceDependencyView DependencyView;
+       
 
         internal PackageManagerExtension pmExtension;
 

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -20,8 +20,11 @@ namespace Dynamo.WorkspaceDependency
         internal MenuItem workspaceReferencesMenuItem;
         private const String extensionName = "Workspace References";
 
-        internal WorkspaceDependencyView DependencyView;
-       
+        internal WorkspaceDependencyView DependencyView
+        {
+            get;
+            set;
+        }
 
         internal PackageManagerExtension pmExtension;
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -230,6 +230,15 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(initialNum, View.ExtensionTabItems.Count);
         }
 
+        [Test]
+        public void TestPropertiesWithCodeInIt()
+        {
+            Assert.AreEqual("Workspace References", viewExtension.Name);
+
+            Assert.AreEqual("A6706BF5-11C2-458F-B7C8-B745A77EF7FD", viewExtension.UniqueId);
+
+        }
+
         public static void RaiseLoadedEvent(FrameworkElement element)
         {
             MethodInfo eventMethod = typeof(FrameworkElement).GetMethod("OnLoaded",


### PR DESCRIPTION
Description
Added a couple of asserts for the properties that have values on get that comes from a private const variables and remove the getter and setter from WorkspaceDependencyViewExtension.DependencyView because these methods do not get value.

Related GitHub issue or JIRA story
https://jira.autodesk.com/browse/DYN-2418

Checklist
[ - ] PR title reflects the changes it introduces. Consider using this template: QNTM-XXXX: Implement X Feature
[ - ] Code compiles correctly
[ - ] No linting errors
 All tests passing
[ - ] Updated README.md / documentation (if necessary)