### PR TITLE
[WIP][FEEDBACK] Reduce test time by substantially reducing number of serialization tests.

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Dynamo.Configuration;
@@ -1076,9 +1077,9 @@ namespace Dynamo.Graph.Workspaces
             Guid deterministicGuid;
             if (!Guid.TryParse(obj.Value<string>(), out deterministicGuid))
             {
-                Console.WriteLine("the id was not a guid, converting to a guid");
+                Debug.WriteLine("the id was not a guid, converting to a guid");
                 deterministicGuid = GuidUtility.Create(GuidUtility.UrlNamespace, obj.Value<string>());
-                Console.WriteLine(obj + " becomes " + deterministicGuid);
+                Debug.WriteLine(obj + " becomes " + deterministicGuid);
             }
             return deterministicGuid;
         }
@@ -1191,7 +1192,7 @@ namespace Dynamo.Graph.Workspaces
             if (!Guid.TryParse(reference, out id))
             {
                 // If this is not a guid, it won't be in the resolver.
-                Console.WriteLine("not a guid");
+                Debug.WriteLine("not a guid");
                 return null;
             }
             object model;
@@ -1213,7 +1214,7 @@ namespace Dynamo.Graph.Workspaces
             if (!Guid.TryParse(reference, out id))
             {
                 // If this is not a guid, it won't be in the resolver.
-                Console.WriteLine("not a guid");
+                Debug.WriteLine("not a guid");
                 return null;
             }
             object model;

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2065,9 +2065,9 @@ namespace Dynamo.Graph.Workspaces
             Guid deterministicGuid;
             if (!Guid.TryParse(id, out deterministicGuid))
             {
-                Console.WriteLine("The id was not a guid, converting to a guid");
+                Debug.WriteLine("The id was not a guid, converting to a guid");
                 deterministicGuid = GuidUtility.Create(GuidUtility.UrlNamespace, id);
-                Console.WriteLine(id + " becomes " + deterministicGuid);
+                Debug.WriteLine(id + " becomes " + deterministicGuid);
             }
 
             return deterministicGuid;

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -522,6 +522,7 @@ namespace Dynamo.Tests
         public static string jsonNonGuidFolderName = "json_nonGuidIds";
         public static string jsonFolderName = "json";
         public static string jsonFolderNameDifferentCulture = "json_differentCulture";
+        private const int MAXNUM_SERIALIZATIONTESTS_TOEXECUTE = 300;
 
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
@@ -714,7 +715,7 @@ namespace Dynamo.Tests
         {
             var di = new DirectoryInfo(TestDirectory);
             var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
-            return fis.Select(fi => fi.FullName).ToArray();
+            return fis.Select(fi => fi.FullName).Take(MAXNUM_SERIALIZATIONTESTS_TOEXECUTE).ToArray();
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -27,6 +27,8 @@ namespace DynamoCoreWpfTests
 {
     internal class SerializationTests : DynamoViewModelUnitTest
     {
+        private const int MAXNUM_SERIALIZATIONTESTS_TOEXECUTE = 300;
+
         [Test]
         [Category("UnitTests")]
         public void TestBasicAttributes()

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -27,7 +27,6 @@ namespace DynamoCoreWpfTests
 {
     internal class SerializationTests : DynamoViewModelUnitTest
     {
-        private const int MAXNUM_SERIALIZATIONTESTS_TOEXECUTE = 300;
 
         [Test]
         [Category("UnitTests")]
@@ -471,6 +470,8 @@ namespace DynamoCoreWpfTests
 
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
+        private const int MAXNUM_SERIALIZATIONTESTS_TOEXECUTE = 300;
+
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -1008,7 +1009,7 @@ namespace DynamoCoreWpfTests
             var di = new DirectoryInfo(TestDirectory);
             var fis = new string[] { "*.dyn", "*.dyf" }
             .SelectMany(i => di.GetFiles(i, SearchOption.AllDirectories));
-            return fis.Select(fi => fi.FullName).ToArray();
+            return fis.Select(fi => fi.FullName).Take(MAXNUM_SERIALIZATIONTESTS_TOEXECUTE).ToArray();
         }
 
 


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-2666

While investigating the test job timeouts, I found that the serialization tests were a major portion of the testing time, and quite variable, as they require disk access 6 times each.
`(open file, save file, open file, save file, save DS file, save results file)`

In this PR I have simply limited the total number of files returned in the test generation function `FindWorkspaces` each returned workspace acts as a test case, but this function is accessed from multiple test classes for a total of approximately 5000 tests.

`SerializationTests`
`WPFJsonSerializationTests`
`SerializationNonGUIDtests`
`SerializationCultureTests`

After this change, the number becomes 1000~ tests total.

**The time savings is quite large.
The complete install job completes in 1hour 30 minutes compared to 2:30 - 3:30 average.
The parallel job running on each PR completes in 11 minutes when run on the perf machine - compared to 30 minutes.**

I am not sure how a reduction in the number of tests like this will effect coverage - the job is currently in progress. I will add that info when I have it. I am hopeful many of these tests are covering the same functionality... serialization.

Here are a few thoughts:

These serialization tests were used during the transition from xml to json files - that transition has completed, it's *definitely* still valuable to run the json tests over a subset of files (especially .xml files) in the repo - but it does not make sense to run these tests over the ever increasing collection of .json based files we already have! It will continue to grow and IMO does not provide much as a test besides wasting time. 

These tests also used to produce output files that could be used to compare with previous executions - this is quite useful for other implementations of DesignScript, but has been turned off for some time.

If we need this functionality for an ever increasing set of files we should run it as a separate job which produces this suite of executions and not tie to our tests which should be fast!


here are some other proposals to balance testing coverage vs speed.
1. disregard all files inside `FindWorkspaces` which are not xml files.
2. create a handpicked list of files instead of finding the first `n` files in the repo.
3. disable the SerializationTests - but keep the JsonSerialization tests - these duplicate much of the testing in the SerializationTests - as they are a super set.


![Screen Shot 2020-05-01 at 5 04 53 PM](https://user-images.githubusercontent.com/508936/80844270-4975b580-8bd4-11ea-893f-2aee42c8f8ea.png)
![Screen Shot 2020-05-01 at 3 34 42 PM](https://user-images.githubusercontent.com/508936/80844271-4a0e4c00-8bd4-11ea-8ce6-6fc46d20bcfa.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.



