### PR TITLE
Upgrade master to .NET 4.8

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblyInfoGenerator.csproj
+++ b/src/AssemblySharedInfoGenerator/AssemblyInfoGenerator.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AssemblyInfoGenerator</RootNamespace>
     <AssemblyName>AssemblyInfoGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Config/CS.props
+++ b/src/Config/CS.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\AnyCPU\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\AnyCPU\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
@@ -68,6 +68,6 @@
   </PropertyGroup>
   <!--This is used to set the framework version for icon resource dll generation (lookup of system.drawing.dll)-->
   <PropertyGroup>
-    <ResourceGeneration_FrameworkVersion>v4.7</ResourceGeneration_FrameworkVersion>
+    <ResourceGeneration_FrameworkVersion>v4.8</ResourceGeneration_FrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.DocumentationBrowser</RootNamespace>
     <AssemblyName>DocumentationBrowserViewExtension</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/src/DynamoApplications/DynamoApplications.csproj
+++ b/src/DynamoApplications/DynamoApplications.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoApplications</RootNamespace>
     <AssemblyName>DynamoApplications</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoCLI/App.config
+++ b/src/DynamoCLI/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/DynamoCLI/DynamoCLI.csproj
+++ b/src/DynamoCLI/DynamoCLI.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoCLI</RootNamespace>
     <AssemblyName>DynamoCLI</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoCore/App.config
+++ b/src/DynamoCore/App.config
@@ -2,4 +2,4 @@
 <configuration>
   <appSettings>
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -29,7 +29,7 @@ limitations under the License.
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo</RootNamespace>
     <AssemblyName>DynamoCore</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <WarningLevel>4</WarningLevel>
     <FileUpgradeFlags>

--- a/src/DynamoCore/packages.config
+++ b/src/DynamoCore/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
 </packages>

--- a/src/DynamoCoreWpf/App.config
+++ b/src/DynamoCoreWpf/App.config
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0"?>
 <configuration>
