### PR TITLE
Expose CPython3 engine evaluation events

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -40,7 +40,7 @@ namespace DSCPython
     /// then make sure to call Dispose when you are done with the instance.
     /// </summary>
     [IsVisibleInDynamoLibrary(false)]
-    public class DynamoCPythonHandle : IDisposable
+    internal class DynamoCPythonHandle : IDisposable
     {
         /// <summary>
         /// A static map of DynamoCPythonHandle counts, is used to avoid removing the underlying python objects from the 
@@ -133,13 +133,10 @@ namespace DSCPython
     }
 
     [SupressImportIntoVM]
-    internal enum EvaluationState { Begin, Success, Failed }
+    public enum EvaluationState { Begin, Success, Failed }
 
     [SupressImportIntoVM]
-    internal delegate void EvaluationEventHandler(EvaluationState state,
-                                                  PyScope scope,
-                                                  string code,
-                                                  IList bindingValues);
+    public delegate void EvaluationEventHandler(EvaluationState state, PyScope scope, string code, IList bindingValues);
 
     /// <summary>
     ///     Evaluates a Python script in the Dynamo context.
@@ -470,13 +467,13 @@ clr.setPreload(True)
         ///     Emitted immediately before execution begins
         /// </summary>
         [SupressImportIntoVM]
-        internal static event EvaluationEventHandler EvaluationBegin;
+        public static event EvaluationEventHandler EvaluationBegin;
 
         /// <summary>
         ///     Emitted immediately after execution ends or fails
         /// </summary>
         [SupressImportIntoVM]
-        internal static event EvaluationEventHandler EvaluationEnd;
+        public static event EvaluationEventHandler EvaluationEnd;
 
         /// <summary>
         /// Called immediately before evaluation starts


### PR DESCRIPTION
### Purpose

These events were created with internal visibility, which does not make
them available for integrators. Integrators need, for instance, to
react to the start and end of an evaluation to disable/re-enable
certain UI elements.

At the same time makes DynamoCPythonHandle internal, so that we do not
accidentally expose this type.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@DynamoDS/dynamo 
