### PR TITLE
[DYN-2786] PythonMigrationExtension should find CustomNodes that use IronPython2.x

### DIFF
--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -44,15 +44,15 @@ namespace Dynamo.PythonMigration
             var customNodeManager = ViewLoaded.StartupParams.CustomNodeManager;
             var customNodes = workspace.Nodes.OfType<Function>();
 
-            return CustomNodeContainsIronPythonDependency(customNodes, customNodeManager);           
+            return CustomNodesContainIronPythonDependency(customNodes, customNodeManager);           
         }
 
         // This function returns true, if any of the custom nodes in the input list has an IronPython dependency. 
         // It traverses all CN's in the given list of customNodes and marks them as true in CustomNodePythonDependency, 
         // if the prarent custom node or any of its child custom nodes contain an IronPython dependency.
-        internal static bool CustomNodeContainsIronPythonDependency(IEnumerable<Function> customNodes, ICustomNodeManager customNodeManager)
+        internal static bool CustomNodesContainIronPythonDependency(IEnumerable<Function> customNodes, ICustomNodeManager customNodeManager)
         {
-            var currentCNContainsPythonDependency = false;
+            var containIronPythonDependency = false;
 
             foreach (var customNode in customNodes)
             {
@@ -64,7 +64,7 @@ namespace Dynamo.PythonMigration
                 {
                     if (dependency == CNPythonDependency.DirectDependency || dependency == CNPythonDependency.NestedDependency)
                     {
-                        currentCNContainsPythonDependency = true;
+                        containIronPythonDependency = true;
                     }
                     continue;
                 }
@@ -74,7 +74,7 @@ namespace Dynamo.PythonMigration
                 if (hasPythonNodesInCustomNodeWorkspace)
                 {
                     CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNPythonDependency.DirectDependency);
-                    currentCNContainsPythonDependency = true;
+                    containIronPythonDependency = true;
                 }
                 else
                 {
@@ -86,19 +86,19 @@ namespace Dynamo.PythonMigration
 
                 if (nestedCustomNodes.Any())
                 {
-                    hasPythonNodesInCustomNodeWorkspace = CustomNodeContainsIronPythonDependency(nestedCustomNodes, customNodeManager);
+                    hasPythonNodesInCustomNodeWorkspace = CustomNodesContainIronPythonDependency(nestedCustomNodes, customNodeManager);
 
                     // If a custom node contains an IronPython dependency in its sub-tree,
                     // update its corresponding value to 'NestedDependency' in CustomNodePythonDependency.
                     if (hasPythonNodesInCustomNodeWorkspace)
                     {
                         CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.NestedDependency;
-                        currentCNContainsPythonDependency = true;
+                        containIronPythonDependency = true;
                     }
                 }
             }
 
-            return currentCNContainsPythonDependency;
+            return containIronPythonDependency;
         }
 
         internal bool ContainsCPythonDependencies()

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -13,9 +13,10 @@ namespace Dynamo.PythonMigration
     {
         private ViewLoadedParams ViewLoaded { get; set; }
 
-        private static Dictionary<Guid, CNDependency> CustomNodePythonDependency = new Dictionary<Guid, CNDependency>();
+        // A dictionary to mark Custom Nodes if they have a IronPython dependency or not. 
+        private static Dictionary<Guid, CNPythonDependency> CustomNodePythonDependency = new Dictionary<Guid, CNPythonDependency>();
 
-        enum CNDependency
+        private enum CNPythonDependency
         {
             NoDependency,
             SubtreeDependency,
@@ -59,9 +60,9 @@ namespace Dynamo.PythonMigration
 
                 // If a custom node workspace is already checked for IronPython dependencies, 
                 // check the CustomNodePythonDependency dictionary instead of processing it again. 
-                if (CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out CNDependency dependency))
+                if (CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out CNPythonDependency dependency))
                 {
-                    if (dependency == CNDependency.DirectDependency || dependency == CNDependency.SubtreeDependency)
+                    if (dependency == CNPythonDependency.DirectDependency || dependency == CNPythonDependency.SubtreeDependency)
                     {
                         currentCNContainsPythonDependency = true;
                     }
@@ -72,12 +73,12 @@ namespace Dynamo.PythonMigration
 
                 if (hasPythonNodesInCustomNodeWorkspace)
                 {
-                    CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNDependency.DirectDependency);
+                    CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNPythonDependency.DirectDependency);
                     currentCNContainsPythonDependency = true;
                 }
                 else
                 {
-                    CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNDependency.NoDependency);
+                    CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNPythonDependency.NoDependency);
                 }
 
                 // Recursively check for IronPython dependencies in the nested custom nodes.
