### PR TITLE
Avoid duplication in package assembly list

### DIFF
--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -294,7 +294,7 @@ namespace Dynamo.PackageManager
         /// <param name="packages"></param>
         public void LoadPackages(IEnumerable<Package> packages)
         {
-            var enumerable = packages.ToList();
+            var packageList = packages.ToList();
 
             // This fix is in reference to the crash reported in task: https://jira.autodesk.com/browse/DYN-2101
             // TODO: https://jira.autodesk.com/browse/DYN-2120. we will be re-evaluating this workflow, to find the best clean solution.
@@ -308,7 +308,7 @@ namespace Dynamo.PackageManager
             // Disabling the run here since new packages are being loaded. 
             EngineController.DisableRun = true;
 
-            foreach (var pkg in enumerable)
+            foreach (var pkg in packageList)
             {
                 // If the pkg is null, then don't load that package into the Library.
                 if (pkg != null)
@@ -320,9 +320,11 @@ namespace Dynamo.PackageManager
             // Setting back the DisableRun property back to false, as the package loading is completed.
             EngineController.DisableRun = false;
 
-            var assemblies =
-                enumerable.SelectMany(x => x.EnumerateAssembliesInBinDirectory().Where(y => y.IsNodeLibrary));
-            OnPackagesLoaded(assemblies.Select(x => x.Assembly));
+            var assemblies = packageList
+                .SelectMany(p => p.LoadedAssemblies.Where(y => y.IsNodeLibrary))
+                .Select(a => a.Assembly)
+                .ToList();
+            OnPackagesLoaded(assemblies);
         }
 
         public void LoadCustomNodesAndPackages(LoadPackageParams loadPackageParams, CustomNodeManager customNodeManager)

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -46,6 +46,19 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
+        public void LoadPackagesDoesNotDuplicateLoadedAssemblies()
+        {
+            var pkgDir = Path.Combine(PackagesDirectory, "AnotherPackage");
+            var loader = GetPackageLoader();
+            var pkg = loader.ScanPackageDirectory(pkgDir);
+
+            loader.LoadPackages(new List<Package> { pkg });
+            Assert.AreEqual(1, pkg.LoadedAssemblies.Count);
+            Assert.AreEqual("AnotherPackage", pkg.LoadedAssemblies.First().Name);
+            Assert.IsTrue(pkg.LoadedAssemblies.First().IsNodeLibrary);
+        }
+
+        [Test]
         public void PackageLoaderRequestsExtensionsBeLoaded()
         {
             var loader = GetPackageLoader();


### PR DESCRIPTION
### Purpose

Fixes the issue described here https://forum.dynamobim.com/t/package-contents-listed-twice-in-the-package-manager/48994. Tracked as DYN-2602.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @QilongTang

### FYIs

@mjkkirschner 
