### PR TITLE
Turn on Anti-aliasing in Helix

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
@@ -94,6 +94,7 @@
             IsInertiaEnabled="False" 
             IsChangeFieldOfViewEnabled="False" 
             SpinReleaseTime="0" 
+            MSAA="Maximum"
             EffectsManager="{Binding EffectsManager}"
             Background="{Binding Path=DataContext.ViewingHomespace, RelativeSource={RelativeSource AncestorType={x:Type controls:DynamoView}}, Converter={StaticResource Watch3DBackgroundColorConverter}}"
             BackgroundColor="{Binding Path=DataContext.ViewingHomespace, RelativeSource={RelativeSource AncestorType={x:Type controls:DynamoView}}, Converter={StaticResource Watch3DBackgroundColorConverter}}">


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3087
Anti-aliasing has been disabled by default in newer versions of Helix, which explains the regression in the quality of curve rendering in 2.7 (see https://github.com/helix-toolkit/helix-toolkit/issues/530). This has been turned on explicitly to fix the issue. This may have some performance impact but I don't think it should be significant considering it was on by default prior to 2.7 and we have made other performance gains after that with the helix pipeline.   

The image on the left is with anti-aliasing on in my latest build. The one on the right is the current state:
![image](https://user-images.githubusercontent.com/5710686/91467649-d832d000-e85e-11ea-855e-b554cbc70704.png)

### Declarations

**This needs to be cherry-picked into RC_2.8 branch**

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate - _Currently running image comparison tests to verify_
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

