### PR TITLE
Prevent SO for unknown type in CPython

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -249,10 +249,8 @@ namespace DSCPython
                                     }
                                 }
                             }
-                            else
-                            {
-                                return outputMarshaler.Marshal(unmarshalled);
-                            }
+
+                            return outputMarshaler.Marshal(unmarshalled);
                         });
                 }
                 return outputMarshaler;

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -251,7 +251,7 @@ namespace DSCPython
                             }
                             else
                             {
-                                return unmarshalled;
+                                return outputMarshaler.Marshal(unmarshalled);
                             }
                         });
                 }

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -233,7 +233,26 @@ namespace DSCPython
                                 }
                             }
 
-                            return outputMarshaler.Marshal(pyObj.AsManagedObject(typeof(object)));
+                            var unmarshalled = pyObj.AsManagedObject(typeof(object));
+                            if (unmarshalled is PyObject)
+                            {
+                                using (unmarshalled as PyObject)
+                                {
+                                    if (unmarshalled.Equals(pyObj))
+                                    {
+                                        // Object can't be unmarshalled. Prevent a stack overflow.
+                                        throw new InvalidOperationException(Properties.Resources.FailedToUnmarshalOutput);
+                                    }
+                                    else
+                                    {
+                                        return outputMarshaler.Marshal(unmarshalled);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                return unmarshalled;
+                            }
                         });
                 }
                 return outputMarshaler;

--- a/src/Libraries/DSCPython/Properties/Resources.Designer.cs
+++ b/src/Libraries/DSCPython/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace DSCPython.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Output could not be converted to a .NET value.
+        /// </summary>
+        internal static string FailedToUnmarshalOutput {
+            get {
+                return ResourceManager.GetString("FailedToUnmarshalOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Internal error, please report: Trace back information could not be extracted.
         /// </summary>
         internal static string InternalErrorTraceBackInfo {

--- a/src/Libraries/DSCPython/Properties/Resources.en-US.resx
+++ b/src/Libraries/DSCPython/Properties/Resources.en-US.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FailedToUnmarshalOutput" xml:space="preserve">
+    <value>Output could not be converted to a .NET value</value>
+  </data>
   <data name="InternalErrorTraceBackInfo" xml:space="preserve">
     <value>Internal error, please report: Trace back information could not be extracted</value>
   </data>

--- a/src/Libraries/DSCPython/Properties/Resources.resx
+++ b/src/Libraries/DSCPython/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FailedToUnmarshalOutput" xml:space="preserve">
+    <value>Output could not be converted to a .NET value</value>
+  </data>
   <data name="InternalErrorTraceBackInfo" xml:space="preserve">
     <value>Internal error, please report: Trace back information could not be extracted</value>
   </data>

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -168,5 +168,32 @@ print 'hello'
                 Assert.AreEqual(@"SyntaxError : ('invalid syntax', ('<string>', 3, 7, ""print 'hello'\n""))", exc.Message);
             }
         }
+
+        [Test]
+        public void UnsupportedOutputShouldFailGracefullyInCPython()
+        {
+            var code = @"
+import weakref
+
+class myobj:
+  pass
+
+o = myobj()
+wr = weakref.ref(o)
+
+OUT = wr
+";
+            var empty = new ArrayList();
+
+            try
+            {
+                DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty);
+                Assert.Fail("An exception was expected");
+            }
+            catch (Exception exc)
+            {
+                Assert.AreEqual("Output could not be converted to a .NET value", exc.Message);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose

When unmarhsalling output data from a Python script using the CPython
engine, a StackOverlowException would occur for certain uncommon types
like Python set. The unmarshaller is trying to recursively convert the
output by calling AsManagedObject, but in cases where Python.NET does
not have a specialized representation, like it is the case for set, it
just returns a different object pointing to the same handle, thus
causing the unmarshaller to call himself again with basically the same
underlying Python object.

The problem is fixed by explicitly checking if the returned object by
AsManagedObject has the same handle as the original one, in which case
an exception is thrown with a proper message.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Amoursol This should better handle the bug you found, by providing a warning instead of a crash.