### PR TITLE
Style Workspace References consistently

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -683,6 +683,68 @@
         </Setter>
     </Style>
 
+    <Style x:Key="SmallTextButton" TargetType="{x:Type Button}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border x:Name="container"
+                                Background="Transparent"
+                                BorderBrush="#3c3c3c"
+                                BorderThickness="1">
+                        <Grid x:Name="inner"
+                                    Background="#373737">
+                            <TextBlock x:Name="text"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       Margin="5,0"
+                                       Foreground="#bbbbbb"
+                                       FontSize="10px"
+                                       Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}"></TextBlock>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Button.IsMouseOver"
+                                    Value="true">
+                            <Setter TargetName="container"
+                                        Property="BorderBrush"
+                                        Value="#656565" />
+                            <Setter TargetName="inner"
+                                        Property="Background"
+                                        Value="#373737" />
+                        </Trigger>
+                        <Trigger Property="Button.IsPressed"
+                                    Value="true">
+                            <Setter TargetName="container"
+                                        Property="BorderBrush"
+                                        Value="#656565" />
+                            <Setter TargetName="inner"
+                                        Property="Background"
+                                        Value="#272727" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                    Value="true">
+                            <Setter TargetName="text"
+                                        Property="Foreground"
+                                        Value="#bbbbbb" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                    Value="false">
+                            <Setter TargetName="container"
+                                        Property="BorderBrush"
+                                        Value="Transparent" />
+                            <Setter TargetName="inner"
+                                        Property="Background"
+                                        Value="#373737" />
+                            <Setter TargetName="text"
+                                        Property="Foreground"
+                                        Value="#555555" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="STextButtonWithShapeIcon"
            TargetType="{x:Type Button}">
         <Setter Property="Template">

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -153,16 +153,16 @@
                             TextAlignment="Center"
                             Foreground="{DynamicResource MemberButtonText}"
                             Margin="10"
-                            FontSize="13">
+                            FontSize="11">
                         </TextBlock>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <Button Style="{DynamicResource STextButton}"
+                            <Button Style="{StaticResource SmallTextButton}"
                                 Visibility="{Binding Path=ShowDownloadButton, Converter={StaticResource BoolToVis}}"
                                 Name="DownloadPackageButton"
                                 Click="DownloadPackage"
                                 Margin="10"
                                 Content="{x:Static w:Resources.InstallButtonText}"/>
-                            <Button Style="{DynamicResource STextButton}"
+                            <Button Style="{StaticResource SmallTextButton}"
                                 Visibility="{Binding Path=ShowKeepLocalButton, Converter={StaticResource BoolToVis}}"
                                 Name="KeepLocalPackageButton"
                                 Click="KeepLocalPackage"

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -60,10 +60,13 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
+            <Style TargetType="{x:Type fa:ImageAwesome}">
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="{DynamicResource LibraryItemHostBackground}"/>
+                        <Setter Property="Foreground" Value="White"/>
+                    </Trigger>
+                    <Trigger Property="IsMouseOver" Value="False">
+                        <Setter Property="Foreground" Value="{DynamicResource MemberButtonText}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -100,16 +103,10 @@
                     IsReadOnly="True"
                     Width="38">
                     <DataGridTemplateColumn.Header>
-                        <Button Width="Auto"
-                                Background="Transparent"
-                                Foreground="Transparent"
-                                BorderThickness="0">
-                            <fa:ImageAwesome Name="Refresh" 
+                        <fa:ImageAwesome Name="Refresh" 
                                          Icon="Refresh" 
-                                         Foreground="{DynamicResource MemberButtonText}" 
                                          ToolTip="{x:Static w:Resources.RefreshButtonTooltipText}" 
                                          MouseLeftButtonDown="Refresh_MouseLeftButtonDown"/>
-                        </Button>
                     </DataGridTemplateColumn.Header>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -156,44 +153,21 @@
                             TextAlignment="Center"
                             Foreground="{DynamicResource MemberButtonText}"
                             Margin="10"
-                            FontSize="11">
+                            FontSize="13">
                         </TextBlock>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <Button
+                            <Button Style="{DynamicResource STextButton}"
                                 Visibility="{Binding Path=ShowDownloadButton, Converter={StaticResource BoolToVis}}"
                                 Name="DownloadPackageButton"
                                 Click="DownloadPackage"
-                                HorizontalAlignment="Center"
                                 Margin="10"
-                                Height="20"
-                                Background="#000000"
-                                BorderThickness="0">
-                                <TextBlock 
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Margin="5,0,5,0"
-                                    Foreground="#cccccc"
-                                    FontSize="10px"
-                                    Text="{x:Static w:Resources.InstallButtonText}">
-                                </TextBlock>
-                            </Button>
-                            <Button
+                                Content="{x:Static w:Resources.InstallButtonText}"/>
+                            <Button Style="{DynamicResource STextButton}"
                                 Visibility="{Binding Path=ShowKeepLocalButton, Converter={StaticResource BoolToVis}}"
                                 Name="KeepLocalPackageButton"
                                 Click="KeepLocalPackage"
-                                HorizontalAlignment="Center"
                                 Margin="10"
-                                Height="20"
-                                Background="#000000"
-                                BorderThickness="0">
-                                <TextBlock 
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Margin="5,0,5,0"
-                                    Foreground="#cccccc"
-                                    FontSize="10px"
-                                    Text="{x:Static w:Resources.KeepLocalButtonText}">
-                                </TextBlock>
+                                Content="{x:Static w:Resources.KeepLocalButtonText}">
                             </Button>
                         </StackPanel>
                     </StackPanel>


### PR DESCRIPTION
### Purpose

Changed the styles of the workspace references extension window to be
more consistent with respect to Dynamo. Particularly, buttons that used
default WPF button style were switched to now use the same style as in
the "Geometry Scaling" window. Also, refresh is no longer a button, to
get rid of the undesired hover style, and the image foreground is
changed on hover.

Here is how it looks like now:

<img width="410" alt="workspace_references" src="https://user-images.githubusercontent.com/10048120/93535289-aa4c2300-f914-11ea-8b52-74bb0fa0bb3f.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @aparajit-pratap 

### FYIs

@Amoursol 
