### PR TITLE
Guard against parser errors detected while migrating python code

### DIFF
--- a/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
+++ b/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
@@ -32,14 +32,14 @@
             <Style x:Key="HasDifferenceController"
                    TargetType="{x:Type ContentControl}">
                 <Style.Triggers>
-                    <DataTrigger Binding="{Binding Path=CurrentViewModel.HasChanges}"
-                                 Value="True">
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.DiffState}"
+                                 Value="{x:Static viewModels:State.HasChanges}">
                         <Setter Property="Content"
                                 Value="{Binding Path=CurrentViewModel}">
                         </Setter>
                     </DataTrigger>
-                    <DataTrigger Binding="{Binding Path=CurrentViewModel.HasChanges}"
-                                 Value="False">
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.DiffState}"
+                                 Value="{x:Static viewModels:State.NoChanges}">
                         <Setter Property="ContentTemplate">
                             <Setter.Value>
                                 <DataTemplate>
@@ -53,6 +53,31 @@
                                                    Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
                                                    TextWrapping="Wrap" />
                                         <TextBlock Text="{x:Static p:Resources.MigrationAssistantNoChangesStateMessage}"
+                                                   TextAlignment="Center"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="14"
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Path=CurrentViewModel.DiffState}"
+                                 Value="{x:Static viewModels:State.Error}">
+                        <Setter Property="ContentTemplate">
+                            <Setter.Value>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Vertical"
+                                                VerticalAlignment="Center"
+                                                Width="400">
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssistantErrorStateHeader}"
+                                                   TextAlignment="Center"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="24"
+                                                   Foreground="{StaticResource WorkspaceTabHeaderActiveTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock Text="{x:Static p:Resources.MigrationAssistantErrorStateMessage}"
                                                    TextAlignment="Center"
                                                    HorizontalAlignment="Center"
                                                    FontSize="14"

--- a/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
+++ b/src/PythonMigrationViewExtension/Controls/BaseDiffViewer.xaml
@@ -23,6 +23,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
+            <viewModels:DiffStateToVisibilityConverter x:Key="DiffStateToVis" />
             <DataTemplate DataType="{x:Type viewModels:InLineViewModel}">
                 <local:InLineControl DataContext="{Binding}" />
             </DataTemplate>
@@ -133,6 +134,7 @@
                         HorizontalAlignment="Left"
                         Grid.Column="0">
                 <Button  Name="DiffButton"
+                         Visibility="{Binding Path=CurrentViewModel.DiffState, Converter={StaticResource DiffStateToVis}}"
                          Click="OnDiffButtonClick"
                          HorizontalAlignment="Right"
                          ToolTip="{x:Static p:Resources.DiffButtonTooltip}"
@@ -150,6 +152,7 @@
                         HorizontalAlignment="Right"
                         Grid.Column="1">
                 <Button  x:Name="AcceptButton"
+                         Visibility="{Binding Path=CurrentViewModel.DiffState, Converter={StaticResource DiffStateToVis}}"
                          Click="OnAcceptButtonClicked"
                          HorizontalAlignment="Right"
                          ToolTip="{x:Static p:Resources.AcceptButtonTooltip}"

--- a/src/PythonMigrationViewExtension/Differ/DiffStateToVisibilityConverter.cs
+++ b/src/PythonMigrationViewExtension/Differ/DiffStateToVisibilityConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Dynamo.PythonMigration.Differ
+{
+    public class DiffStateToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value != null)
+            {
+                var state = (State)value;
+                if (state == State.Error)
+                    return Visibility.Hidden;
+            }
+
+            return Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
@@ -1,34 +1,10 @@
-﻿using System;
-using System.Windows;
-using System.Windows.Data;
-
-namespace Dynamo.PythonMigration.Differ
+﻿namespace Dynamo.PythonMigration.Differ
 {
     public enum State
     {
         NoChanges,
         HasChanges,
         Error
-    }
-
-    public class DiffStateToVisibilityConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if (value != null)
-            {
-                var state = (State) value;
-                if (state == State.Error)
-                    return Visibility.Hidden;
-            }
-
-            return Visibility.Visible;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            throw new NotSupportedException();
-        }
     }
 
     public interface IDiffViewViewModel

