### PR TITLE
Dyn 3026 code coverage analysis folder

### DIFF
--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -630,7 +630,7 @@ namespace Dynamo.Wpf.Rendering
         internal static string CleanTag(string tag)
         {
             var splits = tag.Split(':');
-            return splits.Count() <= 1 ? "[0]" : string.Format("[{0}]", string.Join(",", splits.Skip(1)));
+            return splits.Count() <= 1 ? tag : string.Format("[{0}]", string.Join(",", splits.Skip(1)));
         }
 
         private static Color4 Color4FromBytes(byte red, byte green, byte blue, byte alpha)

--- a/src/Libraries/Analysis/Label.cs
+++ b/src/Libraries/Analysis/Label.cs
@@ -21,7 +21,6 @@ namespace Analysis
         /// <param name="point"></param>
         /// <param name="label"></param>
         /// <returns></returns>
-        [IsVisibleInDynamoLibrary(false)]
         public static Label ByPointAndString(Point point, string label)
         {
             if (point == null)

--- a/src/Libraries/Analysis/Properties/AssemblyInfo.cs
+++ b/src/Libraries/Analysis/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -11,3 +12,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c274730c-bee7-4d7f-af07-c9dbf7c40110")]
 
+[assembly: InternalsVisibleTo("AnalysisTests")]

--- a/src/Libraries/Analysis/SurfaceData.cs
+++ b/src/Libraries/Analysis/SurfaceData.cs
@@ -110,39 +110,6 @@ namespace Analysis
             return new SurfaceData(surface, uvs, values);
         }
 
-        #region private methods
-
-        /// <summary>
-        /// Cull calculation locations that aren't within 1e-6 of the surface.
-        /// </summary>
-        /// <returns></returns>
-        private IEnumerable<UV> CullCalculationLocations(Surface surface, IEnumerable<UV> calculationLocations)
-        {
-            var pts = new List<UV>();
-
-            foreach (var uv in calculationLocations)
-            {
-                var pt = surface.PointAtParameter(uv.U, uv.V);
-                var dist = pt.DistanceTo(surface);
-                if (dist < 1e-6 && dist > -1e-6)
-                {
-                    pts.Add(uv);
-                }
-            }
-
-            return pts;
-        }
-
-        #endregion
-
-        private static void DebugTime(Stopwatch sw, string message)
-        {
-            sw.Stop();
-            Debug.WriteLine("{0}:{1}", sw.Elapsed, message);
-            sw.Reset();
-            sw.Start();
-        }
-
         /// <summary>
         /// This method constructs a surface through the UV locations,
         /// converting UVs to Points in the 0,0->1,1 domain. This surface is used

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -802,7 +802,11 @@
           "text": "Display",
           "iconUrl": "./dist/resources/Category.Display.svg",
           "elementType": "category",
-          "include": [],
+          "include": [
+            {
+              "path": "Analysis.Analysis.Label"
+            }
+          ],
           "childElements": [
             {
               "text": "Color",
@@ -849,7 +853,7 @@
                   "path": "Core.Color.Color Palette"
                 }
               ],
-              "childElements": [ ]
+              "childElements": []
             },
             {
               "text": "Color Range",
@@ -866,7 +870,7 @@
                   "path": "DSCoreNodes.DSCore.ColorRange.GetColorAtParameter"
                 }
               ],
-              "childElements": [ ]
+              "childElements": []
             },
             {
               "text": "Watch",
@@ -883,7 +887,7 @@
                   "path": "Core.View.Watch 3D"
                 }
               ],
-              "childElements": [ ]
+              "childElements": []
             }
           ]
         },

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -124,6 +124,7 @@
     </Compile>
     <Compile Include="ColorPaletteTests.cs" />
     <Compile Include="InfoBubbleTests.cs" />
+    <Compile Include="Libraries\LabelTests.cs" />
     <Compile Include="ListAtLevelTest.cs" />
     <Compile Include="NodeHelpPromptTest.cs" />
     <Compile Include="NoteViewTests.cs" />
