### PR TITLE
Add DSCPython to Core NuGet package

### DIFF
--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
@@ -18,7 +18,8 @@
         6) DynamoUtilities.dll
         7) ProtoCore.dll
         8) DesignScriptBuiltin.dll
-        9) VMDataBridge.dll</description>
+        9) VMDataBridge.dll
+		10) DSCPython.dll</description>
         <summary>This package contains the core assemblies for Dynamo.</summary>
         <copyright>Copyright Autodesk 2020</copyright>
         <dependencies>
@@ -43,5 +44,6 @@
         <file src="DesignScriptBuiltin.dll" target="lib\net48" />
         <file src="VMDataBridge.dll" target="lib\net48" />
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
+		<file src="DSCPython.dll" target="lib\net48" />
     </files>
 </package>

--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
@@ -19,7 +19,7 @@
         7) ProtoCore.dll
         8) DesignScriptBuiltin.dll
         9) VMDataBridge.dll
-		10) DSCPython.dll</description>
+        10) DSCPython.dll</description>
         <summary>This package contains the core assemblies for Dynamo.</summary>
         <copyright>Copyright Autodesk 2020</copyright>
         <dependencies>
@@ -44,6 +44,6 @@
         <file src="DesignScriptBuiltin.dll" target="lib\net48" />
         <file src="VMDataBridge.dll" target="lib\net48" />
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
-		<file src="DSCPython.dll" target="lib\net48" />
+        <file src="DSCPython.dll" target="lib\net48" />
     </files>
 </package>


### PR DESCRIPTION
### Purpose

This is to be used in Dynamo for Revit, in order to be able to add a
reference to the assembly. This is required to provide customized
behavior for the CPython3 engine, in a similar way as provided for the
IronPython2 engine.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@DynamoDS/dynamo 
