### PR TITLE
DoesCurrentUserOwnPackage Test Update

### DIFF
--- a/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
@@ -415,11 +415,11 @@ namespace Dynamo.PackageManager.Tests
 
             var c = new Mock<IGregClient>();
             c.Setup(x =>
-                x.ExecuteAndDeserializeWithContent<PackageHeader>(It.IsAny<HeaderDownload>()))
+                x.ExecuteAndDeserializeWithContent<PackageHeader>(It.IsAny<GetMaintainers>()))
                 .Returns(mp);
 
             var pc = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
-            var res = pc.DoesCurrentUserOwnPackage(new Package("1","1","2.0.4","1"), username);
+            var res = pc.DoesCurrentUserOwnPackage(new Package("1","Package","2.0.4","1"), username);
 
             Assert.IsFalse(res);
         }
@@ -445,11 +445,11 @@ namespace Dynamo.PackageManager.Tests
 
             var c = new Mock<IGregClient>();
             c.Setup(x =>
-                x.ExecuteAndDeserializeWithContent<PackageHeader>(It.IsAny<HeaderDownload>()))
+                x.ExecuteAndDeserializeWithContent<PackageHeader>(It.IsAny<GetMaintainers>()))
                 .Returns(mp);
 
             var pc = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
-            var res = pc.DoesCurrentUserOwnPackage(new Package("1", "1", "2.0.4", "1"), usrname);
+            var res = pc.DoesCurrentUserOwnPackage(new Package("1", "Package", "2.0.4", "1"), usrname);
 
             Assert.IsTrue(res);
         }


### PR DESCRIPTION
### Purpose

Fixing the regression caused due to the previous commit,
Updated unit test to include latest addition of the new endpoint via greg.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.




