### PR TITLE
Allow printing in Python nodes with DynamoPrint

### DIFF
--- a/src/DynamoCore/Configuration/ExecutionSession.cs
+++ b/src/DynamoCore/Configuration/ExecutionSession.cs
@@ -25,6 +25,7 @@ namespace Dynamo.Configuration
             parameters[ParameterKeys.NumberFormat] = model.PreferenceSettings.NumberFormat;
             parameters[ParameterKeys.LastExecutionDuration] = new TimeSpan(updateTask.ExecutionEndTime.TickCount - updateTask.ExecutionStartTime.TickCount);
             parameters[ParameterKeys.PackagePaths] = pathManager.PackagesDirectories;
+            parameters[ParameterKeys.Logger] = model.Logger;
         }
 
         /// <summary>

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -244,8 +244,9 @@ namespace DSCPython
         /// <param name="bindingValues">List of binding values received for evaluation</param>
         private static void ProcessAdditionalBindings(PyScope scope, IList bindingNames, IList bindingValues)
         {
+            const string NodeNameInput = "Name";
             string nodeName;
-            if (bindingNames.Count == 0 || !bindingNames[0].Equals("Name"))
+            if (bindingNames.Count == 0 || !bindingNames[0].Equals(NodeNameInput))
             {
                 // Defensive code to fallback in case the additional binding is not there, like
                 // when the evaluator is called directly in unit tests.

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using Autodesk.DesignScript.Runtime;
 using DSCPython.Encoders;
+using Dynamo.Events;
+using Dynamo.Session;
 using Dynamo.Utilities;
 using Python.Runtime;
 
@@ -196,6 +198,10 @@ namespace DSCPython
                         {
                             scope.Set((string)bindingNames[i], InputMarshaler.Marshal(bindingValues[i]).ToPython());
                         }
+
+                        dynamic logger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger);
+                        Action<string> logFunction = msg => logger.Log($"USER: {msg}");
+                        scope.Set("DynamoPrint", logFunction.ToPython());
 
                         try
                         {

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -254,6 +254,7 @@ namespace DSCPython
             {
                 bindingNames.RemoveAt(0);
                 nodeName = (string)bindingValues[0];
+                bindingValues.RemoveAt(0);
             }
             dynamic logger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger);
             Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}");

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -171,6 +171,7 @@ namespace DSIronPython
             {
                 bindingNames.RemoveAt(0);
                 nodeName = (string)bindingValues[0];
+                bindingValues.RemoveAt(0);
             }
             dynamic logger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger);
             Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}");

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Autodesk.DesignScript.Runtime;
+using Dynamo.Events;
+using Dynamo.Session;
 using Dynamo.Utilities;
 using IronPython.Hosting;
 
@@ -121,6 +123,8 @@ namespace DSIronPython
             ScriptEngine engine = prev_script.Engine;
             ScriptScope scope = engine.CreateScope();
 
+            ProcessAdditionalBindings(scope, bindingNames, bindingValues);
+
             int amt = Math.Min(bindingNames.Count, bindingValues.Count);
 
             for (int i = 0; i < amt; i++)
@@ -146,6 +150,31 @@ namespace DSIronPython
             var result = scope.ContainsVariable("OUT") ? scope.GetVariable("OUT") : null;
 
             return OutputMarshaler.Marshal(result);
+        }
+
+        /// <summary>
+        /// Processes additional bindings that are not actual inputs.
+        /// Currently, only the node name is received in this way.
+        /// </summary>
+        /// <param name="scope">Python scope where execution will occur</param>
+        /// <param name="bindingNames">List of binding names received for evaluation</param>
+        /// <param name="bindingValues">List of binding values received for evaluation</param>
+        private static void ProcessAdditionalBindings(ScriptScope scope, IList bindingNames, IList bindingValues)
+        {
+            string nodeName;
+            if (!bindingNames[0].Equals("Name"))
+            {
+                // Defensive code to fallback in case the additional binding is not there for some reason
+                nodeName = "USER";
+            }
+            else
+            {
+                bindingNames.RemoveAt(0);
+                nodeName = (string)bindingValues[0];
+            }
+            dynamic logger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger);
+            Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}");
+            scope.SetVariable("DynamoPrint", logFunction);
         }
 
         #region Marshalling

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -161,8 +161,9 @@ namespace DSIronPython
         /// <param name="bindingValues">List of binding values received for evaluation</param>
         private static void ProcessAdditionalBindings(ScriptScope scope, IList bindingNames, IList bindingValues)
         {
+            const string NodeNameInput = "Name";
             string nodeName;
-            if (bindingNames.Count == 0 || !bindingNames[0].Equals("Name"))
+            if (bindingNames.Count == 0 || !bindingNames[0].Equals(NodeNameInput))
             {
                 // Defensive code to fallback in case the additional binding is not there, like
                 // when the evaluator is called directly in tests, passing bindings manually.

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -181,7 +181,10 @@ namespace PythonNodeModels
                 CreateOutputAST(
                     AstFactory.BuildStringNode(script),
                     inputAstNodes,
-                    new List<Tuple<string, AssociativeNode>>())
+                    new List<Tuple<string, AssociativeNode>>()
+                    {
+                        Tuple.Create<string, AssociativeNode>(nameof(Name), AstFactory.BuildStringNode(Name))
+                    })
             };
         }
 
