### PR TITLE
Avoid rendering Gizmo multiple times on rotate

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoGeometryModel3D.cs
@@ -64,44 +64,44 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <summary>
         /// Is this model Frozen.
         /// </summary>
-        public bool IsFrozenData { get => isFrozenData; internal set { SetAffectsRender(ref isFrozenData, value); } }
+        public bool IsFrozenData { get { return isFrozenData; } internal set { SetAffectsRender(ref isFrozenData, value); } }
 
         private bool isSelectedData;
 
         /// <summary>
         /// Is this model currently selected.
         /// </summary>
-        public bool IsSelectedData { get => isSelectedData; internal set { SetAffectsRender(ref isSelectedData, value); } }
+        public bool IsSelectedData { get { return isSelectedData; } internal set { SetAffectsRender(ref isSelectedData, value); } }
 
         private bool isIsolatedData;
         /// <summary>
         /// Is IsolationMode active.
         /// </summary>
-        public bool IsIsolatedData { get => isIsolatedData; internal set { SetAffectsRender(ref isIsolatedData, value); } }
+        public bool IsIsolatedData { get { return isIsolatedData; } internal set { SetAffectsRender(ref isIsolatedData, value); } }
 
         private bool isSpecialData;
         /// <summary>
         /// Is this model marked as a special render package.
         /// </summary>
-        public bool IsSpecialRenderPackageData { get => isSpecialData; internal set { SetAffectsRender(ref isSpecialData, value); } }
+        public bool IsSpecialRenderPackageData { get { return isSpecialData; } internal set { SetAffectsRender(ref isSpecialData, value); } }
 
         private bool hasTransparencyData;
         /// <summary>
         /// Does this model have alpha less than 255.
         /// </summary>
-        public bool HasTransparencyData { get => hasTransparencyData; internal set { SetAffectsRender(ref hasTransparencyData, value); } }
+        public bool HasTransparencyData { get { return hasTransparencyData; } internal set { SetAffectsRender(ref hasTransparencyData, value); } }
 
         private bool requiresPerVertexColor;
         /// <summary>
         /// Should this model display vertex colors.
         /// </summary>
-        public bool RequiresPerVertexColor { get => requiresPerVertexColor; internal set { SetAffectsRender(ref requiresPerVertexColor, value); } }
+        public bool RequiresPerVertexColor { get { return requiresPerVertexColor; } internal set { SetAffectsRender(ref requiresPerVertexColor, value); } }
 
         private bool isFlatShaded;
         /// <summary>
         /// Should this model disregard lighting calculations and display unlit texture or vertex colors.
         /// </summary>
-        public bool IsFlatShaded { get => isFlatShaded; internal set { SetAffectsRender(ref isFlatShaded, value); } }
+        public bool IsFlatShaded { get { return isFlatShaded; } internal set { SetAffectsRender(ref isFlatShaded, value); } }
 
         /// <summary>
         /// Generates an int that packs all enum flags into a single int.

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
@@ -126,72 +125,16 @@ namespace Dynamo.Controls
                 ViewModel.OnViewMouseMove(sender, args);
             };
 
-            //watch_view.CameraCore.PropertyChanged += (sender, args) =>
-            //{
-            //    if (args.PropertyName == nameof(watch_view.CameraCore.Position))
-            //    {
-            //        args.Source = view.GetCameraPosition();
-            //        ViewModel.OnViewCameraChanged(watch_view, )
-            //    }
-            //}
-
-            // Throttling: Fluid, but you can actually see the arrows move.
-            //watch_view.CameraChanged += (sender, args) =>
-            //{
-            //    if (throttle == null || throttle.IsCompleted)
-            //    {
-            //        throttle = Task.Delay(TimeSpan.FromMilliseconds(1)).ContinueWith(_ =>
-            //        {
-            //            Dispatcher.Invoke(() =>
-            //            {
-            //                var view = sender as Viewport3DX;
-            //                if (view != null)
-            //                {
-            //                    args.Source = view.GetCameraPosition();
-            //                }
-            //                ViewModel.OnViewCameraChanged(watch_view, args);
-            //            });
-            //        });
-            //    }
-            //};
-
-            // Throttling 2: Same issues here.
-            //watch_view.CameraChanged += (sender, args) =>
-            //{
-            //    if (DateTime.Now - lastCameraUpdate > cameraChangedThrottleTime)
-            //    {
-            //        var view = sender as Viewport3DX;
-            //        if (view != null)
-            //        {
-            //            args.Source = view.GetCameraPosition();
-            //        }
-            //        ViewModel.OnViewCameraChanged(watch_view, args);
-            //        lastCameraUpdate = DateTime.Now;
-            //    }
-            //};
-
-            // Limit update to position change only: Still shows up choppy.
             watch_view.CameraChanged += (sender, args) =>
             {
                 var view = sender as Viewport3DX;
-                var sameCameraPosition = false;
                 if (view != null)
                 {
                     args.Source = view.GetCameraPosition();
-                    sameCameraPosition = view.GetCameraPosition() == lastCameraPosition;
-                    lastCameraPosition = view.GetCameraPosition();
                 }
-                if (!sameCameraPosition)
-                {
-                    ViewModel.OnViewCameraChanged(sender, args);
-                }
+                ViewModel.OnViewCameraChanged(sender, args);
             };
         }
