### PR TITLE
Add support for alternate resource names

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -345,7 +345,7 @@ namespace Dynamo.DocumentationBrowser
         /// </summary>
         /// <param name="name">Resource name</param>
         /// <returns>Resource name with the culture name appended before the extension</returns>
-        private static string GetResourceNameWithCultureName(string name, CultureInfo culture)
+        internal static string GetResourceNameWithCultureName(string name, CultureInfo culture)
         {
             var extension = Path.GetExtension(name);
             if (string.IsNullOrEmpty(extension) || culture == null)

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -284,7 +284,14 @@ namespace Dynamo.DocumentationBrowser
             var matchingResource = availableResources
                 .FirstOrDefault(str => str.EndsWith(name));
 
-            if (string.IsNullOrEmpty(matchingResource)) return null;
+            if (string.IsNullOrEmpty(matchingResource))
+            {
+                // The resource might exist by a name that includes the culture name in it
+                var nameWithCulture = GetResourceNameWithCultureName(name, resourceAssembly.GetName().CultureInfo);
+                matchingResource = availableResources.FirstOrDefault(n => n.EndsWith(nameWithCulture));
+
+                if (string.IsNullOrEmpty(matchingResource)) return null;
+            }
 
             Stream stream = null;
             try
@@ -333,6 +340,23 @@ namespace Dynamo.DocumentationBrowser
         }
 
         /// <summary>
+        /// Given a file resource name and a culture, it returns an alternate resource name that includes
+        /// the culture name before the file extension. Example: NoContent.html => NoContent.de-DE.html
+        /// </summary>
+        /// <param name="name">Resource name</param>
+        /// <returns>Resource name with the culture name appended before the extension</returns>
+        private static string GetResourceNameWithCultureName(string name, CultureInfo culture)
+        {
+            var extension = Path.GetExtension(name);
+            if (string.IsNullOrEmpty(extension) || culture == null)
+            {
+                return name;
+            }
+
+            return $"{name.Substring(0, name.LastIndexOf(extension))}.{culture.Name}{extension}";
+        }
+
+        /// <summary>
         /// Checks if the assembly contains a manifest resource that ends with the specified name.
         /// </summary>
         /// <param name="assembly">Assembly to search for resources</param>
@@ -342,7 +366,8 @@ namespace Dynamo.DocumentationBrowser
         {
             if (assembly != null)
             {
-                return assembly.GetManifestResourceNames().Any(resName => resName.EndsWith(name));
+                var nameWithCulture = GetResourceNameWithCultureName(name, assembly.GetName().CultureInfo);
+                return assembly.GetManifestResourceNames().Any(resName => resName.EndsWith(name) || resName.EndsWith(nameWithCulture));
             }
             return false;
         }

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -400,6 +400,30 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(htmlContent.Contains(@"function adaptDPI()"));
         }
 
+        [Test]
+        public void GetResourceNameWithCultureNameReturnsSameAsInputWhenCultureIsNull()
+        {
+            var name = "MyPage.html";
+            var result = DocumentationBrowserViewModel.GetResourceNameWithCultureName(name, null);
+            Assert.AreEqual(name, result);
+        }
+
+        [Test]
+        public void GetResourceNameWithCultureNameReturnsSameAsInputWhenItDoesNotHaveAnExtension()
+        {
+            var name = "NotAPage";
+            var result = DocumentationBrowserViewModel.GetResourceNameWithCultureName(name, CultureInfo.GetCultureInfo("en-US"));
+            Assert.AreEqual(name, result);
+        }
+
+        [Test]
+        public void GetResourceNameWithCultureNameWorksWithValidCultureAndInputName()
+        {
+            var name = "MyPage.html";
+            var result = DocumentationBrowserViewModel.GetResourceNameWithCultureName(name, CultureInfo.GetCultureInfo("en-US"));
+            Assert.AreEqual("MyPage.en-US.html", result);
+        }
+
         #region Helpers
 
         private DocumentationBrowserViewExtension SetupNewViewExtension(bool runLoadedMethod = false)


### PR DESCRIPTION
### Purpose

The alternate name supported is the same as the original resource name,
but adds the culture name before the extension.

This is needed to support the workflow the localization team is using
for translations. The tool they are using produces resources with names
that do not match the name of the original embedded resource.

Example: German translation of NoContent.html will be searched in de-DE
satellite assembly by the names of:
1. NoContent.html
2. NoContent.de-DE.html

Unfortunately, I couldn't add a unit test for this, because it requires to use the tool the localization team is using to generate a test satellite assembly. I did manual test with a fictitious translation of German they did and was able to see the localized content after these changes. Here is a screenshot:
<img width="1268" alt="Screen Shot 2020-06-22 at 1 02 44 PM" src="https://user-images.githubusercontent.com/10048120/85316534-e9d8af80-b48a-11ea-8ee2-9991a05ec525.png">
 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 