--- a/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
@@ -1,4 +1,8 @@
-﻿namespace Dynamo.PythonMigration.Differ
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Dynamo.PythonMigration.Differ
 {
     public enum State
     {
@@ -7,11 +11,30 @@
         Error
     }
 
+    public class DiffStateToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value != null)
+            {
+                var state = (State) value;
+                if (state == State.Error)
+                    return Visibility.Hidden;
+            }
+
+            return Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
     public interface IDiffViewViewModel
     {
         ViewMode ViewMode { get; }
-        State DiffState { get; }
-        bool Error { get; set; }
+        State DiffState { get; set; }
     }
 
     public enum ViewMode

--- a/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/IDiffViewViewModel.cs
@@ -1,9 +1,17 @@
 ﻿namespace Dynamo.PythonMigration.Differ
 {
+    public enum State
+    {
+        NoChanges,
+        HasChanges,
+        Error
+    }
+
     public interface IDiffViewViewModel
     {
         ViewMode ViewMode { get; }
-        bool HasChanges { get; }
+        State DiffState { get; }
+        bool Error { get; set; }
     }
 
     public enum ViewMode

--- a/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
@@ -10,17 +10,19 @@ namespace Dynamo.PythonMigration.Differ
         public DiffPaneModel DiffModel { get; set; }
         private bool HasChanges { get { return DiffModel.HasDifferences; } }
 
+        private State diffState;
         public State DiffState
         {
             get
             {
-                if (Error) return State.Error;
-                if (HasChanges) return State.HasChanges;
-                return State.NoChanges;
-            }
-        }
+                if (diffState == State.Error) return State.Error;
 
-        public bool Error { get; set; }
+                diffState = HasChanges ? State.HasChanges : State.NoChanges;
+
+                return diffState;
+            }
+            set { diffState = value; }
+        }
 
         public InLineViewModel(SideBySideDiffModel diffModel)
         {

--- a/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
@@ -26,7 +26,6 @@ namespace Dynamo.PythonMigration.Differ
         {
             ViewMode = ViewMode.Inline;
             DiffModel = ConvertToInline(diffModel);
-            Error = false;
         }
 
         /// <summary>

--- a/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/InLineViewModel.cs
@@ -8,12 +8,25 @@ namespace Dynamo.PythonMigration.Differ
     {
         public ViewMode ViewMode { get; set; }
         public DiffPaneModel DiffModel { get; set; }
-        public bool HasChanges { get { return DiffModel.HasDifferences; } } 
+        private bool HasChanges { get { return DiffModel.HasDifferences; } }
+
+        public State DiffState
+        {
+            get
+            {
+                if (Error) return State.Error;
+                if (HasChanges) return State.HasChanges;
+                return State.NoChanges;
+            }
+        }
+
+        public bool Error { get; set; }
 
         public InLineViewModel(SideBySideDiffModel diffModel)
         {
-            this.ViewMode = ViewMode.Inline;
-            this.DiffModel = ConvertToInline(diffModel);
+            ViewMode = ViewMode.Inline;
+            DiffModel = ConvertToInline(diffModel);
+            Error = false;
         }
 
         /// <summary>

--- a/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
@@ -8,12 +8,24 @@ namespace Dynamo.PythonMigration.Differ
         public SideBySideDiffModel DiffModel { get; set; }
         public DiffPaneModel AfterPane { get { return DiffModel.NewText; } }
         public DiffPaneModel BeforePane { get { return DiffModel.OldText; } }
-        public bool HasChanges { get { return DiffModel.NewText.HasDifferences | DiffModel.OldText.HasDifferences; } }
+        private bool HasChanges { get { return DiffModel.NewText.HasDifferences | DiffModel.OldText.HasDifferences; } }
+        public bool Error { get; set; }
+
+        public State DiffState
+        {
+            get
+            {
+                if (Error) return State.Error;
+                if (HasChanges) return State.HasChanges;
+                return State.NoChanges;
+            }
+        }
 
         public SideBySideViewModel(SideBySideDiffModel diffModel)
         {
             ViewMode = ViewMode.SideBySide;
             DiffModel = diffModel;
+            Error = false;
         }
     }
 }

--- a/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
+++ b/src/PythonMigrationViewExtension/Differ/SideBySideViewModel.cs
@@ -9,23 +9,25 @@ namespace Dynamo.PythonMigration.Differ
         public DiffPaneModel AfterPane { get { return DiffModel.NewText; } }
         public DiffPaneModel BeforePane { get { return DiffModel.OldText; } }
         private bool HasChanges { get { return DiffModel.NewText.HasDifferences | DiffModel.OldText.HasDifferences; } }
