### PR TITLE
Opening graph with custom nodes from missing packages correctly loads in Dynamo.

### DIFF
--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -353,6 +353,6 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(GraphPythonDependencies.PythonPackage, pkgDependencyInfo.Name);
             Assert.AreEqual(GraphPythonDependencies.PythonPackageVersion, pkgDependencyInfo.Version);
         }
-    }
 
+    }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -354,4 +354,5 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(GraphPythonDependencies.PythonPackageVersion, pkgDependencyInfo.Version);
         }
     }
+
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -353,6 +353,5 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(GraphPythonDependencies.PythonPackage, pkgDependencyInfo.Name);
             Assert.AreEqual(GraphPythonDependencies.PythonPackageVersion, pkgDependencyInfo.Version);
         }
-
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -241,13 +242,22 @@ namespace DynamoCoreWpfTests
         [Test]
         public void VerifyDynamoLoadingOnOpeningWorkspaceWithMissingCustomNodes()
         {
+            List<string> dependenciesList = new List<string>() { "MeshToolkit", "Clockwork for Dynamo 1.x", "Clockwork for Dynamo 2.x", "Dynamo Samples" };
             DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
+
             var examplePath = Path.Combine(@"core\packageDependencyTests\PackageDependencyStates.dyn");
             Open(examplePath);
             Assert.AreEqual(1, View.ExtensionTabItems.Count);
-            var workspaceViewExtension = View.viewExtensionManager.ViewExtensions.Where(x => x.Name.Equals("Workspace References")).Count();
-            Assert.AreEqual(1, workspaceViewExtension);
+
+            var workspaceViewExtension = (WorkspaceDependencyViewExtension) View.viewExtensionManager.ViewExtensions
+                                                                                .Where(x => x.Name.Equals("Workspace References")).FirstOrDefault();
+
+            foreach (PackageDependencyRow packageDependencyRow in workspaceViewExtension.DependencyView.dataRows) 
+            {
+                var dependencyInfo = packageDependencyRow.DependencyInfo;
+                Assert.Contains(dependencyInfo.Name, dependenciesList);
+            }
         }
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -236,9 +236,18 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual("Workspace References", viewExtension.Name);
 
             Assert.AreEqual("A6706BF5-11C2-458F-B7C8-B745A77EF7FD", viewExtension.UniqueId);
-
         }
 
-        
+        [Test]
+        public void VerifyDynamoLoadingOnOpeningWorkspaceWithMissingCustomNodes()
+        {
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
+            DynamoModel.IsTestMode = false;
+            var examplePath = Path.Combine(@"core\packageDependencyTests\PackageDependencyStates.dyn");
+            Open(examplePath);
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            var workspaceViewExtension = View.viewExtensionManager.ViewExtensions.Where(x => x.Name.Equals("Workspace References")).Count();
+            Assert.AreEqual(1, workspaceViewExtension);
+        }
     }
 }


### PR DESCRIPTION
### Purpose

The regression mentioned in https://jira.autodesk.com/browse/DYN-2936 is already fixed by @aparajit-pratap here in this PR: 
https://github.com/DynamoDS/Dynamo/pull/10869/files#diff-f13147450a5b0038bab03d9f6493aff8R100

The reason it was failing was because if the package that contains the custom node is missing, the custom manager will not have the CN information and in that case we just want to skip it. In that case, it wont be shown in the PythonMigration dialog even if the CN has IronPython2 nodes in it. Users will need to resolve the custom nodes first from WorkspaceDependency viewer and then when they switch to that workspace, the dialog will be shown.

I am just adding a test for that regression in this PR as the fix is already in master. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @mjkkirschner 

### FYIs

@DynamoDS/dynamo 