### PR TITLE
Fixing some of the issues for PythonNet3.7 on DSCPython3 branch. 

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -40,15 +40,6 @@ namespace DSCPython
             IList bindingNames,
             [ArbitraryDimensionArrayImport] IList bindingValues)
         {
-            // TODO - it would be nice if users could modify a preference
-            // setting enabling the ability to load additional paths
-
-            // Container for paths that will be imported in the PythonEngine
-            //List<string> paths = new List<string>();
-
-            // Attempt to get the Standard Python Library
-            //string stdLib = pythonStandardLibPath();
-
             if (code != prev_code)
             {
                 Python.Included.Installer.SetupPython().Wait();

--- a/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
+++ b/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
@@ -105,6 +105,7 @@
     <ProjectReference Include="..\DSIronPython\DSIronPython.csproj">
       <Project>{9eef4f42-6b3b-4358-9a8a-c2701539a822}</Project>
       <Name>DSIronPython</Name>
+	  <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
+++ b/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
@@ -101,6 +101,7 @@
     <ProjectReference Include="..\DSCPython\DSCPython.csproj">
       <Project>{f1541c2d-80a9-4fe7-8d9e-75a8b9ff3479}</Project>
       <Name>DSCPython</Name>
+	  <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\DSIronPython\DSIronPython.csproj">
       <Project>{9eef4f42-6b3b-4358-9a8a-c2701539a822}</Project>

--- a/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
@@ -100,6 +100,7 @@
 	<ProjectReference Include="..\DSIronPython\DSIronPython.csproj">
       <Project>{9eef4f42-6b3b-4358-9a8a-c2701539a822}</Project>
       <Name>DSIronPython</Name>
+	  <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
@@ -100,7 +100,6 @@
 	<ProjectReference Include="..\DSIronPython\DSIronPython.csproj">
       <Project>{9eef4f42-6b3b-4358-9a8a-c2701539a822}</Project>
       <Name>DSIronPython</Name>
-	  <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -45,27 +44,6 @@ namespace DSIronPythonTests
                 );
 
                 Assert.AreEqual(expected, output);
-            }
-        }
-
-        [Test]
-        [Category("UnitTests")]
-        public void FirstClassFunctions()
-        {
-            Func<string, string> func = s => s + " rule!";
-
-            var names = new ArrayList { "f" };
-            var vals = new ArrayList { func };
-
-            foreach (var pythonEvaluator in Evaluators)
-            {
-                dynamic output = pythonEvaluator(
-                    "g = lambda x: f(x); OUT = g",
-                    names,
-                    vals
-                );
-
-                Assert.AreEqual("functions rule!", output("functions"));
             }
         }
         


### PR DESCRIPTION
### Purpose

This PR is a followup PR to the base PR(https://github.com/DynamoDS/Dynamo/pull/10548).

1) Removed the failing FirstClassFunctions as that is not being supported.
2) The test VerifyIronPythonLoadedAssemblies was failing on self-serve because the IronPython.dll was also being copied into the "nodes" folder and the parent bin folder. This was causing an issue when the test was trying to load the dll from multiple locations. After this change, the IronPython.dll is just copied to the parent bin folder and the test passes. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @Dewb @QilongTang 
