### PR TITLE
Update pan/orbit state icon

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -881,6 +881,7 @@ namespace Dynamo.ViewModels
 
             // Reset workspace state
             CurrentSpaceViewModel.CancelActiveState();
+            BackgroundPreviewViewModel.RefreshState();
         }
 
         internal void ForceRunExprCmd(object parameters)
@@ -2441,12 +2442,7 @@ namespace Dynamo.ViewModels
         public void Escape(object parameter)
         {
             CurrentSpaceViewModel.CancelActiveState();
-
-            // Since panning and orbiting modes are exclusive from one another,
-            // turning one on may turn the other off. This is the reason we must
-            // raise property change for both at the same time to update visual.
-            RaisePropertyChanged("IsPanning");
-            RaisePropertyChanged("IsOrbiting");
+            BackgroundPreviewViewModel.RefreshState();
         }
 
         internal bool CanEscape(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -575,8 +575,16 @@ namespace Dynamo.ViewModels
                         break;
                 }
 
+
+                var panChanged = currentState == State.PanMode || newState == State.PanMode;
+
                 owningWorkspace.CurrentCursor = CursorLibrary.GetCursor(cursorToUse);
                 this.currentState = newState; // update state
+
+                if (panChanged)
+                {
+                    owningWorkspace.RaisePropertyChanged(nameof(IsPanning));
+                }
             }
 
             #endregion

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -575,15 +575,17 @@ namespace Dynamo.ViewModels
                         break;
                 }
 
-
-                var panChanged = currentState == State.PanMode || newState == State.PanMode;
-
+                var previousState = this.currentState;
                 owningWorkspace.CurrentCursor = CursorLibrary.GetCursor(cursorToUse);
                 this.currentState = newState; // update state
 
-                if (panChanged)
+                if (previousState == State.PanMode || newState == State.PanMode)
                 {
                     owningWorkspace.RaisePropertyChanged(nameof(IsPanning));
+                }
+                if (previousState == State.OrbitMode || newState == State.OrbitMode)
+                {
+                    owningWorkspace.RaisePropertyChanged(nameof(IsOrbiting));
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -267,35 +267,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             IRenderPackageFactory renderPackageFactory)
         {
             this.viewModel = viewModel;
-            //foreach (WorkspaceViewModel workspace in this.viewModel.Workspaces)
-            //{
-            //    workspace.PropertyChanged += Workspace_PropertyChanged;
-            //}
-            //this.viewModel.Workspaces.CollectionChanged += Workspaces_CollectionChanged;
             this.renderPackageFactory = renderPackageFactory;
         }
-
-        //private void Workspaces_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        //{
-        //    foreach (WorkspaceViewModel workspace in e.OldItems)
-        //    {
-        //        workspace.PropertyChanged -= Workspace_PropertyChanged;
-        //    }
-        //    foreach (WorkspaceViewModel workspace in e.NewItems)
-        //    {
-        //        workspace.PropertyChanged += Workspace_PropertyChanged;
-        //    }
-        //}
-
-        //private void Workspace_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        //{
-        //    if (e.PropertyName == nameof(IsPanning))
-        //    {
-        //        RaisePropertyChanged("IsPanning");
-        //        RaisePropertyChanged("IsOrbiting");
-        //        RaisePropertyChanged("LeftClickCommand");
-        //    }
-        //}
 
         protected virtual void OnShutdown()
         {
@@ -758,13 +731,17 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         internal void TogglePan(object parameter)
         {
             CurrentSpaceViewModel.RequestTogglePanMode();
+            RefreshState();
+        }
 
+        internal void RefreshState()
+        {
             // Since panning and orbiting modes are exclusive from one another,
             // turning one on may turn the other off. This is the reason we must
             // raise property change for both at the same time to update visual.
-            //RaisePropertyChanged("IsPanning");
-            //RaisePropertyChanged("IsOrbiting");
-            //RaisePropertyChanged("LeftClickCommand");
+            RaisePropertyChanged("IsPanning");
+            RaisePropertyChanged("IsOrbiting");
+            RaisePropertyChanged("LeftClickCommand");
         }
 
         private static bool CanTogglePan(object parameter)
@@ -775,13 +752,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private void ToggleOrbit(object parameter)
         {
             CurrentSpaceViewModel.RequestToggleOrbitMode();
-
-            // Since panning and orbiting modes are exclusive from one another,
-            // turning one on may turn the other off. This is the reason we must
-            // raise property change for both at the same time to update visual.
-            RaisePropertyChanged("IsPanning");
-            RaisePropertyChanged("IsOrbiting");
-            RaisePropertyChanged("LeftClickCommand");
+            RefreshState();
         }
 
         private static bool CanToggleOrbit(object parameter)
@@ -826,10 +797,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected virtual void Dispose(bool disposing)
         {
-            //if (this.viewModel != null)
-            //{
-            //    this.viewModel.Workspaces.CollectionChanged -= Workspaces_CollectionChanged;
-            //}
+            // Nothing to do here.
         }
 
         public void Dispose()

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -267,8 +267,35 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             IRenderPackageFactory renderPackageFactory)
         {
             this.viewModel = viewModel;
+            //foreach (WorkspaceViewModel workspace in this.viewModel.Workspaces)
+            //{
+            //    workspace.PropertyChanged += Workspace_PropertyChanged;
+            //}
+            //this.viewModel.Workspaces.CollectionChanged += Workspaces_CollectionChanged;
             this.renderPackageFactory = renderPackageFactory;
         }
