### PR TITLE
harden discovery of codeCompletionProvider.

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/SharedCompletionProvider.cs
+++ b/src/Libraries/PythonNodeModelsWpf/SharedCompletionProvider.cs
@@ -47,7 +47,7 @@ namespace Dynamo.Python
                         {
                             return new Type[0];
                         }
-                    }).Where(p => completionType.IsAssignableFrom(p) && !p.IsInterface);
+                    }).Where(p => completionType.IsAssignableFrom(p) && !p.IsInterface).ToList();
                 //instantiate them - so we can check which is a match using their match method
                 foreach (var type in loadedCodeCompletionTypes)
                 {


### PR DESCRIPTION
### Purpose

When search the appdomain for the CompletionProvider interfaces, if this linq statement encountered an exception it would bail out and fail to find the loaded completion providers. Now it does continues.

I could not figure out quick way to test this, if others believe this is required for this scenario I appreciate ideas.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
