### PR TITLE
add no changes state to diff viewer

### DIFF
--- a/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
+++ b/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
@@ -44,15 +44,20 @@
                             <Setter.Value>
                                 <DataTemplate>
                                     <StackPanel Orientation="Vertical"
-                                                VerticalAlignment="Center">
+                                                VerticalAlignment="Center"
+                                                Width="400">
                                         <TextBlock Text="{x:Static p:Resources.MigrationAssistantNoChangesStateHeader}"
+                                                   TextAlignment="Center"
                                                    HorizontalAlignment="Center"
                                                    FontSize="24"
-                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
+                                                   TextWrapping="Wrap" />
                                         <TextBlock Text="{x:Static p:Resources.MigrationAssisantNoChangesStateMessage}"
+                                                   TextAlignment="Center"
                                                    HorizontalAlignment="Center"
                                                    FontSize="14"
-                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
+                                                   TextWrapping="Wrap" />
                                     </StackPanel>
                                 </DataTemplate>
                             </Setter.Value>

--- a/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
+++ b/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
@@ -29,6 +29,37 @@
             <DataTemplate DataType="{x:Type viewModels:SideBySideViewModel}">
                 <local:SideBySideControl DataContext="{Binding}" />
             </DataTemplate>
+            <Style x:Key="HasDifferenceController"
+                   TargetType="{x:Type ContentControl}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.HasChanges}"
+                                 Value="True">
+                        <Setter Property="Content"
+                                Value="{Binding Path=CurrentViewModel}">
+                        </Setter>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.HasChanges}"
+                                 Value="False">
+                        <Setter Property="ContentTemplate">
+                            <Setter.Value>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Vertical"
+                                                VerticalAlignment="Center">
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssistantNoChangesStateHeader}"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="24"
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssisantNoChangesStateMessage}"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="14"
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
 
@@ -56,8 +87,9 @@
             </Style>
         </Grid.Resources>
         
-        <ContentControl Content="{Binding CurrentViewModel}"
+        <ContentControl Style="{StaticResource HasDifferenceController}"
                         Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+        
 
         <!-- Buttons row -->
         <Grid HorizontalAlignment="Stretch"

--- a/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
+++ b/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
@@ -52,7 +52,7 @@
                                                    FontSize="24"
                                                    Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
                                                    TextWrapping="Wrap" />
-                                        <TextBlock Text="{x:Static p:Resources.MigrationAssisantNoChangesStateMessage}"
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssistantNoChangesStateMessage}"
                                                    TextAlignment="Center"
                                                    HorizontalAlignment="Center"
                                                    FontSize="14"

--- a/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
@@ -3,6 +3,7 @@
     public interface IDiffViewViewModel
     {
         ViewMode ViewMode { get; }
+        bool HasChanges { get; }
     }
 
     public enum ViewMode

