### PR TITLE
Find alternative IronPython.Std lib location

### DIFF
--- a/src/Libraries/DSIronPython/IronPythonCodeCompletionProviderCore.cs
+++ b/src/Libraries/DSIronPython/IronPythonCodeCompletionProviderCore.cs
@@ -1042,7 +1042,7 @@ namespace DSIronPython
             // Determine if the Python Standard Library is available in the DynamoCore path
             if (!String.IsNullOrEmpty(dynamoCorePath))
             {
-                pythonLibDir = Path.Combine(dynamoCorePath, @"IronPython.StdLib.2.7.9");
+                pythonLibDir = Path.Combine(dynamoCorePath, IronPythonEvaluator.PythonLibName);
             }
 
             // If IronPython.Std folder is excluded from DynamoCore (which could be user mistake or integrator exclusion)
@@ -1050,7 +1050,7 @@ namespace DSIronPython
             if (!Directory.Exists(pythonLibDir) || pythonLibDir != executionPath)
             {
                 // Try to load IronPython from extension package
-                pythonLibDir = Path.Combine((new DirectoryInfo(Path.GetDirectoryName(executionPath))).Parent.FullName, @"extra", @"IronPython.StdLib.2.7.9");
+                pythonLibDir = Path.Combine((new DirectoryInfo(Path.GetDirectoryName(executionPath))).Parent.FullName, IronPythonEvaluator.packageExtraFolderName, IronPythonEvaluator.PythonLibName);
             }
 
             if (!String.IsNullOrEmpty(pythonLibDir))

