### PR TITLE
[DYN-2681] Handle Replication for an input list that has only empty lists inside it. 

### DIFF
--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -81,6 +81,10 @@ namespace ProtoCore
             out HashSet<FunctionEndPoint> lookup)
         {
             lookup = new HashSet<FunctionEndPoint>();
+
+            if (reducedFormalParams.Count == 0)
+                return false;
+
             foreach (List<StackValue> formalParamSet in reducedFormalParams)
             {
                 List<FunctionEndPoint> feps = GetExactTypeMatches(context, formalParamSet, new List<ReplicationInstruction>(), stackFrame, runtimeCore);

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -131,8 +131,6 @@ namespace ProtoCore.Utils
             var dsArray = runtimeCore.Heap.ToHeapObject<DSArray>(array);
             foreach (var sv in dsArray.Values)
             {
-                if(IsEmpty(sv, runtimeCore)) continue;
-
                 if (!usageFreq.ContainsKey(sv.metaData.type))
                 {
                     usageFreq.Add(sv.metaData.type, sv);

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -4969,6 +4969,32 @@ px2 = DummyPoint2D.X(l2);
             thisTest.Verify("px2", new object[] { new object[] { 0 }, new object[] { } });
         }
 
+        [Test]
+        public void TestReplicationWithNestedEmptyLists()
+        {
+            string code =
+@"
+def foo( x:var[] )
+{
+    return x;
+}
+
+a = [[],[]];
+b = [[1],[]];
+c = [[],[1]];
+d = [null,[]];
+out1 = foo(a);
+out2 = foo(b);
+out3 = foo(c);
+out4 = foo(d);
+";
+            var mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("out1", new object[] { new object[] { }, new object[] { } });
+            thisTest.Verify("out2", new object[] { new object[] { 1 }, new object[] { } });
+            thisTest.Verify("out3", new object[] { new object[] { }, new object[] { 1 } });
+            thisTest.Verify("out4", new object[] { null, new object[] { } });
+        }
+
         // This tests the case 4 block in the computeFeps method (CallSite.cs)
         [Test]
         public void TestReplicationWithNullElementInNestedLists()


### PR DESCRIPTION
### Purpose

This PR fixes the issue mentioned in the task: https://jira.autodesk.com/browse/DYN-2681

### Issue:
A nested list, that has only empty lists inside it, was failing to replicate. 
Example: [[],[]].

<img width="300" alt="Screen Shot 2020-05-21 at 11 58 55 AM" src="https://user-images.githubusercontent.com/43763136/82579860-66126700-9b5c-11ea-8958-8130be938095.png">  <img width="300" alt="Screen Shot 2020-05-21 at 12 15 57 PM" src="https://user-images.githubusercontent.com/43763136/82580211-dc16ce00-9b5c-11ea-800a-a1cb99a7fe68.png">

The custom node's output was null before this fix but we now we get the desired output. 

### Solution:
For this input, the computed replication trials will be
1) **Empty replication instruction list**: This is the default one and no FEP is found as expected.
2) **[Cartesian:0]** :  This will check for all the input parameter's type at array-rank level 1, so the reduced params list will have only one ArrayPointer object in it as both inputs are empty nested lists. This will find a matching FEP and replication instruction is set to this option. This is expected.  
3) **[Cartesian:0, Cartesian:0]**: Then we check for the input parameter's type at array-rank level 2. The reduced params list will be empty here as both the lists inside the main input list are empty. With the reduced params list being empty, we check for the matching FEP here: https://github.com/DynamoDS/Dynamo/blob/ac05e1cf4613ca656f895827d2dbdaacb7b25763/src/Engine/ProtoCore/Lang/FunctionGroup.cs#L84

Previously, if the reduced params list is empty, we would not check for any matching FEP and return true by default. This will overwrite the replication instruction to this new option. This should not be happening as we couldn't find a matching FEP with this option. To avoid it, we check for the reduced params list in the CanGetExactMatchStatics() beforehand and return false if it is empty. 

@aparajit-pratap I reverted the fix where you would skip adding it to the reduced params list if it is empty. As we saw in the regression case where the custom node function will just return the input list as it is,  we still want to process the empty list for the first time and skip it for following empty lists. This is already handled.

While investigating this bug, I found some more but they are not regressions. They were just present from the beginning but the output doesn't look correct. Still investigating these. 

<img width="1326" alt="Screen Shot 2020-05-21 at 1 42 21 PM" src="https://user-images.githubusercontent.com/43763136/82588771-3cac0800-9b69-11ea-9ff5-08c919858f46.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
