### PR TITLE
Fix line number for IronPython errors

### DIFF
--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -104,7 +104,6 @@ namespace DSIronPython
                 ScriptEngine PythonEngine = Python.CreateEngine();
                 if (!string.IsNullOrEmpty(stdLib))
                 {
-                    code = "import sys" + System.Environment.NewLine + code;
                     paths = PythonEngine.GetSearchPaths().ToList();
                     paths.Add(stdLib);
                 }

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -122,6 +122,8 @@ namespace DSIronPython
 
             ScriptEngine engine = prev_script.Engine;
             ScriptScope scope = engine.CreateScope();
+            // For backwards compatibility: "sys" was imported by default due to a bug so we keep it that way
+            scope.ImportModule("sys");
 
             ProcessAdditionalBindings(scope, bindingNames, bindingValues);
 

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -172,6 +172,26 @@ print 'hello'
         }
 
         [Test]
+        public void IronPythonGivesCorrectErrorLineNumberAndLoadsStdLib()
+        {
+            var code = @"
+from xml.dom.minidom import parseString
+my_xml = parseString('invalid XML!')
+";
+            try
+            {
+                DSIronPython.IronPythonEvaluator.EvaluateIronPythonScript(code, new ArrayList(), new ArrayList());
+                Assert.Fail("An exception was expected");
+            }
+            catch (Exception exc)
+            {
+                StringAssert.StartsWith(@"Traceback (most recent call last):
+  File ""<string>"", line 3, in <module>", exc.Message);
+                StringAssert.EndsWith("Data at the root level is invalid. Line 1, position 1.", exc.Message);
+            }
+        }
+
+        [Test]
         public void OutputPythonObjectDoesNotThrow()
         {
             var code = @"


### PR DESCRIPTION
### Purpose

The IronPython evaluator was adding an 'import sys' and a new line as a
prefix to the code entered in a Python script node. This was causing
errors to be reported in the the line next to where they actually
occurred.

The issue is fixed by removing the prefixed code, since it was not
really needed.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@reddyashish @mjkkirschner 

### FYIs

@DynamoDS/dynamo 
