### PR TITLE
Translate DS array to NET array for description

### DIFF
--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -154,6 +154,8 @@ namespace Dynamo.Engine
                 documentNode = documentNodes[fullyQualifiedName];
             else
             {
+                // Note that the following may take the incorrect overload.
+                // Unfortunately we can't map back to the exact .NET parameter types from the DS function descriptor.
                 var overloadedName = documentNodes.Keys.
                         Where(key => key.Contains(function.ClassName + "." + function.FunctionName)).FirstOrDefault();
 
@@ -199,6 +201,10 @@ namespace Dynamo.Engine
             }
         }
 
+        /// <summary>
+        /// Attempts to translate a DS type into a .NET type. Note that,
+        /// given these do not map 1 to 1, this is just a heuristic.
+        /// </summary>
         private static string PrimitiveMap(string s)
         {
             switch (s)
@@ -211,12 +217,20 @@ namespace Dynamo.Engine
                     return "System.Object";
                 case "double":
                     return "System.Double";
+                case "double[]":
+                    return "System.Double[]";
                 case "int":
                     return "System.Int32";
+                case "int[]":
+                    return "System.Int32[]";
                 case "bool":
                     return "System.Boolean";
+                case "bool[]":
+                    return "System.Boolean[]";
                 case "string":
                     return "System.String";
+                case "string[]":
+                    return "System.String[]";
                 default:
                     return s;
             }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -283,7 +283,7 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         public NodeSearchElementViewModel FindViewModelForNode(string nodeName)
         {
-            var result = dynamoViewModel.Model.SearchModel.SearchEntries.Where(e => {
+            var result = Model.SearchEntries.Where(e => {
                 if (e.CreationName.Equals(nodeName))
                 {
                     return true;


### PR DESCRIPTION
### Purpose

This fixes a bug where the description of Curve.SplitByParameter in the
library would show up a description of an obsoleted overload.

The cause of the issue was the inability of XmlDocumentationExtensions
to handle conversion from primitve DS arrays to their equivalent .NET
arrays. This made the module unable to find the exact overload, so it
resorted to a fallback which returns the first overload available,
which in this case was the incorrect one.

The problem is fixed for this particular instance, as it is now able to
find the exact overload. Note, however, that the mechanism is not
bullet-proof, as there is no guaranteed way to translate back a type
from DS to the original .NET type.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@aparajit-pratap @QilongTang 

### FYIs

@DynamoDS/dynamo 
