### PR TITLE
Sys.path value should be limited to the scope of the python node(CPython3 Engine)

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Autodesk.DesignScript.Runtime;
@@ -146,6 +147,7 @@ namespace DSCPython
     {
         static PyScope globalScope;
         internal static readonly string globalScopeName = "global";
+
         static CPythonEvaluator()
         {
             InitializeEncoders();
@@ -176,7 +178,6 @@ namespace DSCPython
             {
                 PythonEngine.Initialize();
                 PythonEngine.BeginAllowThreads();
-
             }
 
             IntPtr gs = PythonEngine.AcquireLock();
@@ -188,6 +189,10 @@ namespace DSCPython
                     {
                         globalScope = CreateGlobalScope();
                     }
+                   
+                    // Reset the 'sys.path' value to the default python paths on node evaluation. 
+                    code = "import sys" + Environment.NewLine + "sys.path = sys.path[0:3]" + Environment.NewLine + code;
+
                     using (PyScope scope = Py.CreateScope())
                     {
                         ProcessAdditionalBindings(scope, bindingNames, bindingValues);

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -189,12 +189,14 @@ namespace DSCPython
                     {
                         globalScope = CreateGlobalScope();
                     }
-                   
-                    // Reset the 'sys.path' value to the default python paths on node evaluation. 
-                    code = "import sys" + Environment.NewLine + "sys.path = sys.path[0:3]" + Environment.NewLine + code;
 
+                    var path = PythonEngine.PythonPath;
                     using (PyScope scope = Py.CreateScope())
                     {
+                        // Reset the 'sys.path' value to the default python paths on node evaluation. 
+                        var pythonNodeSetupCode = "import sys" + Environment.NewLine + "sys.path = sys.path[0:3]";
+                        scope.Exec(pythonNodeSetupCode);
+
                         ProcessAdditionalBindings(scope, bindingNames, bindingValues);
 
                         int amt = Math.Min(bindingNames.Count, bindingValues.Count);

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -190,7 +190,6 @@ namespace DSCPython
                         globalScope = CreateGlobalScope();
                     }
 
-                    var path = PythonEngine.PythonPath;
                     using (PyScope scope = Py.CreateScope())
                     {
                         // Reset the 'sys.path' value to the default python paths on node evaluation. 

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -637,6 +637,7 @@ namespace Dynamo.Tests
             var pynode = nodeModel as PythonNode;
             UpdatePythonEngineAndRun(pynode, PythonEngineVersion.CPython3);
             sysPathList = GetFlattenedPreviewValues(secondPythonNodeGUID);
+            Assert.AreEqual(sysPathList.Count(), 3);
             Assert.AreNotEqual(sysPathList.Last(), "C:\\Program Files\\dotnet");
         }
     }

--- a/test/core/python/CPythonSysPath.dyn
+++ b/test/core/python/CPythonSysPath.dyn
@@ -1,0 +1,129 @@
+{
+  "Uuid": "3348b9fe-5576-42f3-976c-90f052a7219e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "CPythonSysPath",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\n\r\nsys.path.append(r'C:\\Program Files\\dotnet')\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = sys.path",
+      "Engine": "CPython3",
+      "VariableInputPorts": true,
+      "Id": "07ea2d39811e4df7a38c8c784d5079b0",
+      "Inputs": [
+        {
+          "Id": "6b7043ae0a0846dd9129ff998b0aa262",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e3d405ee70cb4ab584b1fb12a1843fb0",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = sys.path",
+      "Engine": "IronPython2",
+      "VariableInputPorts": true,
+      "Id": "a3058920586a43d998067d41c36803bb",
+      "Inputs": [
+        {
+          "Id": "aa6f8c3aad5f4d318d8971c0ebc9c83b",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ecc81eeca005417f8cb37f9c4e4fe7c1",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.8.0.2195",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "07ea2d39811e4df7a38c8c784d5079b0",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 236.5,
+        "Y": 185.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "a3058920586a43d998067d41c36803bb",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 482.5,
+        "Y": 383.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

This PR is to address the task https://jira.autodesk.com/browse/DYN-2956. 

Issue: For CPython3 Engine, when you add a custom path to the 'sys.path' variable, its value was persistent for the whole Dynamo session. This wasn't the case with IronPython2. To make this consistent, we have decided to limit the scope of this variable to individual python node. 

To fix this, whenever a python node is evaluated, the 'sys.path' value is reset to contain only the default python values. For CPython engine, the first 3 paths correspond to the default python paths. 

To test this, I have added a custom path "C:\\Program Files\\dotnet" in the Python script editor and checked that this path is not reflected in the 2nd python node. I wasn't sure if using such paths in our test could cause any issues. My thought was this dotnot folder should be present on all Windows machines with dotnet installed. Looking for suggestions.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@mjkkirschner @mmisol 

### FYIs
@DynamoDS/dynamo 
