### PR TITLE
Make side panel handles size to content

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1516,7 +1516,7 @@
                     VerticalAlignment="Top"
                     Margin="0,310,0,0">
             <Grid Background="#353535"
-                  Width="100"
+                  Width="Auto"
                   Cursor="Hand">
                 <Button Click="OnCollapsedLeftSidebarClick"
                         Template="{DynamicResource BackgroundButton}">
@@ -1533,8 +1533,8 @@
                             </Border>
                         </ControlTemplate>
                     </Button.Resources>
-                    <Grid Mouse.MouseEnter="Button_MouseEnter"
-                          Mouse.MouseLeave="Button_MouseLeave">
+                    <Grid Mouse.MouseEnter="LibraryHandle_MouseEnter"
+                          Mouse.MouseLeave="LibraryHandle_MouseLeave">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
@@ -1581,9 +1581,10 @@
                     Background="{StaticResource HighlightedBrush}"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
-                    Margin="0,310,-79,0">
+                    Margin="0,310,0,0"
+                    RenderTransformOrigin="1,0">
             <Grid Background="#353535"
-                  Width="100"
+                  Width="Auto"
                   Cursor="Hand">
                 <Button Click="OnCollapsedRightSidebarClick"
                         Template="{DynamicResource BackgroundButton}">
@@ -1600,22 +1601,14 @@
                             </Border>
                         </ControlTemplate>
                     </Button.Resources>
-                    <Grid Mouse.MouseEnter="Button_MouseEnter"
-                          Mouse.MouseLeave="Button_MouseLeave">
+                    <Grid Mouse.MouseEnter="ExtensionHandle_MouseEnter"
+                          Mouse.MouseLeave="ExtensionHandle_MouseLeave">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel Orientation="Horizontal" 
                                     HorizontalAlignment="Center">
-                            <TextBlock Grid.Column="0"
-                                   Name="ExtensionSidebarText"
-                                   VerticalAlignment="Center"
-                                   Foreground="#aaaaaa"
-                                   FontWeight="Normal"
-                                   Margin="5,0,0,5"
-                                   Text="{x:Static p:Resources.ExtensionsViewTitle}">
-                            </TextBlock>
                             <Image Grid.Column="0"
                                Name="ExtensionSidebarIcon"
                                Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
@@ -1625,9 +1618,21 @@
                                Margin="5,5,5,5"
                                RenderTransformOrigin="0.5, 0.5">
                                 <Image.RenderTransform>
-                                    <RotateTransform Angle="90" />
+                                    <RotateTransform Angle="-90" />
                                 </Image.RenderTransform>
                             </Image>
+                            <TextBlock Grid.Column="0"
+                                   Name="ExtensionSidebarText"
+                                   VerticalAlignment="Center"
+                                   Foreground="#aaaaaa"
+                                   FontWeight="Normal"
+                                   Margin="0,5,5,0"
+                                   Text="{x:Static p:Resources.ExtensionsViewTitle}"
+                                   RenderTransformOrigin="0.5,0.5">
+                                <TextBlock.RenderTransform>
+                                    <RotateTransform Angle="180"/>
+                                </TextBlock.RenderTransform>
+                            </TextBlock>
                         </StackPanel>
                     </Grid>
                 </Button>
@@ -1635,7 +1640,7 @@
             </Grid>
 
             <StackPanel.RenderTransform>
-                <RotateTransform Angle="-90" />
+                <RotateTransform Angle="90" />
             </StackPanel.RenderTransform>
         </StackPanel>
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -120,7 +120,7 @@ namespace Dynamo.Controls
             LocationChanged += DynamoView_LocationChanged;
 
             // Apply appropriate expand/collapse library button state depending on initial width
-            updateCollapseIcon();
+            UpdateLibraryCollapseIcon();
 
             // Check that preference bounds are actually within one
             // of the available monitors.
@@ -1780,23 +1780,38 @@ namespace Dynamo.Controls
             }
         }
 
