### PR TITLE
Update PerformanceTest preloaded libraries

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/PerformanceTestHelper.cs
+++ b/tools/Performance/DynamoPerformanceTests/PerformanceTestHelper.cs
@@ -25,7 +25,6 @@ namespace DynamoPerformanceTests
                 "DesignScriptBuiltin.dll",
                 "DSCoreNodes.dll",
                 "DSOffice.dll",
-                "DSIronPython.dll",
                 "FunctionObject.ds",
                 "BuiltIn.ds",
                 "DynamoConversions.dll",


### PR DESCRIPTION
remove DSIronPython from default load as extension now loads it.

PTAL @QilongTang 