### PR TITLE
Enable Python engine selection by default

### DIFF
--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -34,7 +34,7 @@ namespace Dynamo.Configuration
             public bool IsEnabled;
         }
 
-        private static void AddDebugMode(string name, string description, bool isEnabled = false)
+        internal static void AddDebugMode(string name, string description, bool isEnabled = false)
         {
             debugModes[name] = new DebugMode()
             {
@@ -43,6 +43,7 @@ namespace Dynamo.Configuration
                 IsEnabled = isEnabled
             };
         }
+
         private static void RegisterDebugModes()
         {
             // Register app wide new debug modes here.

--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -12,7 +12,6 @@ namespace Dynamo.Configuration
     internal static class DebugModes
     {
         static private readonly Dictionary<string, DebugMode> debugModes = new Dictionary<string, DebugMode>();
-        private static bool debugModesEnabled;
 
         /// <summary>
         /// Represents an instance of a debug mode
@@ -35,32 +34,30 @@ namespace Dynamo.Configuration
             public bool IsEnabled;
         }
 
-        private static void AddDebugMode(string name, string description)
+        private static void AddDebugMode(string name, string description, bool isEnabled = false)
         {
             debugModes[name] = new DebugMode()
             {
                 Name = name,
                 Description = description,
-                IsEnabled = false
+                IsEnabled = isEnabled
             };
         }
         private static void RegisterDebugModes()
         {
             // Register app wide new debug modes here.
-            AddDebugMode("Python3DebugMode", "Enable/disable Python3 Engine.");
+            AddDebugMode("Python3DebugMode", "Enable/disable Python3 Engine.", true);
+            AddDebugMode("Python2ObsoleteMode", "Enable/disable warnings regarding Python 2 obsoletion.");
         }
 
         internal static void LoadDebugModesStatusFromConfig(string configPath)
         {
             try
             {
-                debugModesEnabled = false;
                 XmlDocument xmlDoc;
                 Exception ex;
                 if (DynamoUtilities.PathHelper.isValidXML(configPath, out xmlDoc, out ex))
                 {
-                    debugModesEnabled = true;
-
                     var debugItems = xmlDoc.DocumentElement.SelectNodes("DebugMode");
                     foreach (XmlNode item in debugItems)
                     {
@@ -131,7 +128,7 @@ namespace Dynamo.Configuration
         public static bool IsEnabled(string name)
         {
             DebugMode dbgMode;
-            return debugModesEnabled && debugModes.TryGetValue(name, out dbgMode) && dbgMode.IsEnabled;
+            return debugModes.TryGetValue(name, out dbgMode) && dbgMode.IsEnabled;
         }
     }
 }

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -123,7 +123,8 @@ namespace Dynamo.PythonMigration
 
         private void OnNodeAdded(Graph.Nodes.NodeModel obj)
         {
-            if (!NotificationTracker.ContainsKey(CurrentWorkspace.Guid)
+            if (Configuration.DebugModes.IsEnabled("Python2ObsoleteMode")
+                && !NotificationTracker.ContainsKey(CurrentWorkspace.Guid)
                 && GraphPythonDependencies.IsIronPythonNode(obj))
             {
                 LogIronPythonNotification();
@@ -134,7 +135,7 @@ namespace Dynamo.PythonMigration
         {
             NotificationTracker.Remove(CurrentWorkspace.Guid);
             CurrentWorkspace = workspace as WorkspaceModel;
-            if (Configuration.DebugModes.IsEnabled("Python3DebugMode")
+            if (Configuration.DebugModes.IsEnabled("Python2ObsoleteMode")
                 && !Models.DynamoModel.IsTestMode
                 && PythonDependencies.ContainsIronPythonDependencies())
             {

--- a/test/DynamoCoreTests/Configuration/DebugModesTests.cs
+++ b/test/DynamoCoreTests/Configuration/DebugModesTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Xml;
 using Dynamo.Configuration;
 using NUnit.Framework;
@@ -26,18 +25,15 @@ namespace Dynamo.Tests.Configuration
             {
                 testDebugModes[item.Attributes["name"].Value] = bool.Parse(item.Attributes["enabled"].Value);
             }
-
-            Type dbgModesType = typeof(DebugModes);
    
             // Register the test debug modes.
-            MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModes)
             {
-                addDebugMode.Invoke(null, new object[] { dbgModeName.Key, dbgModeName.Key, false });
+                DebugModes.AddDebugMode(dbgModeName.Key, dbgModeName.Key);
             }
 
             // Load the enabled/disabled status from the test config file.
-            dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
+            DebugModes.LoadDebugModesStatusFromConfig(configPath);
 
             foreach (var item in testDebugModes)
             {
@@ -57,6 +53,7 @@ namespace Dynamo.Tests.Configuration
                 Assert.AreEqual(DebugModes.IsEnabled(item.Key), forceEnabled);
             }
         }
+
         [Test]
         [Category("UnitTests")]
         public void TestLoadNoDebugModes()
@@ -69,18 +66,15 @@ namespace Dynamo.Tests.Configuration
 
             Assert.IsEmpty(debugItems);
 
-            Type dbgModesType = typeof(DebugModes);
-
             var testDebugModeNames = new List<string>() { "test5", "test6" };
             // Register the test debug modes.
-            MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModeNames)
             {
-                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName, false });
+                DebugModes.AddDebugMode(dbgModeName, dbgModeName);
             }
 
             // Load the enabled/disabled status from the test config file.
-            dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
+            DebugModes.LoadDebugModesStatusFromConfig(configPath);
 
             foreach (var dbgModeName in testDebugModeNames)
             {
@@ -88,6 +82,7 @@ namespace Dynamo.Tests.Configuration
                 Assert.AreEqual(DebugModes.IsEnabled(dbgModeName), false);
             }        
         }
+
         [Test]
         [Category("UnitTests")]
         public void TestMissingConfig()
@@ -96,15 +91,14 @@ namespace Dynamo.Tests.Configuration
 
             var testDebugModeNames = new List<string>() { "test7", "test8" };
             // Register the test debug modes.
-            MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModeNames)
             {
-                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName, false });
+                DebugModes.AddDebugMode(dbgModeName, dbgModeName);
             }
 
             // Load the enabled/disabled status from the test config file.
             string configPath = Path.Combine(TestDirectory, "testDebugModes", "missing.config");
