### PR TITLE
Fix path to custom fixers for python migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Dynamo.sln.DotSettings
 *.sdf
 *.backup
 *.pdf
+*.dgml
 
 #ASM
 extern/DynamoAsm/

--- a/src/PythonMigrationViewExtension/MigrationAssistant/migrate_2to3.py
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/migrate_2to3.py
@@ -12,7 +12,6 @@ def transform(source):
     python_zip_folder = zipfile.ZipFile(os.path.join(python_zip_path, python_zip_file))
     fixers = get_all_fixers_from_zipfolder(python_zip_folder)
 
-    # dir_path = os.getcwd()
     sys.path.append(os.path.join(path_name, '.\\python_migration_fixers'))
     fixers.extend(['fix_none'])
 

--- a/src/PythonMigrationViewExtension/MigrationAssistant/migrate_2to3.py
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/migrate_2to3.py
@@ -12,8 +12,8 @@ def transform(source):
     python_zip_folder = zipfile.ZipFile(os.path.join(python_zip_path, python_zip_file))
     fixers = get_all_fixers_from_zipfolder(python_zip_folder)
 
-    dir_path = os.getcwd()
-    sys.path.append(os.path.join(dir_path, '.\\python_migration_fixers'))
+    # dir_path = os.getcwd()
+    sys.path.append(os.path.join(path_name, '.\\python_migration_fixers'))
     fixers.extend(['fix_none'])
 
     refactoring_tool = RefactoringTool(fixers)


### PR DESCRIPTION
### Purpose

Fixes issue with python migration assistant not working for host environments.
See slack thread: https://autodesk.slack.com/archives/C0W60575Z/p1600674768017200

Manually tested in Revit.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate 
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Amoursol 
@QilongTang 