@@ -313,6 +314,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\DocumentationBrowserScriptsTest.html" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/DynamoCoreWpfTests/Libraries/LabelTests.cs
+++ b/test/DynamoCoreWpfTests/Libraries/LabelTests.cs
@@ -1,14 +1,36 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Dynamo.Graph.Nodes;
+using Dynamo.Wpf.ViewModels.Watch3D;
 using HelixToolkit.Wpf.SharpDX;
 using NUnit.Framework;
+using SystemTestServices;
 
 namespace AnalysisTests
 {
     [TestFixture, RequiresSTA]
-    class LabelTests : WpfVisualizationTests.VisualizationTest
+    class LabelTests : SystemTestBase
     {
+        protected void OpenVisualizationTest(string fileName)
+        {
+            string relativePath = Path.Combine(
+                GetTestDirectory(ExecutingDirectory),
+                string.Format(@"core\visualization\{0}", fileName));
+
+            if (!File.Exists(relativePath))
+            {
+                throw new FileNotFoundException("The specified .dyn file could not be found.");
+            }
+
+            ViewModel.OpenCommand.Execute(relativePath);
+        }
+
+        protected IEnumerable<Element3D> BackgroundPreviewGeometry
+        {
+            get { return ((HelixWatch3DViewModel)ViewModel.BackgroundPreviewViewModel).SceneItems; }
+        }
+
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
             libraries.Add("ProtoGeometry.dll");

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -56,9 +56,16 @@
     <Compile Include="..\..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="LabelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SurfaceDataTests.cs" />
+    <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\DynamoCore\DynamoCore.csproj">
+      <Project>{7858FA8C-475F-4B8E-B468-1F8200778CF8}</Project>
+      <Name>DynamoCore</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\DynamoUtilities\DynamoUtilities.csproj">
       <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
       <Name>DynamoUtilities</Name>

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -36,9 +36,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.11.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d" />
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
@@ -50,6 +53,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnalysisTests.cs" />
@@ -62,6 +66,10 @@
     <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\DynamoCoreWpf\DynamoCoreWpf.csproj">
+      <Project>{51BB6014-43F7-4F31-B8D3-E3C37EBEDAF4}</Project>
+      <Name>DynamoCoreWpf</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\DynamoCore\DynamoCore.csproj">
       <Project>{7858FA8C-475F-4B8E-B468-1F8200778CF8}</Project>
       <Name>DynamoCore</Name>
@@ -75,6 +83,10 @@
       <Project>{76686ed6-e759-4772-81c2-768740be13fa}</Project>
       <Name>Analysis</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\src\Libraries\CoreNodeModels\CoreNodeModels.csproj">
+      <Project>{D8262D40-4880-41E4-91E4-AF8F480C8637}</Project>
+      <Name>CoreNodeModels</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\Libraries\CoreNodes\CoreNodes.csproj">
       <Project>{87550b2b-6cb8-461e-8965-dfafe3aafb5c}</Project>
       <Name>CoreNodes</Name>
@@ -83,6 +95,14 @@
       <Project>{ef879a10-041d-4c68-83e7-3192685f1bae}</Project>
       <Name>DynamoServices</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\VisualizationTests\WpfVisualizationTests.csproj">
+      <Project>{c4964946-b367-44ee-9ed2-451ff2a83d32}</Project>
+      <Name>WpfVisualizationTests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SystemTestServices\SystemTestServices.csproj">
+      <Project>{89563CD0-509B-40A5-8728-9D3EC6FE8410}</Project>
+      <Name>SystemTestServices</Name>
     </ProjectReference>
     <ProjectReference Include="..\TestServices\TestServices.csproj">
       <Project>{6cd0f0cf-8199-49f9-b0ea-0b9598b44419}</Project>

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -36,12 +36,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.11.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d" />
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
@@ -53,23 +50,17 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnalysisTests.cs" />
     <Compile Include="..\..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
-    <Compile Include="LabelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SurfaceDataTests.cs" />
     <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\DynamoCoreWpf\DynamoCoreWpf.csproj">
-      <Project>{51BB6014-43F7-4F31-B8D3-E3C37EBEDAF4}</Project>
-      <Name>DynamoCoreWpf</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\src\DynamoCore\DynamoCore.csproj">
       <Project>{7858FA8C-475F-4B8E-B468-1F8200778CF8}</Project>
       <Name>DynamoCore</Name>
@@ -83,10 +74,6 @@
       <Project>{76686ed6-e759-4772-81c2-768740be13fa}</Project>
       <Name>Analysis</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\src\Libraries\CoreNodeModels\CoreNodeModels.csproj">
-      <Project>{D8262D40-4880-41E4-91E4-AF8F480C8637}</Project>
-      <Name>CoreNodeModels</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\src\Libraries\CoreNodes\CoreNodes.csproj">
       <Project>{87550b2b-6cb8-461e-8965-dfafe3aafb5c}</Project>
       <Name>CoreNodes</Name>
@@ -96,21 +83,13 @@
       <Name>DynamoServices</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\src\VisualizationTests\WpfVisualizationTests.csproj">
-      <Project>{c4964946-b367-44ee-9ed2-451ff2a83d32}</Project>
-      <Name>WpfVisualizationTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\SystemTestServices\SystemTestServices.csproj">
-      <Project>{89563CD0-509B-40A5-8728-9D3EC6FE8410}</Project>
-      <Name>SystemTestServices</Name>
+    <ProjectReference Include="..\..\..\src\Tools\DynamoShapeManager\DynamoShapeManager.csproj">
+      <Project>{263fa9c1-f81e-4a8e-95e0-8cdae20f177b}</Project>
+      <Name>DynamoShapeManager</Name>
     </ProjectReference>
     <ProjectReference Include="..\TestServices\TestServices.csproj">
       <Project>{6cd0f0cf-8199-49f9-b0ea-0b9598b44419}</Project>
       <Name>TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\Tools\DynamoShapeManager\DynamoShapeManager.csproj">
-      <Project>{263fa9c1-f81e-4a8e-95e0-8cdae20f177b}</Project>
-      <Name>DynamoShapeManager</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Libraries/AnalysisTests/LabelTests.cs
+++ b/test/Libraries/AnalysisTests/LabelTests.cs
@@ -25,10 +25,10 @@ namespace AnalysisTests
             var package = factory.CreateRenderPackage();
 
             //Act
+            Assert.IsNotNull(labelTest);
             labelTest.Tessellate(package, new TessellationParameters());
 
             //Assert
-            Assert.IsNotNull(labelTest);
             //Validates when Point is null
             Assert.Throws<ArgumentNullException>( () => Label.ByPointAndString(null, "TestingLabel"));
             //Validates when the label string is null

--- a/test/Libraries/AnalysisTests/LabelTests.cs
+++ b/test/Libraries/AnalysisTests/LabelTests.cs
@@ -1,15 +1,26 @@
-﻿using System;
-using Analysis;
-using Autodesk.DesignScript.Geometry;
-using Autodesk.DesignScript.Interfaces;
-using Dynamo.Visualization;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Graph.Nodes;
+using HelixToolkit.Wpf.SharpDX;
 using NUnit.Framework;
 
 namespace AnalysisTests
 {
-    [TestFixture]
-    class LabelTests
+    [TestFixture, RequiresSTA]
+    class LabelTests : WpfVisualizationTests.VisualizationTest
     {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DSIronPython.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("GeometryColor.dll");
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("Analysis.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
         /// <summary>
         /// This test method will execute the next methods from the Label class:
         /// private Label(Point point, string label)
@@ -17,22 +28,76 @@ namespace AnalysisTests
         /// public void Tessellate(IRenderPackage package, TessellationParameters parameters)
         /// </summary>
         [Test, Category("UnitTests")]
-        public void LabelByPointAndStringTest()
+        public void ByPointAndString_ShowLabel_Test()
         {
             //Arrange
-            var labelTest = Label.ByPointAndString(Point.ByCoordinates(100,100), "TestingLabel");
-            var factory = new DefaultRenderPackageFactory();
-            var package = factory.CreateRenderPackage();
+            OpenVisualizationTest("Test_CBN_Label.dyn");
+            Assert.IsTrue(ViewModel.HomeSpace.Nodes.All(x => x.DisplayLabels != true));
+
+            var cbn =
+              Model.CurrentWorkspace.Nodes.FirstOrDefault(
+                  x => x.GUID.ToString() == "6087ac20-e784-4ffb-8391-35b627625c9f") as
+                  CodeBlockNodeModel;
+
+            //Check that the Code Block node was found
+            Assert.IsNotNull(cbn);
+            //This will make visible the labels in the Background Preview
+            cbn.DisplayLabels = true;
 
             //Act
-            Assert.IsNotNull(labelTest);
-            labelTest.Tessellate(package, new TessellationParameters());
+            //Internally it will call the Label.ByPointAndString method located inside the CodeBlock node
+            ViewModel.HomeSpace.Run();
+
+            //It won't have any warnings then it will be false
+            bool hasWarnings = ViewModel.HomeSpace.Nodes.Any(n => n.State == ElementState.Warning || n.State == ElementState.PersistentWarning);
+
+            //This will get the text elements in the Background Preview
+            var textElements = BackgroundPreviewGeometry
+                               .Where(g => g is BillboardTextModel3D)
+                               .Cast<BillboardTextModel3D>()
+                               .Select(bb => bb.Geometry).Cast<BillboardText3D>()
+                               .ToArray();
 
             //Assert
-            //Validates when Point is null
-            Assert.Throws<ArgumentNullException>( () => Label.ByPointAndString(null, "TestingLabel"));
-            //Validates when the label string is null
-            Assert.Throws<ArgumentNullException>(() => Label.ByPointAndString(Point.ByCoordinates(100, 100), null));
+            //Be Sure that we have no warning
+            Assert.IsFalse(hasWarnings);
+
+            //Check that the Label contains the right text
+            Assert.That(textElements.First().TextInfo.First().Text, Is.EqualTo("test"));
+        }
+
+
+        /// <summary>
+        /// This test method will execute the Label.ByPointAndString method and will raise the exceptions due to the parameters passed
+        /// </summary>
+        [Test, Category("UnitTests")]
+        [TestCase("Test_CBN_Label_InvalidPoint.dyn", Description = "Passing a NULL Point to the Label.ByPointAndString method")]
+        [TestCase("Test_CBN_Label_EmptyText.dyn", Description = "Passing an empty text to the Label.ByPointAndString method")]
+        public void ByPointAndString_EmptyLabel_ThrowArgumentNullException(string dynFileName)
+        {
+            //Arrange
+            OpenVisualizationTest(dynFileName);
+            Assert.IsTrue(ViewModel.HomeSpace.Nodes.All(x => x.DisplayLabels != true));
+
+            var cbn =
+              Model.CurrentWorkspace.Nodes.FirstOrDefault(
+                  x => x.GUID.ToString() == "6087ac20-e784-4ffb-8391-35b627625c9f") as
+                  CodeBlockNodeModel;
+
+            //Check that the Code Block node was found
+            Assert.IsNotNull(cbn);
+            cbn.DisplayLabels = true;
+
+            //Act
+            //Internally it will call the Label.ByPointAndString method located inside the CodeBlock node
+            ViewModel.HomeSpace.Run();
+            bool hasWarnings = ViewModel.HomeSpace.Nodes.Any(n => n.State == ElementState.Warning || n.State == ElementState.PersistentWarning);
+
+            //Assert
+            //It will have warnings due that the graph is not compiling
+            Assert.IsTrue(hasWarnings);
+            //Due that the parameters passed to the Label.ByPointAndString method are invalid it will raise an exception (that cannot be catched) but is recorded in the ToolTipText parameter
+            Assert.That(cbn.ToolTipText, Is.StringContaining("ArgumentNullException"));
         }
     }
 }

--- a/test/Libraries/AnalysisTests/LabelTests.cs
+++ b/test/Libraries/AnalysisTests/LabelTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Analysis;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Interfaces;
+using Dynamo.Visualization;
+using NUnit.Framework;
+
+namespace AnalysisTests
+{
+    [TestFixture]
+    class LabelTests
+    {
+        /// <summary>
+        /// This test method will execute the next methods from the Label class:
+        /// private Label(Point point, string label)
+        /// public static Label ByPointAndString(Point point, string label)
+        /// public void Tessellate(IRenderPackage package, TessellationParameters parameters)
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void LabelByPointAndStringTest()
+        {
+            //Arrange
+            var labelTest = Label.ByPointAndString(Point.ByCoordinates(100,100), "TestingLabel");
+            var factory = new DefaultRenderPackageFactory();
+            var package = factory.CreateRenderPackage();
+
+            //Act
+            labelTest.Tessellate(package, new TessellationParameters());
+
+            //Assert
+            Assert.IsNotNull(labelTest);
+            //Validates when Point is null
+            Assert.Throws<ArgumentNullException>( () => Label.ByPointAndString(null, "TestingLabel"));
+            //Validates when the label string is null
+            Assert.Throws<ArgumentNullException>(() => Label.ByPointAndString(Point.ByCoordinates(100, 100), null));
+        }
+    }
+}

--- a/test/Libraries/AnalysisTests/SurfaceDataTests.cs
+++ b/test/Libraries/AnalysisTests/SurfaceDataTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using Analysis;
+using Autodesk.DesignScript.Geometry;
+using NUnit.Framework;
+
+namespace AnalysisTests
+{
+    [TestFixture]
+    class SurfaceDataTests : TestServices.GeometricTestBase
+    {
+        /// <summary>
+        /// This test method will execute the BySurfaceAndPoints method from the SurfaceData class passing different parameters
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void SurfaceAnalysisDataBySurfaceAndPointsTest_Exceptions()
+        {
+            //Act
+            var sad = SurfaceData.BySurfaceAndPoints(TestSurface(),TestUvs());
+
+            //Assert
+            Assert.NotNull(sad);
+            Assert.NotNull(sad.Surface);
+            //The BySurfaceAndPoints method creates a surface without values, then we validate that values is null
+            Assert.IsNull(sad.Values);
+
+            //It will raise an ArgumentNullException when we pass the Surface as null
+            Assert.Throws<ArgumentNullException>(() => SurfaceData.BySurfaceAndPoints(null, TestUvs()));
+
+            //It will raise an ArgumentNullException when we pass the UV values as null
+            Assert.Throws<ArgumentNullException>(() => SurfaceData.BySurfaceAndPoints(TestSurface(), null));
+
+            //It will raise an ArgumentNullException when we pass the UV values as empty IEnumerable
+            Assert.Throws<ArgumentException>(() => SurfaceData.BySurfaceAndPoints(TestSurface(), new UV[0]));
+
+        }
+
+        /// <summary>
+        /// This test method will execute the BySurfacePointsAndValues method from the SurfaceData class passing an empty values List
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void SurfaceAnalysisDataBySurfacePointsAndResults_ValuesException()
+        {
+            //This will raise the exception thrown when the values list passed to BySurfacePointsAndValues method is empty
+            Assert.Throws<ArgumentException>(() => SurfaceData.BySurfacePointsAndValues(
+                TestSurface(),
+                TestUvs(),
+                new List<double>()) );
+        }
+
+        /// <summary>
+        /// This test method will execute the IsAlmostEqualTo method from the AnalysisExtensions class
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void AnalysisExtensionsIsAlmostEqualToTest()
+        {
+            //Arrange
+            //Define two UV coordinates that are extremely close
+            var UVCoord1 = UV.ByCoordinates(0.0000005, 0.0000005);
+            var UVCoord2 = UV.ByCoordinates(0.0000004, 0.0000004);
+
+            //Act
+            var boolResult = AnalysisExtensions.IsAlmostEqualTo(UVCoord1, UVCoord2);
+
+            //Assert
+            //If is true means that the coordinates are almost equal
+            Assert.IsTrue(boolResult);
+        }      
+
+        private static Surface TestSurface()
+        {
+            var points = new[]
+            {
+                Point.ByCoordinates(0, 0, 0),
+                Point.ByCoordinates(0, 1, 0),
+                Point.ByCoordinates(1, 1, 0),
+                Point.ByCoordinates(1, 0, 0)
+            };
+
+            var srf = Surface.ByPerimeterPoints(points);
+            return srf;
+        }
+
+        private static IEnumerable<UV> TestUvs()
+        {
+            var uvs = new[]
+            {
+                UV.ByCoordinates(0, 0),
+                UV.ByCoordinates(0.5, 0.5),
+                UV.ByCoordinates(1, 1)
+            };
+
+            return uvs;
+        }
+    }
+}

--- a/test/Libraries/AnalysisTests/SurfaceDataTests.cs
+++ b/test/Libraries/AnalysisTests/SurfaceDataTests.cs
@@ -19,8 +19,8 @@ namespace AnalysisTests
             var sad = SurfaceData.BySurfaceAndPoints(TestSurface(),TestUvs());
 
             //Assert
-            Assert.NotNull(sad);
-            Assert.NotNull(sad.Surface);
+            Assert.IsNotNull(sad);
+            Assert.IsNotNull(sad.Surface);
             //The BySurfaceAndPoints method creates a surface without values, then we validate that values is null
             Assert.IsNull(sad.Values);
 

--- a/test/Libraries/AnalysisTests/UtilsTests.cs
+++ b/test/Libraries/AnalysisTests/UtilsTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Analysis;
+using Autodesk.DesignScript.Geometry;
+using DSCore;
+using NUnit.Framework;
+
+namespace AnalysisTests
+{
+    [TestFixture]
+    class UtilsTests
+    {
+        
+        /// <summary>
+        /// This test method will execute the CreateGradientValueMap method from the Utils class
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void CreateGradientValueMapTest()
+        {
+            //Arrange
+            //Creates a IEnumerable range with values from 1 to 20
+            IEnumerable<double> values = from value in Enumerable.Range(1, 20)
+                                               select (double)value;
+
+            //Creates a IEnumerable locations with coordinate values like (1,1), (2,2) .....
+            IEnumerable<UV> locationsUV = from value in Enumerable.Range(1, 20)
+                                               select UV.ByCoordinates(value, value);
+
+            //Act
+            var colorDouble = Utils.CreateGradientValueMap(values, locationsUV, 0, 0);
+            //Pass the values with a empty IEnumerable so it will return a empty value map
+            var emptyDouble = Utils.CreateGradientValueMap(new double[0] , locationsUV, 0, 0);
+
+            //Assert
+            //Validates that the Gradient Value Map was created sucessfully with 1 value
+            Assert.IsNotNull(colorDouble);
+            Assert.AreEqual(colorDouble.Count(), 1);
+            //Validates that the Gradient Value Map was NOT created
+            Assert.AreEqual(emptyDouble.Count(), 0);
+        }
+
+        /// <summary>
+        /// This test method will execute the CreateGradientColorMap and CreateAnalyticalColorRange methods from the Utils class
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void CreateGradientColorMapTest()
+        {
+            //Arrange
+            //Create a color range (3 colors)
+            var colorRange = Utils.CreateAnalyticalColorRange();
+
+            IEnumerable<UV> locations = new List<UV>() { UV.ByCoordinates(0, 0), UV.ByCoordinates(1, 0), UV.ByCoordinates(0, 1) };
+
+            var colorsArray = (from color in colorRange.IndexedColors select color.Color).ToArray();
+
+            //Act
+            var colorMapArray = Utils.CreateGradientColorMap(colorsArray, locations, 2, 2);
+            //When passing the Colors array empty it will return an empty Color array
+            var empyColor = Utils.CreateGradientColorMap(new Color[0], locations, 2, 2);
+
+            //Assert
+            //Validate that the CreateAnalyticalColorRange method returned a valid ColorRange1D
+            Assert.IsNotNull(colorRange);
+            Assert.AreEqual(empyColor.Count(), 0);
+            Assert.AreEqual(colorMapArray.Count(),2);
+        }      
+    }
+}

--- a/test/core/visualization/Test_CBN_Label.dyn
+++ b/test/core/visualization/Test_CBN_Label.dyn
@@ -1,0 +1,96 @@
+{
+  "Uuid": "df853748-8c28-401a-baac-be745776000e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Test_CBN_Label",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Label": {
+        "Key": "Analysis.Label",
+        "Value": "Analysis.dll"
+      },
+      "Autodesk.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Geometry.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Analysis.Label": {
+        "Key": "Analysis.Label",
+        "Value": "Analysis.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Label.ByPointAndString(Point.ByCoordinates(50,100),\"test\");",
+      "Id": "6087ac20e7844ffb839135b627625c9f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8d64194a80444e4c81e716d6db7649e0",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.3.7984",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6087ac20e7844ffb839135b627625c9f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 119.62811241843366,
+        "Y": 54.291527072929057
+      }
+    ],
+    "Annotations": [],
+    "X": 10.861113088132868,
+    "Y": 9.698779503225694,
+    "Zoom": 0.916413219375351
+  }
+}

