### PR TITLE
[DYN-2797] Provide custom node info in the IronPython2 migration dialog. 

### DIFF
--- a/src/Libraries/DSCPython/DSCPython.csproj
+++ b/src/Libraries/DSCPython/DSCPython.csproj
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- TODO Remove this dummy reference in Dynamo 3.0 or a version that is delivered with newer version of Global lunch products -->

--- a/src/Libraries/DSCPython/DSCPython.csproj
+++ b/src/Libraries/DSCPython/DSCPython.csproj
@@ -25,7 +25,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,7 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- TODO Remove this dummy reference in Dynamo 3.0 or a version that is delivered with newer version of Global lunch products -->

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -14,9 +14,9 @@ namespace Dynamo.PythonMigration
         private ViewLoadedParams ViewLoaded { get; set; }
 
         // A dictionary to mark Custom Nodes if they have a IronPython dependency or not. 
-        internal static Dictionary<Guid, CNPythonDependency> CustomNodePythonDependency = new Dictionary<Guid, CNPythonDependency>();
+        internal static Dictionary<Guid, CNPythonDependencyType> CustomNodePythonDependencyMap = new Dictionary<Guid, CNPythonDependencyType>();
 
-        internal enum CNPythonDependency
+        internal enum CNPythonDependencyType
         {
             NoDependency,
             NestedDependency,
@@ -28,7 +28,7 @@ namespace Dynamo.PythonMigration
             this.ViewLoaded = viewLoadedParams;
         }
 
-        internal bool ContainsIronPythonDependency()
+        internal bool ContainsIronPythonDependencyInCurrentWS()
         {
             var containsIronPythonDependency = false;
             var workspace = ViewLoaded.CurrentWorkspaceModel;
@@ -66,9 +66,9 @@ namespace Dynamo.PythonMigration
 
                 // If a custom node workspace is already checked for IronPython dependencies, 
                 // check the CustomNodePythonDependency dictionary instead of processing it again. 
-                if (CustomNodePythonDependency.TryGetValue(customNodeWS.CustomNodeId, out CNPythonDependency dependency))
+                if (CustomNodePythonDependencyMap.TryGetValue(customNodeWS.CustomNodeId, out CNPythonDependencyType dependency))
                 {
-                    if (dependency == CNPythonDependency.DirectDependency || dependency == CNPythonDependency.NestedDependency)
+                    if (dependency == CNPythonDependencyType.DirectDependency || dependency == CNPythonDependencyType.NestedDependency)
                     {
                         containIronPythonDependency = true;
                     }
@@ -79,12 +79,12 @@ namespace Dynamo.PythonMigration
 
                 if (hasPythonNodesInCustomNodeWorkspace)
                 {
-                    CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNPythonDependency.DirectDependency);
+                    CustomNodePythonDependencyMap.Add(customNodeWS.CustomNodeId, CNPythonDependencyType.DirectDependency);
                     containIronPythonDependency = true;
                 }
                 else
                 {
-                    CustomNodePythonDependency.Add(customNodeWS.CustomNodeId, CNPythonDependency.NoDependency);
+                    CustomNodePythonDependencyMap.Add(customNodeWS.CustomNodeId, CNPythonDependencyType.NoDependency);
                 }
 
                 // Recursively check for IronPython dependencies in the nested custom nodes.
@@ -96,9 +96,9 @@ namespace Dynamo.PythonMigration
 
                     // If a custom node contains an IronPython dependency in its sub-tree,
                     // update its corresponding value to 'NestedDependency' in CustomNodePythonDependency.
-                    if (hasPythonNodesInCustomNodeWorkspace && CustomNodePythonDependency[customNodeWS.CustomNodeId] != CNPythonDependency.DirectDependency)
+                    if (hasPythonNodesInCustomNodeWorkspace && CustomNodePythonDependencyMap[customNodeWS.CustomNodeId] != CNPythonDependencyType.DirectDependency)
                     {
-                        CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.NestedDependency;
+                        CustomNodePythonDependencyMap[customNodeWS.CustomNodeId] = CNPythonDependencyType.NestedDependency;
                         containIronPythonDependency = true;
                     }
                 }

--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -14,9 +14,9 @@ namespace Dynamo.PythonMigration
         private ViewLoadedParams ViewLoaded { get; set; }
 
         // A dictionary to mark Custom Nodes if they have a IronPython dependency or not. 
-        private static Dictionary<Guid, CNPythonDependency> CustomNodePythonDependency = new Dictionary<Guid, CNPythonDependency>();
+        internal static Dictionary<Guid, CNPythonDependency> CustomNodePythonDependency = new Dictionary<Guid, CNPythonDependency>();
 
