### PR TITLE
Avoid IsReNamed/Named property loop.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -225,7 +225,13 @@ namespace Dynamo.ViewModels
         public bool IsRenamed
         {
             get { return isRenamed; }
-            set { isRenamed = value; RaisePropertyChanged(nameof(IsRenamed)); }
+            set {
+            if(isRenamed != value)
+                {
+            isRenamed = value;
+            RaisePropertyChanged(nameof(IsRenamed));
+                }
+            }
         }
 
         [JsonIgnore]

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -225,11 +225,12 @@ namespace Dynamo.ViewModels
         public bool IsRenamed
         {
             get { return isRenamed; }
-            set {
-            if(isRenamed != value)
+            set
+            {
+                if (isRenamed != value)
                 {
-            isRenamed = value;
-            RaisePropertyChanged(nameof(IsRenamed));
+                    isRenamed = value;
+                    RaisePropertyChanged(nameof(IsRenamed));
                 }
             }
         }

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -326,5 +326,27 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(nodeViewModel.Name, newName);
             Assert.AreEqual(nodeViewModel.OriginalName, expectedOriginalName);
         }
+
+        [Test]
+        [Category("RegressionTests")]
+        public void GettingNodeNameDoesNotTriggerPropertyChangeCycle()
+        {
+            //add a node
+            var numNode = new CoreNodeModels.Input.DoubleInput { X = 100, Y = 100 };
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(numNode, true);
+
+            //subscribe to all property changes
+            var nvm = ViewModel.CurrentSpaceViewModel.Nodes.First();
+            nvm.PropertyChanged += NodeNameTest_PropChangedHandler;
+            //get the nodes's name.
+            _ = nvm.Name;
+            nvm.PropertyChanged -= NodeNameTest_PropChangedHandler;
+        }
+
+        private void NodeNameTest_PropChangedHandler(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            //get the name,this will sometimes cause another propertyChanged event
+             _ = (sender as NodeViewModel).Name;
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -339,14 +339,14 @@ namespace DynamoCoreWpfTests
             var nvm = ViewModel.CurrentSpaceViewModel.Nodes.First();
             nvm.PropertyChanged += NodeNameTest_PropChangedHandler;
             //get the nodes's name.
-            _ = nvm.Name;
+            var temp = nvm.Name;
             nvm.PropertyChanged -= NodeNameTest_PropChangedHandler;
         }
 
         private void NodeNameTest_PropChangedHandler(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             //get the name,this will sometimes cause another propertyChanged event
-             _ = (sender as NodeViewModel).Name;
+             var temp = (sender as NodeViewModel).Name;
         }
     }
 }


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/DYN-2650
avoid a stackoverflow / loop that effects integrators that subscribe to property changes on the NodeViewModel and attempt to get a Node's name.

Don't raise a property change event unless the property actually changes. This is required because this setter is called whenever the Name getter is called.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

