### PR TITLE
Support heterogeneous arrays in repl FEP matching

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -923,10 +923,7 @@ namespace ProtoCore
             #region Case 5: Replication and replication guide with type conversion and array promotion
             {
                 //Add as a first attempt a no-replication, but allowing up-promoting
-                if (!replicationTrials.Any(rt => rt.Count == 0))
-                {
-                    replicationTrials.Insert(0, new List<ReplicationInstruction>());
-                }
+                replicationTrials.Add(new List<ReplicationInstruction>());
 
                 foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                 {

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -923,7 +923,10 @@ namespace ProtoCore
             #region Case 5: Replication and replication guide with type conversion and array promotion
             {
                 //Add as a first attempt a no-replication, but allowing up-promoting
-                replicationTrials.Add(new List<ReplicationInstruction>());
+                if (!replicationTrials.Any(rt => rt.Count == 0))
+                {
+                    replicationTrials.Insert(0, new List<ReplicationInstruction>());
+                }
 
                 foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                 {

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -191,7 +191,7 @@ namespace ProtoCore
             RuntimeCore runtimeCore)
         {
             Dictionary<FunctionEndPoint, int> ret = new Dictionary<FunctionEndPoint, int>();
-            var reducedParams = Replicator.ComputeAllReducedParams(formalParams, replicationInstructions, runtimeCore);
+            var reducedParams = Replicator.ComputeAllReducedParamsWithoutArraySampling(formalParams, replicationInstructions, runtimeCore);
 
             foreach (FunctionEndPoint fep in FunctionEndPoints)
             {

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -142,6 +142,44 @@ namespace ProtoCore.Utils
             return usageFreq;
         }
 
+        /// <summary>
+        /// Similar to GetTypeExamplesForLayer but it returns all arrays. Its purpose is to support
+        /// inspecting heterogeneous arrays in replication scenarios.
+        /// </summary>
+        /// <param name="array"></param>
+        /// <param name="runtimeCore"></param>
+        /// <returns></returns>
+        internal static List<StackValue> GetTypeExamplesForLayerWithoutArraySampling(StackValue array, RuntimeCore runtimeCore)
+        {
+            var result = new List<StackValue>();
+            var alreadyFoundTypes = new HashSet<int>();
+
+            if (!array.IsArray)
+            {
+                result.Add(array);
+                return result;
+            }
+
+            var dsArray = runtimeCore.Heap.ToHeapObject<DSArray>(array);
+            foreach (var sv in dsArray.Values)
+            {
+                if (sv.IsArray)
+                {
+                    result.Add(sv);
+                }
+                else
+                {
+                    if (!alreadyFoundTypes.Contains(sv.metaData.type))
+                    {
+                        alreadyFoundTypes.Add(sv.metaData.type);
+                        result.Add(sv);
+                    }
+                }
+            }
+
+            return result;
+        }
+
 
         /// <summary>
         /// Generate type statistics for given layer of an array

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -143,8 +143,8 @@ namespace ProtoCore.Utils
         }
 
         /// <summary>
-        /// Similar to GetTypeExamplesForLayer but it returns all arrays. Its purpose is to support
-        /// inspecting heterogeneous arrays in replication scenarios.
+        /// Similar to GetTypeExamplesForLayer but it returns all non-empty arrays.
+        /// Its purpose is to support inspecting heterogeneous arrays in replication scenarios.
         /// </summary>
         /// <param name="array"></param>
         /// <param name="runtimeCore"></param>
@@ -165,7 +165,10 @@ namespace ProtoCore.Utils
             {
                 if (sv.IsArray)
                 {
-                    result.Add(sv);
+                    if (!IsEmpty(sv, runtimeCore))
+                    {
+                        result.Add(sv);
+                    }
                 }
                 else
                 {

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -1098,7 +1098,7 @@ r2 = Dictionary.ValueAtKey(c, ""out"");
             thisTest.Verify("r2", new object[] { new object[] { new object[] { 24 } }, 42 });
         }
 
-        [Test, Category("Failure")]
+        [Test]
         public void TestTryGetValuesFromDictionary11()
         {
             string code = @"


### PR DESCRIPTION
### Purpose

The no longer failing test pictures this scenario better than words.
Before this change, we would not be able to find a function endpoint
that matched the arguments, even with replication and loose type check.

This was caused by a heuristic done at the Replicator that I have named
'array sampling'. Basically, when getting type examples to produce the
reduced parameters for replication, this optimization would sample only
the first non-empty array it found in the given parent array layer.

In the failing test, the first non-empty array led to reduced params of
types string and int for the first argument of Dictionary.ValueAtKey.
As the function was expecting a dictionary, and no cast is possible
from those types, the FEP was not resolved.

In order to solve this problem, an alternative replication parameter
production strategy that does not sample arrays was introduced. By
applying this in the failing test case, we are now also inspecting the
nested array that contains the dictionary, which leads to resolving the
FEP as compliant.

For performance reasons, this strategy is used only in the context of
the most permissive FEP matching, which is case 6, as the amount of
reduced parameters to consider for replication could increase greatly.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