-            dbgModesType.GetMethod("LoadDebugModesStatusFromConfig", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { configPath });
+            DebugModes.LoadDebugModesStatusFromConfig(configPath);
 
             foreach (var dbgModeName in testDebugModeNames)
             {

--- a/test/DynamoCoreTests/Configuration/DebugModesTests.cs
+++ b/test/DynamoCoreTests/Configuration/DebugModesTests.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Tests.Configuration
             MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModes)
             {
-                addDebugMode.Invoke(null, new object[] { dbgModeName.Key, dbgModeName.Key });
+                addDebugMode.Invoke(null, new object[] { dbgModeName.Key, dbgModeName.Key, false });
             }
 
             // Load the enabled/disabled status from the test config file.
@@ -76,7 +76,7 @@ namespace Dynamo.Tests.Configuration
             MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModeNames)
             {
-                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName });
+                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName, false });
             }
 
             // Load the enabled/disabled status from the test config file.
@@ -99,7 +99,7 @@ namespace Dynamo.Tests.Configuration
             MethodInfo addDebugMode = dbgModesType.GetMethod("AddDebugMode", BindingFlags.Static | BindingFlags.NonPublic);
             foreach (var dbgModeName in testDebugModeNames)
             {
-                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName });
+                addDebugMode.Invoke(null, new object[] { dbgModeName, dbgModeName, false });
             }
 
             // Load the enabled/disabled status from the test config file.

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -30,7 +30,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void CanChangeEngineFromScriptEditorDropDown()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
             // Arrange
             var expectedAvailableEnignes = Enum.GetValues(typeof(PythonNodeModels.PythonEngineVersion)).Cast<PythonNodeModels.PythonEngineVersion>();
             var expectedDefaultEngine = PythonNodeModels.PythonEngineVersion.IronPython2;
