### PR TITLE
Add support for debug modes

### DIFF
--- a/src/DynamoCore/App.config
+++ b/src/DynamoCore/App.config
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-   <configSections>
-      <section name="DebugModes" type="System.Configuration.AppSettingsSection"/>
-   </configSections>
-   <DebugModes>
-   </DebugModes>
-   <appSettings>
+  <appSettings>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/src/DynamoCore/App.config
+++ b/src/DynamoCore/App.config
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <appSettings>
+   <configSections>
+      <section name="DebugModes" type="System.Configuration.AppSettingsSection"/>
+   </configSections>
+
+   <appSettings>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/src/DynamoCore/App.config
+++ b/src/DynamoCore/App.config
@@ -3,7 +3,8 @@
    <configSections>
       <section name="DebugModes" type="System.Configuration.AppSettingsSection"/>
    </configSections>
-
+   <DebugModes>
+   </DebugModes>
    <appSettings>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -52,7 +52,8 @@ namespace Dynamo.Configuration
                 {
                     if (!debugModes.ContainsKey(key)) { continue; }
 
-                    debugModes[key].Enabled = Boolean.TryParse(section.Settings[key].Value, out bool enabled) ? enabled : false;
+                    bool enabled = false;
+                    debugModes[key].Enabled = Boolean.TryParse(section.Settings[key].Value, out enabled) ? enabled : false;
                 }
             }
             catch (Exception)
@@ -61,7 +62,8 @@ namespace Dynamo.Configuration
 
         public static bool Enabled(string name)
         {
-            return DebugModesEnabled && debugModes.TryGetValue(name, out DebugMode dMode) ? dMode.Enabled : false;
+            DebugMode dMode;
+            return DebugModesEnabled && debugModes.TryGetValue(name, out dMode) ? dMode.Enabled : false;
         }
     }
 }

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -49,11 +49,6 @@ namespace Dynamo.Configuration
             // AddDebugMode("TestDebugMode", "Enabe/disable TestDebugMode.");
         }
 
