### PR TITLE
Fix multiple engine in Python editor bug

### DIFF
--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -61,11 +61,11 @@ namespace PythonNodeModels
             }
         }
 
-        private ObservableCollection<PythonEngineVersion> availableEngines;
+        private static ObservableCollection<PythonEngineVersion> availableEngines;
         /// <summary>
         /// Available Python engines.
         /// </summary>
-        public ObservableCollection<PythonEngineVersion> AvailableEngines
+        public static ObservableCollection<PythonEngineVersion> AvailableEngines
         {
             get
             {


### PR DESCRIPTION
### Purpose

The source of the combo was set to a non-static property. This caused
a really strange behavior when multiple Python nodes were present in
the graph. In that case the engines would appear repeated multiple
times.

Changing the property to static fixed the issue and it actually makes
more sense.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@DynamoDS/dynamo 
