### PR TITLE
Cherry pick: Friendly message 2to3 migration when no changes

### DIFF
--- a/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
+++ b/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
@@ -29,6 +29,42 @@
             <DataTemplate DataType="{x:Type viewModels:SideBySideViewModel}">
                 <local:SideBySideControl DataContext="{Binding}" />
             </DataTemplate>
+            <Style x:Key="HasDifferenceController"
+                   TargetType="{x:Type ContentControl}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.HasChanges}"
+                                 Value="True">
+                        <Setter Property="Content"
+                                Value="{Binding Path=CurrentViewModel}">
+                        </Setter>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.HasChanges}"
+                                 Value="False">
+                        <Setter Property="ContentTemplate">
+                            <Setter.Value>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Vertical"
+                                                VerticalAlignment="Center"
+                                                Width="400">
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssistantNoChangesStateHeader}"
+                                                   TextAlignment="Center"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="24"
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssistantNoChangesStateMessage}"
+                                                   TextAlignment="Center"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="14"
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
 
@@ -56,8 +92,9 @@
             </Style>
         </Grid.Resources>
         
-        <ContentControl Content="{Binding CurrentViewModel}"
+        <ContentControl Style="{StaticResource HasDifferenceController}"
                         Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+        
 
         <!-- Buttons row -->
         <Grid HorizontalAlignment="Stretch"

--- a/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
@@ -3,6 +3,7 @@
     public interface IDiffViewViewModel
     {
         ViewMode ViewMode { get; }
+        bool HasChanges { get; }
     }
 
     public enum ViewMode

--- a/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
@@ -8,6 +8,7 @@ namespace Dynamo.PythonMigration.Differ
     {
         public ViewMode ViewMode { get; set; }
         public DiffPaneModel DiffModel { get; set; }
+        public bool HasChanges { get { return DiffModel.HasDifferences; } } 
 
         public InLineViewModel(SideBySideDiffModel diffModel)
         {

--- a/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
@@ -8,6 +8,7 @@ namespace Dynamo.PythonMigration.Differ
         public SideBySideDiffModel DiffModel { get; set; }
         public DiffPaneModel AfterPane { get { return DiffModel.NewText; } }
         public DiffPaneModel BeforePane { get { return DiffModel.OldText; } }
+        public bool HasChanges { get { return DiffModel.NewText.HasDifferences | DiffModel.OldText.HasDifferences; } }
 
         public SideBySideViewModel(SideBySideDiffModel diffModel)
         {

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -68,6 +68,14 @@ namespace Dynamo.PythonMigration.MigrationAssistant
         /// </summary>
         public void ChangeCode()
         {
+            if (!this.CurrentViewModel.HasChanges)
+            {
+                if (this.PythonNode.Engine == PythonEngineVersion.CPython3)
+                    return;
+                this.PythonNode.Engine = PythonEngineVersion.CPython3;
+                return;
+            }
+
             if (!Models.DynamoModel.IsTestMode && !File.Exists(GetMigrationAssistantDisclaimerDismissFile()))
             {
                 var warningMessage = new MigrationAssistantDisclaimer(this);

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -198,6 +198,24 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Nothing to see here!.
+        /// </summary>
+        public static string MigrationAssistantNoChangesStateHeader {
+            get {
+                return ResourceManager.GetString("MigrationAssistantNoChangesStateHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your code is ready to run with the Python 3 engine. Click accept and we&apos;ll switch to the Python 3 engine for you..
+        /// </summary>
+        public static string MigrationAssistantNoChangesStateMessage {
+            get {
+                return ResourceManager.GetString("MigrationAssistantNoChangesStateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Packaged.
         /// </summary>
         public static string PackagedCustomNodesHeader {

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -164,6 +164,12 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   <data name="MigrationAssistantDisclaimerWindowTitle" xml:space="preserve">
     <value>Migration Assistant Disclaimer</value>
   </data>
+  <data name="MigrationAssistantNoChangesStateHeader" xml:space="preserve">
+    <value>Nothing to see here!</value>
+  </data>
+  <data name="MigrationAssistantNoChangesStateMessage" xml:space="preserve">
+    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
+  </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>
   </data>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -164,6 +164,12 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   <data name="MigrationAssistantDisclaimerWindowTitle" xml:space="preserve">
     <value>Migration Assistant Disclaimer</value>
   </data>
+  <data name="MigrationAssistantNoChangesStateHeader" xml:space="preserve">
+    <value>Nothing to see here!</value>
+  </data>
+  <data name="MigrationAssistantNoChangesStateMessage" xml:space="preserve">
+    <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
+  </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>
   </data>


### PR DESCRIPTION
### Purpose

Include changes from #11001 in 2.8

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