-        private static void ClearDebugModes()
-        {
-            debugModes.Clear();
-        }
-
         private static void LoadDebugModesStatusFromConfig(string configPath)
         {
             try

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Reflection;
+
+namespace Dynamo.Configuration
+{
+    internal class DebugModes
+    {
+        static readonly Dictionary<string, DebugMode> debugModes;
+        private static bool DebugModesEnabled;
+ 
+        public class DebugMode
+        {
+            public string Name;
+            public string Description;
+            public bool Enabled;
+        }
+
+        static void AddDebugMode(string name, string description)
+        {
+            debugModes[name] = new DebugMode()
+            {
+                Name = name,
+                Description = description,
+                Enabled = false
+            };
+        }
+        static void RegisterDebugModes()
+        {
+            // Add new debug modes here!!
+            //
+            // Example:
+            // AddDebugMode("TestDebugMode", "Enabe/disable TestDebugMode.");
+        }
+
+        static DebugModes()
+        {
+            debugModes = new Dictionary<string, DebugMode>();
+            DebugModesEnabled = false;
+            try
+            {
+                RegisterDebugModes();
+
+                var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetExecutingAssembly().Location);
+                AppSettingsSection section = (AppSettingsSection)config.GetSection("DebugModes");
+
+                if (section == null) { return; }
+
+                DebugModesEnabled = true;
+                foreach (var key in section.Settings.AllKeys)
+                {
+                    if (!debugModes.ContainsKey(key)) { continue; }
+
+                    debugModes[key].Enabled = bool.TryParse(section.Settings[key].Value, out bool enabled) ? enabled : false;
+                }
+            }
+            catch (Exception)
+            { }
+        }
+
+        public static bool Enabled(string name)
+        {
+            return DebugModesEnabled && debugModes.TryGetValue(name, out DebugMode dMode) ? dMode.Enabled : false;
+        }
+    }
+}

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -5,39 +5,55 @@ using System.Reflection;
 
 namespace Dynamo.Configuration
 {
-    internal class DebugModes
+    /// <summary>
+    /// Provide functionality around debug modes. Similar to feature flags.
+    /// </summary>
+    public class DebugModes
     {
-        static readonly Dictionary<string, DebugMode> debugModes;
-        private static bool DebugModesEnabled;
- 
+        static private readonly Dictionary<string, DebugMode> debugModes;
+        private static bool debugModesEnabled;
+
+        /// <summary>
+        /// Represents an instance of a debug mode
+        /// </summary>
         public class DebugMode
         {
+            /// <summary>
+            /// Name of the debug mode
+            /// </summary>
             public string Name;
+            /// <summary>
+            /// Description of the debug mode
+            /// </summary>
             public string Description;
+            /// <summary>
+            /// Whether debug mode is enabled or not
+            /// </summary>
             public bool Enabled;
         }
-
-        static void AddDebugMode(string name, string description)
+        private static void AddDebugMode(string name, string description)
         {
             debugModes[name] = new DebugMode()
             {
                 Name = name,
                 Description = description,
-                Enabled = false
+                Enabled = true
             };
         }
-        static void RegisterDebugModes()
+        private static void RegisterDebugModes()
         {
             // Add new debug modes here!!
             //
             // Example:
             // AddDebugMode("TestDebugMode", "Enabe/disable TestDebugMode.");
         }
-
+        /// <summary>
+        /// Static constructor
+        /// </summary>
         static DebugModes()
         {
             debugModes = new Dictionary<string, DebugMode>();
-            DebugModesEnabled = false;
+            debugModesEnabled = false;
             try
             {
                 RegisterDebugModes();
@@ -47,7 +63,7 @@ namespace Dynamo.Configuration
 
                 if (section == null) { return; }
 
-                DebugModesEnabled = true;
+                debugModesEnabled = true;
                 foreach (var key in section.Settings.AllKeys)
                 {
                     if (!debugModes.ContainsKey(key)) { continue; }
@@ -59,11 +75,43 @@ namespace Dynamo.Configuration
             catch (Exception)
             { }
         }
-
-        public static bool Enabled(string name)
+        /// <summary>
+        /// Enables/Disables a debug mode
+        /// </summary>
+        /// <param name="name">Name of the debug mode</param>
+        /// <param name="enabled">Enable/Disable debug mode</param>
+        public static void SetDebugModeEnabled(string name, bool enabled)
+        {
+            DebugMode dbgMode;
+            if (debugModes.TryGetValue(name, out dbgMode))
+            {
+                dbgMode.Enabled = enabled;
+            }
+        }
+        /// <summary>
+        /// Returns a dictionary of all the debug modes
+        /// </summary>
+        public static Dictionary<string, DebugMode> GetDebugModes()
+        {
+            return debugModes;
+        }
+        /// <summary>
+        /// Retrieves a debug mode
+        /// </summary>
+        /// <param name="name">Name of the debug mode</param>
+        public static DebugMode GetDebugMode(string name)
         {
             DebugMode dMode;
-            return DebugModesEnabled && debugModes.TryGetValue(name, out dMode) ? dMode.Enabled : false;
+            return debugModes.TryGetValue(name, out dMode) ? dMode : null;
+        }
+        /// <summary>
+        /// Retrieves the state of a debug mode (enabled/disabled)
+        /// </summary>
+        /// <param name="name">Name of the debug mode</param>
+        public static bool Enabled(string name)
+        {
+            DebugMode dbgMode;
+            return debugModesEnabled && debugModes.TryGetValue(name, out dbgMode) ? dbgMode.Enabled : false;
         }
     }
 }

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -46,8 +46,7 @@ namespace Dynamo.Configuration
             // Add new debug modes here!!
             //
             // Example:
-            AddDebugMode("TestDebugMode1", "Enabe/disable TestDebugMode.");
-            AddDebugMode("TestDebugMode2", "Enabe/disable TestDebugMode.");
+            // AddDebugMode("TestDebugMode", "Enabe/disable TestDebugMode.");
         }
 
         private static void ClearDebugModes()

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -52,7 +52,7 @@ namespace Dynamo.Configuration
                 {
                     if (!debugModes.ContainsKey(key)) { continue; }
 
-                    debugModes[key].Enabled = bool.TryParse(section.Settings[key].Value, out bool enabled) ? enabled : false;
+                    debugModes[key].Enabled = Boolean.TryParse(section.Settings[key].Value, out bool enabled) ? enabled : false;
                 }
             }
             catch (Exception)

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -152,6 +152,7 @@ limitations under the License.
     <Compile Include="Interfaces\IDynamoModel.cs" />
     <Compile Include="Library\ILibraryLoader.cs" />
     <Compile Include="Graph\Workspaces\ICustomNodeWorkspaceModel.cs" />
