### PR TITLE
Custom Node containing IronPython nodes shows dialog alert once per session

### DIFF
--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -73,7 +73,8 @@ namespace Dynamo.PythonMigration
         private void DisplayIronPythonDialog()
         {
             // we only want to create the dialog ones for each graph per Dynamo session, if the global setting is not disabled
-            if (DynamoViewModel.IsIronPythonDialogDisabled || DialogTracker.ContainsKey(CurrentWorkspace.Guid) || DialogTracker.ContainsKey((CurrentWorkspace as CustomNodeWorkspaceModel).CustomNodeId))
+            if (DynamoViewModel.IsIronPythonDialogDisabled || DialogTracker.ContainsKey(CurrentWorkspace.Guid)) return;
+            if (CurrentWorkspace is CustomNodeWorkspaceModel && DialogTracker.ContainsKey((CurrentWorkspace as CustomNodeWorkspaceModel).CustomNodeId))
                 return;
 
             var dialog = new IronPythonInfoDialog(this)
@@ -87,7 +88,7 @@ namespace Dynamo.PythonMigration
             }), DispatcherPriority.Background);
 
             DialogTracker[CurrentWorkspace.Guid] = dialog;
-            if (CurrentWorkspace.GetType() == typeof(CustomNodeWorkspaceModel)){
+            if (CurrentWorkspace is CustomNodeWorkspaceModel){
                 DialogTracker[(CurrentWorkspace as CustomNodeWorkspaceModel).CustomNodeId] = dialog;
             }
         }

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -73,7 +73,7 @@ namespace Dynamo.PythonMigration
         private void DisplayIronPythonDialog()
         {
             // we only want to create the dialog ones for each graph per Dynamo session, if the global setting is not disabled
-            if (DialogTracker.ContainsKey(CurrentWorkspace.Guid) || DynamoViewModel.IsIronPythonDialogDisabled)
+            if (DynamoViewModel.IsIronPythonDialogDisabled || DialogTracker.ContainsKey(CurrentWorkspace.Guid) || DialogTracker.ContainsKey((CurrentWorkspace as CustomNodeWorkspaceModel).CustomNodeId))
                 return;
 
             var dialog = new IronPythonInfoDialog(this)
@@ -87,6 +87,9 @@ namespace Dynamo.PythonMigration
             }), DispatcherPriority.Background);
 
             DialogTracker[CurrentWorkspace.Guid] = dialog;
+            if (CurrentWorkspace.GetType() == typeof(CustomNodeWorkspaceModel)){
+                DialogTracker[(CurrentWorkspace as CustomNodeWorkspaceModel).CustomNodeId] = dialog;
+            }
         }
 
         private void LogIronPythonNotification()

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -334,6 +334,47 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
         }
 
+        /// <summary>
+        /// This test verifies that the IronPython dialog wont show the second time a custom node is opened
+        /// even if it contains IronPython nodes
+        /// </summary>
+        [Test]
+        public void WillNotDisplayDialogWhenOpeningCustomNodeWithIronPythonNodesSecondTimeInSameSession()
+        {
+            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
+            DynamoModel.IsTestMode = false;
+            // Arrange
+            var examplePathIronPython = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "PythonCustomNodeTest.dyf");
+            var examplePathEmptyFile = Path.Combine(UnitTestBase.TestDirectory, @"core\Home.dyn");
+
+            // Act
+            // open file
+            Open(examplePathIronPython);
+            var ironPythonCustomNodeId = (this.ViewModel.CurrentSpace as CustomNodeWorkspaceModel).CustomNodeId;
+            DispatcherUtil.DoEvents();
+
+            var ironPythonDialog = this.View.GetChildrenWindowsOfType<IronPythonInfoDialog>().First();
+            Assert.IsNotNull(ironPythonDialog);
+            Assert.IsTrue(ironPythonDialog.IsLoaded);
+            ironPythonDialog.OkBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            DispatcherUtil.DoEvents();
+            // Open empty file before open the the IronPython file again
+            Open(examplePathEmptyFile);
+            Assert.AreNotEqual(ironPythonCustomNodeId, this.ViewModel.CurrentSpace.Guid);
+            DispatcherUtil.DoEvents();
+
+            Open(examplePathIronPython);
+            Assert.AreEqual(ironPythonCustomNodeId, (this.ViewModel.CurrentSpace as CustomNodeWorkspaceModel).CustomNodeId);
+            var secondIronPythonDialog = this.View.GetChildrenWindowsOfType<IronPythonInfoDialog>();
+
+            DispatcherUtil.DoEvents();
+            // Assert
+            Assert.AreEqual(0, secondIronPythonDialog.Count());
+            DynamoModel.IsTestMode = true;
+            DispatcherUtil.DoEvents();
+        }
+
         [Test]
         public void IronPythonPackageLoadedTest()
         {


### PR DESCRIPTION
### Purpose

Do not let IronPython dialog alerts show more than once for a custom node in a session.
Used Custom Node ID to identify previously opened nodes.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [] All tests pass using the self-service CI.

### Reviewers

@DynamoDS/dynamo 