@@ -92,7 +93,7 @@ namespace Dynamo.PythonMigration
                     CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out dependency);
                     if (hasPythonNodesInCustomNodeWorkspace)
                     {
-                        CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNDependency.SubtreeDependency;
+                        CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.SubtreeDependency;
                     }
 
                     if (hasPythonNodesInCustomNodeWorkspace)

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -69,7 +69,7 @@ namespace Dynamo.PythonMigration
                 // Recursively check for IronPython dependencies in the nested custom nodes.
                 var nestedCustomNodes = customNodeWS.Nodes.OfType<Function>();
 
-                if (nestedCustomNodes.Count() > 0)
+                if (nestedCustomNodes.Any())
                 {
                     hasPythonNodesInCustomNodeWorkspace = CustomNodeContainsIronPythonDependency(nestedCustomNodes, customNodeManager);
 

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -89,8 +89,7 @@ namespace Dynamo.PythonMigration
                     hasPythonNodesInCustomNodeWorkspace = CustomNodeContainsIronPythonDependency(nestedCustomNodes, customNodeManager);
 
                     // If a custom node contains an IronPython dependency in its sub-tree,
-                    // update its corresponding value in CustomNodePythonDependency.
-                    CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out dependency);
+                    // update its corresponding value to 'NestedDependency' in CustomNodePythonDependency.
                     if (hasPythonNodesInCustomNodeWorkspace)
                     {
                         CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.NestedDependency;

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -13,7 +13,7 @@ namespace Dynamo.PythonMigration
     {
         private ViewLoadedParams ViewLoaded { get; set; }
 
-        private Dictionary<Guid, bool> CustomNodePythonDependency = new Dictionary<Guid, bool>();
+        private static Dictionary<Guid, bool> CustomNodePythonDependency = new Dictionary<Guid, bool>();
 
         internal GraphPythonDependencies(ViewLoadedParams viewLoadedParams)
         {
@@ -39,7 +39,10 @@ namespace Dynamo.PythonMigration
             return CustomNodeContainsIronPythonDependency(customNodes, customNodeManager);           
         }
 
-        internal bool CustomNodeContainsIronPythonDependency(IEnumerable<Function> customNodes, ICustomNodeManager customNodeManager)
+        // This function returns true, if any of the custom nodes in the input list has a IronPython dependency. 
+        // It traverses all CN's in the given list of customNodes and their subtrees until the first CN with an IronPython dependency is found. 
+        // It marks them as containing ironPython dependencies if any of their child custom nodes contain IronPython.
+        internal static bool CustomNodeContainsIronPythonDependency(IEnumerable<Function> customNodes, ICustomNodeManager customNodeManager)
         {
             ICustomNodeWorkspaceModel customNodeWS;
 

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -34,12 +34,8 @@ namespace Dynamo.PythonMigration
             var customNodeManager = ViewLoaded.StartupParams.CustomNodeManager;
             var customNodes = workspace.Nodes.OfType<Function>();
 
-            if (CustomNodesContainIronPythonDependencies(customNodes, customNodeManager))
-            {
-                return true;
-            }
-
-            return false;
+            return CustomNodesContainIronPythonDependencies(customNodes, customNodeManager);
+           
         }
 
         internal bool CustomNodesContainIronPythonDependencies(IEnumerable<Function> customNodes, ICustomNodeManager customNodeManager)

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -19,7 +19,7 @@ namespace Dynamo.PythonMigration
         private enum CNPythonDependency
         {
             NoDependency,
-            SubtreeDependency,
+            NestedDependency,
             DirectDependency
         }
 
@@ -62,7 +62,7 @@ namespace Dynamo.PythonMigration
                 // check the CustomNodePythonDependency dictionary instead of processing it again. 
                 if (CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out CNPythonDependency dependency))
                 {
-                    if (dependency == CNPythonDependency.DirectDependency || dependency == CNPythonDependency.SubtreeDependency)
+                    if (dependency == CNPythonDependency.DirectDependency || dependency == CNPythonDependency.NestedDependency)
                     {
                         currentCNContainsPythonDependency = true;
                     }
@@ -93,11 +93,7 @@ namespace Dynamo.PythonMigration
                     CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out dependency);
                     if (hasPythonNodesInCustomNodeWorkspace)
                     {
-                        CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.SubtreeDependency;
-                    }
-
-                    if (hasPythonNodesInCustomNodeWorkspace)
-                    {
+                        CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.NestedDependency;
                         currentCNContainsPythonDependency = true;
                     }
                 }

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -56,8 +56,8 @@ namespace Dynamo.PythonMigration
                 }
 
                 // Recursively check for IronPython dependencies in the nested custom nodes. 