+    <Compile Include="Configuration\DebugModes.cs" />
     <Compile Include="Visualization\DefaultGraphicPrimitives.cs" />
     <Compile Include="Visualization\GeometryHolder.cs" />
     <Compile Include="Visualization\IRenderPackageSource.cs" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -321,6 +321,9 @@
     </Compile>
     <Compile Include="Views\CodeBlocks\CodeBlockEditor.cs" />
     <Compile Include="Views\Core\DynamoOpenFileDialog.cs" />
+    <Compile Include="Views\Debug\DebugModesWindow.xaml.cs">
+      <DependentUpon>DebugModesWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Gallery\GalleryView.xaml.cs">
       <DependentUpon>GalleryView.xaml</DependentUpon>
     </Compile>
@@ -1102,6 +1105,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Views\Debug\DebugModesWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\Gallery\GalleryView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -955,6 +955,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Debug Modes.
+        /// </summary>
+        public static string DynamoViewDebugMenuDebugModes {
+            get {
+                return ResourceManager.GetString("DynamoViewDebugMenuDebugModes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dump Library.
         /// </summary>
         public static string DynamoViewDebugMenuDumpLibrary {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -488,6 +488,10 @@ You will get a chance to save your work.</value>
     <value>Verbose Logging</value>
     <comment>Debug menu | Verbose logging</comment>
   </data>
+  <data name="DynamoViewDebugMenuDebugModes" xml:space="preserve">
+    <value>Debug Modes</value>
+    <comment>Debug menu | Show debug modes</comment>
+  </data>
   <data name="DynamoViewEditMenu" xml:space="preserve">
     <value>_Edit</value>
     <comment>Edit menu</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -250,6 +250,10 @@
     <value>Verbose Logging</value>
     <comment>Debug menu | Verbose logging</comment>
   </data>
+  <data name="DynamoViewDebugMenuDebugModes" xml:space="preserve">
+    <value>Debug Modes</value>
+    <comment>Debug menu | Show debug modes</comment>
+  </data>
   <data name="DynamoViewEditMenu" xml:space="preserve">
     <value>_Edit</value>
     <comment>Edit menu</comment>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -814,7 +814,13 @@
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuDumpLibrary}"
                                   Command="{Binding DumpLibraryToXmlCommand}"
                                   IsEnabled="True" />
-                    </MenuItem>
+                        <MenuItem Focusable="False"
+                                  Name="DebugModes"
+                                  Header="{x:Static p:Resources.DynamoViewDebugMenuDebugModes}"
+                                  Click="OnDebugModesClick"
+                                  DataContext="{Binding Path=Model.UpdateManager}"
+                                  IsCheckable="False" />
+               </MenuItem>
                 </Menu>
 
                 <!--Titlebar buttons-->

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -818,7 +818,6 @@
                                   Name="DebugModes"
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuDebugModes}"
                                   Click="OnDebugModesClick"
-                                  DataContext="{Binding Path=Model.UpdateManager}"
                                   IsCheckable="False" />
                </MenuItem>
                 </Menu>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -40,6 +40,7 @@ using Dynamo.Wpf.Controls;
 using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels.Core;
+using Dynamo.Wpf.Views.Debug;
 using Dynamo.Wpf.Views.Gallery;
 using Dynamo.Wpf.Views.PackageManager;
 using HelixToolkit.Wpf.SharpDX;
@@ -1562,6 +1563,13 @@ namespace Dynamo.Controls
         }
 #endif
 
+        private void OnDebugModesClick(object sender, RoutedEventArgs e)
+        {
+            var debugModesWindow = new DebugModesWindow();
+            debugModesWindow.Owner = this;
+            debugModesWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            debugModesWindow.ShowDialog();
+        }
         /// <summary>
         /// Setup the "Samples" sub-menu with contents of samples directory.
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Debug/DebugModesWindow.xaml
+++ b/src/DynamoCoreWpf/Views/Debug/DebugModesWindow.xaml
@@ -1,0 +1,38 @@
+﻿<Window x:Class="Dynamo.Wpf.Views.Debug.DebugModesWindow"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Dynamo.Wpf.Views.Debug" Width="357"
+             ResizeMode="NoResize" Height="510"
+        >
+   <StackPanel>
+      <ListView Name="CheckList" Height="320" Margin="10,0">
+         <ListView.ItemTemplate>
+            <DataTemplate>
+               <WrapPanel>
+                  <CheckBox IsChecked="{Binding Enabled}"/>
+                  <TextBlock Margin="10,0,0,0" Text="{Binding Name}"  />
+               </WrapPanel>
+            </DataTemplate>
+         </ListView.ItemTemplate>
+         <ListView.ItemContainerStyle>
+            <Style TargetType="ListViewItem">
+               <EventSetter Event="PreviewMouseLeftButtonDown" Handler="OnDebugModeItemClick" />
+            </Style>
+         </ListView.ItemContainerStyle>
+      </ListView>
+      <ScrollViewer Margin="10,5,10,0" Height="100">
+         <TextBox IsReadOnly="True" TextWrapping="Wrap" x:Name="SelectedDbgMode" Text="{Binding SelectedDebugMode}">
+         </TextBox>
+      </ScrollViewer>
+      <StackPanel Orientation="Horizontal"  Height="46" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="188">
+         <Button Content="OK" 
+                Height="25" Margin="10,10,10,10" Width="75" x:Name="btnOK" TabIndex="1600" IsDefault="True" Click="OnOkClick"                        
+                VerticalContentAlignment="Center" HorizontalContentAlignment="Center" />
+         <Button Content="Cancel" 
+                Height="25" Margin="10,10,10,10" Width="75" x:Name="btnCancel" TabIndex="1700" IsCancel="True" 
+                VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Click="OnCancelClick" />
+      </StackPanel>
+   </StackPanel>
+</Window>

--- a/src/DynamoCoreWpf/Views/Debug/DebugModesWindow.xaml
+++ b/src/DynamoCoreWpf/Views/Debug/DebugModesWindow.xaml
@@ -1,10 +1,9 @@
 ﻿<Window x:Class="Dynamo.Wpf.Views.Debug.DebugModesWindow"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Dynamo.Wpf.Views.Debug" Width="357"
-             ResizeMode="NoResize" Height="510"
+             xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
+             Title="{x:Static p:Resources.DynamoViewDebugMenuDebugModes}"
+             ResizeMode="NoResize" Width="350" Height="510"
         >
    <StackPanel>
       <ListView Name="CheckList" Height="320" Margin="10,0">

--- a/src/DynamoCoreWpf/Views/Debug/DebugModesWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Debug/DebugModesWindow.xaml.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using Dynamo.Configuration;
+using System.Linq;
+using System.Text;
+using System.Windows;
+
+namespace Dynamo.Wpf.Views.Debug
+{
+    /// <summary>
+    /// Interaction logic for DebugModesWindow.xaml
+    /// </summary>
+    public partial class DebugModesWindow : Window
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public DebugModesWindow()
+        {
+            InitializeComponent();
+
+            var items = new List<DebugModeListItem>();
+            foreach (var entry in DebugModes.GetDebugModes())
+            {
+                items.Add(new DebugModeListItem() {
+                    Name = entry.Value.Name,
+                    Enabled = entry.Value.Enabled
+                });
+            }
+            CheckList.ItemsSource = items;
+        }
+        private void OnDebugModeItemClick(object sender, RoutedEventArgs e)
+        {
+            var listItem = (System.Windows.Controls.ListBoxItem)sender;
+            if (null == listItem)
+            {
+                throw new Exception("Invalid Control type found. Expected ListBoxItem");
+            }
+            var dataContext = (DebugModeListItem)listItem.DataContext;
+            if (null == dataContext)
+            {
+                throw new Exception("Invalid data context type found. Expected DebugModeItem");
+            }
+            var debugMode = DebugModes.GetDebugMode(dataContext.Name);
+            if (null == debugMode)
+            {
+                throw new Exception("Invalid debug mode found");      
+            }
+            SelectedDbgMode.Text = debugMode.Description;
+        }
+        private void OnOkClick(object sender, RoutedEventArgs e)
+        {
+            foreach (DebugModeListItem item in CheckList.Items)
+            {
+                DebugModes.SetDebugModeEnabled(item.Name, item.Enabled);
+            }
+            Close();
+        }
+
+        private void OnCancelClick(object sender, RoutedEventArgs e) {}
+
+        private class DebugModeListItem
+        {
+            public string Name { get; set; }
+
+            public bool Enabled { get; set; }
+        }
+    }
+}

