### PR TITLE
Add PackagePaths as Parameter of ExecutionSession

### DIFF
--- a/src/DynamoCore/Configuration/ExecutionSession.cs
+++ b/src/DynamoCore/Configuration/ExecutionSession.cs
@@ -24,6 +24,7 @@ namespace Dynamo.Configuration
             parameters[ParameterKeys.MinorVersion] = pathManager.MinorFileVersion;
             parameters[ParameterKeys.NumberFormat] = model.PreferenceSettings.NumberFormat;
             parameters[ParameterKeys.LastExecutionDuration] = new TimeSpan(updateTask.ExecutionEndTime.TickCount - updateTask.ExecutionStartTime.TickCount);
+            parameters[ParameterKeys.PackagePaths] = pathManager.PackagesDirectories;
         }
 
         /// <summary>

--- a/src/NodeServices/ExecutionSession.cs
+++ b/src/NodeServices/ExecutionSession.cs
@@ -69,5 +69,11 @@ namespace Dynamo.Session
         /// The duration of an execution covered by an <see cref="IExecutionSession"/>
         /// </summary>
         public static readonly string LastExecutionDuration = "LastExecutionDuration";
+
+        /// <summary>
+        /// The current collection of packagepaths that Dynamo is loading packages from.
+        /// The Return value is IEnumerable
+        /// </summary>
+        public static readonly string PackagePaths = nameof(PackagePaths);
     }
 }

--- a/src/NodeServices/ExecutionSession.cs
+++ b/src/NodeServices/ExecutionSession.cs
@@ -35,7 +35,7 @@ namespace Dynamo.Session
         /// <returns>True if the file is found</returns>
         bool ResolveFilePath(ref string filepath);
     }
-
+    //TODO(DYN-2879) make this class static for Dynamo 3.
     /// <summary>
     /// List of possible session parameter keys to obtain the session parameters.
     /// </summary>

--- a/test/DynamoCoreTests/Configuration/ExecutionSessionTests.cs
+++ b/test/DynamoCoreTests/Configuration/ExecutionSessionTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Dynamo.Events;
 using NUnit.Framework;
-using System.Linq;
 
 namespace Dynamo.Tests.Configuration
 {

--- a/test/DynamoCoreTests/Configuration/ExecutionSessionTests.cs
+++ b/test/DynamoCoreTests/Configuration/ExecutionSessionTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Dynamo.Events;
 using NUnit.Framework;
+using System.Linq;
 
 namespace Dynamo.Tests.Configuration
 {
@@ -9,6 +10,7 @@ namespace Dynamo.Tests.Configuration
     class ExecutionSessionTests : DynamoModelTestBase
     {
         private TimeSpan lastExecutionDuration = new TimeSpan();
+        private IEnumerable<string> packagePaths;
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -35,6 +37,22 @@ namespace Dynamo.Tests.Configuration
             Assert.IsNotNull(lastExecutionDuration);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void TestExecutionSessionPackagePaths()
+        {
+            ExecutionEvents.GraphPreExecution += ExecutionEvents_GraphPreExecution;
+            RunModel(@"core\HomogeneousList\HomogeneousInputsValid.dyn");
+            Assert.IsNotEmpty(packagePaths, "packgePaths was empty");
+            ExecutionEvents.GraphPreExecution -= ExecutionEvents_GraphPreExecution;
+        }
+
+        private void ExecutionEvents_GraphPreExecution(Session.IExecutionSession session)
+        {
+            packagePaths = ExecutionEvents.ActiveSession.GetParameterValue(Session.ParameterKeys.PackagePaths) as IEnumerable<string>;
+
+        }
+
         [TestFixtureTearDown]
         public void TearDown()
         {
@@ -44,7 +62,6 @@ namespace Dynamo.Tests.Configuration
         private void ExecutionEvents_GraphPostExecution(Session.IExecutionSession session)
         {
             lastExecutionDuration = (TimeSpan)session.GetParameterValue(Session.ParameterKeys.LastExecutionDuration);
-
             Assert.IsNotNull(session.GetParameterKeys());
 
             var filepath = "ExecutionEvents.dyn";

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -489,5 +489,30 @@ namespace Dynamo.Tests
             Assert.IsTrue(ViewModel.Model.CurrentWorkspace.HasUnsavedChanges);
             AssertPreviewValue(pythonNode2GUID, new List<string> { "2.7.9", "2.7.9" });
         }
+
+        [Test]
+
+        public void Python_CanReferenceDynamoServicesExecutionSession()
+        {
+            // open test graph
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "python_refDynamoServices.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            var guid = "296e339254e845b695caa1a116500be0";
+
+            var nodeModel = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace(guid);
+            var pynode = nodeModel as PythonNode;
+            var count = 0;
+            foreach (var pythonEngine in GetPythonEnginesList())
+            {
+                UpdatePythonEngineAndRun(pynode, pythonEngine);
+
+                ViewModel.HomeSpace.Run();
+                count++;
+                Assert.AreEqual(count, (GetModel().CurrentWorkspace as HomeWorkspaceModel).EvaluationCount);
+
+                AssertPreviewCount(guid, 2);
+            }
+        }
     }
 }

--- a/test/core/python/python_refDynamoServices.dyn
+++ b/test/core/python/python_refDynamoServices.dyn
@@ -1,0 +1,87 @@
+{
+  "Uuid": "99dd6664-b359-4d74-83aa-36bece79d03e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "python_refDynamoServices",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\n\r\nclr.AddReference('DynamoServices')\r\nfrom Dynamo.Events import ExecutionEvents\r\n\r\n\r\npackagePathsKey = list(ExecutionEvents.ActiveSession.GetParameterKeys())[-1]\r\n##or packagePathsKey = \"PackagePaths\"\r\n\r\nOUT = ExecutionEvents.ActiveSession.GetParameterValue(packagePathsKey)",
+      "Engine": "IronPython2",
+      "VariableInputPorts": true,
+      "Id": "296e339254e845b695caa1a116500be0",
+      "Inputs": [
+        {
+          "Id": "22a658df633c48b19a35f49b26da7aec",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0b412a6ad87e4044aea3b7f03aca964f",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.8.0.1825",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "296e339254e845b695caa1a116500be0",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 320.55123689610917,
+        "Y": 328.00161373373373
+      }
+    ],
+    "Annotations": [],
+    "X": -218.10250962766781,
+    "Y": -258.68527312857782,
+    "Zoom": 1.442589092933134
+  }
+}


### PR DESCRIPTION
### Purpose

Try to address https://github.com/DynamoDS/DynamoWishlist/issues/71
* add parameter key for packagePaths
* add parameter
* add test
* add python test asserting we can reference and use this parameter.


![Screen Shot 2020-07-01 at 1 20 38 PM](https://user-images.githubusercontent.com/508936/86281489-9f9eaf00-bbab-11ea-913e-a2364c8968b1.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
