### PR TITLE
Display integer overflow exceptions for arithmetic operations

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -3595,7 +3595,21 @@ namespace ProtoCore.DSASM
 
             if (opdata1.IsInteger && opdata2.IsInteger)
             {
-                opdata2 = StackValue.BuildInt(opdata1.IntegerValue * opdata2.IntegerValue);
+                long val;
+                try
+                {
+                    val = checked(opdata1.IntegerValue * opdata2.IntegerValue);
+                }
+                catch (OverflowException)
+                {
+                    opdata2 = StackValue.BuildInt(opdata1.IntegerValue * opdata2.IntegerValue);
+                    runtimeCore.RuntimeStatus.LogWarning(WarningID.Overflow, Resources.OverflowWarning);
+
+                    rmem.Push(opdata2);
+                    ++pc;
+                    return;
+                }
+                opdata2 = StackValue.BuildInt(val);
             }
             else if (opdata1.IsNumeric && opdata2.IsNumeric)
             {


### PR DESCRIPTION
### Purpose

Draft PR for DYN-1084: These changes now show warnings on the "overflowing" nodes but continue to return the same values as before thereby eliminating the risk of breaking existing workflows.

![image](https://user-images.githubusercontent.com/5710686/91252723-1f6c7400-e72c-11ea-8524-81500e8f1127.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### FYIs

@mmisol 