-  <appSettings>
-    <add key="Switch.System.Windows.Controls.Grid.StarDefinitionsCanExceedAvailableSpace" value="true"/>
-  </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
 </configuration>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.Wpf</RootNamespace>
     <AssemblyName>DynamoCoreWpf</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -532,22 +532,6 @@ namespace Dynamo.ViewModels
 
         protected DynamoViewModel(StartConfiguration startConfiguration)
         {
-
-            // This can be removed after this bug is fixed in .net 4.7
-            // https://developercommunity.visualstudio.com/content/problem/244615/setfinalsizemaxdiscrepancy-getting-stuck-in-an-inf.html
-            // if the key "Switch.System.Windows.Controls.Grid.StarDefinitionsCanExceedAvailableSpace" has a value true in the 
-            // dynamoCoreWpf.config file we will set the switch here before the view is created.
-            var path = this.GetType().Assembly.Location;
-            var config = ConfigurationManager.OpenExeConfiguration(path);
-            var gridSwitchKey = "Switch.System.Windows.Controls.Grid.StarDefinitionsCanExceedAvailableSpace";
-            var gridSwitchKeyValue = config.AppSettings.Settings[gridSwitchKey];
-            bool gridSwitch = false;
-            if(gridSwitchKeyValue != null)
-            {
-                bool.TryParse(gridSwitchKeyValue.Value, out gridSwitch);
-                AppContext.SetSwitch(gridSwitchKey, gridSwitch);
-            }
-
             this.ShowLogin = startConfiguration.ShowLogin;
 
             // initialize core data structures

--- a/src/DynamoCoreWpf/packages.config
+++ b/src/DynamoCoreWpf/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net47" />
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="HelixToolkit" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
-  <package id="SharpDX" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net47" />
+  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net48" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net48" />
 </packages>

--- a/src/DynamoCrypto/DynamoCrypto.csproj
+++ b/src/DynamoCrypto/DynamoCrypto.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoCrypto</RootNamespace>
     <AssemblyName>DynamoCrypto</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.Manipulation</RootNamespace>
     <AssemblyName>DynamoManipulation</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoPackages/App.config
+++ b/src/DynamoPackages/App.config
@@ -3,4 +3,4 @@
   <appSettings>
     <add key="packageManagerAddress" value="https://www.dynamopackages.com"/>
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/DynamoPackages/DynamoPackages.csproj
+++ b/src/DynamoPackages/DynamoPackages.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoPackages</RootNamespace>
     <AssemblyName>DynamoPackages</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoPackages/packages.config
+++ b/src/DynamoPackages/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
 </packages>

--- a/src/DynamoPackagesWPF/DynamoPackagesWPF.csproj
+++ b/src/DynamoPackagesWPF/DynamoPackagesWPF.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoPackagesWPF</RootNamespace>
     <AssemblyName>DynamoPackagesWPF</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoSandbox/DynamoSandbox.csproj
+++ b/src/DynamoSandbox/DynamoSandbox.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.DynamoSandbox</RootNamespace>
     <AssemblyName>DynamoSandbox</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/DynamoSandbox/app.config
+++ b/src/DynamoSandbox/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/DynamoUtilities/DynamoUtilities.csproj
+++ b/src/DynamoUtilities/DynamoUtilities.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoUtilities</RootNamespace>
     <AssemblyName>DynamoUtilities</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoWPFCLI/App.config
+++ b/src/DynamoWPFCLI/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/DynamoWPFCLI/DynamoWPFCLI.csproj
+++ b/src/DynamoWPFCLI/DynamoWPFCLI.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoWPFCLI</RootNamespace>
     <AssemblyName>DynamoWPFCLI</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/DynamoWPFCLI/packages.config
+++ b/src/DynamoWPFCLI/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Engine/GraphLayout/GraphLayout.csproj
+++ b/src/Engine/GraphLayout/GraphLayout.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GraphLayout</RootNamespace>
     <AssemblyName>GraphLayout</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/src/Engine/ProtoAssociative/ProtoAssociative.csproj
+++ b/src/Engine/ProtoAssociative/ProtoAssociative.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ProtoAssociative</RootNamespace>
     <AssemblyName>ProtoAssociative</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ProtoCore</RootNamespace>
     <AssemblyName>ProtoCore</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Engine/ProtoImperative/ProtoImperative.csproj
+++ b/src/Engine/ProtoImperative/ProtoImperative.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ProtoImperative</RootNamespace>
     <AssemblyName>ProtoImperative</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Engine/ProtoScript/ProtoScript.csproj
+++ b/src/Engine/ProtoScript/ProtoScript.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ProtoScript</RootNamespace>
     <AssemblyName>ProtoScript</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Analysis</RootNamespace>
     <AssemblyName>Analysis</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/CoreNodeModels/CoreNodeModels.csproj
+++ b/src/Libraries/CoreNodeModels/CoreNodeModels.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CoreNodeModels</RootNamespace>
     <AssemblyName>CoreNodeModels</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/CoreNodeModels/packages.config
+++ b/src/Libraries/CoreNodeModels/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/CoreNodeModelsWpf/CoreNodeModelsWpf.csproj
+++ b/src/Libraries/CoreNodeModelsWpf/CoreNodeModelsWpf.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.Wpf</RootNamespace>
     <AssemblyName>CoreNodeModelsWpf</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/src/Libraries/CoreNodeModelsWpf/packages.config
+++ b/src/Libraries/CoreNodeModelsWpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Extended.Wpf.Toolkit" version="3.0" targetFramework="net45" />
+  <package id="Extended.Wpf.Toolkit" version="3.0" targetFramework="net48" />
 </packages>

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DSCore</RootNamespace>
     <AssemblyName>DSCoreNodes</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DSIronPython/DSIronPython.csproj
+++ b/src/Libraries/DSIronPython/DSIronPython.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DSIronPython</RootNamespace>
     <AssemblyName>DSIronPython</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DSIronPython/packages.config
+++ b/src/Libraries/DSIronPython/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net45" />
-  <package id="IronPython" version="2.7.9" targetFramework="net45" />
-  <package id="IronPython.StdLib" version="2.7.9" targetFramework="net45" />
-  <package id="Microsoft.CodeCoverage" version="16.2.0" targetFramework="net47" />
+  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net48" />
+  <package id="IronPython" version="2.7.9" targetFramework="net48" />
+  <package id="IronPython.StdLib" version="2.7.9" targetFramework="net48" />
+  <package id="Microsoft.CodeCoverage" version="16.2.0" targetFramework="net48" />
 </packages>

--- a/src/Libraries/DSOffice/DSOffice.csproj
+++ b/src/Libraries/DSOffice/DSOffice.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DSOffice</RootNamespace>
     <AssemblyName>DSOffice</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DesignScriptBuiltin/DesignScriptBuiltin.csproj
+++ b/src/Libraries/DesignScriptBuiltin/DesignScriptBuiltin.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Builtin</RootNamespace>
     <AssemblyName>DesignScriptBuiltin</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DesignScriptBuiltin/packages.config
+++ b/src/Libraries/DesignScriptBuiltin/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net48" requireReinstallation="true" />
 </packages>

--- a/src/Libraries/DynamoArduino/Arduino.csproj
+++ b/src/Libraries/DynamoArduino/Arduino.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.Nodes</RootNamespace>
     <AssemblyName>DynamoArduino</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DynamoConversions/DynamoConversions.csproj
+++ b/src/Libraries/DynamoConversions/DynamoConversions.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoConversions</RootNamespace>
     <AssemblyName>DynamoConversions</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DynamoPython/Python.csproj
+++ b/src/Libraries/DynamoPython/Python.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoPython</RootNamespace>
     <AssemblyName>DynamoPython</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/DynamoUnits/Units.csproj
+++ b/src/Libraries/DynamoUnits/Units.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoUnits</RootNamespace>
     <AssemblyName>DynamoUnits</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/GeometryColor/GeometryColor.csproj
+++ b/src/Libraries/GeometryColor/GeometryColor.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GeometryColor</RootNamespace>
     <AssemblyName>GeometryColor</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/GeometryUI/GeometryUI.csproj
+++ b/src/Libraries/GeometryUI/GeometryUI.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GeometryUI</RootNamespace>
     <AssemblyName>GeometryUI</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/GeometryUI/packages.config
+++ b/src/Libraries/GeometryUI/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GeometryUIWpf</RootNamespace>
     <AssemblyName>GeometryUIWpf</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
+++ b/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PythonNodeModels</RootNamespace>
     <AssemblyName>PythonNodeModels</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/PythonNodeModels/packages.config
+++ b/src/Libraries/PythonNodeModels/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net45" />
-  <package id="IronPython" version="2.7.9" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net48" />
+  <package id="IronPython" version="2.7.9" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PythonNodeModelsWpf</RootNamespace>
     <AssemblyName>PythonNodeModelsWpf</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/PythonNodeModelsWpf/packages.config
+++ b/src/Libraries/PythonNodeModelsWpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net45" />
-  <package id="IronPython" version="2.7.9" targetFramework="net45" />
+  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net48" />
+  <package id="IronPython" version="2.7.9" targetFramework="net48" />
 </packages>

--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tessellation</RootNamespace>
     <AssemblyName>Tessellation</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/Tesellation/packages.config
+++ b/src/Libraries/Tesellation/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MIConvexHull" version="1.1.17.0411" targetFramework="net45" />
+  <package id="MIConvexHull" version="1.1.17.0411" targetFramework="net48" />
 </packages>

--- a/src/Libraries/UnitsUI/UnitsUI.csproj
+++ b/src/Libraries/UnitsUI/UnitsUI.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitsUI</RootNamespace>
     <AssemblyName>UnitsUI</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/UnitsUI/packages.config
+++ b/src/Libraries/UnitsUI/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/VMDataBridge/VMDataBridge.csproj
+++ b/src/Libraries/VMDataBridge/VMDataBridge.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VMDataBridge</RootNamespace>
     <AssemblyName>VMDataBridge</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/Watch3DNodeModels/Watch3DNodeModels.csproj
+++ b/src/Libraries/Watch3DNodeModels/Watch3DNodeModels.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Watch3DNodeModels</RootNamespace>
     <AssemblyName>Watch3DNodeModels</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Libraries/Watch3DNodeModels/packages.config
+++ b/src/Libraries/Watch3DNodeModels/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeModelsWpf.csproj
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeModelsWpf.csproj
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Watch3DNodeModelsWpf</RootNamespace>
     <AssemblyName>Watch3DNodeModelsWpf</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/src/Libraries/Watch3DNodeModelsWpf/packages.config
+++ b/src/Libraries/Watch3DNodeModelsWpf/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net47" />
-  <package id="HelixToolkit" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net47" />
-  <package id="SharpDX" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net47" />
+  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net48" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net48" />
 </packages>

--- a/src/LibraryViewExtension/LibraryViewExtension.csproj
+++ b/src/LibraryViewExtension/LibraryViewExtension.csproj
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.LibraryUI</RootNamespace>
     <AssemblyName>LibraryViewExtension</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/LibraryViewExtension/packages.config
+++ b/src/LibraryViewExtension/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="3.3325.1758" targetFramework="net452" />
-  <package id="cef.redist.x86" version="3.3325.1758" targetFramework="net452" />
-  <package id="CefSharp.Common" version="65.0.1" targetFramework="net452" />
-  <package id="CefSharp.Wpf" version="65.0.1" targetFramework="net452" />
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
+  <package id="cef.redist.x64" version="3.3325.1758" targetFramework="net48" />
+  <package id="cef.redist.x86" version="3.3325.1758" targetFramework="net48" />
+  <package id="CefSharp.Common" version="65.0.1" targetFramework="net48" />
+  <package id="CefSharp.Wpf" version="65.0.1" targetFramework="net48" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
 </packages>

--- a/src/LibraryViewExtensionMSWebBrowser/LibraryViewExtensionMSWebBrowser.csproj
+++ b/src/LibraryViewExtensionMSWebBrowser/LibraryViewExtensionMSWebBrowser.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.LibraryViewExtensionMSWebBrowser</RootNamespace>
     <AssemblyName>LibraryViewExtensionMSWebBrowser</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <!-- this is done for now so visual studio can auto increment the revision version number.
     Alternatives include using DynamoCore's shared assemblyVersion script, a seperate assembly version script,
     or setting the version manually or via the build system.-->

--- a/src/LibraryViewExtensionMSWebBrowser/packages.config
+++ b/src/LibraryViewExtensionMSWebBrowser/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Migrations/Migrations.csproj
+++ b/src/Migrations/Migrations.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Migrations</RootNamespace>
     <AssemblyName>Migrations</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/NodeServices/DynamoServices.csproj
+++ b/src/NodeServices/DynamoServices.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoServices</RootNamespace>
     <AssemblyName>DynamoServices</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -12,7 +12,7 @@
     <RootNamespace>Dynamo.Notifications</RootNamespace>
     <AssemblyName>Notifications</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Tools/DynamoInstallDetective/DynamoInstallDetective.csproj
+++ b/src/Tools/DynamoInstallDetective/DynamoInstallDetective.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoInstallDetective</RootNamespace>
     <AssemblyName>DynamoInstallDetective</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Tools/DynamoShapeManager/DynamoShapeManager.csproj
+++ b/src/Tools/DynamoShapeManager/DynamoShapeManager.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoShapeManager</RootNamespace>
     <AssemblyName>DynamoShapeManager</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Tools/InstallUpdate/App.config
+++ b/src/Tools/InstallUpdate/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/Tools/InstallUpdate/InstallUpdate.csproj
+++ b/src/Tools/InstallUpdate/InstallUpdate.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InstallUpdate</RootNamespace>
     <AssemblyName>InstallUpdate</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Tools/NUnitUtility/App.config
+++ b/src/Tools/NUnitUtility/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/Tools/NUnitUtility/NUnitUtility.csproj
+++ b/src/Tools/NUnitUtility/NUnitUtility.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnitUtility</RootNamespace>
     <AssemblyName>NUnitUtility</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Tools/SignDynamo/App.config
+++ b/src/Tools/SignDynamo/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/Tools/SignDynamo/SignDynamo.csproj
+++ b/src/Tools/SignDynamo/SignDynamo.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SignDynamo</RootNamespace>
     <AssemblyName>SignDynamo</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Tools/XmlDocumentationsUtility/App.config
+++ b/src/Tools/XmlDocumentationsUtility/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/Tools/XmlDocumentationsUtility/XmlDocumentationsUtility.csproj
+++ b/src/Tools/XmlDocumentationsUtility/XmlDocumentationsUtility.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XmlDocumentationsUtility</RootNamespace>
     <AssemblyName>XmlDocumentationsUtility</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/src/VisualizationTests/WpfVisualizationTests.csproj
+++ b/src/VisualizationTests/WpfVisualizationTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WpfVisualizationTests</RootNamespace>
     <AssemblyName>WpfVisualizationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/src/VisualizationTests/packages.config
+++ b/src/VisualizationTests/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net47" />
-  <package id="HelixToolkit" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net47" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net47" />
-  <package id="SharpDX" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net47" />
+  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net48" />
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net48" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net48" />
 </packages>

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.csproj
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.WorkspaceDependency</RootNamespace>
     <AssemblyName>WorkspaceDependencyViewExtension</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dynamo.Tests</RootNamespace>
     <AssemblyName>DynamoCoreTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <TargetFrameworkProfile />

--- a/test/DynamoCoreTests/packages.config
+++ b/test/DynamoCoreTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
 </packages>

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoCoreWpfTests</RootNamespace>
     <AssemblyName>DynamoCoreWpfTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -303,7 +303,7 @@ namespace DynamoCoreWpfTests
 
             // preview is expanded, and its size will be slighly larger than the size of node view.
             // See PR: https://github.com/DynamoDS/Dynamo/pull/6799
-            Assert.IsTrue(ElementIsInContainer(nodeView.PreviewControl.HiddenDummy, nodeView, 10));
+            Assert.IsTrue(ElementIsInContainerWithEpsilonCompare(nodeView.PreviewControl.HiddenDummy, nodeView, 10));
         }
 
         [Test]
