### PR TITLE
T1.4-Update ScriptEditorWindow

### DIFF
--- a/src/Libraries/PythonNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/PythonNodeModels/Properties/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace PythonNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use this dropdown to choose the python version/engine to execute your code..
+        /// </summary>
+        public static string PythonScriptEditorEngineDropdownTooltip {
+            get {
+                return ResourceManager.GetString("PythonScriptEditorEngineDropdownTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Load the Python Standard and DesignScript Libraries.
         /// </summary>
         public static string PythonScriptEditorImports {
@@ -194,26 +203,6 @@ namespace PythonNodeModels.Properties {
                 return ResourceManager.GetString("PythonScriptEditorMigrationAssistantButtonTooltip", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Use this dropdown to choose the python version/engine to execute your code..
-        /// </summary>
-        public static string PythonScriptEditorEngineDropdownTooltip
-        {
-            get
-            {
-                return ResourceManager.GetString("PythonScriptEditorEngineDropdownTooltip", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Learn More.
-        /// </summary>
-        public static string PythonScriptEditorMoreInfoButton {
-            get {
-                return ResourceManager.GetString("PythonScriptEditorMoreInfoButton", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to Learn about Python3 updates..
@@ -230,15 +219,6 @@ namespace PythonNodeModels.Properties {
         public static string PythonScriptEditorOutputComment {
             get {
                 return ResourceManager.GetString("PythonScriptEditorOutputComment", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Revert.
-        /// </summary>
-        public static string PythonScriptEditorRevertButton {
-            get {
-                return ResourceManager.GetString("PythonScriptEditorRevertButton", resourceCulture);
             }
         }
         
@@ -266,15 +246,6 @@ namespace PythonNodeModels.Properties {
         public static string PythonScriptEditorRunButtonTooltip {
             get {
                 return ResourceManager.GetString("PythonScriptEditorRunButtonTooltip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Save.
-        /// </summary>
-        public static string PythonScriptEditorSaveChangesButton {
-            get {
-                return ResourceManager.GetString("PythonScriptEditorSaveChangesButton", resourceCulture);
             }
         }
         

--- a/src/Libraries/PythonNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/PythonNodeModels/Properties/Resources.en-US.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,144 +59,138 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="metadata">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" use="required" type="xsd:string"/>
-                            <xsd:attribute name="type" type="xsd:string"/>
-                            <xsd:attribute name="mimetype" type="xsd:string"/>
-                            <xsd:attribute ref="xml:space"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="assembly">
-                        <xsd:complexType>
-                            <xsd:attribute name="alias" type="xsd:string"/>
-                            <xsd:attribute name="name" type="xsd:string"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-                            <xsd:attribute ref="xml:space"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>2.0</value>
-    </resheader>
-    <resheader name="reader">
-        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <resheader name="writer">
-        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <data name="DeletingPythonNodeWithOpenEditorMessage" xml:space="preserve">
-        <value>The Python node "{0}" still has a script editor window open. Are you sure you want to close the editor and delete the node?</value>
-    </data>
-    <data name="DeletingPythonNodeWithOpenEditorTitle" xml:space="preserve">
-        <value>Script Editor Open</value>
-    </data>
-    <data name="EditHeader" xml:space="preserve">
-        <value>Edit...</value>
-    </data>
-    <data name="PythonMigrationWarningUriString" xml:space="preserve">
-        <value>PythonNodeModels;PythonMigrationWarning.html</value>
-    </data>
-    <data name="PythonNodeContextMenuEngineSwitcher" xml:space="preserve">
-        <value>Python Engine Version</value>
-    </data>
-    <data name="PythonNodeContextMenuEngineVersionThree" xml:space="preserve">
-        <value>CPython3</value>
-    </data>
-    <data name="PythonNodeContextMenuEngineVersionTwo" xml:space="preserve">
-        <value>IronPython2</value>
-    </data>
-    <data name="PythonNodeContextMenuLearnMoreButton" xml:space="preserve">
-        <value>Learn more about Python</value>
-    </data>
-    <data name="PythonNodePortDataOutputToolTip" xml:space="preserve">
-        <value>Result of the python script</value>
-    </data>
-    <data name="PythonScriptDescription" xml:space="preserve">
-        <value>Runs an embedded IronPython script.</value>
-        <comment>Description for Python Script</comment>
-    </data>
-    <data name="PythonScriptEditorCaption" xml:space="preserve">
-        <value>Edit Python Script...</value>
-    </data>
-    <data name="PythonScriptEditorCodeComment" xml:space="preserve">
-        <value>Place your code below this line</value>
-    </data>
-    <data name="PythonScriptEditorImports" xml:space="preserve">
-        <value>Load the Python Standard and DesignScript Libraries</value>
-    </data>
-    <data name="PythonScriptEditorInputComment" xml:space="preserve">
-        <value>The inputs to this node will be stored as a list in the IN variables.</value>
-        <comment>It is comment in the code. IN shouldn't be translated.</comment>
-    </data>
-    <data name="PythonScriptEditorMoreInfoButton" xml:space="preserve">
-        <value>Learn More</value>
-    </data>
-    <data name="PythonScriptEditorMoreInfoButtonTooltip" xml:space="preserve">
-        <value>Learn about Python3 updates.</value>
-    </data>
-    <data name="PythonScriptEditorOutputComment" xml:space="preserve">
-        <value>Assign your output to the OUT variable.</value>
-        <comment>It is comment in the code. OUT shouldn't be translated.</comment>
-    </data>
-    <data name="PythonScriptEditorRevertButton" xml:space="preserve">
-        <value>Revert</value>
-    </data>
-    <data name="PythonScriptEditorRevertButtonTooltip" xml:space="preserve">
-        <value>Revert the changes made to current Python node editor and close it.</value>
-    </data>
-    <data name="PythonScriptEditorRunButton" xml:space="preserve">
-        <value>Run</value>
-    </data>
-    <data name="PythonScriptEditorRunButtonTooltip" xml:space="preserve">
-        <value>Save current code in Python node editor and run graph with it.</value>
-    </data>
-    <data name="PythonScriptEditorSaveChangesButton" xml:space="preserve">
-        <value>Save</value>
-    </data>
-    <data name="PythonScriptEditorSaveChangesButtonTooltip" xml:space="preserve">
-        <value>Save the changes made to current Python node editor and close it.</value>
-    </data>
-    <data name="PythonScriptFromStringDescription" xml:space="preserve">
-        <value>Runs a IronPython script from a string.</value>
-        <comment>Description for Python Script From String</comment>
-    </data>
-    <data name="PythonStringPortDataScriptToolTip" xml:space="preserve">
-        <value>Python script to run.</value>
-    </data>
-    <data name="PythonScriptEditorEngineDropdownTooltip" xml:space="preserve">
-        <value>Use this dropdown to choose the python version/engine to execute your code.</value>
-    </data>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DeletingPythonNodeWithOpenEditorMessage" xml:space="preserve">
+    <value>The Python node "{0}" still has a script editor window open. Are you sure you want to close the editor and delete the node?</value>
+  </data>
+  <data name="DeletingPythonNodeWithOpenEditorTitle" xml:space="preserve">
+    <value>Script Editor Open</value>
+  </data>
+  <data name="EditHeader" xml:space="preserve">
+    <value>Edit...</value>
+  </data>
+  <data name="PythonMigrationWarningUriString" xml:space="preserve">
+    <value>PythonNodeModels;PythonMigrationWarning.html</value>
+  </data>
+  <data name="PythonNodeContextMenuEngineSwitcher" xml:space="preserve">
+    <value>Python Engine Version</value>
+  </data>
+  <data name="PythonNodeContextMenuEngineVersionThree" xml:space="preserve">
+    <value>CPython3</value>
+  </data>
+  <data name="PythonNodeContextMenuEngineVersionTwo" xml:space="preserve">
+    <value>IronPython2</value>
+  </data>
+  <data name="PythonNodeContextMenuLearnMoreButton" xml:space="preserve">
+    <value>Learn more about Python</value>
+  </data>
+  <data name="PythonNodePortDataOutputToolTip" xml:space="preserve">
+    <value>Result of the python script</value>
+  </data>
+  <data name="PythonScriptDescription" xml:space="preserve">
+    <value>Runs an embedded IronPython script.</value>
+    <comment>Description for Python Script</comment>
+  </data>
+  <data name="PythonScriptEditorCaption" xml:space="preserve">
+    <value>Edit Python Script...</value>
+  </data>
+  <data name="PythonScriptEditorCodeComment" xml:space="preserve">
+    <value>Place your code below this line</value>
+  </data>
+  <data name="PythonScriptEditorImports" xml:space="preserve">
+    <value>Load the Python Standard and DesignScript Libraries</value>
+  </data>
+  <data name="PythonScriptEditorInputComment" xml:space="preserve">
+    <value>The inputs to this node will be stored as a list in the IN variables.</value>
+    <comment>It is comment in the code. IN shouldn't be translated.</comment>
+  </data>
+  <data name="PythonScriptEditorMoreInfoButtonTooltip" xml:space="preserve">
+    <value>Learn about Python3 updates.</value>
+  </data>
+  <data name="PythonScriptEditorOutputComment" xml:space="preserve">
+    <value>Assign your output to the OUT variable.</value>
+    <comment>It is comment in the code. OUT shouldn't be translated.</comment>
+  </data>
+  <data name="PythonScriptEditorRevertButtonTooltip" xml:space="preserve">
+    <value>Revert the changes made to current Python node editor and close it.</value>
+  </data>
+  <data name="PythonScriptEditorRunButton" xml:space="preserve">
+    <value>Run</value>
+  </data>
+  <data name="PythonScriptEditorRunButtonTooltip" xml:space="preserve">
+    <value>Save current code in Python node editor and run graph with it.</value>
+  </data>
+  <data name="PythonScriptEditorSaveChangesButtonTooltip" xml:space="preserve">
+    <value>Save the changes made to current Python node editor and close it.</value>
+  </data>
+  <data name="PythonScriptFromStringDescription" xml:space="preserve">
+    <value>Runs a IronPython script from a string.</value>
+    <comment>Description for Python Script From String</comment>
+  </data>
+  <data name="PythonStringPortDataScriptToolTip" xml:space="preserve">
+    <value>Python script to run.</value>
+  </data>
+  <data name="PythonScriptEditorEngineDropdownTooltip" xml:space="preserve">
+    <value>Use this dropdown to choose the python version/engine to execute your code.</value>
+  </data>
+  <data name="PythonScriptEditorMigrationAssistantButtonTooltip" xml:space="preserve">
+    <value>Migration Assistant to update your Python 2 scripts to Python 3.</value>
+  </data>
 </root>

--- a/src/Libraries/PythonNodeModels/Properties/Resources.resx
+++ b/src/Libraries/PythonNodeModels/Properties/Resources.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,145 +59,139 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="metadata">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" use="required" type="xsd:string"/>
-                            <xsd:attribute name="type" type="xsd:string"/>
-                            <xsd:attribute name="mimetype" type="xsd:string"/>
-                            <xsd:attribute ref="xml:space"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="assembly">
-                        <xsd:complexType>
-                            <xsd:attribute name="alias" type="xsd:string"/>
-                            <xsd:attribute name="name" type="xsd:string"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-                            <xsd:attribute ref="xml:space"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>2.0</value>
-    </resheader>
-    <resheader name="reader">
-        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <resheader name="writer">
-        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <data name="DeletingPythonNodeWithOpenEditorMessage" xml:space="preserve">
-        <value>The Python node "{0}" still has a script editor window open. Are you sure you want to close the editor and delete the node?</value>
-    </data>
-    <data name="DeletingPythonNodeWithOpenEditorTitle" xml:space="preserve">
-        <value>Script Editor Open</value>
-    </data>
-    <data name="EditHeader" xml:space="preserve">
-        <value>Edit...</value>
-    </data>
-    <data name="PythonMigrationWarningUriString" xml:space="preserve">
-        <value>PythonNodeModels;PythonMigrationWarning.html</value>
-    </data>
-    <data name="PythonNodeContextMenuEngineSwitcher" xml:space="preserve">
-        <value>Python Engine Version</value>
-    </data>
-    <data name="PythonNodeContextMenuEngineVersionThree" xml:space="preserve">
-        <value>CPython3</value>
-    </data>
-    <data name="PythonNodeContextMenuEngineVersionTwo" xml:space="preserve">
-        <value>IronPython2</value>
-    </data>
-    <data name="PythonNodeContextMenuLearnMoreButton" xml:space="preserve">
-        <value>Learn more about Python</value>
-    </data>
-    <data name="PythonNodePortDataOutputToolTip" xml:space="preserve">
-        <value>Result of the python script</value>
-    </data>
-    <data name="PythonScriptDescription" xml:space="preserve">
-        <value>Runs an embedded IronPython script.</value>
-        <comment>Description for Python Script</comment>
-    </data>
-    <data name="PythonScriptEditorCaption" xml:space="preserve">
-        <value>Edit Python Script...</value>
-    </data>
-    <data name="PythonScriptEditorCodeComment" xml:space="preserve">
-        <value>Place your code below this line</value>
-    </data>
-    <data name="PythonScriptEditorImports" xml:space="preserve">
-        <value>Load the Python Standard and DesignScript Libraries</value>
-        <comment>Description for the common import statements that puzzle beginners.</comment>
-    </data>
-    <data name="PythonScriptEditorInputComment" xml:space="preserve">
-        <value>The inputs to this node will be stored as a list in the IN variables.</value>
-        <comment>It is comment in the code. IN shouldn't be translated.</comment>
-    </data>
-    <data name="PythonScriptEditorMoreInfoButton" xml:space="preserve">
-        <value>Learn More</value>
-    </data>
-    <data name="PythonScriptEditorMoreInfoButtonTooltip" xml:space="preserve">
-        <value>Learn about Python3 updates.</value>
-    </data>
-    <data name="PythonScriptEditorOutputComment" xml:space="preserve">
-        <value>Assign your output to the OUT variable.</value>
-        <comment>It is comment in the code. OUT shouldn't be translated.</comment>
-    </data>
-    <data name="PythonScriptEditorRevertButton" xml:space="preserve">
-        <value>Revert</value>
-    </data>
-    <data name="PythonScriptEditorRevertButtonTooltip" xml:space="preserve">
-        <value>Revert the changes made to current Python node editor and close it.</value>
-    </data>
-    <data name="PythonScriptEditorRunButton" xml:space="preserve">
-        <value>Run</value>
-    </data>
-    <data name="PythonScriptEditorRunButtonTooltip" xml:space="preserve">
-        <value>Save current code in Python node editor and run graph with it.</value>
-    </data>
-    <data name="PythonScriptEditorSaveChangesButton" xml:space="preserve">
-        <value>Save</value>
-    </data>
-    <data name="PythonScriptEditorSaveChangesButtonTooltip" xml:space="preserve">
-        <value>Save the changes made to current Python node editor and close it.</value>
-    </data>
-    <data name="PythonScriptFromStringDescription" xml:space="preserve">
-        <value>Runs a IronPython script from a string.</value>
-        <comment>Description for Python Script From String</comment>
-    </data>
-    <data name="PythonStringPortDataScriptToolTip" xml:space="preserve">
-        <value>Python script to run.</value>
-    </data>
-    <data name="PythonScriptEditorEngineDropdownTooltip" xml:space="preserve">
-        <value>Use this dropdown to choose the python version/engine to execute your code.</value>
-    </data>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DeletingPythonNodeWithOpenEditorMessage" xml:space="preserve">
+    <value>The Python node "{0}" still has a script editor window open. Are you sure you want to close the editor and delete the node?</value>
+  </data>
+  <data name="DeletingPythonNodeWithOpenEditorTitle" xml:space="preserve">
+    <value>Script Editor Open</value>
+  </data>
+  <data name="EditHeader" xml:space="preserve">
+    <value>Edit...</value>
+  </data>
+  <data name="PythonMigrationWarningUriString" xml:space="preserve">
+    <value>PythonNodeModels;PythonMigrationWarning.html</value>
+  </data>
+  <data name="PythonNodeContextMenuEngineSwitcher" xml:space="preserve">
+    <value>Python Engine Version</value>
+  </data>
+  <data name="PythonNodeContextMenuEngineVersionThree" xml:space="preserve">
+    <value>CPython3</value>
+  </data>
+  <data name="PythonNodeContextMenuEngineVersionTwo" xml:space="preserve">
+    <value>IronPython2</value>
+  </data>
+  <data name="PythonNodeContextMenuLearnMoreButton" xml:space="preserve">
+    <value>Learn more about Python</value>
+  </data>
+  <data name="PythonNodePortDataOutputToolTip" xml:space="preserve">
+    <value>Result of the python script</value>
+  </data>
+  <data name="PythonScriptDescription" xml:space="preserve">
+    <value>Runs an embedded IronPython script.</value>
+    <comment>Description for Python Script</comment>
+  </data>
+  <data name="PythonScriptEditorCaption" xml:space="preserve">
+    <value>Edit Python Script...</value>
+  </data>
+  <data name="PythonScriptEditorCodeComment" xml:space="preserve">
+    <value>Place your code below this line</value>
+  </data>
+  <data name="PythonScriptEditorImports" xml:space="preserve">
+    <value>Load the Python Standard and DesignScript Libraries</value>
+    <comment>Description for the common import statements that puzzle beginners.</comment>
+  </data>
+  <data name="PythonScriptEditorInputComment" xml:space="preserve">
+    <value>The inputs to this node will be stored as a list in the IN variables.</value>
+    <comment>It is comment in the code. IN shouldn't be translated.</comment>
+  </data>
+  <data name="PythonScriptEditorMoreInfoButtonTooltip" xml:space="preserve">
+    <value>Learn about Python3 updates.</value>
+  </data>
+  <data name="PythonScriptEditorOutputComment" xml:space="preserve">
+    <value>Assign your output to the OUT variable.</value>
+    <comment>It is comment in the code. OUT shouldn't be translated.</comment>
+  </data>
+  <data name="PythonScriptEditorRevertButtonTooltip" xml:space="preserve">
+    <value>Revert the changes made to current Python node editor and close it.</value>
+  </data>
+  <data name="PythonScriptEditorRunButton" xml:space="preserve">
+    <value>Run</value>
+  </data>
+  <data name="PythonScriptEditorRunButtonTooltip" xml:space="preserve">
+    <value>Save current code in Python node editor and run graph with it.</value>
+  </data>
+  <data name="PythonScriptEditorSaveChangesButtonTooltip" xml:space="preserve">
+    <value>Save the changes made to current Python node editor and close it.</value>
+  </data>
+  <data name="PythonScriptFromStringDescription" xml:space="preserve">
+    <value>Runs a IronPython script from a string.</value>
+    <comment>Description for Python Script From String</comment>
+  </data>
+  <data name="PythonStringPortDataScriptToolTip" xml:space="preserve">
+    <value>Python script to run.</value>
+  </data>
+  <data name="PythonScriptEditorEngineDropdownTooltip" xml:space="preserve">
+    <value>Use this dropdown to choose the python version/engine to execute your code.</value>
+  </data>
+  <data name="PythonScriptEditorMigrationAssistantButtonTooltip" xml:space="preserve">
+    <value>Migration Assistant to update your Python 2 scripts to Python 3.</value>
+  </data>
 </root>

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
@@ -1,19 +1,18 @@
-﻿<dww:ModelessChildWindow 
-    x:Class="PythonNodeModelsWpf.ScriptEditorWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:fa="http://schemas.fontawesome.io/icons/"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ui1="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-    xmlns:dww="clr-namespace:Dynamo.Wpf.Windows;assembly=DynamoCoreWpf"
-    xmlns:avalonedit="clr-namespace:ICSharpCode.AvalonEdit;assembly=ICSharpCode.AvalonEdit"
-    xmlns:p="clr-namespace:PythonNodeModels.Properties;assembly=PythonNodeModels"
-    xmlns:pythonNodeModel="clr-namespace:PythonNodeModels;assembly=PythonNodeModels"
-    xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    Title="{Binding nodeModel.Name, Mode=OneWay, RelativeSource={RelativeSource Self}}" 
-    Height="500" 
-    Width="600"
-    MinWidth="500"
-    MinHeight="450">
+﻿<dww:ModelessChildWindow x:Class="PythonNodeModelsWpf.ScriptEditorWindow"
+                         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:fa="http://schemas.fontawesome.io/icons/"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:ui1="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+                         xmlns:dww="clr-namespace:Dynamo.Wpf.Windows;assembly=DynamoCoreWpf"
+                         xmlns:avalonedit="clr-namespace:ICSharpCode.AvalonEdit;assembly=ICSharpCode.AvalonEdit"
+                         xmlns:p="clr-namespace:PythonNodeModels.Properties;assembly=PythonNodeModels"
+                         xmlns:pythonNodeModel="clr-namespace:PythonNodeModels;assembly=PythonNodeModels"
+                         xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                         Title="{Binding nodeModel.Name, Mode=OneWay, RelativeSource={RelativeSource Self}}"
+                         Height="500"
+                         Width="600"
+                         MinWidth="500"
+                         MinHeight="450">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -27,32 +26,83 @@
                     <x:Type TypeName="pythonNodeModel:PythonEngineVersion" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
+            <Style x:Key="IconButton"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource ResourceKey=SButtonWithShapeIcon}">
+                <Setter Property="Margin"
+                        Value="1,2,1,2" />
+            </Style>
+            <Style x:Key="IconTextButton"
+                   TargetType="{x:Type Button}"
+                   BasedOn="{StaticResource ResourceKey=STextButtonWithShapeIcon}">
+                <Setter Property="Margin"
+                        Value="1,2,1,2" />
+            </Style>
+            <Style x:Key="DropDown"
+                   TargetType="{x:Type ComboBox}"
+                   BasedOn="{StaticResource SComboBox}">
+                <Setter Property="Margin"
+                        Value="1,2,1,2" />
+                <Setter Property="VerticalContentAlignment"
+                        Value="Center" />
+                <Setter Property="HorizontalContentAlignment"
+                        Value="Left" />
+                <Setter Property="FontSize"
+                        Value="14px" />
+                <Setter Property="Foreground"
+                        Value="{StaticResource DynamoStandardLableTextBrush}" />
+            </Style>
+            <Style x:Key="ImageAwesomeIcons"
+                   TargetType="{x:Type fa:ImageAwesome}">
+                <Setter Property="Margin"
+                        Value="13,0,13,0" />
+                <Setter Property="Height"
+                        Value="17" />
+                <Setter Property="Margin"
+                        Value="13,0,13,0" />
+                <Setter Property="Foreground"
+                        Value="#bbbbbb" />
+            </Style>
         </ResourceDictionary>
+
     </Window.Resources>
 
     <Grid Background="Black">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="44" />
+        </Grid.RowDefinitions>
 
-        <Border Margin="0,0,0,44" BorderThickness="0" Background="Black" >
-            <avalonedit:TextEditor Name="editText" FontFamily="Consolas" FontSize="10pt" ShowLineNumbers="True" Background="#272822" Foreground="#F8F8F2" HorizontalScrollBarVisibility="Disabled"/>
+        <Border Margin="0,0,0,0"
+                BorderThickness="0"
+                Background="Black"
+                Grid.Row="0">
+            <avalonedit:TextEditor Name="editText"
+                                   FontFamily="Consolas"
+                                   FontSize="10pt"
+                                   ShowLineNumbers="True"
+                                   Background="#272822"
+                                   Foreground="#F8F8F2"
+                                   HorizontalScrollBarVisibility="Disabled" />
         </Border>
-        <Grid HorizontalAlignment="Stretch">
+        <Grid HorizontalAlignment="Stretch"
+              Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"></ColumnDefinition>
                 <ColumnDefinition Width="*"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Grid.Column="0">
-                <Button Content="{x:Static p:Resources.PythonScriptEditorRunButton}" 
-                        Style="{DynamicResource ResourceKey=STextButtonWithShapeIcon}" 
-                        Name="RunPythonScriptButton" 
-                        Click="OnRunClicked" 
-                        HorizontalAlignment="Left" 
-                        VerticalAlignment="Bottom" 
-                        Margin="1"
+
+            <StackPanel Orientation="Horizontal"
+                        Grid.Column="0">
+                <Button Content="{x:Static p:Resources.PythonScriptEditorRunButton}"
+                        Style="{StaticResource IconTextButton}"
+                        Name="RunPythonScriptButton"
+                        Click="OnRunClicked"
                         ToolTip="{x:Static p:Resources.PythonScriptEditorRunButtonTooltip}">
                     <Button.Resources>
-                        <Polygon
-                            x:Key="Shape"
-                            Points="5,0 12,7 5,14 5,0" Height="14">
+                        <Polygon x:Key="Shape"
+                                 Points="5,0 12,7 5,14 5,0"
+                                 Height="14">
                             <Polygon.Fill>
                                 <SolidColorBrush Color="DarkSeaGreen" />
                             </Polygon.Fill>
@@ -61,28 +111,17 @@
                 </Button>
                 <ComboBox ItemsSource="{Binding Source={StaticResource engineEnum}, Mode=OneWay}"
                           SelectedItem="{Binding nodeModel.Engine, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=dww:ModelessChildWindow}}"
-                          Style="{StaticResource ResourceKey=SComboBox}"
-                          Name="EngineSelectorComboBox"
                           SelectionChanged="OnEngineChanged"
-                          VerticalAlignment="Bottom"
-                          VerticalContentAlignment="Center"
-                          HorizontalContentAlignment="Left"
-                          FontSize="14px"
-                          Height="40"
-                          Width="Auto"
-                          Margin="1"
-                          Foreground="{StaticResource DynamoStandardLableTextBrush}"
-                          Visibility="Collapsed" 
-                          ToolTip="{x:Static p:Resources.PythonScriptEditorEngineDropdownTooltip}"/>
-                <Button Style="{DynamicResource ResourceKey=SButtonWithShapeIcon}"
+                          Style="{StaticResource DropDown}"
+                          Name="EngineSelectorComboBox"
+                          Visibility="Collapsed" />
+                <Button Style="{StaticResource IconButton}"
                         Name="MigrationAssistantBtn"
                         Click="OnMigrationAssistantClicked"
-                        VerticalAlignment="Bottom"
-                        Margin="1"
                         ToolTip="{x:Static p:Resources.PythonScriptEditorMigrationAssistantButtonTooltip}">
                     <Button.Resources>
                         <Image x:Key="Shape"
-                               Width="40"
+                               Width="44"
                                Source="/PythonNodeModelsWpf;component/Resources/2to3Icon.png" />
                     </Button.Resources>
                 </Button>
@@ -90,55 +129,34 @@
             <StackPanel Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Grid.Column="1">
-                <Button Content="{x:Static p:Resources.PythonScriptEditorMoreInfoButton}"
-                        Style="{DynamicResource ResourceKey=STextButtonWithShapeIcon}"
+                <Button Style="{StaticResource IconButton}"
                         Name="MoreInfoButton"
                         Click="OnMoreInfoClicked"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Bottom"
-                        Margin="1"
-                        Grid.Column="1"
                         ToolTip="{x:Static p:Resources.PythonScriptEditorMoreInfoButtonTooltip}">
                     <Button.Resources>
                         <fa:ImageAwesome x:Key="Shape"
-                                         Icon="ExclamationCircle"
-                                         Foreground="#bbbbbb"
-                                         Height="14"
-                                         Margin="4,0,0,0" />
+                                         Style="{StaticResource ImageAwesomeIcons}"
+                                         Icon="QuestionCircleOutline" />
                     </Button.Resources>
                 </Button>
-                <Button Content="{x:Static p:Resources.PythonScriptEditorSaveChangesButton}" 
-                        Style="{DynamicResource ResourceKey=STextButtonWithShapeIcon}" 
-                        Name="SaveScriptChangesButton" 
-                        Click="OnSaveClicked" 
-                        HorizontalAlignment="Right" 
-                        VerticalAlignment="Bottom" 
-                        Margin="1" 
-                        Grid.Column="1"
+                <Button Style="{StaticResource IconButton}"
+                        Name="SaveScriptChangesButton"
+                        Click="OnSaveClicked"
                         ToolTip="{x:Static p:Resources.PythonScriptEditorSaveChangesButtonTooltip}">
                     <Button.Resources>
-                        <fa:ImageAwesome x:Key ="Shape"
-                                         Icon="Save"
-                                         Foreground="#bbbbbb"
-                                         Height="14"
-                                         Margin="4,0,0,0"/>
+                        <fa:ImageAwesome x:Key="Shape"
+                                         Style="{StaticResource ImageAwesomeIcons}"
+                                         Icon="Save" />
                     </Button.Resources>
                 </Button>
-                <Button Content="{x:Static p:Resources.PythonScriptEditorRevertButton}"
-                        Style="{DynamicResource ResourceKey=STextButtonWithShapeIcon}"
+                <Button Style="{StaticResource IconButton}"
                         Name="RevertScriptChangesButton"
                         Click="OnRevertClicked"
-                        VerticalAlignment="Bottom"
-                        HorizontalAlignment="Right"
-                        Margin="1"
-                        Grid.Column="1"
                         ToolTip="{x:Static p:Resources.PythonScriptEditorRevertButtonTooltip}">
                     <Button.Resources>
                         <fa:ImageAwesome x:Key="Shape"
-                                         Icon="Undo"
-                                         Foreground="#bbbbbb"
-                                         Height="14"
-                                         Margin="4,0,0,0" />
+                                         Style="{StaticResource ImageAwesomeIcons}"
+                                         Icon="Undo" />
                     </Button.Resources>
                 </Button>
             </StackPanel>


### PR DESCRIPTION
### Purpose

This PR updates the Python ScriptEditor so buttons are aligned and only uses icons and tooltips.

<img width="300" alt="T1 4-UpdatePythonScriptEditor" src="https://user-images.githubusercontent.com/13732445/88305640-a4193c00-cd01-11ea-8b2e-5207c9fe5bea.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mmisol 

### FYIs

@mjkkirschner 
@QilongTang 
@radumg 