### PR TITLE
CPython engine marshals python classes to lists when the expectation is to get a handle.

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -387,6 +387,7 @@ clr.setPreload(True)
                             {
                                 return outputMarshaler.Marshal(clrObj);
                             }
+
                             if (IsMarkedToSkipConversion(pyObj))
                             {
                                 var globalScope = PyScopeManager.Global.Get(globalScopeName);

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -387,6 +387,13 @@ clr.setPreload(True)
                             {
                                 return outputMarshaler.Marshal(clrObj);
                             }
+                            if (IsMarkedToSkipConversion(pyObj))
+                            {
+                                var globalScope = PyScopeManager.Global.Get(globalScopeName);
+                                globalScope.Set(pyObj.Handle.ToString(), pyObj);
+                                return new DynamoCPythonHandle(pyObj.Handle);
+                            }
+
                             // Dictionaries are iterable, so they should come first
                             if (PyDict.IsDictType(pyObj))
                             {
@@ -457,6 +464,11 @@ clr.setPreload(True)
                 }
                 return outputMarshaler;
             }
+        }
+
+        private static bool IsMarkedToSkipConversion(PyObject pyObj)
+        {
+            return pyObj.HasAttr("__dynamoskipconversion__");
         }
 
         private static DataMarshaler inputMarshaler;

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -247,11 +247,12 @@ o = notiterable()
 OUT = o
 ";
             var empty = new ArrayList();
-
-            Assert.IsInstanceOf(typeof(IList), DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty));
+            var result1 = DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty);
+            var result2 = DSCPython.CPythonEvaluator.EvaluatePythonScript(code2, empty, empty);
+            Assert.IsInstanceOf(typeof(IList), result1);
             Assert.IsTrue(new List<object>() { 0L, 1L, 2L, 3L }
-                .SequenceEqual((IEnumerable<Obj>)DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty)));
-            Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle), DSCPython.CPythonEvaluator.EvaluatePythonScript(code2, empty, empty));
+                .SequenceEqual((IEnumerable<Object>)result1));
+            Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle),result2 );
 
         }
 

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
+using System.Linq;
+using ProtoCore.Lang;
 
 namespace DSPythonTests
 {
@@ -213,7 +215,7 @@ OUT = o
         }
 
         [Test]
-        public void PythonObjectWithDynamoSKIPisNotMarshaled()
+        public void PythonObjectWithDynamoSkipisNotMarshaled()
         {
             var code = @"
 
@@ -229,7 +231,7 @@ o = iterable()
 OUT = o
 ";
 
-         var code2 = @"
+            var code2 = @"
 
 class notiterable:
     def __dynamoskipconversion__(self):
@@ -245,10 +247,11 @@ o = notiterable()
 OUT = o
 ";
             var empty = new ArrayList();
-           
-           Assert.IsInstanceOf(typeof(IList),DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty));
-           Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle), DSCPython.CPythonEvaluator.EvaluatePythonScript(code2, empty, empty));
 
+            Assert.IsInstanceOf(typeof(IList), DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty));
+            Assert.IsTrue(new List<object>() { 0L, 1L, 2L, 3L }
+                .SequenceEqual((IEnumerable<Obj>)DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty)));
+            Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle), DSCPython.CPythonEvaluator.EvaluatePythonScript(code2, empty, empty));
 
         }
 

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -213,6 +213,46 @@ OUT = o
         }
 
         [Test]
+        public void PythonObjectWithDynamoSKIPisNotMarshaled()
+        {
+            var code = @"
+
+class iterable:
+    def __str__(self):
+        return 'I want to participate in conversion'
+    def __iter__(self):
+        return iter([0,1,2,3])
+    def __getitem__(self,key):
+        return key
+
+o = iterable()
+OUT = o
+";
+
+         var code2 = @"
+
+class notiterable:
+    def __dynamoskipconversion__(self):
+        pass
+    def __str__(self):
+        return 'I want to skip in conversion'
+    def __iter__(self):
+        return iter([0,1,2,3])
+    def __getitem__(self,key):
+        return key
+
+o = notiterable()
+OUT = o
+";
+            var empty = new ArrayList();
+           
+           Assert.IsInstanceOf(typeof(IList),DSCPython.CPythonEvaluator.EvaluatePythonScript(code, empty, empty));
+           Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle), DSCPython.CPythonEvaluator.EvaluatePythonScript(code2, empty, empty));
+
+
+        }
+
+        [Test]
         public void NonListIterablesCanBeOutput()
         {
             var code = @"


### PR DESCRIPTION
### Purpose

While trying to get data-shapes working with the cpython engine it was discovered that some of the data-shapes python classes implement `__iter__/__getitem__` and sequence protocols.

These classes are marshaled into dynamo as lists, but for use in data-shapes they need to be marshaled as handles only.

To enable this workflow I've added a new "builtin" 👋   attribute the class author can choose to add to their class. `__dynamoskipconversion__`. If this attribute exists at all (the return value does not matter) then the object will skip all conversion attempts and immediately be marshaled as a handle.

For dataShapes this means a one line code change to get this class working.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [ ] **When/If this PR is approved I will update the python3 wiki with information on this attribute.**

