### PR TITLE
Cherry Pick: Obsolete python events

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -134,9 +134,11 @@ namespace DSCPython
     }
 
     [SupressImportIntoVM]
+    [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
     public enum EvaluationState { Begin, Success, Failed }
 
     [SupressImportIntoVM]
+    [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
     public delegate void EvaluationEventHandler(EvaluationState state, PyScope scope, string code, IList bindingValues);
 
     /// <summary>
@@ -490,12 +492,14 @@ clr.setPreload(True)
         ///     Emitted immediately before execution begins
         /// </summary>
         [SupressImportIntoVM]
+        [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
         public static event EvaluationEventHandler EvaluationBegin;
 
         /// <summary>
         ///     Emitted immediately after execution ends or fails
         /// </summary>
         [SupressImportIntoVM]
+        [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
         public static event EvaluationEventHandler EvaluationEnd;
 
         /// <summary>

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -17,9 +17,11 @@ using Microsoft.Scripting.Utils;
 namespace DSIronPython
 {
     [SupressImportIntoVM]
+    [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
     public enum EvaluationState { Begin, Success, Failed }
 
     [SupressImportIntoVM]
+    [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
     public delegate void EvaluationEventHandler(EvaluationState state,
                                                 ScriptEngine engine,
                                                 ScriptScope scope,
@@ -245,12 +247,14 @@ namespace DSIronPython
         ///     Emitted immediately before execution begins
         /// </summary>
         [SupressImportIntoVM]
+        [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
         public static event EvaluationEventHandler EvaluationBegin;
 
         /// <summary>
         ///     Emitted immediately after execution ends or fails
         /// </summary>
         [SupressImportIntoVM]
+        [Obsolete("Do not use! This will be subject to changes in a future version of Dynamo")]
         public static event EvaluationEventHandler EvaluationEnd;
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Python evaluation events are exposing internals of the engines they
use, which is not a good practice. Meanwhile we decide the future of
these events in the context of moving out Python engines from Core, we
will declare these events as 'Obsolete' to make clear our intentions of
making changes in the near future.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 

