### PR TITLE
Bind Python engine selection in cm to model

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -42,6 +42,11 @@ namespace PythonNodeModelsWpf
                 var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
                 nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
                 pythonEngine2Item.Click += UpdateToPython2Engine;
+                // Bind menu item check state to the Engine property in the ViewModel.
+                // By doing this, we make sure the check status is in sync with the ViewModel,
+                // no matter if we update it through the context menu or other means.
+                // Setting the IsChecked property, on the other hand, is error prone and redundant
+                // once data binding has been set up.
                 pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
                 {
                     Source = pythonNodeModel,

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -8,7 +8,6 @@ using Dynamo.Graph.Workspaces;
 using Dynamo.ViewModels;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Windows;
-using ProtoCore.AST;
 using PythonNodeModels;
 using PythonNodeModelsWpf.Controls;
 

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using Dynamo.Controls;
 using Dynamo.Graph.Workspaces;
 using Dynamo.ViewModels;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Windows;
+using ProtoCore.AST;
 using PythonNodeModels;
 using PythonNodeModelsWpf.Controls;
 
@@ -21,8 +23,8 @@ namespace PythonNodeModelsWpf
         private ScriptEditorWindow editWindow;
         private ModelessChildWindow.WindowRect editorWindowRect;
         private readonly MenuItem editWindowItem = new MenuItem { Header = PythonNodeModels.Properties.Resources.EditHeader, IsCheckable = false };
-        private readonly MenuItem pythonEngine2Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo, IsCheckable = true };
-        private readonly MenuItem pythonEngine3Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionThree, IsCheckable = true };
+        private readonly MenuItem pythonEngine2Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo, IsCheckable = false };
+        private readonly MenuItem pythonEngine3Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionThree, IsCheckable = false };
 
         public void CustomizeView(PythonNode nodeModel, NodeView nodeView)
         {
@@ -41,21 +43,21 @@ namespace PythonNodeModelsWpf
                 var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
                 nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
                 pythonEngine2Item.Click += UpdateToPython2Engine;
+                pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
+                {
+                    Source = pythonNodeModel,
+                    Converter = new EnumToBooleanConverter(),
+                    ConverterParameter = PythonEngineVersion.IronPython2.ToString()
+                });
                 pythonEngine3Item.Click += UpdateToPython3Engine;
+                pythonEngine3Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
+                {
+                    Source = pythonNodeModel,
+                    Converter = new EnumToBooleanConverter(),
+                    ConverterParameter = PythonEngineVersion.CPython3.ToString()
+                });
                 pythonEngineVersionMenu.Items.Add(pythonEngine2Item);
-                pythonEngineVersionMenu.Items.Add(pythonEngine3Item);
-
-                // Check the correct item based on NodeModel engine version
-                if (pythonNodeModel.Engine == PythonEngineVersion.IronPython2)
-                {
-                    pythonEngine2Item.IsChecked = true;
-                    pythonEngine3Item.IsChecked = false;
-                }
-                else
-                {
-                    pythonEngine2Item.IsChecked = false;
-                    pythonEngine3Item.IsChecked = true;
-                }      
+                pythonEngineVersionMenu.Items.Add(pythonEngine3Item); 
             }
 
             nodeView.UpdateLayout();
@@ -136,8 +138,6 @@ namespace PythonNodeModelsWpf
         private void UpdateToPython2Engine(object sender, EventArgs e)
         {
             pythonNodeModel.Engine = PythonEngineVersion.IronPython2;
-            pythonEngine2Item.IsChecked = true;
-            pythonEngine3Item.IsChecked = false;
         }
 
         /// <summary>
@@ -146,8 +146,6 @@ namespace PythonNodeModelsWpf
         private void UpdateToPython3Engine(object sender, EventArgs e)
         {
             pythonNodeModel.Engine = PythonEngineVersion.CPython3;
-            pythonEngine2Item.IsChecked = false;
-            pythonEngine3Item.IsChecked = true;
         }
     }
 }

