### PR TITLE
Improve description of equal numbers node

### DIFF
--- a/src/Libraries/CoreNodeModels/Equals.cs
+++ b/src/Libraries/CoreNodeModels/Equals.cs
@@ -5,7 +5,6 @@ using CoreNodeModels.Properties;
 using Dynamo.Graph.Nodes;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
-using ProtoCore.DSASM;
 using ProtoCore.Utils;
 
 namespace CoreNodeModels
@@ -14,6 +13,7 @@ namespace CoreNodeModels
     [NodeDescription("EqualsWithToleranceDescription", typeof(Resources))]
     [NodeCategory("Core.Math")]
     [NodeSearchTags("EqualsWithToleranceSearchTags", typeof(Resources))]
+    [InPortNames("x", "y", "tolerance")]
     [InPortTypes("double", "double", "double")]
     [OutPortTypes("bool")]
     [IsDesignScriptCompatible]

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CoreNodeModels.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -376,7 +376,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Equals with tolerance input..
+        ///   Looks up a localized string similar to Compares if two numbers are equal given a certain tolerance..
         /// </summary>
         public static string EqualsWithToleranceDescription {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -591,7 +591,7 @@
     <value>color</value>
   </data>
   <data name="EqualsWithToleranceDescription" xml:space="preserve">
-    <value>Equals with tolerance input.</value>
+    <value>Compares if two numbers are equal given a certain tolerance.</value>
     <comment>Description for Equals with tolerance node</comment>
   </data>
   <data name="EqualsWithToleranceLhsRhsTooltip" xml:space="preserve">

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -591,7 +591,7 @@
     <value>color</value>
   </data>
   <data name="EqualsWithToleranceDescription" xml:space="preserve">
-    <value>Equals with tolerance input.</value>
+    <value>Compares if two numbers are equal given a certain tolerance.</value>
     <comment>Description for Equals with tolerance node</comment>
   </data>
   <data name="EqualsWithToleranceLhsRhsTooltip" xml:space="preserve">


### PR DESCRIPTION
### Purpose

The summary is changed to reflect the fact that it works with numbers
only. Also the port names are declared on the node class to make them
appear in the library.

Looks like this now:

<img width="693" alt="Screen Shot 2020-09-16 at 4 33 37 PM" src="https://user-images.githubusercontent.com/10048120/93390205-5588a980-f83b-11ea-9941-f896a3c358b8.png">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit 

### FYIs

@Amoursol 
