### PR TITLE
disable latching which causes issues with scroll wheel

### DIFF
--- a/src/LibraryViewExtension/Views/LibraryView.xaml.cs
+++ b/src/LibraryViewExtension/Views/LibraryView.xaml.cs
@@ -22,6 +22,10 @@ namespace Dynamo.LibraryUI.Views
                 CefSharpSettings.LegacyJavascriptBindingEnabled = true;
                 CefSharpSettings.SubprocessExitIfParentProcessClosed = true;
                 CefSharpSettings.ShutdownOnExit = false;
+                //https://bitbucket.org/chromiumembedded/cef/issues/2214/osr-scroll-is-erratic-after-using-mouse#comment-46738015
+                //https://github.com/cefsharp/CefSharp/issues/2408
+                //TODO remove in 67 or up.
+                settings.DisableTouchpadAndWheelScrollLatching();
 
                 Cef.Initialize(settings);
             }


### PR DESCRIPTION
### Purpose

Scrolling with the scroll wheel inside the node library sometimes broke in DynamoSandbox - this fixes it by using a setting flag in CEF as recommended by CefSharp project. - It is already used in Revit so thats why we could not reproduce there - when upgrading to CEF 67 or up we can remove this.

https://github.com/cefsharp/CefSharp/issues/2408


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