@@ -270,7 +273,10 @@ namespace PythonNodeModels
                 CreateOutputAST(
                     inputAstNodes[0],
                     inputAstNodes.Skip(1).ToList(),
-                    new List<Tuple<string, AssociativeNode>>())
+                    new List<Tuple<string, AssociativeNode>>()
+                    {
+                        Tuple.Create<string, AssociativeNode>(nameof(Name), AstFactory.BuildStringNode(Name))
+                    })
             };
         }
     }

--- a/src/NodeServices/ExecutionSession.cs
+++ b/src/NodeServices/ExecutionSession.cs
@@ -35,7 +35,7 @@ namespace Dynamo.Session
         /// <returns>True if the file is found</returns>
         bool ResolveFilePath(ref string filepath);
     }
-    //TODO(DYN-2879) make this class static for Dynamo 3.
+    //TODO(DYN-2879) make this class static for Dynamo 3. Maybe an enum?
     /// <summary>
     /// List of possible session parameter keys to obtain the session parameters.
     /// </summary>
@@ -75,5 +75,11 @@ namespace Dynamo.Session
         /// The Return value is IEnumerable
         /// </summary>
         public static readonly string PackagePaths = nameof(PackagePaths);
+
+        /// <summary>
+        /// The logger that logs to the Dynamo console.
+        /// The return value is an ILogger
+        /// </summary>
+        public static readonly string Logger = nameof(Logger);
     }
 }

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="PythonEvalTests.cs" />
     <Compile Include="PythonEditTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PythonTestsWithLogging.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\DynamoCoreWpf\DynamoCoreWpf.csproj">

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -614,5 +614,15 @@ namespace Dynamo.Tests
             Assert.IsEmpty(DynamoCPythonHandle.HandleCountMap.Where(x => x.ToString().Contains("myClass")));
 
         }
+
+        [Test]
+        public void DynamoPrintInCPython()
+        {
+            var examplePath = Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+            var consoleOut = Console.Out;
+            Console.SetOut()
+            StringAssert.EndsWith("Hello from Python!!!", ViewModel.Model.Logger.LogText);
+        }
     }
 }

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -614,15 +614,5 @@ namespace Dynamo.Tests
             Assert.IsEmpty(DynamoCPythonHandle.HandleCountMap.Where(x => x.ToString().Contains("myClass")));
 
         }
-
-        [Test]
-        public void DynamoPrintInCPython()
-        {
-            var examplePath = Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn");
-            ViewModel.OpenCommand.Execute(examplePath);
-            var consoleOut = Console.Out;
-            Console.SetOut()
-            StringAssert.EndsWith("Hello from Python!!!", ViewModel.Model.Logger.LogText);
-        }
     }
 }

--- a/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
+++ b/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Dynamo;
+using Dynamo.Interfaces;
+using Dynamo.Models;
+using NUnit.Framework;
+
+namespace DynamoPythonTests
+{
+    /// <summary>
+    /// Python tests that require real logging to be enabled (StartInTestMode = false)
+    /// </summary>
+    public class PythonTestsWithLogging : DynamoModelTestBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("DSCPython.dll");
+            libraries.Add("DSIronPython.dll");
+        }
+
+        protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPreferences settings)
+        {
+            var config = base.CreateStartConfiguration(settings);
+            config.StartInTestMode = false;
+            return config;
+        }
+
+        [Test]
+        public void DynamoPrintLogsToConsole()
+        {
+            var expectedOutput = "Greeting CPython node: Hello from Python3!!!" + Environment.NewLine
+                + "Greeting IronPython node: Hello from Python2!!!" + Environment.NewLine;
+
+            CurrentDynamoModel.OpenFileFromPath(Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn"));
+            StringAssert.EndsWith(expectedOutput, CurrentDynamoModel.Logger.LogText);
+        }
+    }
+}

