### PR TITLE
Add tooltip to preview disabled nodes

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -283,6 +283,7 @@
                 Background="#99B8CA"
                 Opacity=".4"
                 Style="{StaticResource SZoomFadePreview}"
+                ToolTipService.ShowDuration="60000"
                 MouseDown="NameBlock_OnMouseDown">
             <Border.Visibility>
                 <Binding Path="IsVisible"
@@ -291,6 +292,38 @@
                          Converter="{StaticResource InverseBoolToVisibilityConverter}">
                 </Binding>
             </Border.Visibility>
+            <Border.ToolTip>
+                <dynui:DynamoToolTip AttachmentSide="Top"
+                                     Style="{DynamicResource ResourceKey=SLightToolTip}">
+                    <Grid>
+                        <StackPanel Orientation="Vertical"
+                                    MaxWidth="320">
+                            <StackPanel>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{x:Static p:Resources.NodeTooltipOriginalName}">
+                                </TextBlock>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{Binding Path=OriginalName}"
+                                           FontWeight="SemiBold">
+                                </TextBlock>
+                            </StackPanel>
+                            <!--Space for splitting the original name and description-->
+                            <StackPanel>
+                                <TextBlock Text="&#xD;" />
+                            </StackPanel>
+                            <StackPanel>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{x:Static p:Resources.NodeTooltipDescription}">
+                                </TextBlock>
+                                <TextBlock TextWrapping="Wrap"
+                                           Text="{Binding Path=Description}"
+                                           FontWeight="Normal">
+                                </TextBlock>
+                            </StackPanel>
+                        </StackPanel>
+                    </Grid>
+                </dynui:DynamoToolTip>
+            </Border.ToolTip>
         </Border>
         <Border Name="previewState"
                 Grid.Row="2"


### PR DESCRIPTION
### Purpose

[DYN-3074 ](https://jira.autodesk.com/browse/DYN-3074)
Add description, out-ports, in-ports tooltip to nodes which had their preview disabled.

![previewtooltip](https://user-images.githubusercontent.com/32665108/91092671-5f493380-e626-11ea-81ee-fda439d84b1d.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@DynamoDS/dynamo 
