### PR TITLE
Drag after right click on annotation fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -112,6 +112,10 @@ namespace Dynamo.Nodes
         {
             if (ViewModel != null)
             {
+                DynamoSelection.Instance.ClearSelection();
+                System.Guid annotationGuid = this.ViewModel.AnnotationModel.GUID;
+                ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                   new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
                 ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
             }
         }
@@ -165,9 +169,7 @@ namespace Dynamo.Nodes
 
         private void AnnotationView_OnMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            System.Guid annotationGuid = this.ViewModel.AnnotationModel.GUID;
-            ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
-               new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
+            ViewModel.Select();                      
         }
 
         /// <summary>
@@ -250,6 +252,7 @@ namespace Dynamo.Nodes
             //Select the group and the models within that group
             if (ViewModel != null)
             {
+                DynamoSelection.Instance.ClearSelection();
                 ViewModel.Select();
                 ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
             }

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -165,7 +165,6 @@ namespace Dynamo.Nodes
 
         private void AnnotationView_OnMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            DynamoSelection.Instance.ClearSelection();
             System.Guid annotationGuid = this.ViewModel.AnnotationModel.GUID;
             ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -107,7 +107,11 @@ namespace Dynamo.Nodes
                     ViewModel.Background = brush.Color;
             }
         }
-
+        /// <summary>
+        /// This function will clear the selection and then select only the annotation node to delete it for ungrouping.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
         private void OnUngroupAnnotation(object sender, RoutedEventArgs e)
         {
             if (ViewModel != null)


### PR DESCRIPTION
### Purpose

[DYN-2877](https://jira.autodesk.com/browse/DYN-2877)
Fixes the bug where dragging after a right click on an annotation detaches the annotation from the nodes it contained temporarily.

The problem discovered was on every right-click on the annotation group the selection was cleared, that removed all the nodes in the annotation space from the active selected nodes. Therefore, whenever any node in the annotation group was moved immediately after a context click it will only move the annotation box and nothing else. 
The fix was to not clear the selection on right click but only clear the selection for the required options, such as delete and ungroup. 

Before:
![image-2020-07-02-12-41-01-104](https://user-images.githubusercontent.com/32665108/94582923-d76ccf80-024a-11eb-98fb-d83d5e679bc9.png)

After:
![Kapture 2020-09-29 at 11 57 10](https://user-images.githubusercontent.com/32665108/94583231-30d4fe80-024b-11eb-94be-bacfd86e31f6.gif)

Related UI Automation Test: [#26](https://git.autodesk.com/Dynamo/DynamoUIAutomation/pull/26) 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 
