### PR TITLE
Initialize CodeCompletionServices with LibraryManagementCore

### DIFF
--- a/src/DynamoCore/Engine/CodeCompletion/CodeCompletionServices.cs
+++ b/src/DynamoCore/Engine/CodeCompletion/CodeCompletionServices.cs
@@ -69,7 +69,7 @@ namespace Dynamo.Engine.CodeCompletion
                 }
             }
 
-            return members.Select(x => CompletionData.ConvertMirrorToCompletionData(x));
+            return members?.Select(x => CompletionData.ConvertMirrorToCompletionData(x));
         }
 
         /// <summary>
@@ -212,6 +212,7 @@ namespace Dynamo.Engine.CodeCompletion
                         cm.Alias = shortNames.ElementAt(i).Value;
                     }
                 }
+                // Filter out empty types
                 completions.AddRange(classMirrorGroup.
                     Where(x => !x.IsEmpty).
                         Select(x =>

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -147,6 +147,7 @@ namespace Dynamo.Engine
             this.libraryServices = libraryServices;
             libraryServices.LibraryLoaded += LibraryLoaded;
             CompilationServices = new CompilationServices(libraryServices);
+            codeCompletionServices = new CodeCompletionServices(libraryServices.LibraryManagementCore);
 
             liveRunnerServices = new LiveRunnerServices(this, geometryFactoryFileName);
 
@@ -510,11 +511,6 @@ namespace Dynamo.Engine
             liveRunnerServices.ReloadAllLibraries(libraryServices.ImportedLibraries);
 
             VMLibrariesReset?.Invoke();
-
-            // The LiveRunner core is newly instantiated whenever a new library is imported
-            // due to which a new instance of CodeCompletionServices needs to be created with the new Core
-            codeCompletionServices = new CodeCompletionServices(LiveRunnerCore);
-            libraryServices.SetLiveCore(LiveRunnerCore);
         }
 
         /// <summary>

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -48,12 +48,6 @@ namespace Dynamo.Engine
         /// Returns core which is used for parsing code and loading libraries
         /// </summary>
         public ProtoCore.Core LibraryManagementCore { get; private set; }
-        private ProtoCore.Core liveRunnerCore = null;
-
-        internal void SetLiveCore(ProtoCore.Core core)
-        {
-            liveRunnerCore = core;
-        }
 
         private class UpgradeHint
         {

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditorUtils.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditorUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Media;
 using System.Xml;
@@ -65,6 +66,8 @@ namespace Dynamo.Wpf.Views
             };
 
             var wordList = engineController.CodeCompletionServices.GetClasses();
+            if (!wordList.Any()) return null;
+
             String regex = String.Format(@"\b({0})\b", String.Join("|", wordList));
             classHighlightRule.Regex = new Regex(regex);
 
@@ -87,6 +90,8 @@ namespace Dynamo.Wpf.Views
             };
 
             var wordList = engineController.CodeCompletionServices.GetGlobals();
+            if (!wordList.Any()) return null;
+
             String regex = String.Format(@"\b({0})\b", String.Join("|", wordList));
             methodHighlightRule.Regex = new Regex(regex);
 
@@ -134,8 +139,12 @@ namespace Dynamo.Wpf.Views
             var rules = editor.SyntaxHighlighting.MainRuleSet.Rules;
 
             rules.Add(CodeHighlightingRuleFactory.CreateNumberHighlightingRule());
-            rules.Add(CodeHighlightingRuleFactory.CreateClassHighlightRule(controller));
-            rules.Add(CodeHighlightingRuleFactory.CreateMethodHighlightRule(controller));
+            
+            var classRule = CodeHighlightingRuleFactory.CreateClassHighlightRule(controller);
+            if(classRule != null) rules.Add(classRule);
+
+            var methodRule = CodeHighlightingRuleFactory.CreateMethodHighlightRule(controller);
+            if(methodRule != null) rules.Add(methodRule);
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
@@ -159,9 +159,10 @@ namespace Dynamo.UI.Controls
             var engineController =
                 dynamoViewModel.EngineController;
 
-            return engineController.CodeCompletionServices.GetCompletionsOnType(
-                code, stringToComplete, dynamoViewModel.CurrentSpace.ElementResolver).
-                Select(x => new CodeCompletionData(x));
+            var completions = engineController.CodeCompletionServices.GetCompletionsOnType(
+                code, stringToComplete, dynamoViewModel.CurrentSpace.ElementResolver);
+            
+            return completions?.Select(x => new CodeCompletionData(x));
         }
 
         private IEnumerable<ICompletionData> SearchCompletions(string stringToComplete, Guid guid)
@@ -238,7 +239,7 @@ namespace Dynamo.UI.Controls
 
                     var completions = this.GetCompletionData(code, stringToComplete);
 
-                    if (!completions.Any())
+                    if (completions == null || !completions.Any())
                         return;
 
                     ShowCompletionWindow(completions);

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1082,10 +1082,6 @@ namespace ProtoScript.Runners
             {
                 return runnerCore;
             }
-            private set
-            {
-                runnerCore = value;
-            }
         }
 
         private ProtoCore.RuntimeCore runtimeCore = null;

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -323,7 +323,7 @@ namespace UnitsUI
         private VolumeFromString(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts):base(inPorts, outPorts)
         {
             Measure = Volume.FromDouble(0.0, VolumeUnit.CubicMeter);
-            Warning("AreaFromString is obsolete.", true);
+            Warning("VolumeFromString is obsolete.", true);
         }
 
         public VolumeFromString()
@@ -332,7 +332,7 @@ namespace UnitsUI
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("volume", Resources.VolumeFromStringPortDataVolumeToolTip)));
             RegisterAllPorts();
 
-            Warning("AreaFromString is obsolete.", true);
+            Warning("VolumeFromString is obsolete.", true);
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)


### PR DESCRIPTION
### Purpose

Related to JIRA: https://jira.autodesk.com/browse/DYN-1682

Initialize `CodeCompletionServices` with `LibraryManagementCore` and not `LiveRunnerCore` as was done previously. There are subtle differences between these 2 cores, and they are not always in sync. For example, `LibraryManagementCore` is used for library management, keeping compile-time records of libraries loaded into the system. It holds information used to display nodes in the Library, for code block precompilation and for CBN autocomplete whereas `LiveRunnerCore` holds runtime information and is used to construct the runtime Core of the VM.

Before:
![screenshot_demo3](https://user-images.githubusercontent.com/5710686/78510897-98ac0000-7766-11ea-9b20-3559e166ed18.gif)

After:
![screenshot_demo4](https://user-images.githubusercontent.com/5710686/78510905-a1043b00-7766-11ea-9422-9628b467c508.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
