### PR TITLE
Handle runtime table gaps on code block deletion

### DIFF
--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -770,7 +770,13 @@ namespace ProtoCore
         private int GetRuntimeTableSize()
         {
             // Due to the way this list is constructed, the largest id is the one of the last block.
-            return CompleteCodeBlockList.Last().codeBlockId + 1;
+            var lastBlock = CompleteCodeBlockList.Last();
+            // If the last block has children, then its last child has the largest id.
+            if (lastBlock.children.Count > 0)
+            {
+                lastBlock = lastBlock.children.Last();
+            }
+            return lastBlock.codeBlockId + 1;
         }
 
         public string GenerateTempVar()

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -771,6 +771,8 @@ namespace ProtoCore
         {
             // Due to the way this list is constructed, the largest id is the one of the last block.
             var lastBlock = CompleteCodeBlockList.LastOrDefault();
+            // If there are no code blocks yet, then the required size for tables is 0.
+            // This happens when the first code block is being created and its id is being generated.
             if (lastBlock == null)
             {
                 return 0;

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -367,21 +367,6 @@ namespace ProtoCore
             }
         }
 
-        //private void RemoveCodeBlockRecursive(CodeBlock root, int cbID)
-        //{
-        //    for (int i = root.children.Count - 1; i >= 0; i--)
-        //    {
-        //        if (root.children[i].codeBlockId == cbID)
-        //        {
-        //            root.children.RemoveAt(i);
-        //        }
-        //        else
-        //        {
-        //            RemoveCodeBlockRecursive(root.children[i], cbID);
-        //        }
-        //    }
-        //}
-
         /// <summary>
         /// Reset the VM state for delta execution.
         /// </summary>

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -763,13 +763,13 @@ namespace ProtoCore
         }
 
         /// <summary>
-        /// Gets the size of the runtime table. Note: since blocks are stored consecutively
-        /// but may have gaps due to procedures being delete, this is based on largest id
-        /// rather than amount of blocks.
+        /// Gets the size to be used for runtime tables of symbols, procedures and instruction streams.
+        /// Note: since blocks are stored consecutively but may have gaps due to procedures being deleted,
+        /// this is based on largest id rather than amount of blocks.
         /// </summary>
         private int GetRuntimeTableSize()
         {
-            // Due to the way this list is constructed, the largest id is the one of the las block.
+            // Due to the way this list is constructed, the largest id is the one of the last block.
             return CompleteCodeBlockList.Last().codeBlockId + 1;
         }
 

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -367,6 +367,21 @@ namespace ProtoCore
             }
         }
 
+        //private void RemoveCodeBlockRecursive(CodeBlock root, int cbID)
+        //{
+        //    for (int i = root.children.Count - 1; i >= 0; i--)
+        //    {
+        //        if (root.children[i].codeBlockId == cbID)
+        //        {
+        //            root.children.RemoveAt(i);
+        //        }
+        //        else
+        //        {
+        //            RemoveCodeBlockRecursive(root.children[i], cbID);
+        //        }
+        //    }
+        //}
+
         /// <summary>
         /// Reset the VM state for delta execution.
         /// </summary>
@@ -727,7 +742,7 @@ namespace ProtoCore
             // The TypeSystem is a record of all primitive and compiler generated types
             DSExecutable.TypeSystem = TypeSystem;
 
-            RuntimeTableIndex = CompleteCodeBlockList.Count;
+            RuntimeTableIndex = GetRuntimeTableSize();
 
 
             // Build the runtime symbols
@@ -760,6 +775,17 @@ namespace ProtoCore
             DSExecutable.Configurations = Configurations;
             DSExecutable.CodeToLocation = CodeToLocation;
             DSExecutable.CurrentDSFileName = CurrentDSFileName;           
+        }
+
+        /// <summary>
+        /// Gets the size of the runtime table. Note: since blocks are stored consecutively
+        /// but may have gaps due to procedures being delete, this is based on largest id
+        /// rather than amount of blocks.
+        /// </summary>
+        private int GetRuntimeTableSize()
+        {
+            // Due to the way this list is constructed, the largest id is the one of the las block.
+            return CompleteCodeBlockList.Last().codeBlockId + 1;
         }
 
         public string GenerateTempVar()

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -767,10 +767,15 @@ namespace ProtoCore
         /// Note: since blocks are stored consecutively but may have gaps due to procedures being deleted,
         /// this is based on largest id rather than amount of blocks.
         /// </summary>