--- a/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
+++ b/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
@@ -30,7 +30,9 @@ namespace DynamoPythonTests
         public void DynamoPrintLogsToConsole()
         {
             var expectedOutput = "Greeting CPython node: Hello from Python3!!!" + Environment.NewLine
-                + "Greeting IronPython node: Hello from Python2!!!" + Environment.NewLine;
+                + "Greeting IronPython node: Hello from Python2!!!" + Environment.NewLine
+                + "Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
+                + "Greeting IronPython String node: Hello from Python2!!!" + Environment.NewLine;
 
             CurrentDynamoModel.OpenFileFromPath(Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn"));
             StringAssert.EndsWith(expectedOutput, CurrentDynamoModel.Logger.LogText);

--- a/test/core/python/DynamoPrint.dyn
+++ b/test/core/python/DynamoPrint.dyn
@@ -12,7 +12,7 @@
     {
       "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
       "NodeType": "PythonScriptNode",
-      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\nclr.AddReference('ProtoGeometry')\r\nfrom Autodesk.DesignScript.Geometry import *\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\nDynamoPrint('Hello from Python!!!')\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = 0",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\nclr.AddReference('ProtoGeometry')\r\nfrom Autodesk.DesignScript.Geometry import *\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\nDynamoPrint('Hello from Python' + str(sys.version_info.major) + '!!!')\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = 0",
       "Engine": "CPython3",
       "VariableInputPorts": true,
       "Id": "7fa1ef232e13484586b692c71d9e5c70",
@@ -40,9 +40,47 @@
       ],
       "Replication": "Disabled",
       "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\nclr.AddReference('ProtoGeometry')\r\nfrom Autodesk.DesignScript.Geometry import *\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\nDynamoPrint('Hello from Python' + str(sys.version_info.major) + '!!!')\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = 0",
+      "Engine": "IronPython2",
+      "VariableInputPorts": true,
+      "Id": "b518fc1118b745898bf5b840e3ea1c35",
+      "Inputs": [
+        {
+          "Id": "1b76bf9b56f943718514b62adb561e28",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e85535a49d2b4850ab95e6950405d015",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
     }
   ],
-  "Connectors": [],
+  "Connectors": [
+    {
+      "Start": "6138bc73890041e5837b37cbd69f47ea",
+      "End": "1b76bf9b56f943718514b62adb561e28",
+      "Id": "b938a0e52e4f4036b4c7f2a2d91debeb"
+    }
+  ],
   "Dependencies": [],
   "NodeLibraryDependencies": [],
   "Bindings": [],
@@ -51,7 +89,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.8.0.2026",
+      "Version": "2.8.0.2035",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -70,13 +108,23 @@
     "NodeViews": [
       {
         "ShowGeometry": true,
-        "Name": "Python Script",
+        "Name": "Greeting CPython node",
         "Id": "7fa1ef232e13484586b692c71d9e5c70",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 300.0,
-        "Y": 202.0
+        "X": 78.399999999999977,
+        "Y": 154.8
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Greeting IronPython node",
+        "Id": "b518fc1118b745898bf5b840e3ea1c35",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 383.2000000000001,
+        "Y": 154.80000000000007
       }
     ],
     "Annotations": [],

--- a/test/core/python/DynamoPrint.dyn
+++ b/test/core/python/DynamoPrint.dyn
@@ -1,0 +1,87 @@
+{
+  "Uuid": "04e3a62a-e290-415b-89c7-0a9255901527",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "DynamoPrint",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\nclr.AddReference('ProtoGeometry')\r\nfrom Autodesk.DesignScript.Geometry import *\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\nDynamoPrint('Hello from Python!!!')\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = 0",
+      "Engine": "CPython3",
+      "VariableInputPorts": true,
+      "Id": "7fa1ef232e13484586b692c71d9e5c70",
+      "Inputs": [
+        {
+          "Id": "706e32b4ce344fea908d1c184e06722b",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6138bc73890041e5837b37cbd69f47ea",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.8.0.2026",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "7fa1ef232e13484586b692c71d9e5c70",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 300.0,
+        "Y": 202.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/python/DynamoPrint.dyn
+++ b/test/core/python/DynamoPrint.dyn
@@ -72,6 +72,106 @@
       ],
       "Replication": "Disabled",
       "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonStringNode, PythonNodeModels",
+      "Engine": "CPython3",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "cb1179986e5a49b68b009fca1f5f1d5e",
+      "Inputs": [
+        {
+          "Id": "a5e1640b724f48d6b45f5fdc99685b80",
+          "Name": "script",
+          "Description": "Python script to run.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "885b416f700c45f3a1528e5d3ceb1c28",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8a5143690b1345f9a9a77057a4a60a0f",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs a IronPython script from a string."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.StringInput, CoreNodeModels",
+      "NodeType": "StringInputNode",
+      "InputValue": "import sys\r\nDynamoPrint('Hello from Python' + str(sys.version_info.major) + '!!!')",
+      "Id": "8dd9296336d04ca8850b267e86f04156",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "b9b37c561566490cb54e6ad8236b71be",
+          "Name": "",
+          "Description": "String",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a string."
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonStringNode, PythonNodeModels",
+      "Engine": "IronPython2",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "f18a8dde5074415da6ac87614b7d53a3",
+      "Inputs": [
+        {
+          "Id": "be1ffa19bc9d4c53a84d8215f262361c",
+          "Name": "script",
+          "Description": "Python script to run.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "49a744a183dc4f0daf079c5dbb959849",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cf0b0de0487f440fb84ecda9e67bc7d7",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs a IronPython script from a string."
     }
   ],
   "Connectors": [
@@ -79,6 +179,26 @@
       "Start": "6138bc73890041e5837b37cbd69f47ea",
       "End": "1b76bf9b56f943718514b62adb561e28",
       "Id": "b938a0e52e4f4036b4c7f2a2d91debeb"
+    },
+    {
+      "Start": "e85535a49d2b4850ab95e6950405d015",
+      "End": "885b416f700c45f3a1528e5d3ceb1c28",
+      "Id": "094dc52bc61b487a9b4cd5eafda72120"
+    },
+    {
+      "Start": "8a5143690b1345f9a9a77057a4a60a0f",
+      "End": "49a744a183dc4f0daf079c5dbb959849",
+      "Id": "d67fd627a8c64f51a36a0eb819d533ae"
+    },
+    {
+      "Start": "b9b37c561566490cb54e6ad8236b71be",
+      "End": "a5e1640b724f48d6b45f5fdc99685b80",
+      "Id": "77aa15954970471fbf4083faa78db2d5"
+    },
+    {
+      "Start": "b9b37c561566490cb54e6ad8236b71be",
+      "End": "be1ffa19bc9d4c53a84d8215f262361c",
+      "Id": "f2bb060269f74f638b266f05b6cb5f98"
     }
   ],
   "Dependencies": [],
@@ -113,8 +233,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 78.399999999999977,
-        "Y": 154.8
+        "X": 15.199999999999989,
+        "Y": 27.600000000000037
       },
       {
         "ShowGeometry": true,
@@ -123,8 +243,38 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 383.2000000000001,
-        "Y": 154.80000000000007
+        "X": 279.6,
+        "Y": 28.400000000000077
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Greeting CPython String node",
+        "Id": "cb1179986e5a49b68b009fca1f5f1d5e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 26.0,
+        "Y": 283.2000000000001
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "String",
+        "Id": "8dd9296336d04ca8850b267e86f04156",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 13.999999999999943,
+        "Y": 151.59999999999991
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Greeting IronPython String node",
+        "Id": "f18a8dde5074415da6ac87614b7d53a3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 315.2,
+        "Y": 284.40000000000009
       }
     ],
     "Annotations": [],

--- a/test/core/python/python_refDynamoServices.dyn
+++ b/test/core/python/python_refDynamoServices.dyn
@@ -12,7 +12,7 @@
     {
       "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
       "NodeType": "PythonScriptNode",
-      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\n\r\nclr.AddReference('DynamoServices')\r\nfrom Dynamo.Events import ExecutionEvents\r\n\r\n\r\npackagePathsKey = list(ExecutionEvents.ActiveSession.GetParameterKeys())[-1]\r\n##or packagePathsKey = \"PackagePaths\"\r\n\r\nOUT = ExecutionEvents.ActiveSession.GetParameterValue(packagePathsKey)",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\n\r\nclr.AddReference('DynamoServices')\r\nfrom Dynamo.Events import ExecutionEvents\r\nfrom Dynamo.Session import ParameterKeys\r\n\r\n\r\npackagePathsKey = ParameterKeys.PackagePaths\r\n\r\nOUT = ExecutionEvents.ActiveSession.GetParameterValue(packagePathsKey)",
       "Engine": "IronPython2",
       "VariableInputPorts": true,
       "Id": "296e339254e845b695caa1a116500be0",
@@ -51,7 +51,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.8.0.1825",
+      "Version": "2.8.0.2036",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },


### PR DESCRIPTION
### Purpose

Adds basic logging functionality to Python node and Python String node.
Logging is done to the Dynamo console using a function added to the
Python scopes named DynamoPrint. The function prefixes the node name to
the log entry. These log entries are only added to the ConsoleLog.

<img width="1121" alt="Screen Shot 2020-07-22 at 12 48 08 PM" src="https://user-images.githubusercontent.com/10048120/88204691-abfdb100-cc19-11ea-9adc-9c1bdbcfe513.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@SHKnudsen @radumg @Amoursol 
