### PR TITLE
Avoid Helix crash due to edge double values

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1607,6 +1607,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <param name="packages">An <see cref="IEnumerable"/> of <see cref="HelixRenderPackage"/>.</param>
         internal virtual void AggregateRenderPackages(IEnumerable<HelixRenderPackage> packages)
         {
+            packages = FilterOutInvalidPackages(packages);
+
             IEnumerable<string> customNodeIdents = null;
             if (InCustomNode())
             {
@@ -1807,6 +1809,29 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 }
 
             }
+        }
+
+        /// <summary>
+        /// Filters out packages that are considered invalid by Helix. This includes any package
+        /// that has a coordinate with a special value like NaN or Infinite.
+        /// </summary>
+        /// <param name="packages">Original packages to render</param>
+        /// <returns>List of packages considered valid</returns>
+        private IEnumerable<HelixRenderPackage> FilterOutInvalidPackages(IEnumerable<HelixRenderPackage> packages)
+        {
+            List<HelixRenderPackage> result = new List<HelixRenderPackage>();
+
+            foreach (var package in packages)
+            {
+                if (!package.Points.Positions.Any(v => v.IsInvalid()) &&
+                    !package.Lines.Positions.Any(v => v.IsInvalid()) &&
+                    !package.Mesh.Positions.Any(v => v.IsInvalid()))
+                {
+                    result.Add(package);
+                }
+            }
+
+            return result;
         }
 
         private void AddLabelPlace(string nodeId, Vector3 pos, IRenderPackage rp)
@@ -2480,6 +2505,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         internal static double DistanceToPlane(this Vector3 point, Vector3 planeOrigin, Vector3 planeNormal)
         {
             return Vector3.Dot(planeNormal, (point - planeOrigin));
+        }
+
+        internal static bool IsInvalid(this Vector3 point)
+        {
+            return float.IsNaN(point.X) || float.IsInfinity(point.X) ||
+                float.IsNaN(point.Y) || float.IsInfinity(point.Y) ||
+                float.IsNaN(point.Z) || float.IsInfinity(point.Z);
         }
     }
 

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
@@ -159,7 +159,7 @@ namespace ProtoFFI
 
         public override object UnMarshal(StackValue dsObject, ProtoCore.Runtime.Context context, Interpreter dsi, Type type)
         {
-            if (dsObject.DoubleValue > MaxValue || dsObject.DoubleValue < MinValue)
+            if (dsObject.DoubleValue > MaxValue || dsObject.DoubleValue < MinValue || double.IsNaN(dsObject.DoubleValue))
             {
                 string message = String.Format(Resources.kFFIInvalidCast, dsObject.DoubleValue, type.Name, MinValue, MaxValue);
                 dsi.LogWarning(ProtoCore.Runtime.WarningID.TypeMismatch, message);

--- a/src/VisualizationTests/CustomGraphicItemVisualizationTest.cs
+++ b/src/VisualizationTests/CustomGraphicItemVisualizationTest.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Graph.Nodes;
+using NUnit.Framework;
+
+namespace WpfVisualizationTests
+{
+    [TestFixture]
+    public class CustomGraphicItemVisualizationTest : VisualizationTest
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            base.GetLibrariesToPreload(libraries);
+            libraries.Add("FFITarget.dll");
+        }
+
+        [Test]
+        public void TestInvalidGeometryIsFilteredOut()
+        {
+            OpenVisualizationTest("NaN.dyn");
+
+            // Only the default scene items should be present
+            Assert.AreEqual(3, BackgroundPreviewGeometry.Count());
+
+            // Nodes should be set to warning status with an appropriate message
+            var nanNode = Model.CurrentWorkspace.Nodes.First(n => n.Name == "NaN");
+            Assert.AreEqual(ElementState.Warning, nanNode.State);
+            StringAssert.Contains("'NaN' is being cast to 'Double'", nanNode.ToolTipText);
+            var negInfNode = Model.CurrentWorkspace.Nodes.First(n => n.Name == "NegativeInfinity");
+            Assert.AreEqual(ElementState.Warning, negInfNode.State);
+            StringAssert.Contains("'-∞' is being cast to 'Double'", negInfNode.ToolTipText);
+            var posInfNode = Model.CurrentWorkspace.Nodes.First(n => n.Name == "PositiveInfinity");
+            Assert.AreEqual(ElementState.Warning, posInfNode.State);
+            StringAssert.Contains("'∞' is being cast to 'Double'", posInfNode.ToolTipText);
+        }
+    }
+}