--- a/src/Libraries/DSIronPython/IronPythonCodeCompletionProviderCore.cs
+++ b/src/Libraries/DSIronPython/IronPythonCodeCompletionProviderCore.cs
@@ -1037,14 +1037,23 @@ namespace DSIronPython
         /// <param name="dynamoCorePath"></param>
         public void Initialize(string dynamoCorePath)
         {
-            string pythonLibDir = string.Empty;
-            // Determine if the Python Standard Library is available in the given context
+            var pythonLibDir = string.Empty;
+            var executionPath = Assembly.GetExecutingAssembly().Location;
+            // Determine if the Python Standard Library is available in the DynamoCore path
             if (!String.IsNullOrEmpty(dynamoCorePath))
             {
                 pythonLibDir = Path.Combine(dynamoCorePath, @"IronPython.StdLib.2.7.9");
             }
 
-            if (!String.IsNullOrEmpty(pythonLibDir) && Directory.Exists(pythonLibDir))
+            // If IronPython.Std folder is excluded from DynamoCore (which could be user mistake or integrator exclusion)
+            // Or if the execution path is different than Dynamo root folder
+            if (!Directory.Exists(pythonLibDir) || pythonLibDir != executionPath)
+            {
+                // Try to load IronPython from extension package
+                pythonLibDir = Path.Combine((new DirectoryInfo(Path.GetDirectoryName(executionPath))).Parent.FullName, @"extra", @"IronPython.StdLib.2.7.9");
+            }
+
+            if (!String.IsNullOrEmpty(pythonLibDir))
             {
                 // Try to load Python Standard Library Type for autocomplete
                 try

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -38,6 +38,16 @@ namespace DSIronPython
         private static string pythonLibDir { get; set; }
 
         /// <summary>
+        /// Name of IronPython Std lib
+        /// </summary>
+        public const string PythonLibName = @"IronPython.StdLib.2.7.9";
+
+        /// <summary>
+        /// extra folder name in package folder
+        /// </summary>
+        public const string packageExtraFolderName = @"extra";
+
+        /// <summary>
         /// Attempts to build a path referencing the Python Standard Library,
         /// returns null if unable to retrieve a valid path.
         /// </summary>
@@ -51,14 +61,14 @@ namespace DSIronPython
                 var executionPath = Assembly.GetExecutingAssembly().Location;
 
                 // Assume the Python Standard Library is available in the DynamoCore path
-                pythonLibDir = Path.Combine(Path.GetDirectoryName(executionPath), @"IronPython.StdLib.2.7.9");
+                pythonLibDir = Path.Combine(Path.GetDirectoryName(executionPath), PythonLibName);
 
                 // If IronPython.Std folder is excluded from DynamoCore (which could be user mistake or integrator exclusion)
                 // Or if the execution path is different than Dynamo root folder
                 if (!Directory.Exists(pythonLibDir))
                 {
                     // Try to load IronPython from extension package
-                    pythonLibDir = Path.Combine((new DirectoryInfo(Path.GetDirectoryName(executionPath))).Parent.FullName, @"extra", @"IronPython.StdLib.2.7.9");
+                    pythonLibDir = Path.Combine((new DirectoryInfo(Path.GetDirectoryName(executionPath))).Parent.FullName, packageExtraFolderName, PythonLibName);
                 }
             }
             return pythonLibDir;

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -33,30 +33,35 @@ namespace DSIronPython
         private static string prev_code { get; set; }
         /// <summary> stores a copy of the previously compiled engine</summary>
         private static ScriptSource prev_script { get; set; }
-        /// <summary> stores a reference to the executing Dynamo Core directory</summary>
-        private static string dynamoCorePath { get; set; }
+
+        /// <summary> stores a reference to path of IronPython std lib</summary>
+        private static string pythonLibDir { get; set; }
 
         /// <summary>
-        /// Attempts to build a path referencing the Python Standard Library in Dynamo Core,
+        /// Attempts to build a path referencing the Python Standard Library,
         /// returns null if unable to retrieve a valid path.
         /// </summary>
         /// <returns>path to the Python Standard Library in Dynamo Core</returns>
-        private static string pythonStandardLibPath()
+        private static string PythonStandardLibPath()
         {
             // Attempt to get and cache the Dynamo Core directory path
-            if(string.IsNullOrEmpty(dynamoCorePath))
+            if (string.IsNullOrEmpty(pythonLibDir))
             {
-                // Gather executing assembly info
-                Assembly assembly = Assembly.GetExecutingAssembly();
-                Version version = assembly.GetName().Version;
-                dynamoCorePath = Path.GetDirectoryName(assembly.Location);
+                // Gather executing location, this could be DynamoCore folder or extension bin folder
+                var executionPath = Assembly.GetExecutingAssembly().Location;
+
+                // Assume the Python Standard Library is available in the DynamoCore path
+                pythonLibDir = Path.Combine(executionPath, @"IronPython.StdLib.2.7.9");
+
+                // If IronPython.Std folder is excluded from DynamoCore (which could be user mistake or integrator exclusion)
+                // Or if the execution path is different than Dynamo root folder
+                if (!Directory.Exists(pythonLibDir))
+                {
+                    // Try to load IronPython from extension package
+                    pythonLibDir = Path.Combine((new DirectoryInfo(Path.GetDirectoryName(executionPath))).Parent.FullName, @"extra", @"IronPython.StdLib.2.7.9");
+                }
             }
-
-            // Return the standard library path
-            if (!string.IsNullOrEmpty(dynamoCorePath))
-            { return dynamoCorePath + @"\IronPython.StdLib.2.7.9"; }
-
-            return null;
+            return pythonLibDir;
         }
 
         /// <summary>
@@ -80,7 +85,7 @@ namespace DSIronPython
             List<string> paths = new List<string>();
 
             // Attempt to get the Standard Python Library
-            string stdLib = pythonStandardLibPath();
+            string stdLib = PythonStandardLibPath();
 
             if (code != prev_code)
             {

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -51,7 +51,7 @@ namespace DSIronPython
                 var executionPath = Assembly.GetExecutingAssembly().Location;
 
                 // Assume the Python Standard Library is available in the DynamoCore path
-                pythonLibDir = Path.Combine(executionPath, @"IronPython.StdLib.2.7.9");
+                pythonLibDir = Path.Combine(Path.GetDirectoryName(executionPath), @"IronPython.StdLib.2.7.9");
 
                 // If IronPython.Std folder is excluded from DynamoCore (which could be user mistake or integrator exclusion)
                 // Or if the execution path is different than Dynamo root folder


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per extension package testing, This PR adds additonal logic to find alternative IronPython.Std lib location other than DynamoCore folder. With this PR, IronPython extension package can pretty much be officially the alternative way to load IronPython instead of including it OOTB in DynamoCore. Notice, we are keeping the Std lib in package `extra` folder due to the limitation that `bin` folder will not keep sub folder structure due to known limitations. ( Discussed with @mjkkirschner that is still a good limitation per security aspects).

I have tested myself both case the evaluation still passed. I believe this piece may have not been covered in @aparajit-pratap 's original testing since the IronPython.Std may still exist in DynamoCore folder, which is going to mute errors.

IronPython Package:
![image](https://user-images.githubusercontent.com/3942418/85890213-e6ab2f80-b7ba-11ea-8fd7-01162eafe920.png)

![image](https://user-images.githubusercontent.com/3942418/85890228-ef036a80-b7ba-11ea-99c6-11a9009eb8c2.png)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
