### PR TITLE
Add Engine property to PythonNodeBase

### DIFF
--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -18,6 +18,26 @@ namespace PythonNodeModels
 {
     public abstract class PythonNodeBase : VariableInputNode
     {
+        public static readonly string DefaultPythonEngine = "IronPython2";
+        private string engine = DefaultPythonEngine;
+
+        /// <summary>
+        /// Evaluation engine used to execute the Python script. 
+        /// Currently supported values: "IronPython2" (the default)
+        /// </summary>
+        public string Engine
+        {
+            get { return engine; }
+            set
+            {
+                if (engine != value)
+                {
+                    engine = value;
+                    RaisePropertyChanged("Engine");
+                }
+            }
+        }
+
         /// <summary>
         /// Private constructor used for serialization.
         /// </summary>


### PR DESCRIPTION
### Purpose

This pulls the definition of the `PythonNodeBase.Engine` property out of PR #10548 / #10472 to unblock UX work that depends on the property.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- n/a Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