--- a/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
@@ -8,6 +8,7 @@ namespace Dynamo.PythonMigration.Differ
     {
         public ViewMode ViewMode { get; set; }
         public DiffPaneModel DiffModel { get; set; }
+        public bool HasChanges { get { return DiffModel.HasDifferences; } } 
 
         public InLineViewModel(SideBySideDiffModel diffModel)
         {

--- a/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
@@ -8,6 +8,7 @@ namespace Dynamo.PythonMigration.Differ
         public SideBySideDiffModel DiffModel { get; set; }
         public DiffPaneModel AfterPane { get { return DiffModel.NewText; } }
         public DiffPaneModel BeforePane { get { return DiffModel.OldText; } }
+        public bool HasChanges { get { return DiffModel.NewText.HasDifferences | DiffModel.OldText.HasDifferences; } }
 
         public SideBySideViewModel(SideBySideDiffModel diffModel)
         {

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -68,6 +68,9 @@ namespace Dynamo.PythonMigration.MigrationAssistant
         /// </summary>
         public void ChangeCode()
         {
+            if (!this.CurrentViewModel.HasChanges)
+                return;
+
             if (!Models.DynamoModel.IsTestMode && !File.Exists(GetMigrationAssistantDisclaimerDismissFile()))
             {
                 var warningMessage = new MigrationAssistantDisclaimer(this);

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -69,7 +69,12 @@ namespace Dynamo.PythonMigration.MigrationAssistant
         public void ChangeCode()
         {
             if (!this.CurrentViewModel.HasChanges)
+            {
+                if (this.PythonNode.Engine == PythonEngineVersion.CPython3)
+                    return;
+                this.PythonNode.Engine = PythonEngineVersion.CPython3;
                 return;
+            }
 
             if (!Models.DynamoModel.IsTestMode && !File.Exists(GetMigrationAssistantDisclaimerDismissFile()))
             {

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -143,6 +143,15 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your code is ready to run with the Python 3 engine..
+        /// </summary>
+        public static string MigrationAssisantNoChangesStateMessage {
+            get {
+                return ResourceManager.GetString("MigrationAssisantNoChangesStateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Continue.
         /// </summary>
         public static string MigrationAssistantDisclaimerContinueButtonContent {
@@ -194,6 +203,15 @@ namespace Dynamo.PythonMigration.Properties {
         public static string MigrationAssistantDisclaimerWindowTitle {
             get {
                 return ResourceManager.GetString("MigrationAssistantDisclaimerWindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nothing to see here!.
+        /// </summary>
+        public static string MigrationAssistantNoChangesStateHeader {
+            get {
+                return ResourceManager.GetString("MigrationAssistantNoChangesStateHeader", resourceCulture);
             }
         }
         

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -143,7 +143,7 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your code is ready to run with the Python 3 engine..
+        ///   Looks up a localized string similar to Your code is ready to run with the Python 3 engine. Click accept and we&apos;ll switch to the Python 3 engine for you..
         /// </summary>
         public static string MigrationAssisantNoChangesStateMessage {
             get {

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -143,15 +143,6 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your code is ready to run with the Python 3 engine. Click accept and we&apos;ll switch to the Python 3 engine for you..
-        /// </summary>
-        public static string MigrationAssisantNoChangesStateMessage {
-            get {
-                return ResourceManager.GetString("MigrationAssisantNoChangesStateMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Continue.
         /// </summary>
         public static string MigrationAssistantDisclaimerContinueButtonContent {
@@ -212,6 +203,15 @@ namespace Dynamo.PythonMigration.Properties {
         public static string MigrationAssistantNoChangesStateHeader {
             get {
                 return ResourceManager.GetString("MigrationAssistantNoChangesStateHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your code is ready to run with the Python 3 engine. Click accept and we&apos;ll switch to the Python 3 engine for you..
+        /// </summary>
+        public static string MigrationAssistantNoChangesStateMessage {
+            get {
+                return ResourceManager.GetString("MigrationAssistantNoChangesStateMessage", resourceCulture);
             }
         }
         

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -146,7 +146,7 @@ There will be a time of transition where both versions of Python node will work 
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
   <data name="MigrationAssisantNoChangesStateMessage" xml:space="preserve">
-    <value>Your code is ready to run with the Python 3 engine.</value>
+    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
   </data>
   <data name="MigrationAssistantDisclaimerContinueButtonContent" xml:space="preserve">
     <value>Continue</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -145,6 +145,9 @@ There will be a time of transition where both versions of Python node will work 
   <data name="IronPythonNotificationShortMessage" xml:space="preserve">
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
+  <data name="MigrationAssisantNoChangesStateMessage" xml:space="preserve">
+    <value>Your code is ready to run with the Python 3 engine.</value>
+  </data>
   <data name="MigrationAssistantDisclaimerContinueButtonContent" xml:space="preserve">
     <value>Continue</value>
   </data>
@@ -163,6 +166,9 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   </data>
   <data name="MigrationAssistantDisclaimerWindowTitle" xml:space="preserve">
     <value>Migration Assistant Disclaimer</value>
+  </data>
+  <data name="MigrationAssistantNoChangesStateHeader" xml:space="preserve">
+    <value>Nothing to see here!</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -145,9 +145,6 @@ There will be a time of transition where both versions of Python node will work 
   <data name="IronPythonNotificationShortMessage" xml:space="preserve">
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
-  <data name="MigrationAssisantNoChangesStateMessage" xml:space="preserve">
-    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
-  </data>
   <data name="MigrationAssistantDisclaimerContinueButtonContent" xml:space="preserve">
     <value>Continue</value>
   </data>
@@ -169,6 +166,9 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   </data>
   <data name="MigrationAssistantNoChangesStateHeader" xml:space="preserve">
     <value>Nothing to see here!</value>
+  </data>
+  <data name="MigrationAssistantNoChangesStateMessage" xml:space="preserve">
+    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -146,7 +146,7 @@ There will be a time of transition where both versions of Python node will work 
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
   <data name="MigrationAssisantNoChangesStateMessage" xml:space="preserve">
-    <value>Your code is ready to run with the Python 3 engine.</value>
+    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
   </data>
   <data name="MigrationAssistantDisclaimerContinueButtonContent" xml:space="preserve">
     <value>Continue</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -145,6 +145,9 @@ There will be a time of transition where both versions of Python node will work 
   <data name="IronPythonNotificationShortMessage" xml:space="preserve">
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
+  <data name="MigrationAssisantNoChangesStateMessage" xml:space="preserve">
+    <value>Your code is ready to run with the Python 3 engine.</value>
+  </data>
   <data name="MigrationAssistantDisclaimerContinueButtonContent" xml:space="preserve">
     <value>Continue</value>
   </data>
@@ -163,6 +166,9 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   </data>
   <data name="MigrationAssistantDisclaimerWindowTitle" xml:space="preserve">
     <value>Migration Assistant Disclaimer</value>
+  </data>
+  <data name="MigrationAssistantNoChangesStateHeader" xml:space="preserve">
+    <value>Nothing to see here!</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -145,9 +145,6 @@ There will be a time of transition where both versions of Python node will work 
   <data name="IronPythonNotificationShortMessage" xml:space="preserve">
     <value>This graph currently contains nodes that are using the old IronPython2 (Python 2) engine which will be deprecated in later versions. A new CPython3 (Python 3) has been implemented and is accessible inside the Python editor.</value>
   </data>
-  <data name="MigrationAssisantNoChangesStateMessage" xml:space="preserve">
-    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
-  </data>
   <data name="MigrationAssistantDisclaimerContinueButtonContent" xml:space="preserve">
     <value>Continue</value>
   </data>
@@ -169,6 +166,9 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   </data>
   <data name="MigrationAssistantNoChangesStateHeader" xml:space="preserve">
     <value>Nothing to see here!</value>
+  </data>
+  <data name="MigrationAssistantNoChangesStateMessage" xml:space="preserve">
+    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>


### PR DESCRIPTION
### Purpose

When the Migration Assistant is used on code that is already Python 3 compatible the diff viewer will still show the code. This can lead to confusion as it looks like the Migration Assistant isnt working/doing anything.

This PR adds a `No Changes` state to the Diff viewer which will let the user know if no changes are needed.

![PythonMigrationNoChangeState](https://user-images.githubusercontent.com/13732445/90237804-c7c13500-de1c-11ea-9384-180def47d1e0.gif)

<img width="923" alt="NoChangeStateSideBySide" src="https://user-images.githubusercontent.com/13732445/90237823-d0197000-de1c-11ea-8364-541d73b9fec4.png">
<img width="465" alt="NoChangeStateInLine" src="https://user-images.githubusercontent.com/13732445/90237828-d1e33380-de1c-11ea-9e18-7f87c1ee6e65.png">
 
### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mmisol 

### FYIs

@mjkkirschner 
@QilongTang 
@Amoursol 
