### PR TITLE
Parse long.MinValue in Design Script

### DIFF
--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2253,13 +2253,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			}
 			Expect(2);
 			Int64 value;
-			if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			var tokenWithSign = sign == -1 ? "-" + t.val : t.val;
+			if (Int64.TryParse(tokenWithSign, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
-			   node = new ProtoCore.AST.AssociativeAST.IntNode(sign*value);
+			   node = new ProtoCore.AST.AssociativeAST.IntNode(value);
 			}
 			else
 			{
-			   errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+			   errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, tokenWithSign));
 			}
 			
 			NodeUtils.SetNodeLocation(node, t);
@@ -2283,9 +2284,10 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		if (la.kind == 2) {
 			Get();
 			Int64 value;
-			if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			var tokenWithSign = sign == -1 ? "-" + t.val : t.val;
+			if (Int64.TryParse(tokenWithSign, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
-			   node = new ProtoCore.AST.AssociativeAST.IntNode(value * sign);
+			   node = new ProtoCore.AST.AssociativeAST.IntNode(value);
 			}
 			else
 			{
@@ -3742,9 +3744,10 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		if (la.kind == 2) {
 			Get();
 			Int64 value;
-			if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			var tokenWithSign = sign == -1 ? "-" + t.val : t.val;
+			if (Int64.TryParse(tokenWithSign, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
-			   node = new ProtoCore.AST.ImperativeAST.IntNode(value * sign);
+			   node = new ProtoCore.AST.ImperativeAST.IntNode(value);
 			}
 			else
 			{

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1361,13 +1361,14 @@ Associative_Level<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
         ] number
         (.
             Int64 value;
-            if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            var tokenWithSign = sign == -1 ? "-" + t.val : t.val;
+            if (Int64.TryParse(tokenWithSign, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
-                node = new ProtoCore.AST.AssociativeAST.IntNode(sign*value);
+                node = new ProtoCore.AST.AssociativeAST.IntNode(value);
             }
             else
             {
-                errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+                errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, tokenWithSign));
             }
 
             NodeUtils.SetNodeLocation(node, t);
@@ -1395,9 +1396,10 @@ Associative_Number<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
         number  
         (.  
             Int64 value;
-            if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            var tokenWithSign = sign == -1 ? "-" + t.val : t.val;
+            if (Int64.TryParse(tokenWithSign, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
-                node = new ProtoCore.AST.AssociativeAST.IntNode(value * sign);
+                node = new ProtoCore.AST.AssociativeAST.IntNode(value);
             }
             else
             {

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -1135,9 +1135,10 @@ Imperative_num<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         number  
         (.  
             Int64 value;
-            if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            var tokenWithSign = sign == -1 ? "-" + t.val : t.val;
+            if (Int64.TryParse(tokenWithSign, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
-                node = new ProtoCore.AST.ImperativeAST.IntNode(value * sign);
+                node = new ProtoCore.AST.ImperativeAST.IntNode(value);
             }
             else
             {

--- a/test/Engine/ProtoTest/ParserTest/ParserTest.cs
+++ b/test/Engine/ProtoTest/ParserTest/ParserTest.cs
@@ -11,7 +11,7 @@ namespace ProtoTest.ParserTest
         [Test]
         public void TestInvalidEscape1()
         {
-            string code = @"x = ""\\""";
+            string code = @"x = ""\"";";
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
             {
                 thisTest.RunScriptSource(code);
@@ -21,12 +21,18 @@ namespace ProtoTest.ParserTest
         [Test]
         public void TestInvalidEscape2()
         {
-            string code = @"x = ""\\X""";
+            string code = @"x = ""\X"";";
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
             {
                 thisTest.RunScriptSource(code);
             });
         }
 
+        [Test]
+        public void CanParseMinLongValue()
+        {
+            var code = "x = -9223372036854775808;";
+            thisTest.RunScriptSource(code);            thisTest.Verify("x", long.MinValue);
+        }
     }
 }

--- a/test/Engine/ProtoTest/ParserTest/ParserTest.cs
+++ b/test/Engine/ProtoTest/ParserTest/ParserTest.cs
@@ -32,7 +32,8 @@ namespace ProtoTest.ParserTest
         public void CanParseMinLongValue()
         {
             var code = "x = -9223372036854775808;";
-            thisTest.RunScriptSource(code);            thisTest.Verify("x", long.MinValue);
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("x", long.MinValue);
         }
     }
 }


### PR DESCRIPTION
### Purpose

Values of type long were parsed in a two-step process where the unsigned
value was parsed first and then multiplied by its sign if present. This
type of processing did not work for -9223372036854775808, as its
unsigned value is not a valid long. The issue is fixed by prepending
the '-' sign in case the number is negative before parsing it.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@aparajit-pratap  @QilongTang 

### FYIs

@DynamoDS/dynamo 