-        public bool Error { get; set; }
 
+        private State diffState;
         public State DiffState
         {
             get
             {
-                if (Error) return State.Error;
-                if (HasChanges) return State.HasChanges;
-                return State.NoChanges;
+                if (diffState == State.Error) return State.Error;
+
+                diffState = HasChanges ? State.HasChanges : State.NoChanges;
+
+                return diffState;
             }
+            set { diffState = value; }
         }
 
         public SideBySideViewModel(SideBySideDiffModel diffModel)
         {
             ViewMode = ViewMode.SideBySide;
             DiffModel = diffModel;
-            Error = false;
         }
     }
 }

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -61,7 +61,7 @@ namespace Dynamo.PythonMigration.MigrationAssistant
 
                 SetSideBySideViewModel();
                 
-                CurrentViewModel.Error = true;
+                CurrentViewModel.DiffState = State.Error;
                 return;
             }
             SetSideBySideViewModel();
@@ -149,20 +149,12 @@ namespace Dynamo.PythonMigration.MigrationAssistant
 
         private void SetSideBySideViewModel()
         {
-            var previousViewModel = CurrentViewModel;
-            CurrentViewModel = new SideBySideViewModel(diffModel)
-            {
-                Error = previousViewModel?.Error ?? false
-            };
+            CurrentViewModel = new SideBySideViewModel(diffModel);
         }
 
         private void SetInlineViewModel()
         {
-            var previousViewModel = CurrentViewModel;
-            CurrentViewModel = new InLineViewModel(diffModel)
-            {
-                Error = previousViewModel?.Error ?? false
-            };
+            CurrentViewModel = new InLineViewModel(diffModel);
         }
 
         #endregion

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -83,7 +83,7 @@ namespace Dynamo.PythonMigration.MigrationAssistant
         /// </summary>
         public void ChangeCode()
         {
-            if (CurrentViewModel.DiffState == State.Error || CurrentViewModel.DiffState == State.NoChanges)
+            if (CurrentViewModel.DiffState == State.NoChanges)
             {
                 PythonNode.Engine = PythonEngineVersion.CPython3;
                 return;

--- a/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/PythonMigrationAssistantViewModel.cs
@@ -144,19 +144,25 @@ namespace Dynamo.PythonMigration.MigrationAssistant
                 case ViewMode.SideBySide:
                     SetSideBySideViewModel();
                     break;
-                default:
-                    break;
             }
         }
 
         private void SetSideBySideViewModel()
         {
-            this.CurrentViewModel = new SideBySideViewModel(this.diffModel);
+            var previousViewModel = CurrentViewModel;
+            CurrentViewModel = new SideBySideViewModel(diffModel)
+            {
+                Error = previousViewModel?.Error ?? false
+            };
         }
 
         private void SetInlineViewModel()
         {
-            this.CurrentViewModel = new InLineViewModel(this.diffModel);
+            var previousViewModel = CurrentViewModel;
+            CurrentViewModel = new InLineViewModel(diffModel)
+            {
+                Error = previousViewModel?.Error ?? false
+            };
         }
 
         #endregion

--- a/src/PythonMigrationViewExtension/MigrationAssistant/ScriptMigrator.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/ScriptMigrator.cs
@@ -55,6 +55,7 @@ namespace Dynamo.PythonMigration.MigrationAssistant
                     return output;
                 }
             }
+
             finally
             {
                 PythonEngine.ReleaseLock(gs);

--- a/src/PythonMigrationViewExtension/MigrationAssistant/ScriptMigrator.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/ScriptMigrator.cs
@@ -55,7 +55,6 @@ namespace Dynamo.PythonMigration.MigrationAssistant
                     return output;
                 }
             }
