### PR TITLE
Allow extension panel to grow without bounds

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -207,7 +207,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="5*" MinWidth="200" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition MaxWidth="500"
+            <ColumnDefinition Width="0"
                               MinWidth="1"
                               Name="RightExtensionsViewColumn">
             </ColumnDefinition>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1816,9 +1816,11 @@ namespace Dynamo.Controls
 
         private bool libraryCollapsed;
         private bool extensionsCollapsed;
+        private GridLength? extensionsColumnWidth;
 
         // Default side bar width
         private const int defaultSideBarWidth = 200;
+        private const int DefaultExtensionBarWidthMultiplier = 2;
 
         /// <summary>
         /// Check if library is collapsed or expanded
@@ -1873,14 +1875,29 @@ namespace Dynamo.Controls
         // Show the extensions right side bar when there is atleast one extension
         private void HideOrShowRightSideBar()
         {
-            if (ExtensionTabItems.Count < 1)
+            if (ExtensionTabItems.Count == 0)
             {
+                if (RightExtensionsViewColumn.Width.Value != 0)
+                {
+                    extensionsColumnWidth = RightExtensionsViewColumn.Width;
+                }
                 RightExtensionsViewColumn.Width = new GridLength(0, GridUnitType.Star);
                 collapsedExtensionSidebar.Visibility = Visibility.Collapsed;
             }
             else
             {
-                RightExtensionsViewColumn.Width = new GridLength(defaultSideBarWidth, GridUnitType.Star);
+                // The introduction of extensionsColumnWidth is two-fold:
+                // 1. It allows the resized width to be remembered which is nice to have.
+                // 2. It allows to avoid a slider glitch which sets the panels size in pixel amount but using star,
+                // changing the proportions so that the initial value is counted as pixels after the first resize.
+                if (extensionsColumnWidth == null)
+                {
+                    RightExtensionsViewColumn.Width = new GridLength(DefaultExtensionBarWidthMultiplier, GridUnitType.Star);
+                }
+                else
+                {
+                    RightExtensionsViewColumn.Width = extensionsColumnWidth.Value;
+                }
                 collapsedExtensionSidebar.Visibility = Visibility.Visible;
             }
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1820,6 +1820,7 @@ namespace Dynamo.Controls
 
         // Default side bar width
         private const int defaultSideBarWidth = 200;
+        // By default the extension bar over canvas size ratio is 2/5
         private const int DefaultExtensionBarWidthMultiplier = 2;
 
         /// <summary>

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -9,7 +9,7 @@
              xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
              mc:Ignorable="d" 
              VerticalAlignment="Top"
-             HorizontalAlignment="Left">
+             HorizontalAlignment="Stretch">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -153,6 +153,7 @@
                         <TextBlock
                             Text="{Binding DetailsMessage}"
                             TextWrapping="Wrap"
+                            TextAlignment="Center"
                             Foreground="{DynamicResource MemberButtonText}"
                             Margin="10"
                             FontSize="11">


### PR DESCRIPTION
### Purpose

Removes the 500 units bound on the extension panel width. The panel can
be enlarged as much as needed, while respecting the minimum size of the
canvas panel, which remains as 200 units.

Also, the extension panel size is remembered during a session. Serves
both as a nice to have and a avoids a splitter bug.

Also, the workspace references extension is fixed so that it adapts to
bigger sizes. It didn't stretch beyond 600 units.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @reddyashish 

### FYIs

@DynamoDS/dynamo 