--- a/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using Dynamo.Controls;
 using Dynamo.Wpf;
 using PythonNodeModels;
@@ -12,8 +13,8 @@ namespace PythonNodeModelsWpf
     {
         private PythonStringNode pythonStringNodeModel;
         private NodeView pythonStringNodeView;
-        private MenuItem pythonEngine2Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo, IsCheckable = true };
-        private MenuItem pythonEngine3Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionThree, IsCheckable = true };
+        private MenuItem pythonEngine2Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo, IsCheckable = false };
+        private MenuItem pythonEngine3Item = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionThree, IsCheckable = false };
 
         public void CustomizeView(PythonStringNode nodeModel, NodeView nodeView)
         {
@@ -28,21 +29,21 @@ namespace PythonNodeModelsWpf
                 var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
                 nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
                 pythonEngine2Item.Click += UpdateToPython2Engine;
+                pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonStringNodeModel.Engine))
+                {
+                    Source = pythonStringNodeModel,
+                    Converter = new EnumToBooleanConverter(),
+                    ConverterParameter = PythonEngineVersion.IronPython2.ToString()
+                });
                 pythonEngine3Item.Click += UpdateToPython3Engine;
+                pythonEngine3Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonStringNodeModel.Engine))
+                {
+                    Source = pythonStringNodeModel,
+                    Converter = new EnumToBooleanConverter(),
+                    ConverterParameter = PythonEngineVersion.CPython3.ToString()
+                });
                 pythonEngineVersionMenu.Items.Add(pythonEngine2Item);
                 pythonEngineVersionMenu.Items.Add(pythonEngine3Item);
-
-                // Check the correct item based on NodeModel engine version
-                if (pythonStringNodeModel.Engine == PythonEngineVersion.IronPython2)
-                {
-                    pythonEngine2Item.IsChecked = true;
-                    pythonEngine3Item.IsChecked = false;
-                }
-                else
-                {
-                    pythonEngine2Item.IsChecked = false;
-                    pythonEngine3Item.IsChecked = true;
-                }
             }
 
             nodeModel.Disposed += NodeModel_Disposed;
@@ -63,8 +64,6 @@ namespace PythonNodeModelsWpf
         private void UpdateToPython2Engine(object sender, EventArgs e)
         {
             pythonStringNodeModel.Engine = PythonEngineVersion.IronPython2;
-            pythonEngine2Item.IsChecked = true;
-            pythonEngine3Item.IsChecked = false;
         }
 
         /// <summary>