--- a/test/core/visualization/Test_CBN_Label_EmptyText.dyn
+++ b/test/core/visualization/Test_CBN_Label_EmptyText.dyn
@@ -1,0 +1,96 @@
+{
+  "Uuid": "df853748-8c28-401a-baac-be745776000e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Test_CBN_Label_EmptyText",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Label": {
+        "Key": "Analysis.Label",
+        "Value": "Analysis.dll"
+      },
+      "Autodesk.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Geometry.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Analysis.Label": {
+        "Key": "Analysis.Label",
+        "Value": "Analysis.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Label.ByPointAndString(Point.ByCoordinates(50,100),\"\");",
+      "Id": "6087ac20e7844ffb839135b627625c9f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e55a3e2a9e124057a9e6ec37f3759998",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.3.7984",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6087ac20e7844ffb839135b627625c9f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 119.62811241843366,
+        "Y": 54.291527072929057
+      }
+    ],
+    "Annotations": [],
+    "X": 10.861113088132868,
+    "Y": 9.698779503225694,
+    "Zoom": 0.916413219375351
+  }
+}

--- a/test/core/visualization/Test_CBN_Label_InvalidPoint.dyn
+++ b/test/core/visualization/Test_CBN_Label_InvalidPoint.dyn
@@ -1,0 +1,96 @@
+{
+  "Uuid": "df853748-8c28-401a-baac-be745776000e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Test_CBN_Label_InvalidPoint",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Label": {
+        "Key": "Analysis.Label",
+        "Value": "Analysis.dll"
+      },
+      "Autodesk.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Geometry.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Analysis.Label": {
+        "Key": "Analysis.Label",
+        "Value": "Analysis.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Label.ByPointAndString(null,\"test\");",
+      "Id": "6087ac20e7844ffb839135b627625c9f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4c31bf81b6b94318a04b6db073d8b6f3",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.3.7984",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6087ac20e7844ffb839135b627625c9f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 119.62811241843366,
+        "Y": 54.291527072929057
+      }
+    ],
+    "Annotations": [],
+    "X": 10.861113088132868,
+    "Y": 9.698779503225694,
+    "Zoom": 0.916413219375351
+  }
+}


### PR DESCRIPTION
### Purpose

Increase the code coverage adding test cases for the Libraries/Analysis folder.
I created several unit tests methods using nUnit for the next classes:

- Label
- SurfaceData
- AnalysisExtensions
- Utils

Also I removed two methods from the SurfaceData.cs file since both have zero references and both are private.
The job DynamoSelfServe ran successfully in master-5.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 


### FYIs

@alfredo-pozo 