-        private int GetRuntimeTableSize()
+        internal int GetRuntimeTableSize()
         {
             // Due to the way this list is constructed, the largest id is the one of the last block.
-            var lastBlock = CompleteCodeBlockList.Last();
+            var lastBlock = CompleteCodeBlockList.LastOrDefault();
+            if (lastBlock == null)
+            {
+                return 0;
+            }
+
             // If the last block has children, then its last child has the largest id.
             if (lastBlock.children.Count > 0)
             {

--- a/src/Engine/ProtoCore/DSASM/Executable.cs
+++ b/src/Engine/ProtoCore/DSASM/Executable.cs
@@ -155,10 +155,10 @@ namespace ProtoCore.DSASM
             procedureTable = procTable;
 
             isBreakable = isBreakableBlock;
+            codeBlockId = core.GetRuntimeTableSize();
             core.CompleteCodeBlockList.Add(this);
-            this.codeBlockId = core.CompleteCodeBlockList.Count - 1;
 
-            symbols.RuntimeIndex = this.codeBlockId;
+            symbols.RuntimeIndex = codeBlockId;
 
             if (core.ProcNode != null)
             {

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -455,7 +455,6 @@ namespace ProtoScript.Runners
                     {
                         if (removeSubTree.AstNodes != null)
                         {
-                            // deletedBinaryExpressions.AddRange(removeSubTree.AstNodes.Where(n => n is BinaryExpressionNode));
                             deletedBinaryExpressions.AddRange(removeSubTree.AstNodes);
                         }
                     }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -455,6 +455,7 @@ namespace ProtoScript.Runners
                     {
                         if (removeSubTree.AstNodes != null)
                         {
+                            // deletedBinaryExpressions.AddRange(removeSubTree.AstNodes.Where(n => n is BinaryExpressionNode));
                             deletedBinaryExpressions.AddRange(removeSubTree.AstNodes);
                         }
                     }

--- a/test/DynamoCoreTests/ImperativeClodeBlockTest.cs
+++ b/test/DynamoCoreTests/ImperativeClodeBlockTest.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Scheduler;
 using NUnit.Framework;
+using static Dynamo.Models.DynamoModel;
 
 namespace Dynamo.Tests
 {
@@ -21,6 +24,30 @@ namespace Dynamo.Tests
         {
             RunModel(@"core\imperative\call_static_function.dyn");
             AssertPreviewValue("250880ed-5d34-49e7-b92b-2a7f9336f62b", new object[] { 3, 5 });
+        }
+
+        [Test]
+        public void DeletingImperativeCBNShouldNotLeadToCrash()
+        {
+            TaskStateChangedEventHandler evaluationDidNotFailHandler =
+                (DynamoScheduler sender, TaskStateChangedEventArgs args) =>
+                {
+                    Assert.AreNotEqual(TaskStateChangedEventArgs.State.ExecutionFailed, args.CurrentState);
+                };
+            try
+            {
+                CurrentDynamoModel.Scheduler.TaskStateChanged += evaluationDidNotFailHandler;
+                OpenModel(@"core\imperative\delete_imperative_cbn_crash.dyn");
+                AssertPreviewValue("0692b19256834a9187f3bcd500d513f1", 5.86);
+                CurrentDynamoModel.ExecuteCommand(new DeleteModelCommand("45f0db0f-c014-481e-9b7f-939da54f2adc"));
+                CurrentDynamoModel.ExecuteCommand(new DeleteModelCommand("235f53ba-d913-45d0-986a-b9c6588cba45"));
+                AssertPreviewValue("0692b19256834a9187f3bcd500d513f1", 5.86);
+                Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            }
+            finally
+            {
+                CurrentDynamoModel.Scheduler.TaskStateChanged -= evaluationDidNotFailHandler;
+            }
         }
     }
 }

--- a/test/core/imperative/delete_imperative_cbn_crash.dyn
+++ b/test/core/imperative/delete_imperative_cbn_crash.dyn
@@ -1,0 +1,174 @@
+{
+  "Uuid": "5cbd5e74-0c40-4731-8de5-a14376da2743",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "crash_repro",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Curve.StartPoint": {
+        "Key": "Autodesk.DesignScript.Geometry.Curve",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Curve.EndPoint": {
+        "Key": "Autodesk.DesignScript.Geometry.Curve",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Math": {
+        "Key": "DSCore.Math",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def giveMeEPlusPi()\n{\n  impPi = [Imperative]\n  {\n    return giveMePi();\n  }\n  impE = [Imperative]\n  {\n    return giveMeE();\n  }\n  return Math.Sum([impPi, impE]);\n}\n\ndef giveMeE()\n{\n  return 2.718;\n}\n\ndef giveMePi()\n{\n  return 3.142;\n};",
+      "Id": "a531f0bb1b8b42418b58a5676e2b0107",
+      "Inputs": [],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "a=giveMeEPlusPi();",
+      "Id": "0692b19256834a9187f3bcd500d513f1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "6867de1c60b84ac5944f76aea5f0520a",
+          "Name": "",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "b=a+1;",
+      "Id": "235f53bad91345d0986ab9c6588cba45",
+      "Inputs": [
+        {
+          "Id": "44f93bd8548141c9a8f2f7338c925e21",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "db93f82ac4874eff840022e9abeb5731",
+          "Name": "",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def grpCrvs(Curve:var[]..[])\n    {\n    \tdis1 = (Curve.StartPoint)<1>.DistanceTo(Curve<2>)==0\n        ||(Curve.EndPoint)<1>.DistanceTo(Curve<2>)==0;\n    \tind1 = DSCore.List.AllIndicesOf(dis1<1>,true);\n    \tbln1 = true;\n    \tind2 = [Imperative]\n    \t{\n    \t\twhile (bln1)\n    \t\t{\n    \t\t\tcnt1 = DSCore.List.Count(ind1);\n    \t\t\tind1 = grpIndx(ind1);\n    \t\t\tcnt2 = DSCore.List.Count(ind1);\n    \t\t\tbln1 = cnt2!=cnt1;\n    \t\t}\n    \t\treturn = ind1;\n    \t}\n    \tcrv1 = DSCore.List.GetItemAtIndex(Curve,ind2);\n    \treturn = crv1;\n    };\n\n    def grpIndx(ind:var[]..[])\n    {\n    \tind1 = DSCore.List.SetIntersection(ind<1>,ind<2>);\n    \tcnt1 = DSCore.List.Count(ind1<1><2>)>1;\n    \tind2 = DSCore.List.FilterByBoolMask(ind,cnt1<1>)[\"in\"];\n    \tind3 = DSCore.List.UniqueItems(DSCore.List.Flatten(ind2<1>,-1)<1>);\n    \tind4 = DSCore.List.UniqueItems(DSCore.List.Sort(ind3<1>));\n    \treturn = ind4;\n    };",
+      "Id": "45f0db0fc014481e9b7f939da54f2adc",
+      "Inputs": [],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "6867de1c60b84ac5944f76aea5f0520a",
+      "End": "44f93bd8548141c9a8f2f7338c925e21",
+      "Id": "27eebd44113640e7a1f161caeadac75e"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.7.0.8475",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "a531f0bb1b8b42418b58a5676e2b0107",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 554.2,
+        "Y": 95.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "0692b19256834a9187f3bcd500d513f1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -19.0,
+        "Y": 26.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "235f53bad91345d0986ab9c6588cba45",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 213.83216955952196,
+        "Y": 28.548083791714419
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "45f0db0fc014481e9b7f939da54f2adc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -113.913086330586,
+        "Y": 147.03575124246467
+      }
+    ],
+    "Annotations": [],
+    "X": 83.554627092476267,
+    "Y": 60.75454555821301,
+    "Zoom": 0.68246059654089
+  }
+}


### PR DESCRIPTION
### Purpose

When the runtime table are built there is an implicit assumption that
the code block ids are consecutive. However, that is not always the
case, as the deletion of a procedure causes the deletion of its child
code blocks, which may generate gaps in the id numbering.

In order to make the code resiliant to these gaps, the runtime tables
are sized based on the largest code block id, rather than in the amount
of code blocks.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @mjkkirschner 

### FYIs

@QilongTang 