### PR TITLE
Tab with spaces when using Python 3

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -207,6 +207,8 @@ namespace PythonNodeModelsWpf
             {
                 UpdateScript(editText.Text);
             }
+
+            editText.Options.ConvertTabsToSpaces = nodeModel.Engine != PythonEngineVersion.IronPython2;
         }
 
         private void OnScriptEditorWindowClosed(object sender, EventArgs e)

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Dynamo.Controls;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Utilities;
@@ -121,6 +122,16 @@ namespace DynamoCoreWpfTests
             //still only 2 executions.
             Assert.AreEqual(2,(Model.CurrentWorkspace as HomeWorkspaceModel).EvaluationCount);
             DispatcherUtil.DoEvents();
+        }
+
+        private static ICSharpCode.AvalonEdit.TextEditor FindCodeEditor(ScriptEditorWindow view)
+        {
+            DispatcherUtil.DoEvents();
+            var windowGrid = view.Content as Grid;
+            var codeEditor = windowGrid
+                .ChildrenOfType<ICSharpCode.AvalonEdit.TextEditor>()
+                .First();
+            return codeEditor;
         }
 
         private static ComboBox FindEditorDropDown(ScriptEditorWindow view)
@@ -302,6 +313,55 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(ViewModel.Model.CurrentWorkspace.HasUnsavedChanges);
             Assert.AreEqual(new List<string> { "2.7.9", "2.7.9" }, pynode2.CachedValue.GetElements().Select(x => x.Data));
             DispatcherUtil.DoEvents();
+        }
+
+        [Test]
+        public void TabWithSpacesMatchesEngine()
+        {
+            // Arrange
+            Open(@"core\python\python.dyn");
+
+            var nodeView = NodeViewWithGuid("3bcad14e-d086-4278-9e08-ed2759ef92f3");
+            var nodeModel = nodeView.ViewModel.NodeModel as PythonNodeBase;
+            Assert.NotNull(nodeModel);
+
+            var scriptWindow = EditPythonCode(nodeView, View);
+            var codeEditor = FindCodeEditor(scriptWindow);
+            var engineSelectorComboBox = FindEditorDropDown(scriptWindow);
+
+            Assert.AreEqual(PythonEngineVersion.IronPython2, engineSelectorComboBox.SelectedItem);
+
+            // Act
+            codeEditor.Focus();
+            codeEditor.SelectionStart = 0;
+            var textArea = Keyboard.FocusedElement;
+            textArea.RaiseEvent(new KeyEventArgs(
+                Keyboard.PrimaryDevice,
+                PresentationSource.FromVisual(codeEditor),
+                0,
+                Key.Tab)
+                {
+                    RoutedEvent = Keyboard.KeyDownEvent
+                }
+            );
+            DispatcherUtil.DoEvents();
+
+            engineSelectorComboBox.SelectedItem = PythonEngineVersion.CPython3;
+
+            codeEditor.SelectionStart = 0;
+            textArea.RaiseEvent(new KeyEventArgs(
+                Keyboard.PrimaryDevice,
+                PresentationSource.FromVisual(codeEditor),
+                0,
+                Key.Tab)
+            {
+                RoutedEvent = Keyboard.KeyDownEvent
+            }
+            );
+            DispatcherUtil.DoEvents();
+
+            // Assert
+            StringAssert.StartsWith("    \t", codeEditor.Text);
         }
     }
 }


### PR DESCRIPTION
### Purpose

The Python text editor now inserts spaces when the tab key is pressed
if the engine is not 'IronPython2'. This is done in order to remain
consistent with the reindent that occurs in 2to3 migration, which will
avoid errors from Python 3 complaining about mixing spaces and tabs.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 
