### PR TITLE
add try catch to CLR Object Marshaler getStringValue

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
@@ -1256,21 +1256,28 @@ namespace ProtoFFI
 
             if (clrObject != null)
             {
-                if (!DumpXmlProperties)
+                try
                 {
-                    return clrObject.ToString();
-                }
-                else
-                {
-                    XmlWriterSettings settings = new XmlWriterSettings { Indent = false, OmitXmlDeclaration = true };
-                    using (StringWriter sw = new StringWriter())
+                    if (!DumpXmlProperties)
                     {
-                        using (XmlWriter xw = XmlTextWriter.Create(sw, settings))
-                        {
-                            GeneratePrimaryPropertiesAsXml(clrObject, xw);
-                        }
-                        return sw.ToString();
+                        return clrObject.ToString();
                     }
+                    else
+                    {
+                        XmlWriterSettings settings = new XmlWriterSettings { Indent = false, OmitXmlDeclaration = true };
+                        using (StringWriter sw = new StringWriter())
+                        {
+                            using (XmlWriter xw = XmlTextWriter.Create(sw, settings))
+                            {
+                                GeneratePrimaryPropertiesAsXml(clrObject, xw);
+                            }
+                            return sw.ToString();
+                        }
+                    }
+                }
+                catch
+                {
+                    return string.Empty;
                 }
             }
             else

--- a/test/Engine/FFITarget/ClassFunctionality.cs
+++ b/test/Engine/FFITarget/ClassFunctionality.cs
@@ -11,7 +11,7 @@ namespace FFITarget
         private int intVal;
         public int IntVal {
             get { return intVal; }
-            set { 
+            set {
                 this.intVal = value;
                 this.classProperty = new ValueContainer(intVal);
             }
@@ -19,7 +19,7 @@ namespace FFITarget
 
         public ClassFunctionality()
         {
-                
+
         }
 
         public ClassFunctionality(int intVal)
@@ -103,8 +103,8 @@ namespace FFITarget
         {
             StaticProp++;
         }
-        
-        
+
+
     }
 
     public class ValueContainer
@@ -116,7 +116,7 @@ namespace FFITarget
 
         public ValueContainer Square()
         {
-            return  new ValueContainer(SomeValue * SomeValue);
+            return new ValueContainer(SomeValue * SomeValue);
         }
 
         public int SomeValue { get; set; }
@@ -152,6 +152,18 @@ namespace FFITarget
 
         public void Dispose()
         {
+        }
+    }
+
+    public class ClassWithExceptionToString{
+
+        public static ClassWithExceptionToString Construct()
+        {
+            return new ClassWithExceptionToString();
+        }
+        public override string ToString()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/Engine/ProtoTest/FFITests/FFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/FFITest.cs
@@ -41,7 +41,7 @@ import (""FFITarget.dll"");
             thisTest.Verify("vc1Value", 3);
             thisTest.Verify("vc2Value", 3);
 
-        }
+}
 
         [Test]
         [Category("SmokeTest")]
@@ -179,6 +179,19 @@ import (TestData from ""FFITarget.dll"");
 
             string expression = o as string;
             Assert.IsTrue(expression.Equals("TestData.GetFloat()"));
+        }
+
+        [Test]
+        public void TestToStringDoesNotThrow()
+        {
+            string code = @"
+import (ClassWithExceptionToString from ""FFITarget.dll"");
+x = ClassWithExceptionToString.Construct();
+";
+            var mirror = thisTest.RunScriptSource(code);
+            var x = mirror.GetValue("x");
+            Assert.DoesNotThrow(() => { mirror.GetStringValue(x,this.core.Heap, 0); }); 
+            
         }
     }
 }


### PR DESCRIPTION
### Purpose

Address the situation where a `ToString` call on a clr object that is not null results in an exception - it turns out this happens quite frequently in Autocad and Revit.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
