### PR TITLE
Fix regressions

### DIFF
--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -133,7 +133,9 @@ namespace Dynamo.PythonMigration
         {
             NotificationTracker.Remove(CurrentWorkspace.Guid);
             CurrentWorkspace = workspace as WorkspaceModel;
-            if (Configuration.DebugModes.IsEnabled("Python3DebugMode") && !Models.DynamoModel.IsTestMode && PythonDependencies.ContainsIronPythonDependencies())
+            if (Configuration.DebugModes.IsEnabled("Python3DebugMode")
+                && !Models.DynamoModel.IsTestMode
+                && PythonDependencies.ContainsIronPythonDependencies())
             {
                 LogIronPythonNotification();
                 DisplayIronPythonDialog();

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -133,7 +133,7 @@ namespace Dynamo.PythonMigration
         {
             NotificationTracker.Remove(CurrentWorkspace.Guid);
             CurrentWorkspace = workspace as WorkspaceModel;
-            if (Configuration.DebugModes.IsEnabled("Python3DebugMode") && PythonDependencies.ContainsIronPythonDependencies())
+            if (Configuration.DebugModes.IsEnabled("Python3DebugMode") && !Models.DynamoModel.IsTestMode && PythonDependencies.ContainsIronPythonDependencies())
             {
                 LogIronPythonNotification();
                 DisplayIronPythonDialog();

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -42,6 +42,7 @@ namespace DynamoCoreWpfTests
         public void WillDisplayDialogWhenOpeningGraphWithIronPythonNodes()
         {
             DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
+            DynamoModel.IsTestMode = false;
             // Arrange
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;
@@ -57,6 +58,7 @@ namespace DynamoCoreWpfTests
         
             // Assert
             Assert.IsTrue(isIronPythonDialogOpen);
+            DynamoModel.IsTestMode = true;
         }
 
         /// <summary>
@@ -134,6 +136,7 @@ namespace DynamoCoreWpfTests
         public void WillNotDisplayDialogWhenOpeningGraphWithIronPythonNodesSecondTimeInSameSession()
         {
             DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
+            DynamoModel.IsTestMode = false;
             // Arrange
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;
@@ -160,6 +163,7 @@ namespace DynamoCoreWpfTests
 
             // Assert
             Assert.AreEqual(0, secondGraphIronPythonDialog.Count());
+            DynamoModel.IsTestMode = true;
         }
 
         /// <summary>
@@ -194,6 +198,7 @@ namespace DynamoCoreWpfTests
         public void CanOpenDocumentationBrowserWhenMoreInformationIsClicked()
         {
             DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
+            DynamoModel.IsTestMode = false;
             // Arrange
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;
@@ -214,6 +219,7 @@ namespace DynamoCoreWpfTests
             // Assert
             Assert.AreEqual(viewExtensionTabsBeforeBtnClick + 1, this.View.ExtensionTabItems.Count);
             Assert.IsTrue(hasDocumentationBrowserTab);
+            DynamoModel.IsTestMode = true;
         }
 
         #region Helpers


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Fix regressions on `master` by not displaying Python migration dialog upon workspace opening in test mode. Follow existing dummy node warning as example.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers



### FYIs

@DynamoDS/dynamo 