@@ -374,6 +374,20 @@ namespace DynamoCoreWpfTests
             relativePosition.X += offset;
             
             return (relativePosition.X == 0) && (element.ActualWidth <= container.ActualWidth);
+        }
+
+        /// <summary>
+        /// Similar to ElementIsInContainer but allows for an epsilon difference
+        /// when comparing equality.
+        /// </summary>
+        private bool ElementIsInContainerWithEpsilonCompare(FrameworkElement element, FrameworkElement container, int offset)
+        {
+            const double Epsilon = 1e-10;
+            Func<double, double, bool> epsilonEqual = (a, b) => a >= b - Epsilon && a <= b + Epsilon;
+            var relativePosition = element.TranslatePoint(new Point(), container);
+            relativePosition.X += offset;
+
+            return epsilonEqual(relativePosition.X, 0) && (element.ActualWidth <= container.ActualWidth);
         }
 
         private void RaiseMouseEnterOnNode(IInputElement nv)

--- a/test/DynamoCoreWpfTests/packages.config
+++ b/test/DynamoCoreWpfTests/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net47" />
-  <package id="HelixToolkit" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net47" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net47" />
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
-  <package id="SharpDX" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net47" />
-  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net47" />
+  <package id="Cyotek.Drawing.BitmapFont" version="1.3.4" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.11.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.11.0" targetFramework="net48" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net48" />
 </packages>

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FFITarget</RootNamespace>
     <AssemblyName>FFITarget</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Engine/ProtoTest/ProtoTest.csproj
