### PR TITLE
Obsolete public classes referencing Helix in Core

### DIFF
--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -12,6 +12,7 @@ namespace Dynamo.Wpf.Rendering
     /// <summary>
     /// A Helix-specific IRenderPackageFactory implementation.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class HelixRenderPackageFactory : IRenderPackageFactory
     {
         private const int MaxTessellationDivisionsDefault = 128;
@@ -35,6 +36,7 @@ namespace Dynamo.Wpf.Rendering
     /// <summary>
     /// A Helix-specifc IRenderPackage implementation.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class HelixRenderPackage : IRenderPackage, ITransformable
     {
         #region private members

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Wpf.Rendering
     /// <summary>
     /// A Helix-specific IRenderPackageFactory implementation.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class HelixRenderPackageFactory : IRenderPackageFactory
     {
         private const int MaxTessellationDivisionsDefault = 128;
@@ -36,7 +36,7 @@ namespace Dynamo.Wpf.Rendering
     /// <summary>
     /// A Helix-specifc IRenderPackage implementation.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class HelixRenderPackage : IRenderPackage, ITransformable
     {
         #region private members

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// Properties used by Dynamo to extend the capabilities of 
     /// GeometryModel3D objects. 
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public static class AttachedProperties
     {
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
@@ -11,6 +11,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// Properties used by Dynamo to extend the capabilities of 
     /// GeometryModel3D objects. 
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public static class AttachedProperties
     {
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -305,7 +305,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// Handle requests to reset colors on geometry graphics objects given an id.
         /// </summary>
         /// <param name="objId">id of the object</param>
-        [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+        [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
         protected virtual void AttachedProperties_RequestResetColorsForDynamoGeometryModel(string objId)
         {
             //override in derived classes

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -305,6 +305,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// Handle requests to reset colors on geometry graphics objects given an id.
         /// </summary>
         /// <param name="objId">id of the object</param>
+        [Obsolete("This will be moved to a new project in a future version of Dynamo")]
         protected virtual void AttachedProperties_RequestResetColorsForDynamoGeometryModel(string objId)
         {
             //override in derived classes

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoEffectsManager.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoEffectsManager.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// For an intro to dx vertex and fragment shaders see 
     /// https://docs.microsoft.com/en-us/windows/win32/direct3dgetstarted/work-with-shaders-and-shader-resources
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class DynamoEffectsManager : DefaultEffectsManager
     {
         internal static readonly string DynamoMeshShaderName = "DynamoMeshShader";

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoEffectsManager.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoEffectsManager.cs
@@ -1,5 +1,6 @@
 ﻿using HelixToolkit.Wpf.SharpDX;
 using HelixToolkit.Wpf.SharpDX.Shaders;
+using System;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
 {
@@ -13,6 +14,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// For an intro to dx vertex and fragment shaders see 
     /// https://docs.microsoft.com/en-us/windows/win32/direct3dgetstarted/work-with-shaders-and-shader-resources
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class DynamoEffectsManager : DefaultEffectsManager
     {
         internal static readonly string DynamoMeshShaderName = "DynamoMeshShader";

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoGeometryModel3D.cs
@@ -172,6 +172,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// <summary>
     /// A Dynamo mesh class which supports sending data to our custom shader.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class DynamoGeometryModel3D : MaterialGeometryModel3D
     {
         public DynamoGeometryModel3D()
@@ -212,6 +213,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// Each WPF Model object relates to a sharpdx - scene node - Element3d is a wrapper on sceneNode so
     /// these are essentially the same.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class DynamoMeshNode : MeshNode
     {
    

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoGeometryModel3D.cs
@@ -172,7 +172,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// <summary>
     /// A Dynamo mesh class which supports sending data to our custom shader.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class DynamoGeometryModel3D : MaterialGeometryModel3D
     {
         public DynamoGeometryModel3D()
@@ -213,7 +213,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// Each WPF Model object relates to a sharpdx - scene node - Element3d is a wrapper on sceneNode so
     /// these are essentially the same.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class DynamoMeshNode : MeshNode
     {
    

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoLineGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoLineGeometryModel3D.cs
@@ -1,10 +1,12 @@
 ﻿using HelixToolkit.Wpf.SharpDX;
+using System;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
 {
     /// <summary>
     /// A Dynamo line class which supports the RenderCustom technique.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class DynamoLineGeometryModel3D : LineGeometryModel3D
     {
         

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoLineGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoLineGeometryModel3D.cs
@@ -6,7 +6,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// <summary>
     /// A Dynamo line class which supports the RenderCustom technique.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class DynamoLineGeometryModel3D : LineGeometryModel3D
     {
         

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoPointGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoPointGeometryModel3D.cs
@@ -1,10 +1,12 @@
 ﻿using HelixToolkit.Wpf.SharpDX;
+using System;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
 {
     /// <summary>
     /// A Dynamo point class which supports the RenderCustom technique.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class DynamoPointGeometryModel3D : PointGeometryModel3D
     {
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoPointGeometryModel3D.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoPointGeometryModel3D.cs
@@ -6,7 +6,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// <summary>
     /// A Dynamo point class which supports the RenderCustom technique.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class DynamoPointGeometryModel3D : PointGeometryModel3D
     {
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -136,6 +136,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// context using the HelixToolkit. An instance of this class
     /// can act as the data source for a <see cref="Watch3DView"/>
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class HelixWatch3DViewModel : DefaultWatch3DViewModel
     {
         #region private members
@@ -2341,6 +2342,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// 5. All transparent geometry, ordered by distance from the camera.
     /// 6. All text.
     /// </summary>
+    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
     public class Element3DComparer : IComparer<Element3D>
     {
         private readonly Vector3 cameraPosition;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -136,7 +136,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// context using the HelixToolkit. An instance of this class
     /// can act as the data source for a <see cref="Watch3DView"/>
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class HelixWatch3DViewModel : DefaultWatch3DViewModel
     {
         #region private members
@@ -2342,7 +2342,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// 5. All transparent geometry, ordered by distance from the camera.
     /// 6. All text.
     /// </summary>
-    [Obsolete("This will be moved to a new project in a future version of Dynamo")]
+    [Obsolete("Do not use! This will be moved to a new project in a future version of Dynamo.")]
     public class Element3DComparer : IComparer<Element3D>
     {
         private readonly Vector3 cameraPosition;

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Controls
 
         #region public properties
 
-        [Obsolete("This will change its type in a future version of Dynamo")]
+        [Obsolete("Do not use! This will change its type in a future version of Dynamo.")]
         public Viewport3DX View
         {
             get { return watch_view; }

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -29,6 +29,7 @@ namespace Dynamo.Controls
 
         #region public properties
 
+        [Obsolete("This will change its type in a future version of Dynamo")]
         public Viewport3DX View
         {
             get { return watch_view; }


### PR DESCRIPTION
### Purpose

This is done in anticipation of a refactor that will move these code
elements out of DynamoCoreWPF. This would allow to establish a boundary
between what's considered Dynamo's core and our rendering library,
which would in turn simplify upgrading Helix safely in the future.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
