### PR TITLE
CPython eval always fails

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -166,6 +166,7 @@ namespace DSCPython
             IList bindingNames,
             [ArbitraryDimensionArrayImport] IList bindingValues)
         {
+            var evaluationSuccess = true;
             if (code == null)
             {
                 return null;
@@ -210,6 +211,7 @@ namespace DSCPython
                         }
                         catch (Exception e)
                         {
+                            evaluationSuccess = false;
                             var traceBack = GetTraceBack(e);
                             if (!string.IsNullOrEmpty(traceBack))
                             {
@@ -223,7 +225,7 @@ namespace DSCPython
                         }
                         finally
                         {
-                            OnEvaluationEnd(false, scope, code, bindingValues);
+                            OnEvaluationEnd(evaluationSuccess, scope, code, bindingValues);
                         }
                     }
                 }

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -76,6 +76,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
+    <Reference Include="Python.Runtime, Version=2.5.1.0, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -3,9 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 using System.Linq;
-using ProtoCore.Lang;
 using DSCPython;
-using Python.Runtime;
 
 namespace DSPythonTests
 {
@@ -175,7 +173,7 @@ print 'hello'
         [Test]
         public void CPythonEngineWithErrorRaisesCorrectEvent()
         {
-            var code = @"1";
+          
             var count = 0;
             DSCPython.EvaluationEventHandler CPythonEvaluator_EvaluationEnd = (state, scope, codeString, bindings) =>
             {
@@ -192,6 +190,7 @@ print 'hello'
 
             CPythonEvaluator.EvaluationEnd += CPythonEvaluator_EvaluationEnd;
 
+            var code = @"1";
             try
             {
                 DSCPython.CPythonEvaluator.EvaluatePythonScript(code, new ArrayList(), new ArrayList());
@@ -200,8 +199,8 @@ print 'hello'
             {
                 Assert.AreEqual(1, count);
             }
-            code = @"1/a";
 
+            code = @"1/a";
             try
             {
                 DSCPython.CPythonEvaluator.EvaluatePythonScript(code, new ArrayList(), new ArrayList());
@@ -298,7 +297,7 @@ OUT = o
             Assert.IsInstanceOf(typeof(IList), result1);
             Assert.IsTrue(new List<object>() { 0L, 1L, 2L, 3L }
                 .SequenceEqual((IEnumerable<Object>)result1));
-            Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle),result2 );
+            Assert.IsInstanceOf(typeof(DSCPython.DynamoCPythonHandle), result2);
 
         }
 


### PR DESCRIPTION
### Purpose

Cpython eval should reflect actual evaluation results similar to DSIronPython engine.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
