### PR TITLE
Respect the "Show Grid" setting when 3D background preview is disabled

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -167,7 +167,7 @@ namespace Dynamo.Configuration
                 if (value == isBackgroundGridVisible) return;
                 isBackgroundGridVisible = value;
 
-                RaisePropertyChanged("IsBackgroundGridVisible");
+                RaisePropertyChanged(nameof(IsBackgroundGridVisible));
             }
         }
 

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -20,6 +20,7 @@ namespace Dynamo.Configuration
         private string numberFormat;
         private string lastUpdateDownloadPath;
         private int maxNumRecentFiles;
+        private bool isBackgroundGridVisible;
 
         #region Constants
         /// <summary>
@@ -155,7 +156,21 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Should the background grid be shown?
         /// </summary>
-        public bool IsBackgroundGridVisible { get; set; }
+        public bool IsBackgroundGridVisible
+        {
+            get
+            {
+                return isBackgroundGridVisible;
+            }
+            set
+            {
+                if (value == isBackgroundGridVisible) return;
+                isBackgroundGridVisible = value;
+
+                RaisePropertyChanged("IsBackgroundGridVisible");
+            }
+        }
+
 
         /// <summary>
         /// Indicates whether background preview is active or not.

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1800,9 +1800,15 @@ namespace Dynamo.ViewModels
 
         public void ToggleBackgroundGridVisibility(object parameter)
         {
-            if (BackgroundPreviewViewModel == null || !BackgroundPreviewViewModel.Active) return;
-
-            BackgroundPreviewViewModel.IsGridVisible = !BackgroundPreviewViewModel.IsGridVisible;
+            if (BackgroundPreviewViewModel != null)
+            {
+                // This will change both the live object property and the PreferenceSettings for persistence
+                BackgroundPreviewViewModel.IsGridVisible = !BackgroundPreviewViewModel.IsGridVisible;
+            }
+            else
+            {
+                PreferenceSettings.IsBackgroundGridVisible = !PreferenceSettings.IsBackgroundGridVisible;
+            }
         }
 
         internal bool CanToggleBackgroundGridVisibility(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -390,7 +390,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public override bool IsGridVisible
         {
-            get { return isGridVisible && Active; }
+            get { return isGridVisible; }
             set
             {
                 if (isGridVisible == value) return;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -583,8 +583,8 @@
                             </MenuItem>
 
                             <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuShowGrid}"
-                                      IsEnabled="{Binding BackgroundPreviewActive}"
-                                      IsChecked="{Binding BackgroundPreviewViewModel.IsGridVisible}"
+                                      IsEnabled="True"
+                                      IsChecked="{Binding PreferenceSettings.IsBackgroundGridVisible}"
                                       Focusable="False"
                                       Command="{Binding ToggleBackgroundGridVisibilityCommand}" />
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -136,11 +136,22 @@
 
         <controls:InfiniteGridView x:Name="infiniteGridView"
                                    IsHitTestVisible="False">
-            <controls:InfiniteGridView.Visibility>
-                <Binding Path="DataContext.BackgroundPreviewActive"
-                         Converter="{StaticResource InverseBoolToVisibilityConverter}"
-                         RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
-            </controls:InfiniteGridView.Visibility>
+            <controls:InfiniteGridView.Style>
+                <Style TargetType="controls:InfiniteGridView">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Value="True" Binding="{Binding Path=DataContext.PreferenceSettings.IsBackgroundGridVisible,
+                                           RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                                <Condition Value="False" Binding="{Binding Path=DataContext.BackgroundPreviewViewModel.Active,
+                                           RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </controls:InfiniteGridView.Style>
         </controls:InfiniteGridView>
 
         <!-- Assigning a ZoomBorder.Background so that it can receive mouse input -->


### PR DESCRIPTION
### Purpose

When the 3D background preview is disabled, a 2D grid is shown behind the node graph. This grid cannot be disabled, while the 3D coordinate system grid can be turned off by unchecking View > Background Preview > Show Grid. This PR causes this setting to control the display of both the 3D and the 2D grid.

#### UI when 3D preview is off and Show Grid is off
![image](https://user-images.githubusercontent.com/712405/88019816-9775c780-caf8-11ea-8d00-105f00898e55.png)


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