+++ b/test/Engine/ProtoTest/ProtoTest.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ProtoTest</RootNamespace>
     <AssemblyName>ProtoTest</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/test/Engine/ProtoTestConsoleRunner/ProtoTestConsoleRunner.csproj
+++ b/test/Engine/ProtoTestConsoleRunner/ProtoTestConsoleRunner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ProtoTestConsoleRunner</RootNamespace>
     <AssemblyName>ProtoTestConsoleRunner</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/test/Engine/ProtoTestConsoleRunner/app.config
+++ b/test/Engine/ProtoTestConsoleRunner/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/test/Engine/ProtoTestFx/ProtoTestFx.csproj
+++ b/test/Engine/ProtoTestFx/ProtoTestFx.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ProtoTestFx</RootNamespace>
     <AssemblyName>ProtoTestFx</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/test/Engine/ProtoTestFx/packages.config
+++ b/test/Engine/ProtoTestFx/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AnalysisTests</RootNamespace>
     <AssemblyName>AnalysisTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/CommandLineTests/CommandLineTests.csproj
+++ b/test/Libraries/CommandLineTests/CommandLineTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CommandLineTests</RootNamespace>
     <AssemblyName>CommandLineTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/CommandLineTests/packages.config
+++ b/test/Libraries/CommandLineTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
+++ b/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DSCoreNodesTests</RootNamespace>
     <AssemblyName>DSCoreNodesTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/DataBridgeTests/DataBridgeTests.csproj
