### PR TITLE
Focus extension when activated

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1933,7 +1933,10 @@ namespace Dynamo.Controls
             ToggleExtensionBarCollapseStatus();
         }
 
-        private void ToggleExtensionBarCollapseStatus()
+        /// <summary>
+        /// Made internal for testing purposes only.
+        /// </summary>
+        internal void ToggleExtensionBarCollapseStatus()
         {
             if (ExtensionsCollapsed)
             {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -205,18 +205,22 @@ namespace Dynamo.Controls
             FocusableGrid.InputBindings.Clear();
         }
 
-        // This method adds a tab item to the right side bar and 
-        // sets the extension window as the tab content.
+        /// <summary>
+        /// Adds a tab item to the extension bar and sets the extension window/control as the tab
+        /// content. It also makes sure the extension is visible.
+        /// </summary>
+        /// <param name="viewExtension">View extension adding the content</param>
+        /// <param name="contentControl">Control being added to the extension bar</param>
+        /// <returns>The tab item if it was added, otherwise null</returns>
         internal TabItem AddExtensionTabItem(IViewExtension viewExtension, ContentControl contentControl)
         {
-            int count = ExtensionTabItems.Count;
-
-            if (!IsExtensionAddedToRightSideBar(viewExtension))
+            var tab = FindExtensionTab(viewExtension);
+            if (tab == null)
             {
                 tabDynamic.DataContext = null;
 
                 // creates a new tab item
-                TabItem tab = new TabItem();
+                tab = new TabItem();
                 tab.Header = viewExtension.Name;
                 tab.Tag = viewExtension.GetType();
                 tab.Uid = viewExtension.UniqueId;
@@ -240,13 +244,21 @@ namespace Dynamo.Controls
                 }
 
                 //Insert the tab at the end
-                ExtensionTabItems.Insert(count, tab);
+                ExtensionTabItems.Insert(ExtensionTabItems.Count, tab);
 
                 tabDynamic.DataContext = ExtensionTabItems;
                 tabDynamic.SelectedItem = tab;
 
                 return tab;
             }
+
+            // Make sure the extension bar is visible
+            if (ExtensionsCollapsed)
+            {
+                ToggleExtensionBarCollapseStatus();
+            }
+
+            tabDynamic.SelectedItem = tab;
             return null;
         }
 
@@ -316,16 +328,9 @@ namespace Dynamo.Controls
             this.HideOrShowRightSideBar();
         }
 
-        private Boolean IsExtensionAddedToRightSideBar(IViewExtension viewExtension)
+        private TabItem FindExtensionTab(IViewExtension viewExtension)
         {
-            foreach (TabItem tabItem in ExtensionTabItems)
-            {
-                if (tabItem.Tag.Equals(viewExtension.GetType()))
-                {
-                    return true;
-                }
-            }
-            return false;
+            return ExtensionTabItems.FirstOrDefault(tab => tab.Tag.Equals(viewExtension.GetType()));
         }
 
         private void OnRequestReturnFocusToView()
@@ -1924,6 +1929,11 @@ namespace Dynamo.Controls
         }
 
         private void OnCollapsedRightSidebarClick(object sender, EventArgs e)
+        {
+            ToggleExtensionBarCollapseStatus();
+        }
+
+        private void ToggleExtensionBarCollapseStatus()
         {
             if (ExtensionsCollapsed)
             {

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Controls;
 using Dynamo.Wpf.Extensions;
 using NUnit.Framework;
 
@@ -66,6 +67,29 @@ namespace DynamoCoreWpfTests
             extensionsSideBarViewExtensionNew.UniqueId = "ExtensionsSideBarDummyIDNew";
             extensionManager.Add(extensionsSideBarViewExtensionNew);
             Assert.AreEqual(initialNum + 2, View.ExtensionTabItems.Count); 
+        }
+
+        [Test]
+        public void ExtensionSideBarIsUncollapsedOnActivation()
+        {
+            RaiseLoadedEvent(this.View);
+
+            // Add extension
+            View.viewExtensionManager.Add(viewExtension);
+            
+            // Extension bar is shown
+            Assert.IsFalse(View.ExtensionsCollapsed);
+
+            // Collapse extension bar
+            View.ToggleExtensionBarCollapseStatus();
+            Assert.IsTrue(View.ExtensionsCollapsed);
+
+            // Simulate the extension activating the tab content again.
+            // The content here should not matter because it won't be used.
+            View.AddExtensionTabItem(viewExtension, new UserControl());
+
+            // Extension bar is shown
+            Assert.IsFalse(View.ExtensionsCollapsed);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Modifies the mechanism used to add/display extensions to make sure the
extension bar is actually visible and that the right tab is actually
displayed.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @reddyashish 

