### PR TITLE
Bump up version of IronPython test package, code cleanup

### DIFF
--- a/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
+++ b/src/PythonMigrationViewExtension/GraphPythonDependencies.cs
@@ -13,7 +13,7 @@ namespace Dynamo.PythonMigration
     {
         private ViewLoadedParams ViewLoaded { get; set; }
         internal static readonly string PythonPackage = "DSIronPython_Test";
-        internal static readonly Version PythonPackageVersion = new Version(1, 0, 7);
+        internal static readonly Version PythonPackageVersion = new Version(1, 0, 8);
 
 
         // A dictionary to mark Custom Nodes if they have a IronPython dependency or not. 
@@ -33,19 +33,12 @@ namespace Dynamo.PythonMigration
 
         private static bool IsIronPythonPackageLoaded()
         {
-            try
+            PythonEngineSelector.Instance.GetEvaluatorInfo(PythonEngineVersion.IronPython2,
+                out string evaluatorClass, out string evaluationMethod);
+            if (evaluatorClass == PythonEngineSelector.Instance.IronPythonEvaluatorClass &&
+                evaluationMethod == PythonEngineSelector.Instance.IronPythonEvaluationMethod)
             {
-                PythonEngineSelector.Instance.GetEvaluatorInfo(PythonEngineVersion.IronPython2,
-                    out string evaluatorClass, out string evaluationMethod);
-                if (evaluatorClass == PythonEngineSelector.Instance.IronPythonEvaluatorClass &&
-                    evaluationMethod == PythonEngineSelector.Instance.IronPythonEvaluationMethod)
-                {
-                    return true;
-                }
-            }
-            catch (Exception)
-            {
-                return false;
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
### Purpose

- Update version of IronPython test package to be installed from PM Dev for testing purposes. Make sure you target the Dev PM by changing the `DynamoPackages.dll.config` file to point to it. 
- Cleanup code that calls PythonEngineSelector API as it no longer throws an exception after #10897 

This is the final change that wraps up the following workflow:
1. Open workspace containing IronPython reference(s)
2. IronPython node displays warning saying the selected engine is missing (IronPython in this case)
3. The IP package displays as missing in the workspace references view
4. Installing the package specified in the WS references panel prompts user to install the same package
5. Installing the package from the PM automatically resolves the node and executes it

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@DynamoDS/dynamo 