-        private void Button_MouseEnter(object sender, MouseEventArgs e)
+        private void LibraryHandle_MouseEnter(object sender, MouseEventArgs e)
         {
             Grid g = (Grid)sender;
             StackPanel sp = (StackPanel)(g.Children[0]);
             TextBlock tb = (TextBlock)(sp.Children[0]);
-            var bc = new BrushConverter();
-            tb.Foreground = (Brush)bc.ConvertFrom("#cccccc");
             Image collapseIcon = (Image)sp.Children[1];
 
-            // When hovered swap appropriate expand/collapse button state
+            UpdateHandleHoveredStyle(tb, collapseIcon);
+        }
+
+        private void UpdateHandleHoveredStyle(TextBlock text, Image icon)
+        {
+            var bc = new BrushConverter();
+            text.Foreground = (Brush)bc.ConvertFrom("#cccccc");
+
             if (LibraryCollapsed || ExtensionsCollapsed)
             {
                 Uri imageUri;
                 imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_hover.png");
                 BitmapImage hover = new BitmapImage(imageUri);
-                collapseIcon.Source = hover;
+                icon.Source = hover;
             }
+        }
+
+        private void ExtensionHandle_MouseEnter(object sender, MouseEventArgs e)
+        {
+            Grid g = (Grid)sender;
+            StackPanel sp = (StackPanel)(g.Children[0]);
+            TextBlock tb = (TextBlock)(sp.Children[1]);
+            Image collapseIcon = (Image)sp.Children[0];
+
+            UpdateHandleHoveredStyle(tb, collapseIcon);
         }
 
         private bool libraryCollapsed;
@@ -1842,7 +1857,7 @@ namespace Dynamo.Controls
         }
 
         // Check if library is collapsed or expanded and apply appropriate button state
-        private void updateCollapseIcon()
+        private void UpdateLibraryCollapseIcon()
         {
             if (LibraryCollapsed)
             {
@@ -1882,7 +1897,7 @@ namespace Dynamo.Controls
                 LeftExtensionsViewColumn.Width = new GridLength(0, GridUnitType.Star);
             }
 
-            updateCollapseIcon();
+            UpdateLibraryCollapseIcon();
         }
 
         private void OnCollapsedRightSidebarClick(object sender, EventArgs e)
@@ -1898,24 +1913,39 @@ namespace Dynamo.Controls
             }
 
             // TODO: Maynot need this depending on tab design
-            updateCollapseIcon();
+            UpdateLibraryCollapseIcon();
         }
 
-        private void Button_MouseLeave(object sender, MouseEventArgs e)
+        private void LibraryHandle_MouseLeave(object sender, MouseEventArgs e)
         {
             Grid g = (Grid)sender;
             StackPanel sp = (StackPanel)(g.Children[0]);
             TextBlock tb = (TextBlock)(sp.Children[0]);
-            var bc = new BrushConverter();
-            tb.Foreground = (Brush)bc.ConvertFromString("#aaaaaa");
             Image collapseIcon = (Image)sp.Children[1];
+
+            UpdateHandleUnhoveredStyle(tb, collapseIcon);
+            UpdateLibraryCollapseIcon();
+        }
+
+        private void UpdateHandleUnhoveredStyle(TextBlock text, Image icon)
+        {
+            var bc = new BrushConverter();
+            text.Foreground = (Brush)bc.ConvertFromString("#aaaaaa");
 
             Uri imageUri;
             imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_normal.png");
             BitmapImage hover = new BitmapImage(imageUri);
-            collapseIcon.Source = hover;
+            icon.Source = hover;
+        }
 
-            updateCollapseIcon();
+        private void ExtensionHandle_MouseLeave(object sender, MouseEventArgs e)
+        {
+            Grid g = (Grid)sender;
+            StackPanel sp = (StackPanel)(g.Children[0]);
+            TextBlock tb = (TextBlock)(sp.Children[1]);
+            Image collapseIcon = (Image)sp.Children[0];
+
+            UpdateHandleUnhoveredStyle(tb, collapseIcon);
         }
 
         private double restoreWidth = 0;
@@ -2004,7 +2034,7 @@ namespace Dynamo.Controls
             ToggleWorkspaceTabVisibility(WorkspaceTabs.SelectedIndex);
 
             // When workspace is resized apply appropriate library expand/collapse icon
-            updateCollapseIcon();
+            UpdateLibraryCollapseIcon();
         }
 
         private void DynamoView_OnDrop(object sender, DragEventArgs e)


### PR DESCRIPTION
### Purpose

The handles for size panels were using a fixed size, which was not
enough to fit some translated texts. The handles are now allowed to
size to content by doing some extra gimnastics to rotate them in the
right way.

Here is a screenshot of how it looks with the German translation:
![extension_handle](https://user-images.githubusercontent.com/10048120/91325083-c682f700-e790-11ea-9239-ff082e1c1080.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit 

### FYIs

@DynamoDS/dynamo 