@@ -73,8 +72,6 @@ namespace PythonNodeModelsWpf
         private void UpdateToPython3Engine(object sender, EventArgs e)
         {
             pythonStringNodeModel.Engine = PythonEngineVersion.CPython3;
-            pythonEngine2Item.IsChecked = false;
-            pythonEngine3Item.IsChecked = true;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -31,7 +31,7 @@ namespace DynamoCoreWpfTests
         public void CanChangeEngineFromScriptEditorDropDown()
         {
             // Arrange
-            var expectedAvailableEnignes = Enum.GetValues(typeof(PythonNodeModels.PythonEngineVersion)).Cast<PythonNodeModels.PythonEngineVersion>();
+            var expectedAvailableEngines = Enum.GetValues(typeof(PythonNodeModels.PythonEngineVersion)).Cast<PythonNodeModels.PythonEngineVersion>();
             var expectedDefaultEngine = PythonNodeModels.PythonEngineVersion.IronPython2;
             var engineChange = PythonNodeModels.PythonEngineVersion.CPython3;
 
@@ -45,9 +45,7 @@ namespace DynamoCoreWpfTests
             var editMenuItem = nodeView.MainContextMenu
                 .Items
                 .Cast<MenuItem>()
-                .Where(x => x.Header.ToString() == "Edit...")
-                .Select(x => x)
-                .First();
+                .First(x => x.Header.ToString() == "Edit...");
 
             editMenuItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
 
@@ -57,9 +55,7 @@ namespace DynamoCoreWpfTests
             var windowGrid = scriptEditorWindow.Content as Grid;
             var engineSelectorComboBox = windowGrid
                 .ChildrenOfType<ComboBox>()
-                .Where(x=>x.Name == "EngineSelectorComboBox")
-                .Select(x=>x)
-                .First();
+                .First(x=>x.Name == "EngineSelectorComboBox");
 
             // Act
             var engineBeforeChange = engineSelectorComboBox.SelectedItem;
@@ -68,10 +64,22 @@ namespace DynamoCoreWpfTests
 
             // Assert
             Assert.AreEqual(engineSelectorComboBox.Visibility, Visibility.Visible);
-            CollectionAssert.AreEqual(expectedAvailableEnignes, comboBoxEngines);
+            CollectionAssert.AreEqual(expectedAvailableEngines, comboBoxEngines);
             Assert.AreEqual(expectedDefaultEngine, engineBeforeChange);
             Assert.AreEqual(engineSelectorComboBox.SelectedItem, PythonNodeModels.PythonEngineVersion.CPython3);
             Assert.AreEqual(nodeModel.Engine, engineAfterChange);
+            var engineMenuItem = nodeView.MainContextMenu
+                .Items
+                .Cast<MenuItem>()
+                .First(x => x.Header.ToString() == "Python Engine Version");
+            var ironPython2MenuItem = engineMenuItem.Items
+                .Cast<MenuItem>()
+                .First(x => x.Header.ToString() == PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo);
+            var cPython3MenuItem = engineMenuItem.Items
+                .Cast<MenuItem>()
+                .First(x => x.Header.ToString() == PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionThree);
+            Assert.AreEqual(false, ironPython2MenuItem.IsChecked);
+            Assert.AreEqual(true, cPython3MenuItem.IsChecked);
         }
 
         /// <summary>
@@ -98,16 +106,15 @@ namespace DynamoCoreWpfTests
             var editMenuItem = nodeView.MainContextMenu
                 .Items
                 .Cast<MenuItem>()
-                .Where(x => x.Header.ToString() == "Python Engine Version")
-                .Select(x => x)
-                .First();
+                .First(x => x.Header.ToString() == "Python Engine Version");
 
             var engineMenuItems = editMenuItem.Items;
             var ironPython2MenuItem = engineMenuItems
                 .Cast<MenuItem>()
-                .Where(x => x.Header.ToString() == PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo)
-                .Select(x => x)
-                .First();
+                .First(x => x.Header.ToString() == PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionTwo);
+            var cPython3MenuItem = engineMenuItems
+                .Cast<MenuItem>()
+                .First(x => x.Header.ToString() == PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineVersionThree);
 
             // Act
             ironPython2MenuItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
@@ -117,6 +124,15 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(expectedEngineVersionOnOpen, engineVersionOnOpen);
             CollectionAssert.AreEqual(expectedEngineMenuItems, engineMenuItems.Cast<MenuItem>().Select(x => x.Header));
             Assert.AreEqual(expectedEngineVersionAfterChange, engineVersionAfterChange);
+            Assert.AreEqual(true, ironPython2MenuItem.IsChecked);
+            Assert.AreEqual(false, cPython3MenuItem.IsChecked);
+
+            // Act
+            nodeModel.Engine = PythonNodeModels.PythonEngineVersion.CPython3;
+
+            // Assert
+            Assert.AreEqual(false, ironPython2MenuItem.IsChecked);
+            Assert.AreEqual(true, cPython3MenuItem.IsChecked);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

The content menu for Python nodes and Python string nodes was not
binding to the 'Engine' property of the model, but was instead updating
the check state of the menu items manually. This caused the check state
to get out of sync with the model when the engine was selected using
the Python node 'Edit' dialog.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 