### PR TITLE
Add LogLevel.ConsoleOnly for DynamoLogger

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Logging
     /// <summary>
     /// Specifies the level for log messages. A log message could be a console or file or warning.
     /// </summary>
-    public enum LogLevel{Console, File, Warning}
+    public enum LogLevel{Console, File, Warning, ConsoleOnly}
 
     /// <summary>
     /// Specifies the warning level for log messages.
@@ -199,7 +199,7 @@ namespace Dynamo.Logging
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="level">The level.</param>
-        internal void Log(string message, LogLevel level)
+        public void Log(string message, LogLevel level)
         {
             Log(message, level, true);
         }
@@ -227,9 +227,25 @@ namespace Dynamo.Logging
 
                 switch (level)
                 {
-                        //write to the console
-                    case LogLevel.Console:
+                    //write to the console only
+                    case LogLevel.ConsoleOnly:
                         if (ConsoleWriter != null)
+                        {
+                            try
+                            {
+                                ConsoleWriter.AppendLine(string.Format("{0}", message));
+                                RaisePropertyChanged("ConsoleWriter");
+                            }
+                            catch
+                            {
+                                // likely caught if the writer is closed
+                            }
+                        }
+                        break;
+
+                    //write to both console and file
+                    case LogLevel.Console:
+                        if (ConsoleWriter != null && FileWriter != null)
                         {
                             try
                             {
@@ -245,7 +261,7 @@ namespace Dynamo.Logging
                         }
                         break;
 
-                        //write to the file
+                    //write to the file
                     case LogLevel.File:
                         if (FileWriter != null)
                         {

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Autodesk.DesignScript.Runtime;
 using DSCPython.Encoders;
 using Dynamo.Events;
+using Dynamo.Logging;
 using Dynamo.Session;
 using Dynamo.Utilities;
 using Python.Runtime;
@@ -263,7 +264,7 @@ namespace DSCPython
             if (ExecutionEvents.ActiveSession != null)
             {
                 dynamic logger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger);
-                Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}");
+                Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}", LogLevel.ConsoleOnly);
                 scope.Set("DynamoPrint", logFunction.ToPython());
             }
         }

--- a/src/Libraries/DSCPython/DSCPython.csproj
+++ b/src/Libraries/DSCPython/DSCPython.csproj
@@ -73,6 +73,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">
+      <Project>{7858FA8C-475F-4B8E-B468-1F8200778CF8}</Project>
+      <Name>DynamoCore</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\DynamoUtilities\DynamoUtilities.csproj">
       <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
       <Name>DynamoUtilities</Name>

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Events;
+using Dynamo.Logging;
 using Dynamo.Session;
 using Dynamo.Utilities;
 using IronPython.Hosting;
@@ -180,7 +181,7 @@ namespace DSIronPython
             if (ExecutionEvents.ActiveSession != null)
             {
                 dynamic logger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger);
-                Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}");
+                Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}", LogLevel.ConsoleOnly);
                 scope.SetVariable("DynamoPrint", logFunction);
             }
         }


### PR DESCRIPTION
### Purpose

This log level allows to log messages only to the console, skipping
file logging. The addition of a new level valuie was required because
counterintuitively LogLevel.Console logs to both the console and file.

This new level is currently used only for logging with DynamoPrint, but
the overload was added as a public function in DynamoLogger, so it can
be used in arbitrary code, like ZT nodes.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 

### FYIs

@smangarole 