+++ b/test/Libraries/DataBridgeTests/DataBridgeTests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DataBridgeTests</RootNamespace>
     <AssemblyName>DataBridgeTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/DynamoMSOfficeTests/DynamoMSOfficeTests.csproj
+++ b/test/Libraries/DynamoMSOfficeTests/DynamoMSOfficeTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoMSOfficeTests</RootNamespace>
     <AssemblyName>DynamoMSOfficeTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/DynamoPythonTests/IronPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/IronPythonTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoPythonTests</RootNamespace>
     <AssemblyName>DynamoPythonTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/DynamoPythonTests/packages.config
+++ b/test/Libraries/DynamoPythonTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net45" />
-  <package id="IronPython" version="2.7.9" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net47" />
+  <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net48" />
+  <package id="IronPython" version="2.7.9" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
+++ b/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoUtilitiesTests</RootNamespace>
     <AssemblyName>DynamoUtilitiesTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/DynamoUtilitiesTests/packages.config
+++ b/test/Libraries/DynamoUtilitiesTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net48" />
 </packages>

--- a/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
+++ b/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DisplayTests</RootNamespace>
     <AssemblyName>DisplayTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/NodeServicesTest/DynamoServicesTests.csproj
+++ b/test/Libraries/NodeServicesTest/DynamoServicesTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoServicesTests</RootNamespace>
     <AssemblyName>DynamoServicesTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
