### PR TITLE
[DYN-2206] Reset engine on scheduler thread upon creation of new workspace

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -23,6 +23,7 @@ using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.PackageManager;
+using Dynamo.Scheduler;
 using Dynamo.Selection;
 using Dynamo.Services;
 using Dynamo.UI;
@@ -1883,7 +1884,12 @@ namespace Dynamo.ViewModels
         public void MakeNewHomeWorkspace(object parameter)
         {
             if (ClearHomeWorkspaceInternal())
-                this.ShowStartPage = false; // Hide start page if there's one.
+            {
+                var t = new DelegateBasedAsyncTask(model.Scheduler, () => model.ResetEngine());
+                model.Scheduler.ScheduleForExecution(t);
+
+                ShowStartPage = false; // Hide start page if there's one.
+            }
         }
 
         internal bool CanMakeNewHomeWorkspace(object parameter)


### PR DESCRIPTION
## Purpose

Brings back the changes proposed in #10113, the difference being that now we are being careful to reset the engine on the scheduler thread so that in the context of D4R, the engine reset and consequently any Revit element cleanup takes place as a transaction on the Revit idle thread thus preventing the crash in #10281.

As mentioned in #10113, this also fixes https://jira.autodesk.com/browse/DYN-1021.

### Declarations

This fix has been tested with the Revit-Dynamo samples in Revit2020 and the crash is no longer reproducible. To verify I have tried doing the reset outside of the scheduler thread and have been able to reproduce the crash with the same steps.

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@DynamoDS/dynamo 