-        private enum CNPythonDependency
+        internal enum CNPythonDependency
         {
             NoDependency,
             NestedDependency,
@@ -28,8 +28,9 @@ namespace Dynamo.PythonMigration
             this.ViewLoaded = viewLoadedParams;
         }
 
-        internal bool ContainsIronPythonDependencies()
+        internal bool ContainsIronPythonDependency()
         {
+            var containsIronPythonDependency = false;
             var workspace = ViewLoaded.CurrentWorkspaceModel;
 
             if (workspace == null)
@@ -37,14 +38,19 @@ namespace Dynamo.PythonMigration
 
             if (workspace.Nodes.Any(n => IsIronPythonNode(n)))
             {
-                return true;
+                containsIronPythonDependency = true;
             }
 
             // Check if any of the custom nodes has IronPython dependencies in it. 
             var customNodeManager = ViewLoaded.StartupParams.CustomNodeManager;
             var customNodes = workspace.Nodes.OfType<Function>();
 
-            return CustomNodesContainIronPythonDependency(customNodes, customNodeManager);           
+            if (CustomNodesContainIronPythonDependency(customNodes, customNodeManager))
+            {
+                containsIronPythonDependency = true;
+            }
+
+            return containsIronPythonDependency;
         }
 
         // This function returns true, if any of the custom nodes in the input list has an IronPython dependency. 
@@ -90,7 +96,7 @@ namespace Dynamo.PythonMigration
 
                     // If a custom node contains an IronPython dependency in its sub-tree,
                     // update its corresponding value to 'NestedDependency' in CustomNodePythonDependency.
