### PR TITLE
Add tests for conversions in Python method calls

### DIFF
--- a/test/Engine/FFITarget/DummyCollection.cs
+++ b/test/Engine/FFITarget/DummyCollection.cs
@@ -148,5 +148,10 @@ namespace FFITarget
         {
             return dictionary;
         }
+
+        public static int[] MakeArray(params int[] values)
+        {
+            return values;
+        }
     }
 }

--- a/test/Libraries/DynamoPythonTests/PythonEvalTestsWithLibraries.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTestsWithLibraries.cs
@@ -12,6 +12,7 @@ namespace DynamoPythonTests
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
             libraries.Add("FFITarget.dll");
+            libraries.Add("DSCoreNodes.dll");
         }
 
         public IEnumerable<PythonEvaluatorDelegate> Evaluators = new List<PythonEvaluatorDelegate> {
@@ -41,6 +42,165 @@ OUT = sum
             {
                 var result = pythonEvaluator(code, empty, empty);
                 Assert.AreEqual(expected, result);
+            }
+        }
+
+        [Test]
+        [Category("Failure")]
+        public void TestListEncoding()
+        {
+            string code = @"
+import sys
+import clr
+clr.AddReference('DSCoreNodes')
+from DSCore import List
+
+l = ['a']
+# Python list => .NET IList - Does not work in CPython
+l = List.AddItemToEnd('b',l)
+# .NET IList => Python list - Does not work in IronPython. Couldn't test CPython because of previous bug
+# l.append('c')
+l.Add(c)
+
+OUT = l
+";
+            var empty = new ArrayList();
+            var expected = new ArrayList { "a", "b", "c" };
+            foreach (var pythonEvaluator in Evaluators)
+            {
+                var result = pythonEvaluator(code, empty, empty);
+                Assert.IsTrue(result is IEnumerable);
+                CollectionAssert.AreEqual(expected, result as IEnumerable);
+            }
+        }
+
+        [Test]
+        public void TestArrayEncoding()
+        {
+            string code = @"
+import sys
+import clr
+clr.AddReference('FFITarget')
+clr.AddReference('DSCoreNodes')
+from FFITarget import DummyCollection
+from DSCore import List
+from array import array
+
+# Python array => .NET IList - array is in a builtin library. This does not work in either engine
+# native = array('l', [1,2])
+# native = List.AddItemToEnd(3, native) 
+
+# .NET array => Python list - Works in both engines
+a = DummyCollection.MakeArray(1,2)
+a[0] = a[1] + 1
+b = len(a)
+a[1] = b
+a = List.AddItemToEnd(1, a)
+
+OUT = a
+";
+            var empty = new ArrayList();
+            var expected = new ArrayList { 3, 2, 1 };
+            foreach (var pythonEvaluator in Evaluators)
+            {
+                var result = pythonEvaluator(code, empty, empty);
+                Assert.IsTrue(result is IEnumerable);
+                CollectionAssert.AreEqual(expected, result as IEnumerable);
+            }
+        }
+
+        [Test]
+        [Category("Failure")]
+        public void TestTupleEncoding()
+        {
+            string code = @"
+import sys
+import clr
+clr.AddReference('FFITarget')
+clr.AddReference('DSCoreNodes')
+from FFITarget import DummyCollection
+from DSCore import List
+
+t = (1,2,3)
+# Python tuple => .NET array - Works in both
+a = DummyCollection.MakeArray(t)
+# Python tuple => .NET IList - Does not work in CPython
+l = List.AddItemToEnd(4, t)
+
+OUT = a, l
+";
+            var empty = new ArrayList();
+            var expected = new ArrayList { new ArrayList { 1, 2, 3 }, new ArrayList { 1, 2, 3, 4 } };
+            foreach (var pythonEvaluator in Evaluators)
+            {
+                var result = pythonEvaluator(code, empty, empty);
+                Assert.IsTrue(result is IEnumerable);
+                CollectionAssert.AreEqual(expected, result as IEnumerable);
+            }
+        }
+
+        [Test]
+        [Category("Failure")]
+        public void TestRangeEncoding()
+        {
+            string code = @"
+import sys
+import clr
+clr.AddReference('FFITarget')
+clr.AddReference('DSCoreNodes')
+from FFITarget import DummyCollection
+from DSCore import List
+
+r = range(0, 10, 2)
+# Python range => .NET array - Works in both
+a = DummyCollection.MakeArray(r)
+# Python range => .NET IList - Does not work in CPython
+l = List.AddItemToEnd(10, r)
+
+OUT = a, l
+";
+            var empty = new ArrayList();
+            var expected = new ArrayList { new ArrayList { 0, 2, 4, 6, 8 }, new ArrayList { 0, 2, 4, 6, 8, 10 } };
+            foreach (var pythonEvaluator in Evaluators)
+            {
+                var result = pythonEvaluator(code, empty, empty);
+                Assert.IsTrue(result is IEnumerable);
+                CollectionAssert.AreEqual(expected, result as IEnumerable);
+            }
+        }
+
+        [Test]
+        [Category("Failure")]
+        public void TestDictionaryEncoding()
+        {
+            string code = @"
+import sys
+import clr
+clr.AddReference('FFITarget')
+clr.AddReference('DesignScriptBuiltin')
+from DesignScript.Builtin import Dictionary
+from FFITarget import DummyCollection
+
+d = {'one': 1, 'two': 2, 'three': 3}
+# Python dict => DS Dictionary - Does not work in either engine
+# d2 = Dictionary.SetValueAtKeys(d, ['four'], [4])
+
+# Python dict => .NET IDictionary - Does not work in CPython
+d = DummyCollection.AcceptIDictionary(d)
+# .NET IDictionary => Python dict - Works in IronPython. Could not test in CPython due to previous bug
+d['five'] = 5
+
+OUT = d
+";
+            var empty = new ArrayList();
+            var expected = new Dictionary<string, int> {
+                { "one", 1 }, { "two", 2 }, { "three", 3 }, { "five", 5 }
+            };
+            foreach (var pythonEvaluator in Evaluators)
+            {
+                var result = pythonEvaluator(code, empty, empty);
+                Assert.IsTrue(result is IDictionary);
+                CollectionAssert.AreEquivalent(expected, result as IDictionary);
             }
         }
     }


### PR DESCRIPTION
### Purpose

Adds tests for the following conversion scenarios:
- Python list => .NET IList (CPython fails)
- .NET array => Python list
- Python tuple => .NET array
- Python tuple => .NET IList (CPython fails)
- Python range => .NET array
- Python range => .NET IList (CPython fails)
- Python dict => .NET IDictionary (CPython fails)
- .NET IDictionary => Python dict (CPython unkonwn)

Also commented out some tests that fail in both engines but may be
considered to fix in CPython:
- .NET IList => Python list (call a Python list method on an IList?)
- Python array => .NET IList (builtin library, may be uncommon) 
- Python dict => DS Dictionary (may deserve special attention)

Other types considered but not added as tests:
- classes (can't convert them)
- dictionary view objects (uncommon)
- bytes, bytearray, memoryview (uncommon)
- set, frozenset (uncommon)
- complex (uncommon)

Other scenarios that might be interesting:
- Mutability of collections (IronPython supports this for a IList)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo
