### PR TITLE
Python engine property should copy/paste and undo correctly.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2094,6 +2094,30 @@ namespace Dynamo.Graph.Nodes
                         }
                     }
                     return true;
+
+                case nameof(DisplayLabels):
+                    bool newDisplayLabels;
+                    if (bool.TryParse(value, out newDisplayLabels))
+                    {
+                        DisplayLabels = newDisplayLabels;
+                    }
+                    return true;
+
+                case nameof(IsSetAsInput):
+                    bool newIsSetAsInput;
+                    if (bool.TryParse(value, out newIsSetAsInput))
+                    {
+                        IsSetAsInput = newIsSetAsInput;
+                    }
+                    return true;
+
+                case nameof(IsSetAsOutput):
+                    bool newIsSetAsOutput;
+                    if (bool.TryParse(value, out newIsSetAsOutput))
+                    {
+                        IsSetAsOutput = newIsSetAsOutput;
+                    }
+                    return true;
             }
 
             return base.UpdateValueCore(updateValueParams);

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2143,6 +2143,7 @@ namespace Dynamo.Graph.Nodes
             helper.SetAttribute("x", X);
             helper.SetAttribute("y", Y);
             helper.SetAttribute("isVisible", IsVisible);
+            helper.SetAttribute(nameof(DisplayLabels), DisplayLabels);
             helper.SetAttribute("lacing", ArgumentLacing.ToString());
             helper.SetAttribute("isSelectedInput", IsSetAsInput.ToString());
             helper.SetAttribute("isSelectedOutput", IsSetAsOutput.ToString());
@@ -2201,6 +2202,7 @@ namespace Dynamo.Graph.Nodes
             X = helper.ReadDouble("x", 0.0);
             Y = helper.ReadDouble("y", 0.0);
             isVisible = helper.ReadBoolean("isVisible", true);
+            displayLabels = helper.ReadBoolean(nameof(DisplayLabels), false);
             argumentLacing = helper.ReadEnum("lacing", LacingStrategy.Disabled);
             IsSetAsInput = helper.ReadBoolean("isSelectedInput", false);
             IsSetAsOutput = helper.ReadBoolean("isSelectedOutput", false);

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -162,9 +162,8 @@ namespace Dynamo.ViewModels
             {
                 if (nodeLogic.IsSetAsInput != value)
                 {
-                    DynamoViewModel.ExecuteCommand(
-               new DynamoModel.UpdateModelValueCommand(
-                   Guid.Empty, NodeModel.GUID, nameof(IsSetAsInput), value.ToString()));
+                    DynamoViewModel.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                        Guid.Empty, NodeModel.GUID, nameof(IsSetAsInput), value.ToString()));
 
                     RaisePropertyChanged(nameof(IsSetAsInput));
                 }
@@ -190,9 +189,8 @@ namespace Dynamo.ViewModels
             {
                 if (nodeLogic.IsSetAsOutput != value)
                 {
-                    DynamoViewModel.ExecuteCommand(
-               new DynamoModel.UpdateModelValueCommand(
-                   Guid.Empty, NodeModel.GUID, nameof(IsSetAsOutput), value.ToString()));
+                    DynamoViewModel.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                        Guid.Empty, NodeModel.GUID, nameof(IsSetAsOutput), value.ToString()));
 
                     RaisePropertyChanged(nameof(IsSetAsOutput));
                 }
@@ -376,12 +374,13 @@ namespace Dynamo.ViewModels
             get { return nodeLogic.DisplayLabels; }
             set
             {
-                
-                    DynamoViewModel.ExecuteCommand(
-               new DynamoModel.UpdateModelValueCommand(
-                   Guid.Empty, NodeModel.GUID, nameof(nodeLogic.DisplayLabels), value.ToString()));
+                if (nodeLogic.DisplayLabels != value)
+                {
+                    DynamoViewModel.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                    Guid.Empty, NodeModel.GUID, nameof(nodeLogic.DisplayLabels), value.ToString()));
 
                     RaisePropertyChanged(nameof(IsDisplayingLabels));
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -371,7 +371,7 @@ namespace Dynamo.ViewModels
             set
             {
                 nodeLogic.DisplayLabels = value;
-                RaisePropertyChanged("IsDisplayingLabels");
+                RaisePropertyChanged(nameof(IsDisplayingLabels));
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -162,8 +162,11 @@ namespace Dynamo.ViewModels
             {
                 if (nodeLogic.IsSetAsInput != value)
                 {
-                    nodeLogic.IsSetAsInput = value;
-                    RaisePropertyChanged("IsSetAsInput");
+                    DynamoViewModel.ExecuteCommand(
+               new DynamoModel.UpdateModelValueCommand(
+                   Guid.Empty, NodeModel.GUID, nameof(IsSetAsInput), value.ToString()));
+
+                    RaisePropertyChanged(nameof(IsSetAsInput));
                 }
             }
         }
@@ -187,8 +190,11 @@ namespace Dynamo.ViewModels
             {
                 if (nodeLogic.IsSetAsOutput != value)
                 {
-                    nodeLogic.IsSetAsOutput = value;
-                    RaisePropertyChanged("IsSetAsOutput");
+                    DynamoViewModel.ExecuteCommand(
+               new DynamoModel.UpdateModelValueCommand(
+                   Guid.Empty, NodeModel.GUID, nameof(IsSetAsOutput), value.ToString()));
+
+                    RaisePropertyChanged(nameof(IsSetAsOutput));
                 }
             }
         }
@@ -198,10 +204,10 @@ namespace Dynamo.ViewModels
         /// </summary>
         public string Name
         {
-            get 
+            get
             {
                 IsRenamed = OriginalName != nodeLogic.Name;
-                return nodeLogic.Name; 
+                return nodeLogic.Name;
             }
             set { nodeLogic.Name = value; }
         }
@@ -324,7 +330,7 @@ namespace Dynamo.ViewModels
             }
         }
 
-    
+
         [JsonIgnore]
         public Visibility PeriodicUpdateVisibility
         {
@@ -370,8 +376,12 @@ namespace Dynamo.ViewModels
             get { return nodeLogic.DisplayLabels; }
             set
             {
-                nodeLogic.DisplayLabels = value;
-                RaisePropertyChanged(nameof(IsDisplayingLabels));
+                
+                    DynamoViewModel.ExecuteCommand(
+               new DynamoModel.UpdateModelValueCommand(
+                   Guid.Empty, NodeModel.GUID, nameof(nodeLogic.DisplayLabels), value.ToString()));
+
+                    RaisePropertyChanged(nameof(IsDisplayingLabels));
             }
         }
 
@@ -897,7 +907,7 @@ namespace Dynamo.ViewModels
         {
             DynamoViewModel.ExecuteCommand(
                 new DynamoModel.UpdateModelValueCommand(
-                    Guid.Empty, NodeModel.GUID, "ArgumentLacing", param.ToString()));
+                    Guid.Empty, NodeModel.GUID, nameof(ArgumentLacing), param.ToString()));
 
             DynamoViewModel.RaiseCanExecuteUndoRedo();
         }

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -251,6 +251,10 @@ namespace PythonNodeModels
             XmlElement script = element.OwnerDocument.CreateElement("Script");
             script.InnerText = this.script;
             element.AppendChild(script);
+            XmlElement engine = element.OwnerDocument.CreateElement(nameof(Engine));
+            engine.InnerText = Enum.GetName(typeof(PythonEngineVersion), Engine);
+            element.AppendChild(engine);
+
         }
 
         [Obsolete]
@@ -264,6 +268,13 @@ namespace PythonNodeModels
             if (scriptNode != null)
             {
                 script = scriptNode.InnerText;
+            }
+            var engineNode =
+              nodeElement.ChildNodes.Cast<XmlNode>().FirstOrDefault(x => x.Name == nameof(Engine));
+
+            if (engineNode != null)
+            {
+                this.Engine = (PythonEngineVersion)Enum.Parse(typeof(PythonEngineVersion),engineNode.InnerText);
             }
         }
 

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -212,6 +212,17 @@ namespace PythonNodeModels
                 script = value;
                 return true;
             }
+            
+            else if(name == nameof(Engine))
+            {
+                PythonEngineVersion result;
+                if(Enum.TryParse<PythonEngineVersion>(value, out result))
+                {
+                    Engine = result;
+                    return true;
+                }
+              
+            }
 
             return base.UpdateValueCore(updateValueParams);
         }

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -109,6 +109,24 @@ namespace PythonNodeModels
             MigrationAssistantRequested?.Invoke(this, e);
         }
 
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            string name = updateValueParams.PropertyName;
+            string value = updateValueParams.PropertyValue;
+
+            if (name == nameof(Engine))
+            {
+                PythonEngineVersion result;
+                if (Enum.TryParse<PythonEngineVersion>(value, out result))
+                {
+                    Engine = result;
+                    return true;
+                }
+
+            }
+            return base.UpdateValueCore(updateValueParams);
+        }
+
     }
 
     [NodeName("Python Script")]
@@ -211,17 +229,6 @@ namespace PythonNodeModels
             {
                 script = value;
                 return true;
-            }
-            
-            else if(name == nameof(Engine))
-            {
-                PythonEngineVersion result;
-                if(Enum.TryParse<PythonEngineVersion>(value, out result))
-                {
-                    Engine = result;
-                    return true;
-                }
-              
             }
 
             return base.UpdateValueCore(updateValueParams);

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -5,6 +5,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using Dynamo.Controls;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
 using Dynamo.ViewModels;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Windows;
@@ -156,7 +157,9 @@ namespace PythonNodeModelsWpf
         /// </summary>
         private void UpdateToPython2Engine(object sender, EventArgs e)
         {
-            pythonNodeModel.Engine = PythonEngineVersion.IronPython2;
+            dynamoViewModel.ExecuteCommand(
+            new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, pythonNodeModel.GUID, nameof(pythonNodeModel.Engine), PythonEngineVersion.IronPython2.ToString()));
             pythonNodeModel.OnNodeModified();
         }
 
@@ -165,7 +168,9 @@ namespace PythonNodeModelsWpf
         /// </summary>
         private void UpdateToPython3Engine(object sender, EventArgs e)
         {
-            pythonNodeModel.Engine = PythonEngineVersion.CPython3;
+            dynamoViewModel.ExecuteCommand(
+           new DynamoModel.UpdateModelValueCommand(
+               Guid.Empty, pythonNodeModel.GUID, nameof(pythonNodeModel.Engine), PythonEngineVersion.CPython3.ToString()));
             pythonNodeModel.OnNodeModified();
         }
     }

--- a/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using Dynamo.Controls;
+using Dynamo.Models;
 using Dynamo.ViewModels;
 using Dynamo.Wpf;
 using PythonNodeModels;
@@ -66,15 +67,6 @@ namespace PythonNodeModelsWpf
         }
 
         /// <summary>
-        /// MenuItem click handler
-        /// </summary>
-        private void UpdateToPython2Engine(object sender, EventArgs e)
-        {
-            pythonStringNodeModel.Engine = PythonEngineVersion.IronPython2;
-            pythonStringNodeModel.OnNodeModified();
-        }
-
-        /// <summary>
         /// Learn More button handler
         /// </summary>
         /// <param name="sender"></param>
@@ -88,9 +80,22 @@ namespace PythonNodeModelsWpf
         /// <summary>
         /// MenuItem click handler
         /// </summary>
+        private void UpdateToPython2Engine(object sender, EventArgs e)
+        {
+            dynamoViewModel.ExecuteCommand(
+          new DynamoModel.UpdateModelValueCommand(
+              Guid.Empty, pythonStringNodeModel.GUID, nameof(pythonStringNodeModel.Engine), PythonEngineVersion.IronPython2.ToString()));
+            pythonStringNodeModel.OnNodeModified();
+        }
+
+        /// <summary>
+        /// MenuItem click handler
+        /// </summary>
         private void UpdateToPython3Engine(object sender, EventArgs e)
         {
-            pythonStringNodeModel.Engine = PythonEngineVersion.CPython3;
+            dynamoViewModel.ExecuteCommand(
+        new DynamoModel.UpdateModelValueCommand(
+            Guid.Empty, pythonStringNodeModel.GUID, nameof(pythonStringNodeModel.Engine), PythonEngineVersion.CPython3.ToString()));
             pythonStringNodeModel.OnNodeModified();
         }
     }

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -388,7 +388,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void CanCopydAndPasteAndUndoShowLabels()
+        public void CanCopyAndPasteAndUndoShowLabels()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
          
@@ -423,7 +423,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void CanCopydAndPasteAndUndoInputState()
+        public void CanCopyAndPasteAndUndoInputState()
         {
             var numberNode = new DoubleInput();
 
@@ -458,7 +458,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void CanCopydAndPasteAndUndoOutputState()
+        public void CanCopyAndPasteAndUndoOutputState()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
 
@@ -493,7 +493,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void CanCopydAndPasteNodeWithRightOffset()
+        public void CanCopyAndPasteNodeWithRightOffset()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
             addNode.Height = 2;
@@ -519,7 +519,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void CanCopydAndPaste2NodesWithRightOffset()
+        public void CanCopyAndPaste2NodesWithRightOffset()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
             addNode.Height = 2;

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -388,6 +388,111 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void CanCopydAndPasteAndUndoShowLabels()
+        {
+            var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
+         
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            addNode.DisplayLabels = true;
+            CurrentDynamoModel.AddToSelection(addNode);
+            Assert.AreEqual(1, DynamoSelection.Instance.Selection.Count);
+
+            CurrentDynamoModel.Copy();
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.Count);
+
+            CurrentDynamoModel.Paste();
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.Nodes.All(x => x.DisplayLabels));
+
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            addNode.DisplayLabels = false;
+
+            CurrentDynamoModel.ExecuteCommand(
+                 new DynCmd.UpdateModelValueCommand(
+                     Guid.Empty, addNode.GUID, nameof(NodeModel.DisplayLabels), "true"));
+           Assert.IsTrue(addNode.DisplayLabels);
+
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+
+            Assert.IsFalse(addNode.DisplayLabels);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CanCopydAndPasteAndUndoInputState()
+        {
+            var numberNode = new DoubleInput();
+
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(numberNode, false);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            numberNode.IsSetAsInput = true;
+            CurrentDynamoModel.AddToSelection(numberNode);
+            Assert.AreEqual(1, DynamoSelection.Instance.Selection.Count);
+
+            CurrentDynamoModel.Copy();
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.Count);
+
+            CurrentDynamoModel.Paste();
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.Nodes.All(x => x.IsSetAsInput));
+
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            numberNode.IsSetAsInput = false;
+
+            CurrentDynamoModel.ExecuteCommand(
+                 new DynCmd.UpdateModelValueCommand(
+                     Guid.Empty, numberNode.GUID, nameof(NodeModel.IsSetAsInput), "true"));
+            Assert.IsTrue(numberNode.IsSetAsInput);
+
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+
+            Assert.IsFalse(numberNode.IsSetAsInput);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CanCopydAndPasteAndUndoOutputState()
+        {
+            var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
+
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            addNode.IsSetAsOutput = true;
+            CurrentDynamoModel.AddToSelection(addNode);
+            Assert.AreEqual(1, DynamoSelection.Instance.Selection.Count);
+
+            CurrentDynamoModel.Copy();
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.Count);
+
+            CurrentDynamoModel.Paste();
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.Nodes.All(x => x.IsSetAsOutput));
+
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            addNode.IsSetAsOutput = false;
+
+            CurrentDynamoModel.ExecuteCommand(
+                 new DynCmd.UpdateModelValueCommand(
+                     Guid.Empty, addNode.GUID, nameof(NodeModel.IsSetAsOutput), "true"));
+            Assert.IsTrue(addNode.IsSetAsOutput);
+
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+
+            Assert.IsFalse(addNode.IsSetAsOutput);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void CanCopydAndPasteNodeWithRightOffset()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -24,13 +24,18 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
         }
 
