### PR TITLE
Improve the truncated tooltip when the node description is too long

### DIFF
--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
@@ -25,7 +25,7 @@
             Padding="10">
         <Grid Width="325">
             <Grid.RowDefinitions>
-                <RowDefinition Height="96"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>


### PR DESCRIPTION
### Purpose

Improve the truncated tooltip
https://jira.autodesk.com/browse/REVIT-164503 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

Before improvement:
![image](https://user-images.githubusercontent.com/33445445/86420647-e0acd580-bd09-11ea-8435-5d436b4bef72.png)

After improvement:
#### NodeWithNoIcon
![image](https://user-images.githubusercontent.com/33445445/86420684-f4f0d280-bd09-11ea-94da-4d181628f9f5.png)

#### NodeWithIcon
![image](https://user-images.githubusercontent.com/33445445/86420749-26699e00-bd0a-11ea-836d-a4b3a3c1d0eb.png)