-                var nestedCumtomNodes = customNodeWS.Nodes.OfType<Function>();
-                if (CustomNodesContainIronPythonDependencies(nestedCumtomNodes, customNodeManager))
+                var nestedCustomNodes = customNodeWS.Nodes.OfType<Function>();
+                if (CustomNodesContainIronPythonDependencies(nestedCustomNodes, customNodeManager))
                 {
                     return true;
                 }

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Wpf.Extensions;
 using PythonNodeModels;
 
@@ -18,10 +21,49 @@ namespace Dynamo.PythonMigration
         internal bool ContainsIronPythonDependencies()
         {
             var workspace = ViewLoaded.CurrentWorkspaceModel;
+
             if (workspace == null)
                 throw new ArgumentNullException(nameof(workspace));
 
-            return workspace.Nodes.Any(n => IsIronPythonNode(n));
+            if (workspace.Nodes.Any(n => IsIronPythonNode(n)))
+            {
+                return true;
+            }
+
+            // Check if any of the custom nodes has IronPython dependencies in it. 
+            var customNodeManager = ViewLoaded.StartupParams.CustomNodeManager;
+            var customNodes = workspace.Nodes.OfType<Function>();
+
+            if (CustomNodesContainIronPythonDependencies(customNodes, customNodeManager))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        internal bool CustomNodesContainIronPythonDependencies(IEnumerable<Function> customNodes, ICustomNodeManager customNodeManager)
+        {
+            ICustomNodeWorkspaceModel customNodeWS;
+
+            foreach (var customNode in customNodes)
+            {
+                customNodeManager.TryGetFunctionWorkspace(customNode.FunctionSignature, false, out customNodeWS);
+
+                if (customNodeWS.Nodes.Any(n => IsIronPythonNode(n)))
+                {
+                    return true;
+                }
+
+                // Recurrsively check for IronPython dependencies in the nested custom nodes. 
+                var nestedCumtomNodes = customNodeWS.Nodes.OfType<Function>();
+                if (CustomNodesContainIronPythonDependencies(nestedCumtomNodes, customNodeManager))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal bool ContainsCPythonDependencies()

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -55,7 +55,7 @@ namespace Dynamo.PythonMigration
                     return true;
                 }
 
-                // Recurrsively check for IronPython dependencies in the nested custom nodes. 
+                // Recursively check for IronPython dependencies in the nested custom nodes. 
                 var nestedCumtomNodes = customNodeWS.Nodes.OfType<Function>();
                 if (CustomNodesContainIronPythonDependencies(nestedCumtomNodes, customNodeManager))
                 {

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Dynamo;
 using Dynamo.Configuration;
+using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Models;
 using Dynamo.PythonMigration;
 using Dynamo.Utilities;
@@ -283,6 +284,22 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(ironPythonDialog.IsLoaded);
 
             DynamoModel.IsTestMode = true;
+            DispatcherUtil.DoEvents();
+        }
+
+        [Test]
+        public void CustomNodeContainsIronPythonDependencyTest()
+        {
+            // open file
+            var examplePath = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "PythonCustomNodeHomeWorkspace.dyn");
+            Open(examplePath);
+
+            var customNodes = ViewModel.Model.CurrentWorkspace.Nodes.OfType<Function>();
+            var customNodeManager = ViewModel.Model.CustomNodeManager;
+
+            var result = GraphPythonDependencies.CustomNodeContainsIronPythonDependency(customNodes, customNodeManager);
+
+            Assert.IsTrue(result);
             DispatcherUtil.DoEvents();
         }
     }

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -263,7 +263,7 @@ namespace DynamoCoreWpfTests
 
         /// <summary>
         /// This test checks that the IronPython dialog is shown to the user,
-        /// when the workspace has custom nodes that contain python nodes in it. 
+        /// when the workspace has custom nodes that contain a python node in it. 
         /// </summary>
         [Test]
         public void WillDisplayDialogWhenCustomNodeInsideWorkspaceHasIronPythonNode()
@@ -285,6 +285,5 @@ namespace DynamoCoreWpfTests
             DynamoModel.IsTestMode = true;
             DispatcherUtil.DoEvents();
         }