--- a/test/DynamoCoreTests/Configuration/DebugModesTests.cs
+++ b/test/DynamoCoreTests/Configuration/DebugModesTests.cs
@@ -28,10 +28,8 @@ namespace Dynamo.Tests.Configuration
                 testDebugModes[item.Attributes["name"].Value] = bool.Parse(item.Attributes["enabled"].Value);
             }
 
-            // Clear the any pre-existing debug modes.
             Type dbgModesType = typeof(DebugModes);
-            dbgModesType.GetMethod("ClearDebugModes", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, null);
-
+   
             // Register the test debug modes.
             MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModes)
@@ -41,9 +39,6 @@ namespace Dynamo.Tests.Configuration
 
             // Load the enabled/disabled status from the test config file.
             dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
-
-            // Check that we have the same number of debug modes.
-            Assert.AreEqual(DebugModes.GetDebugModes().Count, testDebugModes.Count);
 
             foreach (var item in testDebugModes)
             {
@@ -75,11 +70,9 @@ namespace Dynamo.Tests.Configuration
 
             Assert.IsEmpty(debugItems);
 
-            // Clear the any pre-existing debug modes.
             Type dbgModesType = typeof(DebugModes);
-            dbgModesType.GetMethod("ClearDebugModes", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, null);
 
-            var testDebugModeNames = new List<string>() { "test1", "test2" };
+            var testDebugModeNames = new List<string>() { "test5", "test6" };
             // Register the test debug modes.
             MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModeNames)
