### PR TITLE
Fix crashes by undoing/redoing nodes deletion

### DIFF
--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -152,34 +152,6 @@ namespace Dynamo.Scheduler
             }
         }
 
-        /// <summary>
-        /// Returns true if this task's graph sync data is a super set of the other
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        private bool Contains(UpdateGraphAsyncTask other)
-        {
-            // Be more conservative here. Not only check ModifiedNodes, but
-            // also check *all* nodes in graph sync data. For example, consider
-            // a CBN outputs to a node, the node is a downstream node of cbn.
-            //
-            // Now if node is modified and request a run, task's ModifiedNodes
-            // will cotain this node; then CBN is modified and request a run,
-            // ModifiedNodes would contain both CBN and the node, and previous
-            // task will be thrown away.
-            if (!other.ModifiedNodes.All(ModifiedNodes.Contains))
-                return false;
-
-            if (graphSyncData == null)
-                return other.graphSyncData == null;
-            else if (other.graphSyncData == null)
-                return true;
-
-            return other.graphSyncData.AddedNodeIDs.All(graphSyncData.AddedNodeIDs.Contains) &&
-                   other.graphSyncData.ModifiedNodeIDs.All(graphSyncData.ModifiedNodeIDs.Contains) &&
-                   other.graphSyncData.DeletedNodeIDs.All(graphSyncData.DeletedNodeIDs.Contains);
-        }
-
         protected override TaskMergeInstruction CanMergeWithCore(AsyncTask otherTask)
         {
             // One cannot just simply merge these tasks on a compare one to another basis.

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -94,7 +94,7 @@ namespace Dynamo.Wpf.ViewModels.Core
         {
             // Using Nodes here is not thread safe, as nodes can be added/removed by the UI thread midway.
             // Dispatching this to the UI thread helps avoid concurrency issues and seems more correct.
-            if (!DynamoViewModel.Model.ShutdownRequested)
+            if (!DynamoViewModel.Model.ShutdownRequested && DynamoViewModel.UIDispatcher != null)
             {
                 DynamoViewModel.UIDispatcher.Invoke(() => UpdateNodesDeltaState(e.NodeGuidList, e.GraphExecuted));
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -112,7 +112,7 @@ namespace Dynamo.Wpf.ViewModels.Core
         {
             // if runsettings is manual, and if the graph is not executed, then turing on showrunpreview 
             //should turn on showexectionpreview on every node.
-            if (nodeGuids.Count == 0 && graphExecuted)
+            if (nodeGuids.Count == 0 && !graphExecuted)
             {
                 foreach (var nodeModel in Nodes)
                 {

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -73,7 +73,7 @@
                             Maximum="{Binding Max}" 
                             Minimum="{Binding Min}" 
                             TickFrequency="{Binding Step}" 
-                            Value="{Binding Value, Delay=500}" 
+                            Value="{Binding Value}" 
                             TickPlacement="None" 
                             IsSnapToTickEnabled="true" 
                             Grid.Column="2" 

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -73,7 +73,7 @@
                             Maximum="{Binding Max}" 
                             Minimum="{Binding Min}" 
                             TickFrequency="{Binding Step}" 
-                            Value="{Binding Value}" 
+                            Value="{Binding Value, Delay=500}" 
                             TickPlacement="None" 
                             IsSnapToTickEnabled="true" 
                             Grid.Column="2" 


### PR DESCRIPTION
### Purpose

Fixes two crashes whie doing this at a high pace:

One crash happened in HomeWorkspaceViewModel, when postprocessing the
nodes after execution. These changes were done from the scheduler
thread, which when timed just right conflicted with changes done from
the UI thread, by the undo and redo operations.

Another one happened in ChangeSetComputer, when trying to compute the
delta AST. The cause was an optimization that attempted to skip tasks
based on containment comparison but disrespecting causality. The path
taken was to prevent skipping tasks altogether, but some more elaborate
optimization can probably be put in place.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@aparajit-pratap @mjkkirschner 

### FYIs

@DynamoDS/dynamo 
