### PR TITLE
[FYI: GDiR] Inspect cbn code for referenced assemblies

### DIFF
--- a/src/Engine/ProtoCore/Utils/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CompilerUtils.cs
@@ -336,6 +336,8 @@ namespace ProtoCore.Utils
                     reWrittenNodes = MigrationRewriter.MigrateMethodNames(reWrittenNodes, priorNames, core.BuildStatus.LogDeprecatedMethodWarning);
                 }
 
+                ParserUtils.AssemblyDetector.GetAssemblyFromCodeBlock(core.ClassTable, reWrittenNodes);
+
                 // Clone a disposable copy of AST nodes for PreCompile() as Codegen mutates AST's
                 // while performing SSA transforms and we want to keep the original AST's
                 var codeblock = new CodeBlockNode();

--- a/src/Engine/ProtoCore/Utils/ParserUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ParserUtils.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using ProtoCore.AST;
 using ProtoCore.AST.AssociativeAST;
+using ProtoCore.DSASM;
 using ProtoCore.SyntaxAnalysis;
 
 namespace ProtoCore.Utils
@@ -80,6 +81,42 @@ namespace ProtoCore.Utils
                 node.Accept(c);
                 return c.nodes;
             }
+        }
+
+        public class AssemblyDetector : AstTraversal
+        {
+            private ClassTable classTable;
+
+            private AssemblyDetector(ClassTable classTable)
+            {
+                this.classTable = classTable;
+            }
+
+            public static void GetAssemblyFromCodeBlock(ClassTable classTable, IEnumerable<Node> astNodes)
+            {
+                var assemblyDetector = new AssemblyDetector(classTable);
+                var assocNodes = astNodes.OfType<AssociativeNode>();
+                //assocNodes.Select(astNode => astNode.Accept(assemblyDetector));
+                assocNodes.ElementAt(0).Accept(assemblyDetector);
+            }
+
+            public override bool VisitIdentifierListNode(IdentifierListNode node)
+            {
+                var className = node.LeftNode.ToString();
+                var assembly = CoreUtils.GetAssemblyFromClassName(classTable, className);
+
+                //if (node.RightNode is FunctionCallNode)
+                //    return VisitFunctionCallNode(node.RightNode as FunctionCallNode);
+
+                return VisitAllChildren(node);
+            }
+
+            //public override bool VisitFunctionCallNode(FunctionCallNode node)
+            //{
+            //    var methodName = node.Function.Name;
+
+            //    return true;
+            //}
         }
 
         public static IEnumerable<Node> FindExprListNodes(CodeBlockNode node)


### PR DESCRIPTION
### Purpose

Sample code to demonstrate querying CBN AST's for the assembly corresponding to the function calls in the code. This can be used for example, in determining host (Revit) API assemblies which are referenced in the CBN code.
The following is an example of CBN containing a call to a MeshToolkit method. The assembly referenced is `MeshToolkit.dll`.
![image](https://user-images.githubusercontent.com/5710686/89466570-11858d80-d742-11ea-8e18-e46678593ac8.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated



### FYIs

@LongNguyenP @saintentropy @varvaratou 