-
-        private TimeSpan cameraChangedThrottleTime = new TimeSpan(100000);
-        private DateTime lastCameraUpdate = DateTime.Now;
-        private Point3D lastCameraPosition;
-        private Task throttle;
 
         private void UnRegisterViewEventHandlers()
         {

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
@@ -125,16 +126,72 @@ namespace Dynamo.Controls
                 ViewModel.OnViewMouseMove(sender, args);
             };
 
+            //watch_view.CameraCore.PropertyChanged += (sender, args) =>
+            //{
+            //    if (args.PropertyName == nameof(watch_view.CameraCore.Position))
+            //    {
+            //        args.Source = view.GetCameraPosition();
+            //        ViewModel.OnViewCameraChanged(watch_view, )
+            //    }
+            //}
+
+            // Throttling: Fluid, but you can actually see the arrows move.
+            //watch_view.CameraChanged += (sender, args) =>
+            //{
+            //    if (throttle == null || throttle.IsCompleted)
+            //    {
+            //        throttle = Task.Delay(TimeSpan.FromMilliseconds(1)).ContinueWith(_ =>
+            //        {
+            //            Dispatcher.Invoke(() =>
+            //            {
+            //                var view = sender as Viewport3DX;
+            //                if (view != null)
+            //                {
+            //                    args.Source = view.GetCameraPosition();
+            //                }
+            //                ViewModel.OnViewCameraChanged(watch_view, args);
+            //            });
+            //        });
+            //    }
+            //};
+
+            // Throttling 2: Same issues here.
+            //watch_view.CameraChanged += (sender, args) =>
+            //{
+            //    if (DateTime.Now - lastCameraUpdate > cameraChangedThrottleTime)
+            //    {
+            //        var view = sender as Viewport3DX;
+            //        if (view != null)
+            //        {
+            //            args.Source = view.GetCameraPosition();
+            //        }
+            //        ViewModel.OnViewCameraChanged(watch_view, args);
+            //        lastCameraUpdate = DateTime.Now;
+            //    }
+            //};
+
+            // Limit update to position change only: Still shows up choppy.
             watch_view.CameraChanged += (sender, args) =>
             {
                 var view = sender as Viewport3DX;
+                var sameCameraPosition = false;
                 if (view != null)
                 {
                     args.Source = view.GetCameraPosition();
+                    sameCameraPosition = view.GetCameraPosition() == lastCameraPosition;
+                    lastCameraPosition = view.GetCameraPosition();
                 }
-                ViewModel.OnViewCameraChanged(sender, args);
+                if (!sameCameraPosition)
+                {
+                    ViewModel.OnViewCameraChanged(sender, args);
+                }
             };
         }
+
+        private TimeSpan cameraChangedThrottleTime = new TimeSpan(100000);
+        private DateTime lastCameraUpdate = DateTime.Now;
+        private Point3D lastCameraPosition;
+        private Task throttle;
 
         private void UnRegisterViewEventHandlers()
         {

--- a/src/DynamoManipulation/Gizmo.cs
+++ b/src/DynamoManipulation/Gizmo.cs
@@ -171,10 +171,17 @@ namespace Dynamo.Manipulation
 
         private void OnViewCameraChanged(object o, RoutedEventArgs routedEventArgs)
         {
-            cameraPosition = routedEventArgs.Source as Point3D?;
-
-            // Redraw Gizmos
-            Redraw();
+            var newCameraPosition = routedEventArgs.Source as Point3D?;
+            // A change of behavior in helix when upgrading from v2015 is that the CameraChanged event gets fired
+            // several times, once for each individual property of Camera that changed.
+            // In order to avoid rendering the Gizmo several times, which leads to choppy camera rotation, we limit the
+            // rendering of the Gizmo to only be done when the position of the camera changed.
+            if (cameraPosition != newCameraPosition)
+            {
+                cameraPosition = newCameraPosition;
+                // Redraw Gizmos
+                Redraw();
+            }
         }
 
         public abstract bool HitTest(Point source, Vector direction, out object hitObject);


### PR DESCRIPTION
### Purpose

This PR aims to fix the problem described in the title, which occurs in the `helix-upgrade` branch. 

When a `Point.ByCoordinates` node is placed on the canvas with some unfilled input this triggers the directManipulation extension to draw gizmos that let the user manipulate this point in space directly. When the user rotates the camera when the point node is still selected and the gizmos are drawn the performance is terrible, and the camera cannot be rotated smoothly.
 
![Jan-27-2020 16-35-44](https://user-images.githubusercontent.com/10048120/77091664-3ff70c00-69df-11ea-8934-611c3d8fc632.gif)

The issue is caused by a change of behavior in helix when upgrading from v2015 is that the `CameraChanged` event gets fired several times, once for each individual property of `Camera` that changed.

In order to avoid rendering the `Gizmo` several times, which leads to choppy camera rotation, we limit the rendering of the `Gizmo` to only be done when the position of the camera changed.

![Screen-Recording-2020-03-19-at-12 51 13-PM](https://user-images.githubusercontent.com/10048120/77092791-7da86480-69e0-11ea-94f4-f74e21cfc7b2.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @aparajit-pratap 