-
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -2,15 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo;
 using Dynamo.Configuration;
-using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.PythonMigration;
-using Dynamo.Scheduler;
 using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
@@ -260,6 +257,31 @@ namespace DynamoCoreWpfTests
             // Assert
             Assert.AreEqual(viewExtensionTabsBeforeBtnClick + 1, this.View.ExtensionTabItems.Count);
             Assert.IsTrue(hasDocumentationBrowserTab);
+            DynamoModel.IsTestMode = true;
+            DispatcherUtil.DoEvents();
+        }
+
+        /// <summary>
+        /// This test checks that the IronPython dialog is shown to the user,
+        /// when the workspace has custom nodes that contain python nodes in it. 
+        /// </summary>
+        [Test]
+        public void WillDisplayDialogWhenCustomNodeInsideWorkspaceHasIronPythonNode()
+        {
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
+            DynamoModel.IsTestMode = false;
+
+            // open file
+            var examplePath = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "PythonCustomNodeHomeWorkspace.dyn");
+            Open(examplePath);
+            DispatcherUtil.DoEvents();
+
+            var ironPythonDialog = this.View.GetChildrenWindowsOfType<IronPythonInfoDialog>().First();
+
+            // Assert that the IronPython dialog is shown. 
+            Assert.IsNotNull(ironPythonDialog);
+            Assert.IsTrue(ironPythonDialog.IsLoaded);
+
             DynamoModel.IsTestMode = true;
             DispatcherUtil.DoEvents();
         }

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -297,7 +297,7 @@ namespace DynamoCoreWpfTests
             var customNodes = ViewModel.Model.CurrentWorkspace.Nodes.OfType<Function>();
             var customNodeManager = ViewModel.Model.CustomNodeManager;
 
-            var result = GraphPythonDependencies.CustomNodeContainsIronPythonDependency(customNodes, customNodeManager);
+            var result = GraphPythonDependencies.CustomNodesContainIronPythonDependency(customNodes, customNodeManager);
 
             Assert.IsTrue(result);
             DispatcherUtil.DoEvents();

