### PR TITLE
Fix preview hiding

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -490,8 +490,6 @@ namespace Dynamo.Controls
         {
             ViewModel.ZIndex = oldZIndex;
 
-            Debug.WriteLine($"Mouse over preview: {PreviewControl.IsMouseOver}");
-
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
             if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen || IsMouseInsidePreview(e) ||
                 (Mouse.Captured is DragCanvas && IsMouseInsideNodeOrPreview(e.GetPosition(this)))) return;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -493,8 +493,7 @@ namespace Dynamo.Controls
             Debug.WriteLine($"Mouse over preview: {PreviewControl.IsMouseOver}");
 
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
-            var insidePreview = IsMouseInsidePreview(e);
-            if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen || insidePreview ||
+            if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen || IsMouseInsidePreview(e) ||
                 (Mouse.Captured is DragCanvas && IsMouseInsideNodeOrPreview(e.GetPosition(this)))) return;
 
             // If it's expanded, then first condense it.
@@ -544,7 +543,7 @@ namespace Dynamo.Controls
                             preview.TransitionToState(PreviewControl.State.Expanded);
                         }
 
-                        if (!IsMouseOver && !PreviewControl.IsMouseOver)
+                        if (!IsMouseOver)
                         {
                             // If mouse is captured by DragCanvas and mouse is still over node, preview should stay open.
                             if (!(Mouse.Captured is DragCanvas && IsMouseInsideNodeOrPreview(Mouse.GetPosition(this))))
@@ -659,24 +658,8 @@ namespace Dynamo.Controls
             if (previewControl != null)
             {
                 var bounds = new Rect(0, 0, previewControl.ActualWidth, previewControl.ActualHeight);
-                //var bounds = VisualTreeHelper.GetDescendantBounds(previewControl);
                 var mousePosition = e.GetPosition(previewControl);
-                //var bounds = previewControl.BoundsRelativeTo(this);
-                //var mousePosition = e.GetPosition(this);
                 isInside = bounds.Contains(mousePosition);
-                //var mousePosition = e.GetPosition(previewControl);
-                //VisualTreeHelper.HitTest(
-                //    previewControl,
-                //    d =>
-                //    {
-                //        if (d == previewControl)
-                //        {
-                //            isInside = true;
-                //        }
-                //        return HitTestFilterBehavior.Stop;
-                //    },
-                //    ht => HitTestResultBehavior.Stop,
-                //    new PointHitTestParameters(mousePosition));
             }
 
             return isInside;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -88,7 +88,6 @@ namespace Dynamo.Controls
                 previewControl.StateChanged += OnPreviewControlStateChanged;
                 previewControl.bubbleTools.MouseEnter += OnPreviewControlMouseEnter;
                 previewControl.bubbleTools.MouseLeave += OnPreviewControlMouseLeave;
-                previewControl.MouseLeave += OnNodeViewMouseLeave;
                 expansionBay.Children.Add(previewControl);
             }
         }


### PR DESCRIPTION
### Purpose

Fixes a bug which would make the preview hide even when the mouse was
moved over a visible part of it. This happened only when the preview
area was wider than the node.

The cause of the bug I would argue is some very strange behavior of
HitTest. When run on the NodeView, this test would not consider the
right part of the preview, like if the box was as wide as the node but
displaced to the left.

Likewise, running a HitTest on the PreviewControl itself provided
inconsistent results. Initially this would work as expected, but after
the preview was expanded and recondensed, the box would remain forever
bloated as if still expanded. This resulted in inconsistencies with the
leave event, which used the real margins of the control.

The problem was fixed by checking explicitly that the preview visible
area is abandoned before hiding the preview.


![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/10048120/87478270-7c3a2200-c5f7-11ea-8d60-6973df74b015.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@DynamoDS/dynamo 
