### PR TITLE
[DYN-2609] Fix crash when installing empty package

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -525,9 +525,15 @@ namespace Dynamo.ViewModels
 
                 // determine if any of the packages contain binaries or python scripts.  
                 var containsBinariesOrPythonScripts = dependencyVersionHeaders.Any(x =>
-                    x.contains_binaries ||
-                    x.contents.Contains(PackageManagerClient.PackageContainsBinariesConstant) ||
-                    x.contents.Contains(PackageManagerClient.PackageContainsPythonScriptsConstant));
+                {
+                    var are_contents_empty = string.IsNullOrEmpty(x.contents);
+                    var contains_binaries = x.contains_binaries ||
+                                            !are_contents_empty && x.contents.Contains(PackageManagerClient.PackageContainsBinariesConstant);
+                    var contains_python =
+                        !are_contents_empty && x.contents.Contains(PackageManagerClient.PackageContainsPythonScriptsConstant);
+                    return contains_binaries || contains_python;
+
+                });
 
                 // if any do, notify user and allow cancellation
                 if (containsBinariesOrPythonScripts)


### PR DESCRIPTION
### Purpose

Fix for regression caused by #10544  - crash when installing an empty package like LunchBox. Changes to new package version API's on the PM (I think) return the `PackageVersion` whose contents can be `null` for an empty package. Prior to the API change, the contents would be an empty string for an empty package. Thus it was necessary to add a null check.

The UI automation test _DynamoTests.dll.DynamoTests.Tests.SmokeTestPackage_ was failing, which signaled this regression.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mmisol 
@mjkkirschner 

### FYIs

@alfredo-pozo 
