### PR TITLE
Add ADP optin UI with ADP dependent on Google opt-in

### DIFF
--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -62,6 +62,11 @@ namespace Dynamo.Interfaces
         bool IsAnalyticsReportingApproved { get; set; }
 
         /// <summary>
+        /// Indicates whether ADP analytics reporting is approved or not.
+        /// </summary>
+        bool IsADPAnalyticsReportingApproved { get; set; }
+
+        /// <summary>
         /// Indicates first run
         /// </summary>
         bool IsFirstRun { get; set; }

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -66,6 +66,16 @@ namespace Dynamo.Configuration
         /// Indicates whether analytics reporting is approved or not.
         /// </summary>
         public bool IsAnalyticsReportingApproved { get; set; }
+
+        /// <summary>
+        /// Indicates whether ADP analytics reporting is approved or not.
+        /// </summary>
+        [XmlIgnore]
+        public bool IsADPAnalyticsReportingApproved
+        {
+            get { return Logging.Analytics.ReportingADPAnalytics; }
+            set { Logging.Analytics.ReportingADPAnalytics = value; }
+        }
         #endregion
 
         #region UI & Graphics settings

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -135,6 +135,8 @@ namespace Dynamo.Logging
 
         private IPreferences preferences = null;
 
+        private IAnalyticsUI adpAnalyticsUI = null;
+
         public static IDisposable Disposable { get { return new Dummy(); } }
 
         private ProductInfo product;
@@ -152,6 +154,19 @@ namespace Dynamo.Logging
                     && Service.IsInitialized
                     && preferences.IsAnalyticsReportingApproved;
             }
+        }
+
+        /// <summary>
+        /// Return if ADP Analytics Client is allowed to send analytics info
+        /// </summary>
+        public bool ReportingADPAnalytics
+        {
+            get
+            {
+                if (!Configuration.DebugModes.IsEnabled("ADPAnalyticsTracker")) { return false; }
+                return adpAnalyticsUI?.IsOptedIn() ?? false;
+            }
+            set { adpAnalyticsUI?.SetOptedIn(value); }
         }
 
         /// <summary>
@@ -173,6 +188,8 @@ namespace Dynamo.Logging
             //Set the preferences, so that we can get live value of analytics 
             //reporting approved status.
             preferences = dynamoModel.PreferenceSettings;
+
+            adpAnalyticsUI = new ADPAnalyticsUI();
 
             if (Session == null) Session = new DynamoAnalyticsSession();
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -394,6 +394,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to I agree to data collection in desktop products for Autodesk analytics programs (ADP Analytics)..
+        /// </summary>
+        public static string ConsentFormADPAnalyticsCheckBoxContent {
+            get {
+                return ResourceManager.GetString("ConsentFormADPAnalyticsCheckBoxContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Yes, I would like to contribute to this program (Google Analytics)..
         /// </summary>
         public static string ConsentFormGoogleAnalyticsCheckBoxContent {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -241,6 +241,9 @@
   <data name="ConsentFormInstrumentationCheckBoxContent" xml:space="preserve">
     <value>I give my consent for Autodesk to collect information, using a tool called Instrumentation, on how I use {0}</value>
   </data>
+  <data name="ConsentFormADPAnalyticsCheckBoxContent" xml:space="preserve">
+    <value>I agree to data collection in desktop products for Autodesk analytics programs (ADP Analytics).</value>
+  </data>
   <data name="ContextAddGroupFromSelection" xml:space="preserve">
     <value>Add To Group</value>
     <comment>Context menu item</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1735,6 +1735,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="ConsentFormInstrumentationCheckBoxContent" xml:space="preserve">
     <value>I give my consent for Autodesk to collect information, using a tool called Instrumentation, on how I use {0}</value>
   </data>
+  <data name="ConsentFormADPAnalyticsCheckBoxContent" xml:space="preserve">
+    <value>I agree to data collection in desktop products for Autodesk analytics programs (ADP Analytics).</value>
+  </data>
   <data name="GroupContextMenuDeleteGroup" xml:space="preserve">
     <value>Delete Group</value>
   </data>

--- a/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml.cs
@@ -116,7 +116,6 @@ namespace Dynamo.UI.Prompts
             }
 
             UsageReportingManager.Instance.SetAnalyticsReportingAgreement(AcceptAnalyticsReportingCheck.IsChecked.Value);
-            Analytics.ReportingADPAnalytics = AcceptAnalyticsReportingCheck.IsChecked.Value;
             Close();
         }
 

--- a/src/NodeServices/Analytics.cs
+++ b/src/NodeServices/Analytics.cs
@@ -53,6 +53,15 @@ namespace Dynamo.Logging
         public static bool ReportingAnalytics { get { return client != null && client.ReportingAnalytics; } }
 
         /// <summary>
+        /// Returns if ADP analytics reporting is ON
+        /// </summary>
+        public static bool ReportingADPAnalytics
+        {
+            get { return client?.ReportingADPAnalytics ?? false; }
+            set { if (client != null) client.ReportingADPAnalytics = value; }
+        }
+
+        /// <summary>
         /// Tracks application startup time
         /// </summary>
         /// <param name="productName">Dynamo product name</param>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -166,6 +166,11 @@ namespace Dynamo.Logging
         bool ReportingAnalytics { get; }
 
         /// <summary>
+        /// Checks if ADP analytics reporting is ON.
+        /// </summary>
+        bool ReportingADPAnalytics { get; set; }
+
+        /// <summary>
         /// Cheks if detailed usage reporting is ON.
         /// </summary>
         bool ReportingUsage { get; }


### PR DESCRIPTION
### Purpose 

Added UI for ADP (replaces the Instrumentation consent UI)
Still fully under a debug mode.
Exposed the ADP opt-in/opt-out API in Preferences as a non-serializable property,
ADP is a child option of Google...and is only enabled if Google Analytics is opted-in.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