--- a/src/VisualizationTests/PerformanceVisualizationTests.cs
+++ b/src/VisualizationTests/PerformanceVisualizationTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace WpfVisualizationTests
+{
+    /// <summary>
+    /// Runs the performance graphs as visualization tests. Their purpose is to provide rendering timings only.
+    /// For that, you should make sure the renderTimer Stopwatch in HelixWatch3DViewModel is enabled and logging to Console.
+    /// You should run test including only the PerformanceVisualization category. Output should be redirected to a file.
+    /// You can extract the timings using grep and output them to a CSV file for ease of postprocessing.
+    /// </summary>
+    [TestFixture]
+    [Category("PerformanceVisualization")]
+    [Category("Failure")] // Not really a failure, we just don't want them to run on a normal build.
+    public class PerformanceVisualizationTests : VisualizationTest
+    {
+        // Determines how many times each performance graph will be run.
+        const int SamplingAmount = 10;
+
+        [Test]
+        [TestCaseSource("PerformanceTestSource")]
+        public void TestVisualizationPerformance(string filePath)
+        {
+            ViewModel.OpenCommand.Execute(filePath);
+            RunCurrentModel();
+        }
+
+        public IEnumerable<string> PerformanceTestSource
+        {
+            get
+            {
+                var path = Path.Combine(GetTestDirectory(ExecutingDirectory), @"..\tools\Performance\DynamoPerformanceTests\graphs");
+                return new DirectoryInfo(path).GetFiles("*.dyn").SelectMany(fileInfo => Enumerable.Repeat(fileInfo.FullName, SamplingAmount));
+            }
+        }
+    }
+}

--- a/src/VisualizationTests/WpfVisualizationTests.csproj
+++ b/src/VisualizationTests/WpfVisualizationTests.csproj
@@ -99,6 +99,7 @@
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="CameraTests.cs" />
+    <Compile Include="CustomGraphicItemVisualizationTest.cs" />
     <Compile Include="CustomNodeTests.cs" />
     <Compile Include="HelixImageComparisonTests.cs" />
     <Compile Include="HelixRenderPackageTests.cs" />

--- a/src/VisualizationTests/WpfVisualizationTests.csproj
+++ b/src/VisualizationTests/WpfVisualizationTests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="HelixWatch3dViewModelPrimitiveTests.cs" />
     <Compile Include="HelixWatch3DViewModelTests.cs" />
     <Compile Include="HelixWatch3DViewModelUnitTests.cs" />
+    <Compile Include="PerformanceVisualizationTests.cs" />
     <Compile Include="Preview3DMemoryOutageTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Watch3DViewModelTests.cs" />

--- a/test/Engine/FFITarget/CustomLabel.cs
+++ b/test/Engine/FFITarget/CustomLabel.cs
@@ -1,0 +1,33 @@
+﻿using Autodesk.DesignScript.Interfaces;
+using Autodesk.DesignScript.Runtime;
+
+namespace FFITarget
+{
+    public class CustomLabel : IGraphicItem
+    {
+        private readonly double x;
+        private readonly double y;
+        private readonly double z;
+        private readonly string label;
+
+        private CustomLabel(double x, double y, double z, string label)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.label = label;
+        }
+
+        public static CustomLabel ByCoordinatesAndString(double x = 0, double y = 0, double z = 0, string label = "EMPTY_LABEL")
+        {
+            return new CustomLabel(x, y, z, label);
+        }
+
+        [IsVisibleInDynamoLibrary(false)]
+        public void Tessellate(IRenderPackage package, TessellationParameters parameters)
+        {
+            package.AddPointVertex(x, y, z);
+            package.Description = label;
+        }
+    }
+}

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ClassFunctionality.cs" />
     <Compile Include="ClassWithRefParams.cs" />
     <Compile Include="CodeCompletionClass.cs" />
+    <Compile Include="CustomLabel.cs" />
     <Compile Include="DefaultArguments.cs" />
     <Compile Include="DisposeTest.cs" />
     <Compile Include="DummyMath.cs" />

