### PR TITLE
Adjust ExtensionsCollapsed after size change

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -205,7 +205,7 @@
             </ColumnDefinition>
             <!--MinWidth fix for GridSplitter dragging in frameless window-->
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5*" MinWidth="200" />
+            <ColumnDefinition Width="5*" MinWidth="200" Name="CanvasColumn" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="0"
                               MinWidth="1"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1848,12 +1848,17 @@ namespace Dynamo.Controls
         {
             get
             {
-                // Threshold that determines if button should be displayed
-                if (RightExtensionsViewColumn.Width.Value < 20)
-                { extensionsCollapsed = true; }
-
+                // Special case: when the extension bar was never resized its size will be 2.
+                // While 2 is a valid size for the extension bar, 5 is not one for the canvas,
+                // so that's a safer check to be made.
+                if (CanvasColumn.Width.Value == 5)
+                {
+                    extensionsCollapsed = RightExtensionsViewColumn.Width.Value == 0;
+                }
                 else
-                { extensionsCollapsed = false; }
+                {
+                    extensionsCollapsed = RightExtensionsViewColumn.Width.Value < 20;
+                }
 
                 return extensionsCollapsed;
             }


### PR DESCRIPTION
### Purpose

Fixes the value provided by ExtensionsCollapsed to also account for the
initial state of the columns, where the sizes are 5* for the canvas and
2* for the extension bar. This in turn fixes a bug where the extension
bar wouldn't collapse if never resized.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @reddyashish 

### FYIs

@DynamoDS/dynamo 