### PR TITLE
[DYN-2680] Write logs to std out instead of creating new files for each test.

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -157,7 +157,20 @@ namespace Dynamo.Logging
         /// </summary>
         /// <param name="debugSettings">Debug settings</param>
         /// <param name="logDirectory">Directory path where log file will be written</param>
-        public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean IsTestMode = false)
+        [Obsolete("This will be removed in 3.0, please use DynamoLogger(debugSettings, logDirectory, isTestMode) instead.")]
+        public DynamoLogger(DebugSettings debugSettings, string logDirectory) : this(debugSettings, logDirectory, false)
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DynamoLogger"/> class
+        /// with specified debug settings and directory where to write logs
+        /// </summary>
+        /// <param name="debugSettings">Debug settings</param>
+        /// <param name="logDirectory">Directory path where log file will be written</param>
+        /// <param name="isTestMode">Test mode is true or false.</param>
+        public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean isTestMode)
         {
             lock (guardMutex)
             {
@@ -169,7 +182,7 @@ namespace Dynamo.Logging
 
                 notifications = new List<NotificationMessage>();
 
-                testMode = IsTestMode;
+                testMode = isTestMode;
 
                 if (!testMode)
                 {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -570,7 +570,7 @@ namespace Dynamo.Models
             IsHeadless = config.IsHeadless;
 
             DebugSettings = new DebugSettings();
-            Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory);
+            Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory, IsTestMode);
 
             foreach (var exception in exceptions)
             {

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -16,6 +16,7 @@ using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Selection;
+using Dynamo.Tests.Loggings;
 using NUnit.Framework;
 using DynCmd = Dynamo.Models.DynamoModel;
 
@@ -235,10 +236,17 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void CanClearLog()
         {
-            Assert.AreNotEqual(0, CurrentDynamoModel.Logger.LogText.Length);
+            // Get the dynamo logger in non-test mode, as we write the logs
+            // to dynamo console and to a file only in non-test mode. 
 
-            CurrentDynamoModel.Logger.ClearLog();
-            Assert.AreEqual(0, CurrentDynamoModel.Logger.LogText.Length);
+            DynamoLoggerTest dynamoLoggerTest = new DynamoLoggerTest();
+            var logger = dynamoLoggerTest.GetDynamoLoggerWithTestModeFalse();
+
+            Assert.AreNotEqual(0, logger.LogText.Length);
+
+            logger.ClearLog();
+
+            Assert.AreEqual(0, logger.LogText.Length);
         }
 
         // Clearworkspace

--- a/test/DynamoCoreTests/Migration/WorkspaceMigrationsTests.cs
+++ b/test/DynamoCoreTests/Migration/WorkspaceMigrationsTests.cs
@@ -1,7 +1,8 @@
-﻿using Dynamo.Migration;
-using NUnit.Framework;
+﻿using System;
 using System.IO;
 using System.Xml;
+using Dynamo.Migration;
+using NUnit.Framework;
 
 namespace Dynamo.Tests.Migrations
 {
@@ -15,21 +16,31 @@ namespace Dynamo.Tests.Migrations
         [Category("UnitTests")]
         public void TestWorkspaceMigrations()
         {
+            string consoleOutput;
+
             //Arrange
             string openPath = Path.Combine(TestDirectory, @"core\NodeStates.dyn");
             RunModel(openPath);
             string logFileText = string.Empty;
             XmlDocument xmlDoc = new XmlDocument();
 
-            //Act
-            //Create a instance of WorkspaceMigration and call the function that writes to the log
-            var workMigration = new WorkspaceMigrations(CurrentDynamoModel);
-            workMigration.Migrate_0_5_3_to_0_6_0(xmlDoc);
-            var currentLoggerPath = CurrentDynamoModel.Logger.LogPath;
+            using (StringWriter stringWriter = new StringWriter())
+            {
+                Console.SetOut(stringWriter);
 
-            //Assert
-            Assert.IsTrue(File.Exists(currentLoggerPath));//Check that the log was created successfully
-            Assert.IsTrue(CurrentDynamoModel.Logger.LogText.Contains("migration from 0.5.3.x to 0.6.1.x"));//Checks that the log text contains the migration info
+                //Act
+                //Create a instance of WorkspaceMigration and call the function that writes to the log
+                var workMigration = new WorkspaceMigrations(CurrentDynamoModel);
+                workMigration.Migrate_0_5_3_to_0_6_0(xmlDoc);
+
+                consoleOutput = stringWriter.ToString();
+
+                StreamWriter sw = new StreamWriter(Console.OpenStandardOutput());
+                Console.SetOut(sw);
+            }
+
+            //Checks that the console output text contains the migration info
+            Assert.IsTrue(consoleOutput.Contains("migration from 0.5.3.x to 0.6.1.x"));
         }
     }
 }

--- a/test/DynamoCoreTests/Migration/WorkspaceMigrationsTests.cs
+++ b/test/DynamoCoreTests/Migration/WorkspaceMigrationsTests.cs
@@ -26,6 +26,9 @@ namespace Dynamo.Tests.Migrations
 
             using (StringWriter stringWriter = new StringWriter())
             {
+                TextWriter standardOutput = Console.Out;
+
+                // Set the console out to a string object to verify the log message.
                 Console.SetOut(stringWriter);
 
                 //Act
@@ -35,8 +38,8 @@ namespace Dynamo.Tests.Migrations
 
                 consoleOutput = stringWriter.ToString();
 
-                StreamWriter sw = new StreamWriter(Console.OpenStandardOutput());
-                Console.SetOut(sw);
+                // Set the console out back to std out. 
+                Console.SetOut(standardOutput);
             }
 
             //Checks that the console output text contains the migration info


### PR DESCRIPTION
### Purpose

This PR is in reference to the task: https://jira.autodesk.com/browse/DYN-2680. 

In the current design, a log file is created everytime dynamo is started and closed. So during a test run on the VM, around 5000-10000 logs are created. Over time, this is causing performance issues on the VM. We are not using these logs anyways so it is better to avoid it. 

After this change, during tests, we write the logs only to std out instead of file or to dynamo console. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 