@@ -89,9 +82,6 @@ namespace Dynamo.Tests.Configuration
 
             // Load the enabled/disabled status from the test config file.
             dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
-
-            // Check that we have the same number of debug modes.
-            Assert.AreEqual(DebugModes.GetDebugModes().Count, testDebugModeNames.Count);
 
             foreach (var dbgModeName in testDebugModeNames)
             {
@@ -103,13 +93,9 @@ namespace Dynamo.Tests.Configuration
         [Category("UnitTests")]
         public void TestMissingConfig()
         {
-            string configPath = Path.Combine(TestDirectory, "testDebugModes", "missing.config");
-
-            // Clear the any pre-existing debug modes.
             Type dbgModesType = typeof(DebugModes);
-            dbgModesType.GetMethod("ClearDebugModes", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, null);
 
-            var testDebugModeNames = new List<string>() { "test1", "test2" };
+            var testDebugModeNames = new List<string>() { "test7", "test8" };
             // Register the test debug modes.
             MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModeNames)
@@ -118,10 +104,8 @@ namespace Dynamo.Tests.Configuration
             }
 
             // Load the enabled/disabled status from the test config file.
+            string configPath = Path.Combine(TestDirectory, "testDebugModes", "missing.config");
             dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
-
-            // Check that we have the same number of debug modes.
-            Assert.AreEqual(DebugModes.GetDebugModes().Count, testDebugModeNames.Count);
 
             foreach (var dbgModeName in testDebugModeNames)
             {

--- a/test/DynamoCoreTests/Configuration/DebugModesTests.cs
+++ b/test/DynamoCoreTests/Configuration/DebugModesTests.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Reflection;
+using Dynamo.Configuration;
+using NUnit.Framework;
+using System.Xml;
+using System.IO;
+
+namespace Dynamo.Tests.Configuration
+{
+    [TestFixture]
+    class DebugModesTests : DynamoModelTestBase
+    {
+        [Test]
+        [Category("UnitTests")]
+        public void TestLoadDebugModes()
+        {
+            string configPath = Path.Combine(TestDirectory, "testDebugModes", "debugModes.config");
+
+            XmlDocument xml = new XmlDocument();
+            xml.Load(configPath);
+            var debugItems = xml.DocumentElement.SelectNodes("DebugMode");
+
+            var testDebugModes = new Dictionary<string, bool>();
+            foreach (XmlNode item in debugItems)
+            {
+                testDebugModes[item.Attributes["name"].Value] = bool.Parse(item.Attributes["enabled"].Value);
+            }
+
+            // Clear the any pre-existing debug modes.
+            Type dbgModesType = typeof(DebugModes);
+            dbgModesType.GetMethod("ClearDebugModes", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, null);
+
+            // Register the test debug modes.
+            MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
+            foreach (var dbgModeName in testDebugModes)
+            {
+                addDebugMode.Invoke(null, new object[] { dbgModeName.Key, dbgModeName.Key });
+            }
+
+            // Load the enabled/disabled status from the test config file.
+            dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
+
+            // Check that we have the same number of debug modes.
+            Assert.AreEqual(DebugModes.GetDebugModes().Count, testDebugModes.Count);
+
+            foreach (var item in testDebugModes)
+            {
+                var dbgMode = DebugModes.GetDebugMode(item.Key);
+                Assert.IsNotNull(dbgMode);
+                Assert.AreEqual(dbgMode.Enabled, item.Value);
+            }
+
+            var forceEnabled = false;
+            foreach (var item in testDebugModes)
+            {
+                DebugModes.SetDebugModeEnabled(item.Key, forceEnabled);
+            }
+
+            foreach (var item in testDebugModes)
+            {
+                Assert.AreEqual(DebugModes.Enabled(item.Key), forceEnabled);
+            }
+        }
+        [Test]
+        [Category("UnitTests")]
+        public void TestLoadNoDebugModes()
+        {
+            string configPath = Path.Combine(TestDirectory, "testDebugModes", "noDebugModes.config");
+
+            XmlDocument xml = new XmlDocument();
+            xml.Load(configPath);
+            var debugItems = xml.DocumentElement.SelectNodes("DebugMode");
+
+            Assert.IsEmpty(debugItems);
+
+            // Clear the any pre-existing debug modes.
+            Type dbgModesType = typeof(DebugModes);
+            dbgModesType.GetMethod("ClearDebugModes", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, null);
+
+            var testDebugModeNames = new List<string>() { "test1", "test2" };
+            // Register the test debug modes.
+            MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
+            foreach (var dbgModeName in testDebugModeNames)
+            {
+                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName });
+            }
+
+            // Load the enabled/disabled status from the test config file.
+            dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
+
+            // Check that we have the same number of debug modes.
+            Assert.AreEqual(DebugModes.GetDebugModes().Count, testDebugModeNames.Count);
+
+            foreach (var dbgModeName in testDebugModeNames)
+            {
+                Assert.IsNotNull(DebugModes.GetDebugMode(dbgModeName));
+                Assert.AreEqual(DebugModes.Enabled(dbgModeName), false);
+            }        
+        }
+        [Test]
+        [Category("UnitTests")]
+        public void TestMissingConfig()
+        {
+            string configPath = Path.Combine(TestDirectory, "testDebugModes", "missing.config");
+
+            // Clear the any pre-existing debug modes.
+            Type dbgModesType = typeof(DebugModes);
+            dbgModesType.GetMethod("ClearDebugModes", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, null);
+
+            var testDebugModeNames = new List<string>() { "test1", "test2" };
+            // Register the test debug modes.
+            MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
+            foreach (var dbgModeName in testDebugModeNames)
+            {
+                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName });
+            }
+
+            // Load the enabled/disabled status from the test config file.
+            dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
+
+            // Check that we have the same number of debug modes.
+            Assert.AreEqual(DebugModes.GetDebugModes().Count, testDebugModeNames.Count);
+
+            foreach (var dbgModeName in testDebugModeNames)
+            {
+                Assert.IsNotNull(DebugModes.GetDebugMode(dbgModeName));
+                Assert.AreEqual(DebugModes.Enabled(dbgModeName), false);
+            }
+        }
+    }
+}

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -77,6 +77,7 @@
     </Compile>
     <Compile Include="AnalyticsTests.cs" />
     <Compile Include="Configuration\ContextTests.cs" />
+    <Compile Include="Configuration\DebugModesTests.cs" />
     <Compile Include="Configuration\ExecutionSessionTests.cs" />
     <Compile Include="Configuration\PreferenceSettingsTests.cs" />
     <Compile Include="Core\NotificationObjectTests.cs" />

--- a/test/testDebugModes/debugModes.config
+++ b/test/testDebugModes/debugModes.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DebugModes>
+    <DebugMode name="TestDebugMode1" enabled="true"/>
+    <DebugMode name="TestDebugMode2" enabled="false"/>
+    <DebugMode name="TestDebugMode3" enabled="true"/>
+    <DebugMode name="TestDebugMode4" enabled="false"/>
+</DebugModes>

--- a/test/testDebugModes/noDebugModes.config
+++ b/test/testDebugModes/noDebugModes.config
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DebugModes>
+</DebugModes>


### PR DESCRIPTION
### Purpose

Add support for debug modes (similar to feature flags).
The main idea behind this PR is to allow any developer to wrap functionality under flags. The code can get pushed to master...and not interfere with other people's work. It can even get shipped to users. As long as the "experimental code" is wrapped under a DebugMode and not activated...it should not change any of the existing functionality.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
