### PR TITLE
Improve namespace listing using CPython3 engine

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -189,7 +189,7 @@ namespace DSCPython
                 {
                     if (globalScope == null)
                     {
-                        globalScope = Py.CreateScope(globalScopeName);
+                        globalScope = CreateGlobalScope();
                     }
                     using (PyScope scope = Py.CreateScope())
                     {
@@ -234,6 +234,20 @@ namespace DSCPython
             {
                 PythonEngine.ReleaseLock(gs);
             }
+        }
+
+        /// <summary>
+        /// Creates and initializaes the global Python scope.
+        /// </summary>
+        private static PyScope CreateGlobalScope()
+        {
+            var scope = Py.CreateScope(globalScopeName);
+            // Allows discoverability of modules by inspecting their attributes
+            scope.Exec(@"
+import clr
+clr.setPreload(True)
+");
+            return scope;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Namespace listing using dir would only provide non meaningful results
using the CPython3 engine. This is now fixed by preloading names by
default globally.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 

### FYIs

@DynamoDS/dynamo 
