### PR TITLE
Make sure extension window closes with Dynamo

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -230,6 +230,12 @@ namespace Dynamo.Controls
                 else
                 {
                     tab.Content = contentControl.Content;
+                    var extensionWindow = contentControl as Window;
+                    if (extensionWindow != null)
+                    {
+                        // Make sure the extension window closes with Dynamo
+                        extensionWindow.Owner = this;
+                    }
                 }
 
                 //Insert the tab at the end

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -113,7 +113,6 @@ namespace DynamoCoreWpfTests
             };
             if (SetOwner)
             {
-                // Set the owner of the window to tuIDhe Dynamo window.
                 window.Owner = p.DynamoWindow;
             }
 
@@ -162,7 +161,6 @@ namespace DynamoCoreWpfTests
 
             var window = new Window
             {
-                // Set the owner of the window to tuIDhe Dynamo window.
                 Owner = p.DynamoWindow
             };
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -27,6 +27,23 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void ExtensionWindowIsClosedWithDynamo()
+        {
+            var dummyExtension = new DummyViewExtension()
+            {
+                SetOwner = false
+            };
+
+            RaiseLoadedEvent(this.View);
+            var extensionManager = View.viewExtensionManager;
+            extensionManager.Add(dummyExtension);
+
+            View.Close();
+
+            Assert.IsTrue(dummyExtension.WindowClosed);
+        }
+
+        [Test]
         public void ExtensionsSideBarExtensionsTest()
         {
             RaiseLoadedEvent(this.View);
@@ -63,7 +80,9 @@ namespace DynamoCoreWpfTests
 
     public class DummyViewExtension : IViewExtension
     {
-        public int Counter = 0;
+        public int Counter { get; set; }
+        public bool SetOwner { get; set; } = true;
+        public bool WindowClosed { get; set; }
 
         public string UniqueId
         {
@@ -87,11 +106,16 @@ namespace DynamoCoreWpfTests
                 Counter++;
             };
 
-            var window = new Window
+            var window = new Window();
+            window.Closed += (sender, args) =>
+            {
+                WindowClosed = true;
+            };
+            if (SetOwner)
             {
                 // Set the owner of the window to tuIDhe Dynamo window.
-                Owner = p.DynamoWindow
-            };
+                window.Owner = p.DynamoWindow;
+            }
 
             p.AddToExtensionsSideBar(this, window);
         }


### PR DESCRIPTION
### Purpose

View extensions that add a Window to the extension bar, run the risk of
leaving a window open when Dynamo closes, resulting in a zombie process
. The extension could avoid the problem in either of these two ways:

1. Setting the Owner property of the Window they create to the one
obtained from ViewLoadedParam.DynamoWindow.

2. Calling the Close method on the Window they created when the
Shutdown life-time method is called on the extension.

However, Dynamo should not rely on view extensions doing this. In order
to be able to still close no matter what, we assign the Owner property
explicitly in DynamoView.AddExtensionTabItem.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 