### PR TITLE
fix failing meshtoolkit tests

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.7.0.8624")]
+[assembly: AssemblyVersion("2.8.0.1665")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.7.0.8624")]
+[assembly: AssemblyFileVersion("2.8.0.1665")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -68,9 +68,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("<#= this.MajorVersion #>.<#= this.MinorVersion #>.<#= this.BuildNumber #>.<#= this.RevisionNumber #>")]
 <#+
 int MajorVersion = 2;
-int MinorVersion = 7;
+int MinorVersion = 8;
 int BuildNumber = 0;
 // The datetime baseline we choose using this algorithm will affect build number and all nuget packages uploaded
 // Please only change when major or minor version got incremented
-int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2018,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
+int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2020,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
 #>

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoPointLine.hlsl
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoPointLine.hlsl
@@ -13,8 +13,6 @@ GSInputPS main(VSInputPS input)
 
 	//set position into clip space	
 	output.p = mul(output.p, mWorld);
-	//geometryShader uses this field, so it must be set.
-	output.wp = output.p;
 	output.p = mul(output.p, mView);
 	output.p = mul(output.p, mProjection);
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoPointLine.hlsl
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoPointLine.hlsl
@@ -13,6 +13,8 @@ GSInputPS main(VSInputPS input)
 
 	//set position into clip space	
 	output.p = mul(output.p, mWorld);
+	//geometryShader uses this field, so it must be set.
+	output.wp = output.p;
 	output.p = mul(output.p, mView);
 	output.p = mul(output.p, mProjection);
 

--- a/test/Libraries/WorkflowTests/PackageValidationTest.cs
+++ b/test/Libraries/WorkflowTests/PackageValidationTest.cs
@@ -14,7 +14,8 @@ namespace Dynamo.Tests
             {
                 CustomPackageFolders = new List<string>()
                 {
-                    Path.Combine(TestDirectory, @"core\userdata\0.8")
+                    Path.Combine(TestDirectory, @"core\userdata\0.8"),
+                    Path.Combine(TestDirectory, @"core\userdata\2.7")
                 }
             };
         }


### PR DESCRIPTION
fix failing meshtoolkit tests - now that Dynamo trunk version is 2.8 - we need to force mesh toolkit to be loaded since 2.7 folder is not loaded by default.

To avoid breaking these tests at each update, just set 2.7 as a custom package path. Verified they pass locally.