-        protected override void GetLibrariesToPreload(List<string> libraries)
+        public override void Start()
         {
-            libraries.Add("DSCPython.dll");
-            libraries.Add("DSIronPython.dll");
+            base.Start();
             // Make sure Python Engine Selector Singleton has all the info up-to-date.
             // This is not needed for Dynamo in normal use case but useful in unit test case.
             PythonEngineSelector.Instance.ScanPythonEngines();
+        }
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("DSCPython.dll");
+            libraries.Add("DSIronPython.dll"); 
             base.GetLibrariesToPreload(libraries);
         }
 

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -302,6 +302,14 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(ViewModel.Model.CurrentWorkspace.HasUnsavedChanges);
             Assert.AreEqual(new List<string> { "2.7.9", "2.7.9" }, pynode2.CachedValue.GetElements().Select(x => x.Data));
             DispatcherUtil.DoEvents();
+
+            Model.CurrentWorkspace.Undo();
+            Assert.AreEqual(new List<string> { "2.7.9", "3.8.3" }, pynode2.CachedValue.GetElements().Select(x => x.Data));
+            DispatcherUtil.DoEvents();
+            Model.CurrentWorkspace.Undo();
+            Assert.AreEqual(new List<string> { "3.8.3", "3.8.3" }, pynode2.CachedValue.GetElements().Select(x => x.Data));
+            DispatcherUtil.DoEvents();
+            
         }
     }
 }

--- a/test/Libraries/DynamoPythonTests/PythonEngineSelectorTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEngineSelectorTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Dynamo;
 using NUnit.Framework;
 using PythonNodeModels;
+using static Dynamo.Models.DynamoModel;
 
 namespace DynamoPythonTests
 {
@@ -33,6 +36,39 @@ namespace DynamoPythonTests
 
             Assert.AreEqual(true, PythonEngineSelector.Instance.IsCPythonEnabled);
             Assert.AreEqual(true, PythonEngineSelector.Instance.IsIronPythonEnabled);
+        }
+
+        [Test]
+        public void CanCopydAndPasteAndUndoPythonEngine()
+        {
+            var pyNode = new PythonNode();
+
+            CurrentDynamoModel.ExecuteCommand(new Dynamo.Models.DynamoModel.CreateNodeCommand(pyNode, 0, 0, false, false));
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            pyNode.Engine = PythonEngineVersion.CPython3;
+            CurrentDynamoModel.AddToSelection(pyNode);
+           
+            CurrentDynamoModel.Copy();
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.Count);
+
+            CurrentDynamoModel.Paste();
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<PythonNode>().All(x => x.Engine == PythonEngineVersion.CPython3));
+
+            CurrentDynamoModel.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            pyNode.Engine = PythonEngineVersion.IronPython2;
+
+            CurrentDynamoModel.ExecuteCommand(
+                 new UpdateModelValueCommand(
+                     Guid.Empty, pyNode.GUID, nameof(PythonNode.Engine), PythonEngineVersion.CPython3.ToString()));
+            Assert.AreEqual(pyNode.Engine,PythonEngineVersion.CPython3);
+
+            CurrentDynamoModel.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
+
+            Assert.AreEqual(pyNode.Engine, PythonEngineVersion.IronPython2);
         }
     }
 }


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3022
Some properties of nodeModel cannot be undone using `undo/redo` and do not `copy/paste` correctly. This includes the new Engine property on Python nodes.

This PR does the following:
* adds xml serialization and deserialization of the missing properties to` NodeModel` and `PythonNodeModel` classes, as the undo redo recorder and copy/paste rely on legacy xml model serialization.

* adds cases for the `updateModelValue` command handler on NodeModel to handle the properties we want to be undoable.

* in the viewModel layer - anywhere we wish to have undoable property settings, we use a `UpdateModelValueCommand` to set the property, these are automatically serialized into the undo/redo recorder.

* tests are added for the nodeModel properties, and for the Python engine properties.

* Fix a small issue with the PythonNodeViewCustmizationTests and when the python engines were being scanned for to update the available engines.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

