### PR TITLE
Include rendering time in Perf Vis tests

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -14,6 +14,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Media.Media3D;
+using System.Windows.Threading;
 using System.Xml;
 using Autodesk.DesignScript.Interfaces;
 using Dynamo.Controls;
@@ -855,10 +856,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 (dynamoModel as DynamoModel).Report3DPreviewOutage(summary, description);
             }
 #if DEBUG
-            renderTimer.Stop();
-            Debug.WriteLine(string.Format("RENDER: {0} ellapsed for compiling assets for rendering.", renderTimer.Elapsed));
-            renderTimer.Reset();
-            renderTimer.Start();
+            // Defer stopping the timer until after the rendering has occurred
+            Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() =>
+            {
+                renderTimer.Stop();
+                Debug.WriteLine(string.Format("RENDER: {0} ellapsed time rendering.", renderTimer.Elapsed));
+                renderTimer.Restart();
+            }));
 #endif
 
             OnSceneItemsChanged();
@@ -1026,19 +1030,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             return true;
         }
 
-        #region internal methods
+#region internal methods
 
         internal void ComputeFrameUpdate()
         {
-#if DEBUG
-            if (renderTimer.IsRunning)
-            {
-                renderTimer.Stop();
-                Debug.WriteLine(string.Format("RENDER: {0} ellapsed for setting properties and rendering.", renderTimer.Elapsed));
-                renderTimer.Reset();
-            }
-#endif
-
             // Raising a property change notification for
             // the SceneItems collections causes a full
             // re-render including sorting for transparency.
@@ -1053,9 +1048,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             currentFrameSkipCount++;
         }
 
-        #endregion
+#endregion
 
-        #region private methods
+#region private methods
 
         private void OnSceneItemsChanged()
         {
@@ -2292,7 +2287,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
-        #endregion
+#endregion
 
         protected override void Dispose(bool disposing)
         {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1030,7 +1030,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             return true;
         }
 
-#region internal methods
+        #region internal methods
 
         internal void ComputeFrameUpdate()
         {
@@ -1048,9 +1048,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             currentFrameSkipCount++;
         }
 
-#endregion
+        #endregion
 
-#region private methods
+        #region private methods
 
         private void OnSceneItemsChanged()
         {
@@ -2287,7 +2287,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
-#endregion
+        #endregion
 
         protected override void Dispose(bool disposing)
         {

--- a/src/VisualizationTests/PerformanceVisualizationTests.cs
+++ b/src/VisualizationTests/PerformanceVisualizationTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 
 namespace WpfVisualizationTests
@@ -18,14 +18,16 @@ namespace WpfVisualizationTests
     public class PerformanceVisualizationTests : VisualizationTest
     {
         // Determines how many times each performance graph will be run.
-        const int SamplingAmount = 10;
+        const int SamplingAmount = 3;
 
         [Test]
         [TestCaseSource("PerformanceTestSource")]
         public void TestVisualizationPerformance(string filePath)
         {
             ViewModel.OpenCommand.Execute(filePath);
+            DispatcherUtil.DoEvents();
             RunCurrentModel();
+            DispatcherUtil.DoEvents();
         }
 
         public IEnumerable<string> PerformanceTestSource


### PR DESCRIPTION
### Purpose

Include rendering time in performance visualization tests.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@aparajit-pratap 

### FYIs

@DynamoDS/dynamo 