### PR TITLE
Add version miss check

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3142,6 +3142,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to download package version. Please try again and report the package if you continue to have problems..
+        /// </summary>
+        public static string MessageFailedToDownloadPackageVersion {
+            get {
+                return ResourceManager.GetString("MessageFailedToDownloadPackageVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No node could be found with that Id..
         /// </summary>
         public static string MessageFailedToFindNodeById {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2234,4 +2234,8 @@ Uninstall the following packages: {0}?</value>
   <data name="PackageSearchViewFilterByButton" xml:space="preserve">
     <value>Filter by</value>
   </data>
+  <data name="MessageFailedToDownloadPackageVersion" xml:space="preserve">
+    <value>Failed to download package version. Please try again and report the package if you continue to have problems.</value>
+    <comment>Message box content</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2237,4 +2237,8 @@ Uninstall the following packages: {0}?</value>
   <data name="PackageSearchViewFilterByButton" xml:space="preserve">
     <value>Filter by</value>
   </data>
+  <data name="MessageFailedToDownloadPackageVersion" xml:space="preserve">
+    <value>Failed to download package version. Please try again and report the package if you continue to have problems.</value>
+    <comment>Message box content</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -524,6 +524,14 @@ namespace Dynamo.ViewModels
 
                 var allPackageVersions = PackageManagerSearchElement.ListRequiredPackageVersions(headers, version);
 
+                // if any package version download fails, abort
+                if (allPackageVersions == null)
+                {
+                    MessageBox.Show(String.Format(Resources.MessageFailedToDownloadPackageVersion),
+                        Resources.PackageDownloadErrorMessageBoxTitle,
+                        MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
                 // determine if any of the packages contain binaries or python scripts.  
                 var containsBinaries =
                     allPackageVersions.Any(

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -172,14 +172,23 @@ namespace Dynamo.PackageManager
         public static IEnumerable<Tuple<PackageHeader, PackageVersion>> ListRequiredPackageVersions(
             IEnumerable<PackageHeader> headers, PackageVersion version)
         {
-            return headers.Zip(
-                version.full_dependency_versions,
-                (header, v) => new Tuple<PackageHeader, string>(header, v))
-                .Select(
-                    (pair) =>
-                        new Tuple<PackageHeader, PackageVersion>(
-                        pair.Item1,
-                        pair.Item1.versions.First(x => x.version == pair.Item2)));
+            try
+            {
+                IEnumerable<Tuple<PackageHeader, PackageVersion>> zipped = headers.Zip(
+                    version.full_dependency_versions,
+                    (header, v) => new Tuple<PackageHeader, string>(header, v))
+                    .Select(
+                        (pair) =>
+                            new Tuple<PackageHeader, PackageVersion>(
+                            pair.Item1,
+                            pair.Item1.versions.First(x => x.version == pair.Item2)));
+                return zipped;
+            }
+            catch 
+            {
+                return null;    
+            }
+            
         }
     }
 }


### PR DESCRIPTION
[DYN-2779](https://jira.autodesk.com/browse/DYN-2779)

Added null check for failed version install due to a cache miss and display a dialog box.
Added resource string.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