-                    if (hasPythonNodesInCustomNodeWorkspace)
+                    if (hasPythonNodesInCustomNodeWorkspace && CustomNodePythonDependency[customNodeWS.CustomNodeId] != CNPythonDependency.DirectDependency)
                     {
                         CustomNodePythonDependency[customNodeWS.CustomNodeId] = CNPythonDependency.NestedDependency;
                         containIronPythonDependency = true;

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
@@ -27,21 +27,21 @@
         </Grid.RowDefinitions>
 
         <Image Name="DialogIcon"
-               Width="96"
-               Height="96"
-               Margin="25"
-               VerticalAlignment="Center"
+               Width="100"
+               Height="35"
+               Margin="15,60,15,0"
+               VerticalAlignment="Top"
                HorizontalAlignment="Center"
                Source="/DynamoCoreWpf;component/UI/Images/python-logo.png">
         </Image>
 
         <StackPanel Grid.Row="0"
                     Grid.Column="1"
-                    Margin="0,25,25,25">
+                    Margin="0,25,15,25">
 
             <TextBlock Name="SummaryText"
                        Text="{x:Static w:Resources.IronPythonDialogSummary}"
-                       FontSize="15"
+                       FontSize="16"
                        Foreground="#bbbbbb"
                        HorizontalAlignment="Stretch"
                        TextWrapping="Wrap"
@@ -50,26 +50,26 @@
 
             <TextBlock Name="DescriptionText"
                        Text="{x:Static w:Resources.IronPythonDialogDescription}"
-                       FontSize="12"
+                       FontSize="13"
                        Foreground="#bbbbbb"
                        HorizontalAlignment="Stretch"
                        TextWrapping="Wrap"
                        Margin="0,0,0,10">
             </TextBlock>
-            
+
             <!-- CustomNodes that have IronPython2 Dependency -->
             <Expander x:Name="MainExpander" Header="{x:Static w:Resources.CustomNodesPythonDependencyHeader}" Foreground="#bbbbbb"
                       FontSize="15" Margin="-2,0,0,0" Visibility="Hidden" ScrollViewer.VerticalScrollBarVisibility="Visible">
                 <StackPanel Height="Auto">
-                    <Expander x:Name="ExpanderForPackagedDependencies" Header="Packaged" Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Hidden">
-                        <ListBox x:Name="PackagedCustomNodesContainingPython" FontSize="12" Background="Black" Height="100"
+                    <Expander x:Name="ExpanderForPackagedDependencies" Header="Packaged" Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                        <ListBox x:Name="PackagedCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100"
                                  Margin="25,5,0,0" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>
                                 <CommandBinding Command="ApplicationCommands.Copy" CanExecute="CanExecuteCtrlCCopyCommand" Executed="ExecuteCtrlCCopyCommand" />
                             </ListBox.CommandBindings>
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <Grid Margin="0,1" ToolTip="{x:Static w:Resources.PackagedCustomNodesTooltip}">
+                                    <Grid Margin="0,2" ToolTip="{x:Static w:Resources.PackagedCustomNodesTooltip}">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="100" />
                                             <ColumnDefinition Width="*" />
@@ -81,21 +81,21 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Expander>
-                    <Expander Grid.Row="1" x:Name="ExpanderForLooseDependencies" Header="Loose"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Hidden">
-                        <ListBox x:Name="LooseCustomNodesContainingPython" FontSize="12" Background="Black" Height="100" 
+                    <Expander Grid.Row="1" x:Name="ExpanderForLooseDependencies" Header="Loose"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                        <ListBox x:Name="LooseCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100" 
                                  Margin="25,5,0,0" MouseDoubleClick="OnCustomNodeClick" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>
                                 <CommandBinding Command="ApplicationCommands.Copy" CanExecute="CanExecuteCtrlCCopyCommand" Executed="ExecuteCtrlCCopyCommand" />
                             </ListBox.CommandBindings>
                             <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <Grid Margin="0,1" ToolTip="{x:Static w:Resources.LooseCustomNodesTooltip}">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                            </Grid.ColumnDefinitions>
-                                            <TextBlock Foreground="#bbbbbb" Text="{Binding Name}" />
-                                        </Grid>
-                                    </DataTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,2" ToolTip="{x:Static w:Resources.LooseCustomNodesTooltip}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Foreground="#bbbbbb" Text="{Binding Name}" />
+                                    </Grid>
+                                </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Expander>

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
@@ -81,15 +81,15 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Expander>
-                    <Expander Grid.Row="1" x:Name="ExpanderForLooseDependencies" Header="Loose"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
-                        <ListBox x:Name="LooseCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100" 
+                    <Expander Grid.Row="1" x:Name="ExpanderForUserDefinitionDependencies" Header="Definitions"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                        <ListBox x:Name="UserDefinitionCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100" 
                                  Margin="25,5,0,0" MouseDoubleClick="OnCustomNodeClick" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>
                                 <CommandBinding Command="ApplicationCommands.Copy" CanExecute="CanExecuteCtrlCCopyCommand" Executed="ExecuteCtrlCCopyCommand" />
                             </ListBox.CommandBindings>
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <Grid Margin="0,2" ToolTip="{x:Static w:Resources.LooseCustomNodesTooltip}">
+                                    <Grid Margin="0,2" ToolTip="{x:Static w:Resources.UserDefinitionCustomNodesTooltip}">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
@@ -61,7 +61,7 @@
             <Expander x:Name="MainExpander" Header="{x:Static w:Resources.CustomNodesPythonDependencyHeader}" Foreground="#bbbbbb"
                       FontSize="15" Margin="-2,0,0,0" Visibility="Hidden" ScrollViewer.VerticalScrollBarVisibility="Visible">
                 <StackPanel Height="Auto">
-                    <Expander x:Name="ExpanderForPackagedDependencies" Header="Packaged" Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                    <Expander x:Name="ExpanderForPackagedDependencies" Header="{x:Static w:Resources.PackagedCustomNodesHeader}" Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
                         <ListBox x:Name="PackagedCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100"
                                  Margin="25,5,0,0" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>
@@ -81,7 +81,7 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Expander>
-                    <Expander Grid.Row="1" x:Name="ExpanderForUserDefinitionDependencies" Header="Definitions"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                    <Expander Grid.Row="1" x:Name="ExpanderForUserDefinitionDependencies" Header="{x:Static w:Resources.UserDefinitionsHeader}"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
                         <ListBox x:Name="UserDefinitionCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100" 
                                  Margin="25,5,0,0" MouseDoubleClick="OnCustomNodeClick" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
@@ -16,7 +16,6 @@
         </ResourceDictionary>
     </Window.Resources>
     <Grid Background="#444444">
-
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="auto" />
             <ColumnDefinition Width="*" />
@@ -54,9 +53,54 @@
                        FontSize="12"
                        Foreground="#bbbbbb"
                        HorizontalAlignment="Stretch"
-                       TextWrapping="Wrap">
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,10">
             </TextBlock>
-
+            
+            <!-- CustomNodes that have IronPython2 Dependency -->
+            <Expander x:Name="MainExpander" Header="{x:Static w:Resources.CustomNodesPythonDependencyHeader}" Foreground="#bbbbbb"
+                      FontSize="15" Margin="-2,0,0,0" Visibility="Hidden" ScrollViewer.VerticalScrollBarVisibility="Visible">
+                <StackPanel Height="Auto">
+                    <Expander x:Name="ExpanderForPackagedDependencies" Header="Packaged" Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Hidden">
+                        <ListBox x:Name="PackagedCustomNodesContainingPython" FontSize="12" Background="Black" Height="100"
+                                 Margin="25,5,0,0" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
+                            <ListBox.CommandBindings>
+                                <CommandBinding Command="ApplicationCommands.Copy" CanExecute="CanExecuteCtrlCCopyCommand" Executed="ExecuteCtrlCCopyCommand" />
+                            </ListBox.CommandBindings>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,1" ToolTip="{x:Static w:Resources.PackagedCustomNodesTooltip}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="100" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Foreground="#bbbbbb" Text="{Binding PackageName}" />
+                                        <TextBlock Grid.Column="1" Foreground="#bbbbbb" Text="{Binding Name}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Expander>
+                    <Expander Grid.Row="1" x:Name="ExpanderForLooseDependencies" Header="Loose"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Hidden">
+                        <ListBox x:Name="LooseCustomNodesContainingPython" FontSize="12" Background="Black" Height="100" 
+                                 Margin="25,5,0,0" MouseDoubleClick="OnCustomNodeClick" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
+                            <ListBox.CommandBindings>
+                                <CommandBinding Command="ApplicationCommands.Copy" CanExecute="CanExecuteCtrlCCopyCommand" Executed="ExecuteCtrlCCopyCommand" />
+                            </ListBox.CommandBindings>
+                            <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="0,1" ToolTip="{x:Static w:Resources.LooseCustomNodesTooltip}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Foreground="#bbbbbb" Text="{Binding Name}" />
+                                        </Grid>
+                                    </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Expander>
+                </StackPanel>
+            </Expander>
         </StackPanel>
 
         <StackPanel Name="RightButtonStackPanel"
@@ -75,7 +119,6 @@
                     Style="{StaticResource STextButton}"
                     Visibility="Visible"
                     Click="Button_Click"/>
-
         </StackPanel>
     </Grid>
 </Window>

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml
@@ -12,6 +12,8 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>
@@ -42,7 +44,7 @@
             <TextBlock Name="SummaryText"
                        Text="{x:Static w:Resources.IronPythonDialogSummary}"
                        FontSize="16"
-                       Foreground="#bbbbbb"
+                       Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
                        HorizontalAlignment="Stretch"
                        TextWrapping="Wrap"
                        Margin="0,0,0,5">
@@ -51,17 +53,17 @@
             <TextBlock Name="DescriptionText"
                        Text="{x:Static w:Resources.IronPythonDialogDescription}"
                        FontSize="13"
-                       Foreground="#bbbbbb"
+                       Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
                        HorizontalAlignment="Stretch"
                        TextWrapping="Wrap"
                        Margin="0,0,0,10">
             </TextBlock>
 
             <!-- CustomNodes that have IronPython2 Dependency -->
-            <Expander x:Name="MainExpander" Header="{x:Static w:Resources.CustomNodesPythonDependencyHeader}" Foreground="#bbbbbb"
+            <Expander x:Name="MainExpander" Header="{x:Static w:Resources.CustomNodesPythonDependencyHeader}" Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
                       FontSize="15" Margin="-2,0,0,0" Visibility="Hidden" ScrollViewer.VerticalScrollBarVisibility="Visible">
                 <StackPanel Height="Auto">
-                    <Expander x:Name="ExpanderForPackagedDependencies" Header="{x:Static w:Resources.PackagedCustomNodesHeader}" Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                    <Expander x:Name="ExpanderForPackagedDependencies" Header="{x:Static w:Resources.PackagedCustomNodesHeader}" Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
                         <ListBox x:Name="PackagedCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100"
                                  Margin="25,5,0,0" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>
@@ -74,14 +76,14 @@
                                             <ColumnDefinition Width="100" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <TextBlock Foreground="#bbbbbb" Text="{Binding PackageName}" />
-                                        <TextBlock Grid.Column="1" Foreground="#bbbbbb" Text="{Binding Name}" />
+                                        <TextBlock Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" Text="{Binding PackageName}" />
+                                        <TextBlock Grid.Column="1" Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" Text="{Binding Name}" />
                                     </Grid>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Expander>
-                    <Expander Grid.Row="1" x:Name="ExpanderForUserDefinitionDependencies" Header="{x:Static w:Resources.UserDefinitionsHeader}"  Foreground="#bbbbbb" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
+                    <Expander Grid.Row="1" x:Name="ExpanderForUserDefinitionDependencies" Header="{x:Static w:Resources.UserDefinitionsHeader}"  Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" FontSize="15" Margin="20,5,0,0" Visibility="Collapsed">
                         <ListBox x:Name="UserDefinitionCustomNodesContainingPython" FontSize="12" Background="Black" Height="Auto" MaxHeight="100" 
                                  Margin="25,5,0,0" MouseDoubleClick="OnCustomNodeClick" ScrollViewer.VerticalScrollBarVisibility="Visible" SelectionMode="Extended">
                             <ListBox.CommandBindings>
@@ -93,7 +95,7 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <TextBlock Foreground="#bbbbbb" Text="{Binding Name}" />
+                                        <TextBlock Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" Text="{Binding Name}" />
                                     </Grid>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows;
+﻿using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Dynamo.PythonMigration
 {
@@ -12,8 +16,50 @@ namespace Dynamo.PythonMigration
         {
             this.ViewModel = viewModel;
             InitializeComponent();
+            SetPythonDepedenciesData();
         }
 
+        private void SetPythonDepedenciesData()
+        {
+            // Filter the Custom Nodes that have a direct dependency on IronPython2. 
+            var customNodesWithPythonDependencies = GraphPythonDependencies.CustomNodePythonDependency
+                                                            .Where(x => x.Value.Equals(GraphPythonDependencies.CNPythonDependency.DirectDependency));
+
+            if (customNodesWithPythonDependencies.Any())
+            {
+                foreach (var entry in customNodesWithPythonDependencies)
+                {
+                    ViewModel.CustomNodeManager.TryGetNodeInfo(entry.Key, out CustomNodeInfo customNodeInfo);
+
+                    CustomNodeItem customNodeItem = new CustomNodeItem
+                    {
+                        Name = customNodeInfo.Name,
+                        FunctionId = customNodeInfo.FunctionId,
+                        PackageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : "Loose",
+                    };
+
+                    if (customNodeInfo.PackageInfo != null)
+                    {
+                        PackagedCustomNodesContainingPython.Items.Add(customNodeItem);
+                    }
+                    else
+                    {
+                        LooseCustomNodesContainingPython.Items.Add(customNodeItem);
+                    }
+                }
+
+                if (PackagedCustomNodesContainingPython.Items.Count > 0)
+                {
+                    ExpanderForPackagedDependencies.Visibility = Visibility.Visible;
+                }
+
+                if (LooseCustomNodesContainingPython.Items.Count > 0)
+                {
+                    ExpanderForLooseDependencies.Visibility = Visibility.Visible;
+                }
+                MainExpander.Visibility = Visibility.Visible;
+            }
+        }
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             this.Close();
@@ -23,6 +69,57 @@ namespace Dynamo.PythonMigration
         {
             this.ViewModel.OpenPythonMigrationWarningDocumentation();
             this.Close();
+        }
+
+        private void OnCustomNodeClick(object sender, RoutedEventArgs e)
+        {
+            if (LooseCustomNodesContainingPython.SelectedItems.Count == 1)
+            {
+                CustomNodeItem selectedCNItem = LooseCustomNodesContainingPython.SelectedItem as CustomNodeItem;
+                Guid functionId = selectedCNItem.FunctionId;
+                ViewModel.DynamoViewModel.Model.OpenCustomNodeWorkspace(functionId);
+            }
+        }
+
+        private void ExecuteCtrlCCopyCommand(object sender, ExecutedRoutedEventArgs e)
+        {
+            string collectedText = "";
+            ListBox lb = (ListBox) sender; 
+            
+            foreach (var item in lb.SelectedItems)
+            {
+                collectedText += item.ToString() + "\r\n";
+            }
+
+            if (lb.SelectedItems != null)
+            {
+                Clipboard.SetText(collectedText.ToString());
+            }
+        }
+
+        private void CanExecuteCtrlCCopyCommand(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = true;
+        }
+    }
+
+    // Represents the data for each Custom Node item in the listbox. 
+    internal class CustomNodeItem
+    {
+        public string Name { get; set; }
+        public string PackageName { get; set; }
+        internal Guid FunctionId { get; set; }
+
+        public override string ToString()
+        {
+            if (PackageName.Equals("Loose"))
+            {
+                return Name;
+            }
+            else
+            {
+                return PackageName + " : " + Name;
+            }
         }
     }
 }

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
@@ -31,12 +31,9 @@ namespace Dynamo.PythonMigration
                 {
                     ViewModel.CustomNodeManager.TryGetNodeInfo(entry.Key, out CustomNodeInfo customNodeInfo);
 
-                    CustomNodeItem customNodeItem = new CustomNodeItem
-                    {
-                        Name = customNodeInfo.Name,
-                        FunctionId = customNodeInfo.FunctionId,
-                        PackageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : CustomNodeItem.UserDefinitions,
-                    };
+                    var packageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : CustomNodeItem.UserDefinitions;
+
+                    CustomNodeItem customNodeItem = new CustomNodeItem(customNodeInfo.Name, customNodeInfo.FunctionId, packageName);
 
                     if (customNodeInfo.PackageInfo != null)
                     {
@@ -106,9 +103,16 @@ namespace Dynamo.PythonMigration
     // Represents the data for each Custom Node item in the listbox. 
     internal class CustomNodeItem
     {
-        public string Name { get; set; }
-        public string PackageName { get; set; }
-        internal Guid FunctionId { get; set; }
+        internal CustomNodeItem(string name, Guid functionId, string packageName) 
+        {
+            Name = name;
+            FunctionId = functionId;
+            PackageName = packageName;
+        }
+
+        public string Name { get; private set; }
+        public string PackageName { get; private set; }
+        internal Guid FunctionId { get; private set; }
 
         internal const string UserDefinitions = "Definitions";
 

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
@@ -35,7 +35,7 @@ namespace Dynamo.PythonMigration
                     {
                         Name = customNodeInfo.Name,
                         FunctionId = customNodeInfo.FunctionId,
-                        PackageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : "Loose",
+                        PackageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : "Definitions",
                     };
 
                     if (customNodeInfo.PackageInfo != null)
@@ -112,7 +112,7 @@ namespace Dynamo.PythonMigration
 
         public override string ToString()
         {
-            if (PackageName.Equals("Loose"))
+            if (PackageName.Equals("Definitions"))
             {
                 return Name;
             }

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
@@ -85,7 +85,7 @@ namespace Dynamo.PythonMigration
             
             foreach (var item in lb.SelectedItems)
             {
-                collectedText += item.ToString() + "\r\n";
+                collectedText += item.ToString() + System.Environment.NewLine;
             }
 
             if (lb.SelectedItems != null)

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
@@ -44,7 +44,7 @@ namespace Dynamo.PythonMigration
                     }
                     else
                     {
-                        LooseCustomNodesContainingPython.Items.Add(customNodeItem);
+                        UserDefinitionCustomNodesContainingPython.Items.Add(customNodeItem);
                     }
                 }
 
@@ -53,9 +53,9 @@ namespace Dynamo.PythonMigration
                     ExpanderForPackagedDependencies.Visibility = Visibility.Visible;
                 }
 
-                if (LooseCustomNodesContainingPython.Items.Count > 0)
+                if (UserDefinitionCustomNodesContainingPython.Items.Count > 0)
                 {
-                    ExpanderForLooseDependencies.Visibility = Visibility.Visible;
+                    ExpanderForUserDefinitionDependencies.Visibility = Visibility.Visible;
                 }
                 MainExpander.Visibility = Visibility.Visible;
             }