--- a/test/core/visualization/NaN.dyn
+++ b/test/core/visualization/NaN.dyn
@@ -1,0 +1,416 @@
+{
+  "Uuid": "e52798d9-fd21-4278-84e4-bf47f48c4206",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "NaN",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.CustomLabel.ByCoordinatesAndString@double,double,double,string",
+      "Id": "67f883f8278d4dd7a3dfde19cdee1139",
+      "Inputs": [
+        {
+          "Id": "cad6716a6f2d4b3b8b337c386de18846",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "886dcf93078d4b62b507a0ad54a87f02",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f676ae87e74d4c2198aecb95211157b3",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9291de3fd80946ff8dfe2c5c053a61f8",
+          "Name": "label",
+          "Description": "string\nDefault value : \"EMPTY_LABEL\"",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ed2183b535b04cf0b7a0fbef28a3fa3e",
+          "Name": "CustomLabel",
+          "Description": "CustomLabel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "CustomLabel.ByCoordinatesAndString (x: double = 0, y: double = 0, z: double = 0, label: string = \"EMPTY_LABEL\"): CustomLabel"
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "from System import Double\r\nOUT = Double.NaN",
+      "Engine": "IronPython2",
+      "AvailableEngines": [
+        1,
+        2,
+        1,
+        2,
+        1,
+        2,
+        1,
+        2,
+        1,
+        2
+      ],
+      "VariableInputPorts": true,
+      "Id": "68b4f121d26e4d8aac6d92b6b95f38d4",
+      "Inputs": [
+        {
+          "Id": "b463a208c34d4751a2904b363faf984b",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "fc27cb68e4834a769b75d50610ff8c8d",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded Python script."
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "from System import Double\r\nOUT = Double.NegativeInfinity",
+      "Engine": "IronPython2",
+      "AvailableEngines": [
+        1,
+        2,
+        1,
+        2,
+        1,
+        2
+      ],
+      "VariableInputPorts": true,
+      "Id": "6def54107e8e4fb98bedb9dd20e01f57",
+      "Inputs": [
+        {
+          "Id": "57800d97a7aa4803a9f9e3786fc7e0b4",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cd66bbb3eaa14a66ba1f4a58d7157e2c",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded Python script."
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "from System import Double\r\nOUT = Double.PositiveInfinity",
+      "Engine": "IronPython2",
+      "AvailableEngines": [
+        1,
+        2,
+        1,
+        2,
+        1,
+        2
+      ],
+      "VariableInputPorts": true,
+      "Id": "e2991acae599405cb924058119feb769",
+      "Inputs": [
+        {
+          "Id": "bcc74eb5a4a146568f843a05489fdd9a",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e49405c84619415e82f4b39f29dd6ac3",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded Python script."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.CustomLabel.ByCoordinatesAndString@double,double,double,string",
+      "Id": "eb3747fac9cd496c9418112f3b2976cc",
+      "Inputs": [
+        {
+          "Id": "6e05f6fec466451ba8291efc6f50ff9a",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4b2c5d7095d54d588ca102ddb846b5c1",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "840bc97704c941b8a31c32d7f0c3f5ef",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d01f955f64d54339a38306d5ca829f59",
+          "Name": "label",
+          "Description": "string\nDefault value : \"EMPTY_LABEL\"",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "531941be01374b3bad56f5fd3e62f9d7",
+          "Name": "CustomLabel",
+          "Description": "CustomLabel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "CustomLabel.ByCoordinatesAndString (x: double = 0, y: double = 0, z: double = 0, label: string = \"EMPTY_LABEL\"): CustomLabel"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.CustomLabel.ByCoordinatesAndString@double,double,double,string",
+      "Id": "62cdc0421ef14b1cb78e56b2d1560422",
+      "Inputs": [
+        {
+          "Id": "f2404f56420641f0b4d7a5da0c1c1c3c",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d5b9481cfc514be29f37033b1f2af5ac",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "00b3dd38af4c450bb58f7aa1bebbf2f3",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b29022a1d1194ac6a095230e21326f44",
+          "Name": "label",
+          "Description": "string\nDefault value : \"EMPTY_LABEL\"",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cff3c28ec8474acbbe6696b7c272391e",
+          "Name": "CustomLabel",
+          "Description": "CustomLabel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "CustomLabel.ByCoordinatesAndString (x: double = 0, y: double = 0, z: double = 0, label: string = \"EMPTY_LABEL\"): CustomLabel"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "fc27cb68e4834a769b75d50610ff8c8d",
+      "End": "cad6716a6f2d4b3b8b337c386de18846",
+      "Id": "b96d5d34a5074ef78721579aa0131804"
+    },
+    {
+      "Start": "cd66bbb3eaa14a66ba1f4a58d7157e2c",
+      "End": "4b2c5d7095d54d588ca102ddb846b5c1",
+      "Id": "2f952cfb36ef4e18810d51774a966b19"
+    },
+    {
+      "Start": "e49405c84619415e82f4b39f29dd6ac3",
+      "End": "00b3dd38af4c450bb58f7aa1bebbf2f3",
+      "Id": "0772369f78ac4872bffa27d545571e5f"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.9.0.2326",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "NaN",
+        "Id": "67f883f8278d4dd7a3dfde19cdee1139",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 287.66485765699588,
+        "Y": 23.713574720976112
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "68b4f121d26e4d8aac6d92b6b95f38d4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 13.290390180267991,
+        "Y": 24.134411279120116
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "6def54107e8e4fb98bedb9dd20e01f57",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 18.016731162880234,
+        "Y": 286.57314584297984
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "e2991acae599405cb924058119feb769",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 18.608660866372162,
+        "Y": 551.31474156381137
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "NegativeInfinity",
+        "Id": "eb3747fac9cd496c9418112f3b2976cc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 287.59618988966849,
+        "Y": 261.28305094764374
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "PositiveInfinity",
+        "Id": "62cdc0421ef14b1cb78e56b2d1560422",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 285.94835868048472,
+        "Y": 497.99706144757135
+      }
+    ],
+    "Annotations": [],
+    "X": 64.734629178866214,
+    "Y": 64.682278435914981,
+    "Zoom": 0.55271695853825575
+  }
+}


### PR DESCRIPTION
### Purpose

This prevents the display of geometry located in positions considered
invalid by Helix. This includes the special values PositiveInfinity,
NegativeInfinity and NaN.

Also NaN is checked as a special value when unmarhsalling data from an
FFI. Special values PositiveInfinity and NegativeInfinity were already
handled. This allows to generate a warning over the node with an
appropriate message.

Here is a screenshot of how the message looks:

<img width="612" alt="NaN" src="https://user-images.githubusercontent.com/10048120/90822325-44af4b80-e302-11ea-8cca-c2d5874da6e0.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @aparajit-pratap 

### FYIs

@DynamoDS/dynamo 
