### PR TITLE
Fix non-array item search for dot operation

### DIFF
--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -2582,11 +2582,21 @@ array1 = [[],[a]];
 test1 = array1.a;
 array2 = [[a],[]];
 test2 = array2.a;
+array3 = [[[[]]],[[[],[]],[[],[a]]]];
+test3 = array3.a;
 ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("test1", new object[] { new object[0], new object[] { 1 } });
             thisTest.Verify("test2", new object[] { new object[] { 1 }, new object[0] });
+            thisTest.Verify("test3", new object[] {
+                new object[] { new object[] { new object[0] } },
+                new object[]
+                {
+                    new object[] { new object[0], new object[0] },
+                    new object[] { new object[0], new object[] { 1 } }
+                }
+            });
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -2572,6 +2572,24 @@ test3 = a1.X[0][0];
         }
 
         [Test]
+        [Category("Replication")]
+        public void DotOperationShouldIdentifyTheTypeOfArraysWithSomeEmptyItems()
+        {
+            string code = @"
+import(""FFITarget.dll"");
+a = TestObjectA.TestObjectA(1);
+array1 = [[],[a]];
+test1 = array1.a;
+array2 = [[a],[]];
+test2 = array2.a;
+";
+            ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("test1", new object[] { new object[0], new object[] { 1 } });
+            thisTest.Verify("test2", new object[] { new object[] { 1 }, new object[0] });
+        }
+
+        [Test]
         public void T67_Defect_1460965_ExpressionInParenthesis01()
         {
             string code = @"


### PR DESCRIPTION
### Purpose

When an array is passed to the dot operation, it needs to get an item
to determine the actual class being processed. This was done in
ArrayUtils.GetFirstNonArrayStackValue, but the function only checked
the first item of the array and its descendants. This caused the dot
operation to failed when passed an array that contained an empty array
as its first item.

In order to fix the problem, the function was changed to check for
non-array items in the entire array. The function should stop as soon
as the first non-array item is found.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