+++ b/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PackageManagerTests</RootNamespace>
     <AssemblyName>PackageManagerTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/PackageManagerTests/app.config
+++ b/test/Libraries/PackageManagerTests/app.config
@@ -20,4 +20,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/test/Libraries/PackageManagerTests/packages.config
+++ b/test/Libraries/PackageManagerTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="1.3.7408.23353" targetFramework="net47" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
+  <package id="Greg" version="1.3.7408.23353" targetFramework="net48" />
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/SystemTestServices/SystemTestServices.csproj
+++ b/test/Libraries/SystemTestServices/SystemTestServices.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SystemTestServices</RootNamespace>
     <AssemblyName>SystemTestServices</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/TestServices/TestServices.csproj
+++ b/test/Libraries/TestServices/TestServices.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestServices</RootNamespace>
     <AssemblyName>TestServices</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WorkflowTests</RootNamespace>
     <AssemblyName>WorkflowTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/System/IntegrationTests/IntegrationTests.csproj
+++ b/test/System/IntegrationTests/IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IntegrationTests</RootNamespace>
     <AssemblyName>IntegrationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/TestUINodes/TestUINodes.csproj
+++ b/test/TestUINodes/TestUINodes.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestUINodes</RootNamespace>
     <AssemblyName>TestUINodes</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/TestUINodes/packages.config
+++ b/test/TestUINodes/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/test/ViewExtensionLibraryTests/ViewExtensionLibraryTests.csproj
+++ b/test/ViewExtensionLibraryTests/ViewExtensionLibraryTests.csproj
@@ -19,7 +19,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViewExtensionLibraryTests</RootNamespace>
     <AssemblyName>ViewExtensionLibraryTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/test/ViewExtensionLibraryTests/packages.config
+++ b/test/ViewExtensionLibraryTests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="3.3325.1758" targetFramework="net452" />
-  <package id="cef.redist.x86" version="3.3325.1758" targetFramework="net452" />
-  <package id="CefSharp.Common" version="65.0.1" targetFramework="net452" />
-  <package id="CefSharp.Wpf" version="65.0.1" targetFramework="net452" />
-  <package id="Moq" version="4.2.1507.118" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net47" />
+  <package id="cef.redist.x64" version="3.3325.1758" targetFramework="net48" />
+  <package id="cef.redist.x86" version="3.3325.1758" targetFramework="net48" />
+  <package id="CefSharp.Common" version="65.0.1" targetFramework="net48" />
+  <package id="CefSharp.Wpf" version="65.0.1" targetFramework="net48" />
+  <package id="Moq" version="4.2.1507.118" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
 </packages>

--- a/tools/Performance/DynamoPerformanceTests/Configs/app.config
+++ b/tools/Performance/DynamoPerformanceTests/Configs/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/tools/Performance/DynamoPerformanceTests/DynamoPerformanceTests.csproj
+++ b/tools/Performance/DynamoPerformanceTests/DynamoPerformanceTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoPerformanceTests</RootNamespace>
     <AssemblyName>DynamoPerformanceTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
### Purpose

Changes included in this PR:
1. Targets .NET version for projects upgrade to v4.8.
2. Updates SKUs in app configs.
3. Updates target for nuget packages.
4. Removes StarDefinitionsCanExceedAvailableSpace switch.
5. Fix failing WPF layout-related test by using epsilon comparison.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