-
             finally
             {
                 PythonEngine.ReleaseLock(gs);

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -198,6 +198,24 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is an error in your code!.
+        /// </summary>
+        public static string MigrationAssistantErrorStateHeader {
+            get {
+                return ResourceManager.GetString("MigrationAssistantErrorStateHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix all errors before attempting code migration. Clicking accept will switch to the Python 3 engine without any code changes..
+        /// </summary>
+        public static string MigrationAssistantErrorStateMessage {
+            get {
+                return ResourceManager.GetString("MigrationAssistantErrorStateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Nothing to see here!.
         /// </summary>
         public static string MigrationAssistantNoChangesStateHeader {

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -207,7 +207,7 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fix all errors before attempting code migration. Clicking cancel will switch back to the Python 2 engine without any code changes..
+        ///   Looks up a localized string similar to Fix all errors before attempting code migration..
         /// </summary>
         public static string MigrationAssistantErrorStateMessage {
             get {

--- a/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
+++ b/src/PythonMigrationViewExtension/Properties/Resources.Designer.cs
@@ -207,7 +207,7 @@ namespace Dynamo.PythonMigration.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fix all errors before attempting code migration. Clicking accept will switch to the Python 3 engine without any code changes..
+        ///   Looks up a localized string similar to Fix all errors before attempting code migration. Clicking cancel will switch back to the Python 2 engine without any code changes..
         /// </summary>
         public static string MigrationAssistantErrorStateMessage {
             get {

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -174,7 +174,7 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
     <value>There is an error in your code!</value>
   </data>
   <data name="MigrationAssistantErrorStateMessage" xml:space="preserve">
-    <value>Fix all errors before attempting code migration. Clicking cancel will switch back to the Python 2 engine without any code changes.</value>
+    <value>Fix all errors before attempting code migration.</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -174,7 +174,7 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
     <value>There is an error in your code!</value>
   </data>
   <data name="MigrationAssistantErrorStateMessage" xml:space="preserve">
-    <value>Fix all errors before attempting code migration. Clicking accept will switch to the Python 3 engine without any code changes.</value>
+    <value>Fix all errors before attempting code migration. Clicking cancel will switch back to the Python 2 engine without any code changes.</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.en-US.resx
@@ -170,6 +170,12 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   <data name="MigrationAssistantNoChangesStateMessage" xml:space="preserve">
     <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
   </data>
+  <data name="MigrationAssistantErrorStateHeader" xml:space="preserve">
+    <value>There is an error in your code!</value>
+  </data>
+  <data name="MigrationAssistantErrorStateMessage" xml:space="preserve">
+    <value>Fix all errors before attempting code migration. Clicking accept will switch to the Python 3 engine without any code changes.</value>
+  </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>
   </data>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -174,7 +174,7 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
     <value>There is an error in your code!</value>
   </data>
   <data name="MigrationAssistantErrorStateMessage" xml:space="preserve">
-    <value>Fix all errors before attempting code migration. Clicking cancel will switch back to the Python 2 engine without any code changes.</value>
+    <value>Fix all errors before attempting code migration.</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -174,7 +174,7 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
     <value>There is an error in your code!</value>
   </data>
   <data name="MigrationAssistantErrorStateMessage" xml:space="preserve">
-    <value>Fix all errors before attempting code migration. Clicking accept will switch to the Python 3 engine without any code changes.</value>
+    <value>Fix all errors before attempting code migration. Clicking cancel will switch back to the Python 2 engine without any code changes.</value>
   </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>

--- a/src/PythonMigrationViewExtension/Properties/Resources.resx
+++ b/src/PythonMigrationViewExtension/Properties/Resources.resx
@@ -170,6 +170,12 @@ By clicking “Continue”, you are agreeing to implement the syntax changes to 
   <data name="MigrationAssistantNoChangesStateMessage" xml:space="preserve">
     <value>Your code is ready to run with the Python 3 engine. Click accept and we'll switch to the Python 3 engine for you.</value>
   </data>
+  <data name="MigrationAssistantErrorStateHeader" xml:space="preserve">
+    <value>There is an error in your code!</value>
+  </data>
+  <data name="MigrationAssistantErrorStateMessage" xml:space="preserve">
+    <value>Fix all errors before attempting code migration. Clicking accept will switch to the Python 3 engine without any code changes.</value>
+  </data>
   <data name="PackagedCustomNodesHeader" xml:space="preserve">
     <value>Packaged</value>
   </data>

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.csproj
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Controls\SideBySideControl.xaml.cs">
       <DependentUpon>SideBySideControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Differ\DiffStateToVisibilityConverter.cs" />
     <Compile Include="Differ\IDiffViewViewModel.cs" />
     <Compile Include="Differ\InLineViewModel.cs" />
     <Compile Include="Differ\RichTextBoxHandler.cs" />


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3102
Guard against crash due to parser errors detected while migrating python code. The following message is shown in the migration assistant in such a case:

![image](https://user-images.githubusercontent.com/5710686/91755849-c6706600-eb99-11ea-8d24-807559d9fbaf.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate - **WIP**
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@Amoursol - any inputs on the error message (see screenshot).
@mmisol 