@@ -73,9 +73,9 @@ namespace Dynamo.PythonMigration
 
         private void OnCustomNodeClick(object sender, RoutedEventArgs e)
         {
-            if (LooseCustomNodesContainingPython.SelectedItems.Count == 1)
+            if (UserDefinitionCustomNodesContainingPython.SelectedItems.Count == 1)
             {
-                CustomNodeItem selectedCNItem = LooseCustomNodesContainingPython.SelectedItem as CustomNodeItem;
+                CustomNodeItem selectedCNItem = UserDefinitionCustomNodesContainingPython.SelectedItem as CustomNodeItem;
                 Guid functionId = selectedCNItem.FunctionId;
                 ViewModel.DynamoViewModel.Model.OpenCustomNodeWorkspace(functionId);
             }

--- a/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
+++ b/src/PythonMigrationViewExtension/IronPythonInfoDialog.xaml.cs
@@ -22,8 +22,8 @@ namespace Dynamo.PythonMigration
         private void SetPythonDepedenciesData()
         {
             // Filter the Custom Nodes that have a direct dependency on IronPython2. 
-            var customNodesWithPythonDependencies = GraphPythonDependencies.CustomNodePythonDependency
-                                                            .Where(x => x.Value.Equals(GraphPythonDependencies.CNPythonDependency.DirectDependency));
+            var customNodesWithPythonDependencies = GraphPythonDependencies.CustomNodePythonDependencyMap
+                                                            .Where(x => x.Value.Equals(GraphPythonDependencies.CNPythonDependencyType.DirectDependency));
 
             if (customNodesWithPythonDependencies.Any())
             {
@@ -35,7 +35,7 @@ namespace Dynamo.PythonMigration
                     {
                         Name = customNodeInfo.Name,
                         FunctionId = customNodeInfo.FunctionId,
-                        PackageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : "Definitions",
+                        PackageName = customNodeInfo.PackageInfo != null ? customNodeInfo.PackageInfo.Name : CustomNodeItem.UserDefinitions,
                     };
 
                     if (customNodeInfo.PackageInfo != null)
@@ -84,7 +84,7 @@ namespace Dynamo.PythonMigration
         private void ExecuteCtrlCCopyCommand(object sender, ExecutedRoutedEventArgs e)
         {
             string collectedText = "";
-            ListBox lb = (ListBox) sender; 
+            ListBox lb = (ListBox) sender;
             
             foreach (var item in lb.SelectedItems)
             {
@@ -110,9 +110,11 @@ namespace Dynamo.PythonMigration
         public string PackageName { get; set; }
         internal Guid FunctionId { get; set; }
 
+        internal const string UserDefinitions = "Definitions";
+
         public override string ToString()
         {
-            if (PackageName.Equals("Definitions"))
+            if (PackageName.Equals(UserDefinitions))
             {
                 return Name;
             }

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.PythonMigration.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -116,20 +116,20 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Double-click on the custom node to open its workspace.
-        /// </summary>
-        public static string LooseCustomNodesTooltip {
-            get {
-                return ResourceManager.GetString("LooseCustomNodesTooltip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Please notify the package author to update the package.
         /// </summary>
         public static string PackagedCustomNodesTooltip {
             get {
                 return ResourceManager.GetString("PackagedCustomNodesTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Double-click on the custom node to open its workspace.
+        /// </summary>
+        public static string UserDefinitionCustomNodesTooltip {
+            get {
+                return ResourceManager.GetString("UserDefinitionCustomNodesTooltip", resourceCulture);
             }
         }
     }

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -116,6 +116,15 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Packaged.
+        /// </summary>
+        public static string PackagedCustomNodesHeader {
+            get {
+                return ResourceManager.GetString("PackagedCustomNodesHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please notify the package author to update the package.
         /// </summary>
         public static string PackagedCustomNodesTooltip {
@@ -130,6 +139,15 @@ namespace Dynamo.PythonMigration.Properties {
         public static string UserDefinitionCustomNodesTooltip {
             get {
                 return ResourceManager.GetString("UserDefinitionCustomNodesTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Definitions.
+        /// </summary>
+        public static string UserDefinitionsHeader {
+            get {
+                return ResourceManager.GetString("UserDefinitionsHeader", resourceCulture);
             }
         }
     }

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.PythonMigration.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -57,6 +57,15 @@ namespace Dynamo.PythonMigration.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom Nodes that have an IronPython2 dependency.
+        /// </summary>
+        public static string CustomNodesPythonDependencyHeader {
+            get {
+                return ResourceManager.GetString("CustomNodesPythonDependencyHeader", resourceCulture);
             }
         }
         
@@ -103,6 +112,24 @@ namespace Dynamo.PythonMigration.Properties {
         public static string IronPythonNotificationShortMessage {
             get {
                 return ResourceManager.GetString("IronPythonNotificationShortMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Double-click on the custom node to open its workspace.
+        /// </summary>
+        public static string LooseCustomNodesTooltip {
+            get {
+                return ResourceManager.GetString("LooseCustomNodesTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please notify the package author to update the package.
+        /// </summary>
+        public static string PackagedCustomNodesTooltip {
+            get {
+                return ResourceManager.GetString("PackagedCustomNodesTooltip", resourceCulture);
             }
         }
     }

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -142,4 +142,10 @@ There will be a time of transition where both versions of Python node will work 
   <data name="UserDefinitionCustomNodesTooltip" xml:space="preserve">
     <value>Double-click on the custom node to open its workspace</value>
   </data>
+  <data name="PackagedCustomNodesHeader" xml:space="preserve">
+    <value>Packaged</value>
+  </data>
+  <data name="UserDefinitionsHeader" xml:space="preserve">
+    <value>Definitions</value>
+  </data>
 </root>

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -133,4 +133,13 @@ There will be a time of transition where both versions of Python node will work 
   <data name="IronPythonNotificationShortMessage" xml:space="preserve">
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
+  <data name="CustomNodesPythonDependencyHeader" xml:space="preserve">
+    <value>Custom Nodes that have an IronPython2 dependency</value>
+  </data>
+  <data name="PackagedCustomNodesTooltip" xml:space="preserve">
+    <value>Please notify the package author to update the package</value>
+  </data>
+  <data name="LooseCustomNodesTooltip" xml:space="preserve">
+    <value>Double-click on the custom node to open its workspace</value>
+  </data>
 </root>

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -139,7 +139,7 @@ There will be a time of transition where both versions of Python node will work 
   <data name="PackagedCustomNodesTooltip" xml:space="preserve">
     <value>Please notify the package author to update the package</value>
   </data>
-  <data name="LooseCustomNodesTooltip" xml:space="preserve">
+  <data name="UserDefinitionCustomNodesTooltip" xml:space="preserve">
     <value>Double-click on the custom node to open its workspace</value>
   </data>
 </root>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -142,4 +142,10 @@ There will be a time of transition where both versions of Python node will work 
   <data name="UserDefinitionCustomNodesTooltip" xml:space="preserve">
     <value>Double-click on the custom node to open its workspace</value>
   </data>
+  <data name="PackagedCustomNodesHeader" xml:space="preserve">
+    <value>Packaged</value>
+  </data>
+  <data name="UserDefinitionsHeader" xml:space="preserve">
+    <value>Definitions</value>
+  </data>
 </root>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -133,4 +133,13 @@ There will be a time of transition where both versions of Python node will work 
   <data name="IronPythonNotificationShortMessage" xml:space="preserve">
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
+  <data name="CustomNodesPythonDependencyHeader" xml:space="preserve">
+    <value>Custom Nodes that have an IronPython2 dependency</value>
+  </data>
+  <data name="PackagedCustomNodesTooltip" xml:space="preserve">
+    <value>Please notify the package author to update the package</value>
+  </data>
+  <data name="LooseCustomNodesTooltip" xml:space="preserve">
+    <value>Double-click on the custom node to open its workspace</value>
+  </data>
 </root>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -139,7 +139,7 @@ There will be a time of transition where both versions of Python node will work 
   <data name="PackagedCustomNodesTooltip" xml:space="preserve">
     <value>Please notify the package author to update the package</value>
   </data>
-  <data name="LooseCustomNodesTooltip" xml:space="preserve">
+  <data name="UserDefinitionCustomNodesTooltip" xml:space="preserve">
     <value>Double-click on the custom node to open its workspace</value>
   </data>
 </root>

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -159,12 +159,12 @@ namespace Dynamo.PythonMigration
             if (!IsIronPythonDialogOpen())
             {
                 NotificationTracker.Remove(CurrentWorkspace.Guid);
-                GraphPythonDependencies.CustomNodePythonDependency.Clear();
+                GraphPythonDependencies.CustomNodePythonDependencyMap.Clear();
                 CurrentWorkspace = workspace as WorkspaceModel;
 
                 if (Configuration.DebugModes.IsEnabled("Python2ObsoleteMode")
                     && !Models.DynamoModel.IsTestMode
-                    && PythonDependencies.ContainsIronPythonDependency())
+                    && PythonDependencies.ContainsIronPythonDependencyInCurrentWS())
                 {
                     LogIronPythonNotification();
                     DisplayIronPythonDialog();

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -226,7 +226,7 @@ namespace DynamoCoreWpfTests
                 .First() as PythonMigrationViewExtension;
 
             // Assert
-            Assert.IsTrue(pythonMigration.PythonDependencies.ContainsIronPythonDependency());
+            Assert.IsTrue(pythonMigration.PythonDependencies.ContainsIronPythonDependencyInCurrentWS());
             DispatcherUtil.DoEvents();
         }
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -226,7 +226,7 @@ namespace DynamoCoreWpfTests
                 .First() as PythonMigrationViewExtension;
 
             // Assert
-            Assert.IsTrue(pythonMigration.PythonDependencies.ContainsIronPythonDependencies());
+            Assert.IsTrue(pythonMigration.PythonDependencies.ContainsIronPythonDependency());
             DispatcherUtil.DoEvents();
         }
 


### PR DESCRIPTION
### Purpose

This PR implements UI functionality, to provide more information on the custom nodes in the workspace that have a direct dependency on IronPython2. This info is shown categorically in the Python migration dialog so that the users will have a better understanding of what they need to update. 

The list is shown in a tree view to differentiate between CN's that are from packages and the ones that are user defined. 
If the CN is user defined, then users can double click on the CN item and switch to its workspace to update the custom node to use CPython3 engine. If the CN is from a specific package, we show the package name and would expect the package authors to update the packages to use CPython3. The items in the list can be copy/paste-able. 

Based on the mockup provided in the task (https://jira.autodesk.com/browse/DYN-2797), I have created a first look of how the dialog would look like with all this information. 

![iron python dialog 2](https://user-images.githubusercontent.com/43763136/86849461-b2b6f080-c07d-11ea-9c31-8258b5184de2.gif)

As of now, the custom nodes from a single package are not grouped together and are instead shown as separate list items. To achieve this, we might need another dictionary which would contain all the list of CN's per package id. Also binding wpf dictionary data with multiple values seems little complicated. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

