### PR TITLE
missed some property change notifications to update view

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2297,15 +2297,17 @@ namespace Dynamo.Graph.Nodes
                 // in different ways and their views will always be up-to-date with
                 // respect to their models.
                 RaisePropertyChanged("InteractionEnabled");
-                RaisePropertyChanged("State");
-                RaisePropertyChanged("Name");
-                RaisePropertyChanged("ArgumentLacing");
-                RaisePropertyChanged("IsVisible");
-                 
+                RaisePropertyChanged(nameof(State));
+                RaisePropertyChanged(nameof(Name));
+                RaisePropertyChanged(nameof(ArgumentLacing));
+                RaisePropertyChanged(nameof(IsVisible));
+                RaisePropertyChanged(nameof(DisplayLabels));
+                RaisePropertyChanged(nameof(IsSetAsInput));
+                RaisePropertyChanged(nameof(IsSetAsOutput));
                 //we need to modify the downstream nodes manually in case the
                 //undo is for toggling freeze. This is ONLY modifying the execution hint.
                 // this does not run the graph.
-                RaisePropertyChanged("IsFrozen");
+                RaisePropertyChanged(nameof(IsFrozen));
                 MarkDownStreamNodesAsModified(this);
 
                 // Notify listeners that the position of the node has changed,

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -806,8 +806,14 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged("Height");
                     UpdateErrorBubblePosition();
                     break;
-                case "DisplayLabels":
-                    RaisePropertyChanged("IsDisplayingLables");
+                case nameof(NodeModel.DisplayLabels):
+                    RaisePropertyChanged(nameof(IsDisplayingLabels));
+                    break;
+                case nameof(NodeModel.IsSetAsInput):
+                    RaisePropertyChanged(nameof(IsSetAsInput));
+                    break;
+                case nameof(NodeModel.IsSetAsOutput):
+                    RaisePropertyChanged(nameof(IsSetAsOutput));
                     break;
                 case "Position":
                     UpdateErrorBubblePosition();


### PR DESCRIPTION

### Purpose

During testing @smangarole noted that the UI was not being updated for `showLabels` or `IsInput` or `IsOutput` checkboxes when undoing - I found that the tests are passing because the state is actually being correctly undone - but the UI was not being updated.

Two properties were missing and one was misspelled.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
