### PR TITLE
Fix input port type for instance properties

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -408,7 +408,7 @@ namespace Dynamo.Graph.Nodes
                 string type;
                 // In the case of a node for an instance method, the first port
                 // type is the declaring class type of the method itself.
-                if (fd.Type == FunctionType.InstanceMethod)
+                if (fd.Type == FunctionType.InstanceMethod || fd.Type == FunctionType.InstanceProperty)
                 {
                     if (Index > 0)
                     {

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -69,6 +69,38 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void NodeSuggestions_InputPortZeroTouchNodeForProperty_AreCorrect()
+        {
+            Open(@"UI\ffitarget_property_inputport_suggestion.dyn");
+
+            // Get the node view for a specific node in the graph
+            NodeView nodeView = NodeViewWithGuid(Guid.Parse("ac15a2a0010a4fef98c13a870ce4c55c").ToString());
+
+            var inPorts = nodeView.ViewModel.InPorts;
+            Assert.AreEqual(1, inPorts.Count());
+
+            var port = inPorts[0].PortModel;
+            var type = port.GetInputPortType();
+            Assert.AreEqual("FFITarget.ClassFunctionality", type);
+
+            var searchViewModel = (ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel);
+            searchViewModel.PortViewModel = inPorts[0];
+            var suggestions = searchViewModel.GetMatchingNodes();
+            Assert.AreEqual(4, suggestions.Count());
+
+            var suggestedNodes = suggestions.Select(s => s.FullName).OrderBy(s => s);
+            var nodes = new[] { "FFITarget.FFITarget.ClassFunctionality.ClassFunctionality",
+                "FFITarget.FFITarget.ClassFunctionality.ClassFunctionality",
+                "FFITarget.FFITarget.ClassFunctionality.ClassFunctionality",
+                "FFITarget.FFITarget.ClassFunctionality.Instance" };
+            var expectedNodes = nodes.OrderBy(s => s);
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.AreEqual(expectedNodes.ElementAt(i), suggestedNodes.ElementAt(i));
+            }
+        }
+
+        [Test]
         public void NodeSuggestions_InputPortBuiltInNode_AreCorrect()
         {
             Open(@"UI\builtin_inputport_suggestion.dyn");

--- a/test/UI/ffitarget_property_inputport_suggestion.dyn
+++ b/test/UI/ffitarget_property_inputport_suggestion.dyn
@@ -1,0 +1,85 @@
+{
+  "Uuid": "79ea0296-2698-4563-9ebd-ca50128bd4e7",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "ffitarget_property_inputport_suggestion",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.ClassFunctionality.ClassProperty",
+      "Id": "ac15a2a0010a4fef98c13a870ce4c55c",
+      "Inputs": [
+        {
+          "Id": "bf092fcd041f4f4cbe1b9679c536c752",
+          "Name": "classFunctionality",
+          "Description": "FFITarget.ClassFunctionality",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9587176fdbdd4276bdddc28672eff503",
+          "Name": "ValueContainer",
+          "Description": "ValueContainer",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "ClassFunctionality.ClassProperty: ValueContainer"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.9.0.2806",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "ClassFunctionality.ClassProperty",
+        "Id": "ac15a2a0010a4fef98c13a870ce4c55c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 384.0,
+        "Y": 147.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Fix `GetInputPortType` on `PortModel` to handle nodes that are properties.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

