### PR TITLE
Load library in test, required by extension

### DIFF
--- a/test/ViewExtensionLibraryTests/LibraryViewControllerTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryViewControllerTests.cs
@@ -35,6 +35,14 @@ namespace ViewExtensionLibraryTests
             };
         }
 
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            // The tests here don't really require this library, but the Python migration extension
+            // will attach itself to the workspace and it depends on PythonNodeModels but does not copy it.
+            // Ideally we would remove the extension for these tests, but not sure that can be done.
+            libraries.Add("DSCPython.dll");
+        }
+
         [Test]
         [Category("UnitTests")]
         public void CreatingNodeCustomNodeDefinitionOrUpdatingItShouldRaiseUpdate()


### PR DESCRIPTION
### Purpose

The Python migration extension now depends on PythonNodeModels.
However, the dependency is not private, so the dll might be absent
when running tests in parallel. Since the extension is installed but a
dependency is missing, activating it will result in load exceptions.
That is the case for the test here.

The problem is fixed by forcing the dll to be loaded indirectly, by
adding DSCPython as a library to preload. That makes sure
PythonNodeModels will be available during the test run and that the
extension won't fail because of its absence.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@DynamoDS/dynamo 