+
+        //private void Workspaces_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        //{
+        //    foreach (WorkspaceViewModel workspace in e.OldItems)
+        //    {
+        //        workspace.PropertyChanged -= Workspace_PropertyChanged;
+        //    }
+        //    foreach (WorkspaceViewModel workspace in e.NewItems)
+        //    {
+        //        workspace.PropertyChanged += Workspace_PropertyChanged;
+        //    }
+        //}
+
+        //private void Workspace_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        //{
+        //    if (e.PropertyName == nameof(IsPanning))
+        //    {
+        //        RaisePropertyChanged("IsPanning");
+        //        RaisePropertyChanged("IsOrbiting");
+        //        RaisePropertyChanged("LeftClickCommand");
+        //    }
+        //}
 
         protected virtual void OnShutdown()
         {
@@ -735,9 +762,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Since panning and orbiting modes are exclusive from one another,
             // turning one on may turn the other off. This is the reason we must
             // raise property change for both at the same time to update visual.
-            RaisePropertyChanged("IsPanning");
-            RaisePropertyChanged("IsOrbiting");
-            RaisePropertyChanged("LeftClickCommand");
+            //RaisePropertyChanged("IsPanning");
+            //RaisePropertyChanged("IsOrbiting");
+            //RaisePropertyChanged("LeftClickCommand");
         }
 
         private static bool CanTogglePan(object parameter)
@@ -799,6 +826,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected virtual void Dispose(bool disposing)
         {
+            //if (this.viewModel != null)
+            //{
+            //    this.viewModel.Workspaces.CollectionChanged -= Workspaces_CollectionChanged;
+            //}
         }
 
         public void Dispose()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -308,9 +308,8 @@
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
                 </ui:ImageCheckBox.Command>
                 <ui:ImageCheckBox.IsChecked>
-                    <Binding Path="DataContext.BackgroundPreviewViewModel.IsPanning"
-                             Mode="OneWay"
-                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
+                    <Binding Path="IsPanning"
+                             Mode="OneWay" />
                 </ui:ImageCheckBox.IsChecked>
             </ui:ImageCheckBox>
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -324,9 +324,8 @@
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
                 </ui:ImageCheckBox.Command>
                 <ui:ImageCheckBox.IsChecked>
-                    <Binding Path="DataContext.BackgroundPreviewViewModel.IsOrbiting"
-                             Mode="OneWay"
-                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
+                    <Binding Path="IsOrbiting"
+                             Mode="OneWay" />
                 </ui:ImageCheckBox.IsChecked>
                 <ui:ImageCheckBox.Visibility>
                     <Binding Path="DataContext.BackgroundPreviewViewModel.CanNavigateBackground"


### PR DESCRIPTION
### Purpose

Fixes issues related to the state of the pan icon not reflecting the
actual current state.

There were two problems preventing this from updating.

Some actions did not seem to trigger a property change on IsPlanning
and IsOrbiting at the BackgroundPreviewViewModel. There are properties
with the same name in the local view model that get updated more
consistently.

Some actions were triggering property change events in the wrong place.
These were moved to the right place.

While there were no reported issues with IsOrbiting, this property
should behave in the same way, so the same changes were applied.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit 

### FYIs

@DynamoDS/dynamo 