--- a/test/core/python/CNWithoutPythonNode.dyf
+++ b/test/core/python/CNWithoutPythonNode.dyf
@@ -1,0 +1,119 @@
+{
+  "Uuid": "3302f6ec-a2b9-4013-a5cd-d6b5059f4a6f",
+  "IsCustomNode": true,
+  "Category": "Ampersand",
+  "Description": "",
+  "Name": "CNWithoutPythonNode",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "OUT",
+      "Id": "ba340e70ce5b47da9b00b53a926db4c1",
+      "Inputs": [
+        {
+          "Id": "54efd224e7a044c9a004fd0c5343b3bb",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "IN",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null,
+        "Description": ""
+      },
+      "Id": "c8910613e8c540b39b0799120821037c",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f37c60a6db7e48c58ef8d562c82b051c",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "f37c60a6db7e48c58ef8d562c82b051c",
+      "End": "54efd224e7a044c9a004fd0c5343b3bb",
+      "Id": "bf2c0b68dbbd4db1bf69e0a3663051b8"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.8.0.1775",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "ba340e70ce5b47da9b00b53a926db4c1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 884.4,
+        "Y": 57.2
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Input",
+        "Id": "c8910613e8c540b39b0799120821037c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 544.2,
+        "Y": 41.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/python/PythonCustomNodeHomeWorkspace.dyn
+++ b/test/core/python/PythonCustomNodeHomeWorkspace.dyn
@@ -64,13 +64,13 @@
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
-      "FunctionSignature": "ad7f8950-a02c-4dae-872e-3754d8c354f3",
+      "FunctionSignature": "3302f6ec-a2b9-4013-a5cd-d6b5059f4a6f",
       "FunctionType": "Graph",
       "NodeType": "FunctionNode",
-      "Id": "83c2b47d81e14226a93941f1e47dc47d",
+      "Id": "7375e2b07aec4d2a9cfabaa0dfc4c439",
       "Inputs": [
         {
-          "Id": "0a3849e12a7b4d8d962a6683335bc62e",
+          "Id": "f05dfc34b490497c87f5ff9f8b569429",
           "Name": "IN",
           "Description": "var[]..[]",
           "UsingDefaultValue": false,
@@ -81,7 +81,67 @@
       ],
       "Outputs": [
         {
-          "Id": "2d15ee12629f4dcd8ff2f8587b314d45",
+          "Id": "b10b5c2eba9940f2acd5d503f5c73e4d",
+          "Name": "OUT",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": ""
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "d73c65af12dd4c2b9ae87dfe9c0e74f7",
+      "Inputs": [
+        {
+          "Id": "3983604404ed40ab951eb4ffdb8c0266",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "47aaf3b9b32f4494af7ec37a60588f58",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "ad7f8950-a02c-4dae-872e-3754d8c354f3",
+      "FunctionType": "Graph",
+      "NodeType": "FunctionNode",
+      "Id": "5bfde930fb104f9ea8d7820957aed877",
+      "Inputs": [
+        {
+          "Id": "96cf17bafee74ff48f7160dc99462291",
+          "Name": "IN",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "abf4e348caa54e93886d47190834caa1",
           "Name": "OUT",
           "Description": "return value",
           "UsingDefaultValue": false,
@@ -97,16 +157,27 @@
   "Connectors": [
     {
       "Start": "baa777f60cc548398ad31dc92cc6e0c8",
-      "End": "0a3849e12a7b4d8d962a6683335bc62e",
-      "Id": "f738ce18436b4b08a59e0993db2f5aa9"
+      "End": "f05dfc34b490497c87f5ff9f8b569429",
+      "Id": "58340a6a159044c6b82285bbfe6cdc50"
     },
     {
-      "Start": "2d15ee12629f4dcd8ff2f8587b314d45",
+      "Start": "baa777f60cc548398ad31dc92cc6e0c8",
+      "End": "96cf17bafee74ff48f7160dc99462291",
+      "Id": "cecbf41d8fce461192a5b711a3bf18f1"
+    },
+    {
+      "Start": "b10b5c2eba9940f2acd5d503f5c73e4d",
+      "End": "3983604404ed40ab951eb4ffdb8c0266",
+      "Id": "e3ec06a493cc4bbbb37b387124d1ed99"
+    },
+    {
+      "Start": "abf4e348caa54e93886d47190834caa1",
       "End": "624a10003c78444f9bd526194c0a1eee",
-      "Id": "64d359be969340f9a625c84f6945f6e1"
+      "Id": "0d0a6d47f85e40b896beaa0987077f80"
     }
   ],
   "Dependencies": [
+    "3302f6ec-a2b9-4013-a5cd-d6b5059f4a6f",
     "ad7f8950-a02c-4dae-872e-3754d8c354f3"
   ],
   "NodeLibraryDependencies": [],
@@ -116,7 +187,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.7.0.8544",
+      "Version": "2.8.0.1775",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },
@@ -155,13 +226,33 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "PythonCustomNodeTest",
-        "Id": "83c2b47d81e14226a93941f1e47dc47d",
+        "Name": "CNWithoutPythonNode",
+        "Id": "7375e2b07aec4d2a9cfabaa0dfc4c439",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 766.8,
-        "Y": 404.79999999999995
+        "X": 766.0,
+        "Y": 267.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "d73c65af12dd4c2b9ae87dfe9c0e74f7",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1056.0,
+        "Y": 260.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "PythonCustomNodeTest",
+        "Id": "5bfde930fb104f9ea8d7820957aed877",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 772.0,
+        "Y": 433.0
       }
     ],
     "Annotations": [],

--- a/test/core/python/PythonCustomNodeHomeWorkspace.dyn
+++ b/test/core/python/PythonCustomNodeHomeWorkspace.dyn
@@ -127,7 +127,7 @@
       "FunctionSignature": "ad7f8950-a02c-4dae-872e-3754d8c354f3",
       "FunctionType": "Graph",
       "NodeType": "FunctionNode",
-      "Id": "5bfde930fb104f9ea8d7820957aed877",
+      "Id": "83c2b47d81e14226a93941f1e47dc47d",
       "Inputs": [
         {
           "Id": "96cf17bafee74ff48f7160dc99462291",
@@ -247,7 +247,7 @@
       {
         "ShowGeometry": true,
         "Name": "PythonCustomNodeTest",
-        "Id": "5bfde930fb104f9ea8d7820957aed877",
+        "Id": "83c2b47d81e14226a93941f1e47dc47d",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,


### PR DESCRIPTION
### Purpose

This PR will add the functionality to check for any IronPython dependencies in the CN's that are in the workspace. It recursively checks all the custom nodes in the workspace and marks each custom node with one of the 3 following values. 
 1) NoDependency.
2) NestedDependency.
3) DirectDependency. 

This data is stored in a dictionary and the value from here will be used if the CN is already processed. This is to avoid any performance issues. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

