### PR TITLE
[DYN-2655]: Fix crash for badly formatted xml docs on ZT node

### DIFF
--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -370,7 +370,7 @@ namespace Dynamo.Engine
                                 currentDocNode.Summary = reader.Value.CleanUpDocString();
                                 break;
                             case XmlTagType.Parameter: 
-                                // If <returns> tag is missing around text after <params> tag, the text is added as a new parameter
+                                // If a tag is missing around text after <params> tag, the text is added as a new parameter
                                 // under the previous parameter name. This check avoids that safely.
                                 if (!currentDocNode.Parameters.ContainsKey(currentParamName))
                                 {

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -369,8 +369,14 @@ namespace Dynamo.Engine
                             case XmlTagType.Summary:
                                 currentDocNode.Summary = reader.Value.CleanUpDocString();
                                 break;
-                            case XmlTagType.Parameter:
-                                currentDocNode.Parameters.Add(currentParamName, reader.Value.CleanUpDocString());
+                            case XmlTagType.Parameter: 
+                                // If <returns> tag is missing around text after <params> tag, the text is added as a new parameter
+                                // under the previous parameter name. This check avoids that safely.
+                                if (!currentDocNode.Parameters.ContainsKey(currentParamName))
+                                {
+                                    currentDocNode.Parameters.Add(currentParamName, reader.Value.CleanUpDocString());
+                                }
+
                                 break;
                             case XmlTagType.Returns:
                                 currentDocNode.Returns.Add(new Tuple<string,string>(currentParamName, reader.Value.CleanUpDocString()));

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -386,7 +386,8 @@ namespace Dynamo.Engine
                                 }
                                 else
                                 {
-                                    OnMissingXmlTags($"{currentDocNode.FullyQualifiedName} is missing some XML documentation tags");
+                                    OnMissingXmlTags(
+                                        $"{currentDocNode.FullyQualifiedName} {Properties.Resources.MissingXmlTagConsoleMessage}");
                                 }
 
                                 break;

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Xml;
 using Dynamo.Interfaces;
 using Dynamo.Library;
+using Dynamo.Logging;
 
 namespace Dynamo.Engine
 {
@@ -19,6 +20,8 @@ namespace Dynamo.Engine
                    new Dictionary<string, MemberDocumentNode>();
 
         #region Public methods
+
+        public static event Action<string> LogToConsole;
 
         /// <summary>
         /// Returns a description of a parameter from the its documentation xml,
@@ -297,6 +300,11 @@ namespace Dynamo.Engine
             SearchTagWeights
         }
 
+        private static void OnMissingXmlTags(string warning)
+        {
+            LogToConsole?.Invoke(warning);
+        }
+
         private static void LoadDataFromXml(XmlReader reader, string assemblyName)
         {
             if (reader == null)
@@ -370,11 +378,15 @@ namespace Dynamo.Engine
                                 currentDocNode.Summary = reader.Value.CleanUpDocString();
                                 break;
                             case XmlTagType.Parameter: 
-                                // If a tag is missing around text after <params> tag, the text is added as a new parameter
-                                // under the previous parameter name. This check avoids that safely.
+                                // If a tag is missing around text after <params> tag, the text can be added as a new parameter
+                                // under the previous parameter name. This check avoids the resulting ArgumentException with the dictionary.
                                 if (!currentDocNode.Parameters.ContainsKey(currentParamName))
                                 {
                                     currentDocNode.Parameters.Add(currentParamName, reader.Value.CleanUpDocString());
+                                }
+                                else
+                                {
+                                    OnMissingXmlTags($"{currentDocNode.FullyQualifiedName} is missing some XML documentation tags");
                                 }
 
                                 break;

--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using Dynamo.Configuration;
 using Dynamo.Core;
+using Dynamo.Engine;
 using Dynamo.Exceptions;
 
 namespace Dynamo.Logging
@@ -188,6 +189,8 @@ namespace Dynamo.Logging
                 {
                     StartLoggingToConsoleAndFile(logDirectory);
                 }
+
+                XmlDocumentationExtensions.LogToConsole += Log;
             }
         }
 
@@ -448,6 +451,8 @@ namespace Dynamo.Logging
 
             if (ConsoleWriter != null)
                 ConsoleWriter = null;
+
+            XmlDocumentationExtensions.LogToConsole -= Log;
         }
 
         /// <summary>

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -893,6 +893,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} is missing some XML documentation tags..
+        /// </summary>
+        public static string MissingXmlTagConsoleMessage {
+            get {
+                return ResourceManager.GetString("MissingXmlTagConsoleMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SHOW MORE ({0}).
         /// </summary>
         public static string MoreButtonTextFormat {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -712,4 +712,7 @@ Restart Dynamo to complete the uninstall.</value>
   <data name="Preview3DOutageTitle" xml:space="preserve">
     <value>3D preview has been deactivated</value>
   </data>
+  <data name="MissingXmlTagConsoleMessage" xml:space="preserve">
+    <value>{0} is missing some XML documentation tags.</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -712,4 +712,7 @@ Restart Dynamo to complete the uninstall.</value>
   <data name="Preview3DOutageTitle" xml:space="preserve">
     <value>3D preview has been deactivated</value>
   </data>
+  <data name="MissingXmlTagConsoleMessage" xml:space="preserve">
+    <value>{0} is missing some XML documentation tags.</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

DYN-2655
Take the following example of XML documentation on a zero touch method. Strictly speaking it isn't a badly formatted XML as there is no XML exception that is thrown, however it does result in a different unhandled exception from our own code that parses the XML and converts it into node tooltips. Notice that here the `<returns>` tag following the `<params>` tag was missing that led to the exception and consequently the crash.
```
/// <summary> 
/// Create a T-Spline Surface from the string in T-Spline Mesh format. 
/// </summary> 
/// <param name="content">String representation of T-Spline Mesh file</param> 
/// <param name="inSmoothMode">Show T-Spline Surface in box or smooth visualization</param> 
/// Newly loaded T-Spline surface in list 
/// <search>tspline,import,serialize</search> 
[AllowRankReduction] 
public static TSplineSurface[] DeserializeFromTSM(string content, bool inSmoothMode = false) {...}
```

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