@@ -85,7 +84,6 @@ namespace DynamoCoreWpfTests
             // Arrange
             // Setup the python3 debug mode, otherwise we wont be able to get the engine version selector 
             // from the nodes context menu
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
             var expectedEngineVersionOnOpen = PythonNodeModels.PythonEngineVersion.CPython3;
             var expectedEngineVersionAfterChange = PythonNodeModels.PythonEngineVersion.IronPython2;
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -32,7 +32,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillDisplayDialogWhenOpeningGraphWithIronPythonNodes()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
 
             // Act
@@ -91,6 +91,8 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillOnlyLogNotificationWhenAddingAnIronPythonNodeOnce()
         {
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
+
             // Arrange
             string pythonNodeName = "Python Script";
             raisedEvents = new List<string>();
@@ -121,6 +123,52 @@ namespace DynamoCoreWpfTests
 
         }
 
+        /// <summary>
+        /// Adding Python nodes that use IronPython should not generate notifications
+        /// when the Python2ObsoleteMode is disabled.
+        /// </summary>
+        [Test]
+        public void WillNotLogNotificationWhenAddingNodeWhenPython2ObsoleteFlagIsOff()
+        {
+            var debugMode = DebugModes.GetDebugMode("Python2ObsoleteMode");
+            bool shouldReenable = false;
+            if (debugMode != null && debugMode.IsEnabled)
+            {
+                debugMode.IsEnabled = false;
+                shouldReenable = true;
+            }
+
+            // Arrange
+            string pythonNodeName = "Python Script";
+            raisedEvents = new List<string>();
+
+            // Act
+            // open file
+            this.ViewModel.Model.Logger.NotificationLogged += Logger_NotificationLogged;
+
+
+            var nodesCountBeforeNodeAdded = this.ViewModel.CurrentSpace.Nodes.Count();
+
+            this.ViewModel.ExecuteCommand(new DynamoModel.
+                CreateNodeCommand(Guid.NewGuid().ToString(), pythonNodeName, 0, 0, false, false));
+
+            DispatcherUtil.DoEvents();
+
+            var nodesCountAfterNodeAdded = this.ViewModel.CurrentSpace.Nodes.Count();
+
+            // Assert
+            Assert.AreEqual(nodesCountBeforeNodeAdded + 1, nodesCountAfterNodeAdded);
+            Assert.AreEqual(raisedEvents.Count, 0);
+            raisedEvents.Clear();
+            this.ViewModel.Model.Logger.NotificationLogged -= Logger_NotificationLogged;
+            DispatcherUtil.DoEvents();
+
+            if (shouldReenable)
+            {
+                debugMode.IsEnabled = true;
+            }
+        }
+
 
         /// <summary>
         /// This test verifies that the IronPython dialog wont show the second time a graph is opened
@@ -129,7 +177,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillNotDisplayDialogWhenOpeningGraphWithIronPythonNodesSecondTimeInSameSession()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
             // Arrange
             var examplePathIronPython = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "python.dyn");
@@ -191,7 +239,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void CanOpenDocumentationBrowserWhenMoreInformationIsClicked()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python3DebugMode.config"));
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
 
             // Act

--- a/test/DynamoCoreWpfTests/python2ObsoleteMode.config
+++ b/test/DynamoCoreWpfTests/python2ObsoleteMode.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <DebugModes>
-    <DebugMode name="Python3DebugMode" enabled="true"/>
+    <DebugMode name="Python2ObsoleteMode" enabled="true"/>
 </DebugModes>


### PR DESCRIPTION
### Purpose

This makes the Python3EngineDebugMode enabled by default, no need to
have a config file for it. Also, creates a new mode named
Python2ObsoleteMode which controls whether using IronPython2 engine
should be notified as a warning.

Also fixed a bug where notifications were shown when Python nodes were
added, no matter the state of the flags.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 