### PR TITLE
Fix layout issue hiding Python editor buttons

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
@@ -77,83 +77,76 @@
                                    Foreground="#F8F8F2"
                                    HorizontalScrollBarVisibility="Disabled"/>
         </Border>
-        <Grid HorizontalAlignment="Stretch"
-              Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"></ColumnDefinition>
-                <ColumnDefinition Width="*"></ColumnDefinition>
-            </Grid.ColumnDefinitions>
 
-            <StackPanel Orientation="Horizontal"
-                        Grid.Column="0">
-                <Button Content="{x:Static p:Resources.PythonScriptEditorRunButton}"
-                        Style="{StaticResource IconTextButton}"
-                        Name="RunPythonScriptButton"
-                        Click="OnRunClicked"
-                        ToolTip="{x:Static p:Resources.PythonScriptEditorRunButtonTooltip}">
-                    <Button.Resources>
-                        <Polygon x:Key="Shape"
-                                 Points="5,0 12,7 5,14 5,0"
-                                 Height="14">
-                            <Polygon.Fill>
-                                <SolidColorBrush Color="DarkSeaGreen" />
-                            </Polygon.Fill>
-                        </Polygon>
-                    </Button.Resources>
-                </Button>
-                <ComboBox ItemsSource="{Binding nodeModel.AvailableEngines, RelativeSource={RelativeSource AncestorType=dww:ModelessChildWindow}}"
-                          SelectedItem="{Binding nodeModel.Engine, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=dww:ModelessChildWindow}}"
-                          SelectionChanged="OnEngineChanged"
-                          Style="{StaticResource DropDown}"
-                          Name="EngineSelectorComboBox"
-                          Visibility="Collapsed" 
-                          ToolTip="{x:Static p:Resources.PythonScriptEditorEngineDropdownTooltip}"/>
-                <Button Style="{StaticResource IconButton}"
-                        Name="MigrationAssistantBtn"
-                        Click="OnMigrationAssistantClicked"
-                        ToolTip="{x:Static p:Resources.PythonScriptEditorMigrationAssistantButtonTooltip}">
-                    <Button.Resources>
-                        <Image x:Key="Shape"
-                               Width="44"
-                               Source="/PythonNodeModelsWpf;component/Resources/2to3Icon.png" />
-                    </Button.Resources>
-                </Button>
-                <Button Style="{StaticResource IconButton}"
-                        Name="MoreInfoButton"
-                        Click="OnMoreInfoClicked"
-                        ToolTip="{x:Static p:Resources.PythonScriptEditorMoreInfoButtonTooltip}">
-                    <Button.Resources>
-                        <fa:ImageAwesome x:Key="Shape"
-                                         Style="{StaticResource ImageAwesomeIcons}"
-                                         Icon="QuestionCircleOutline" />
-                    </Button.Resources>
-                </Button>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal"
-                        HorizontalAlignment="Right"
-                        Grid.Column="1">
-                <Button Style="{StaticResource IconButton}"
-                        Name="SaveScriptChangesButton"
-                        Click="OnSaveClicked"
-                        ToolTip="{x:Static p:Resources.PythonScriptEditorSaveChangesButtonTooltip}">
-                    <Button.Resources>
-                        <fa:ImageAwesome x:Key="Shape"
-                                         Style="{StaticResource ImageAwesomeIcons}"
-                                         Icon="Save" />
-                    </Button.Resources>
-                </Button>
-                <Button Style="{StaticResource IconButton}"
-                        Name="RevertScriptChangesButton"
-                        Click="OnRevertClicked"
-                        ToolTip="{x:Static p:Resources.PythonScriptEditorRevertButtonTooltip}">
-                    <Button.Resources>
-                        <fa:ImageAwesome x:Key="Shape"
-                                         Style="{StaticResource ImageAwesomeIcons}"
-                                         Icon="Undo" />
-                    </Button.Resources>
-                </Button>
-            </StackPanel>
-        </Grid>
+        <StackPanel Orientation="Horizontal"
+                    Grid.Row="1">
+            <Button Content="{x:Static p:Resources.PythonScriptEditorRunButton}"
+                    Style="{StaticResource IconTextButton}"
+                    Name="RunPythonScriptButton"
+                    Click="OnRunClicked"
+                    ToolTip="{x:Static p:Resources.PythonScriptEditorRunButtonTooltip}">
+                <Button.Resources>
+                    <Polygon x:Key="Shape"
+                             Points="5,0 12,7 5,14 5,0"
+                             Height="14">
+                        <Polygon.Fill>
+                            <SolidColorBrush Color="DarkSeaGreen" />
+                        </Polygon.Fill>
+                    </Polygon>
+                </Button.Resources>
+            </Button>
+            <ComboBox ItemsSource="{Binding nodeModel.AvailableEngines, RelativeSource={RelativeSource AncestorType=dww:ModelessChildWindow}}"
+                      SelectedItem="{Binding nodeModel.Engine, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=dww:ModelessChildWindow}}"
+                      SelectionChanged="OnEngineChanged"
+                      Style="{StaticResource DropDown}"
+                      Name="EngineSelectorComboBox"
+                      Visibility="Collapsed" 
+                      ToolTip="{x:Static p:Resources.PythonScriptEditorEngineDropdownTooltip}"/>
+            <Button Style="{StaticResource IconButton}"
+                    Name="MigrationAssistantBtn"
+                    Click="OnMigrationAssistantClicked"
+                    ToolTip="{x:Static p:Resources.PythonScriptEditorMigrationAssistantButtonTooltip}">
+                <Button.Resources>
+                    <Image x:Key="Shape"
+                           Width="44"
+                           Source="/PythonNodeModelsWpf;component/Resources/2to3Icon.png" />
+                </Button.Resources>
+            </Button>
+            <Button Style="{StaticResource IconButton}"
+                    Name="MoreInfoButton"
+                    Click="OnMoreInfoClicked"
+                    ToolTip="{x:Static p:Resources.PythonScriptEditorMoreInfoButtonTooltip}">
+                <Button.Resources>
+                    <fa:ImageAwesome x:Key="Shape"
+                                     Style="{StaticResource ImageAwesomeIcons}"
+                                     Icon="QuestionCircleOutline" />
+                </Button.Resources>
+            </Button>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Grid.Row="1">
+            <Button Style="{StaticResource IconButton}"
+                    Name="SaveScriptChangesButton"
+                    Click="OnSaveClicked"
+                    ToolTip="{x:Static p:Resources.PythonScriptEditorSaveChangesButtonTooltip}">
+                <Button.Resources>
+                    <fa:ImageAwesome x:Key="Shape"
+                                     Style="{StaticResource ImageAwesomeIcons}"
+                                     Icon="Save" />
+                </Button.Resources>
+            </Button>
+            <Button Style="{StaticResource IconButton}"
+                    Name="RevertScriptChangesButton"
+                    Click="OnRevertClicked"
+                    ToolTip="{x:Static p:Resources.PythonScriptEditorRevertButtonTooltip}">
+                <Button.Resources>
+                    <fa:ImageAwesome x:Key="Shape"
+                                     Style="{StaticResource ImageAwesomeIcons}"
+                                     Icon="Undo" />
+                </Button.Resources>
+            </Button>
+        </StackPanel>
     </Grid>
 
 </dww:ModelessChildWindow>


### PR DESCRIPTION
### Purpose

This fixes an issue that partially hid the "More info" button in the
Python editor window when the UI was shown in German language. In that
case "Run" would display as "Ausführen" which pushed the content to the
right causing the "More info" button to be trimmed because it fell out
of the boundaries of its container.

The issue is fixed by removing the parent grid, resulting in a simpler
and more flexible layout.

Here is a screenshot of the button bar after the fix:
<img width="737" alt="Screen Shot 2020-08-24 at 11 42 50 AM" src="https://user-images.githubusercontent.com/10048120/91066817-25fdcd00-e600-11ea-989f-275bfc6b3cfb.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @reddyashish 

### FYIs

@DynamoDS/dynamo 
