### PR TITLE
Place suggested node wrt node height and width

### DIFF
--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -123,6 +123,7 @@ namespace Dynamo.ViewModels
                 case "UngroupModelCommand":
                 case "AddModelToGroupCommand":
                 case "CreateAndConnectNodeCommand":
+                case "PlaceAndConnectNodeCommand":
                     RaiseCanExecuteUndoRedo();
                     break;
 
@@ -187,6 +188,7 @@ namespace Dynamo.ViewModels
                 case "AddPresetCommand":
                 case "ApplyPresetCommand":
                 case "CreateAndConnectNodeCommand":
+                case "PlaceAndConnectNodeCommand":
                     // for this commands there is no need
                     // to do anything before execution
                     break;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -235,12 +235,12 @@ namespace Dynamo.Wpf.ViewModels
         /// </summary>
         public ICommand CreateAndConnectCommand { get; private set; }
 
-        public event Action<string, PortModel> CreateAndConnectToPort;
+        public event Action<NodeSearchElement, PortModel> CreateAndConnectToPort;
         protected virtual void OnRequestCreateAndConnectToPort(PortModel portModel)
         {
             if (CreateAndConnectToPort != null)
             {
-                CreateAndConnectToPort(Model.CreationName, portModel);
+                CreateAndConnectToPort(Model, portModel);
             }
         }
 


### PR DESCRIPTION
### Purpose

This builds on top of PR #11164 

The new node chosen from node autocomplete needs to be placed relative to the initial node relative to its location as well as the sizes of the initial node and new node. However, the size of the new node is not available until the node's view is created. For this reason, we have tried to split the creation of the node and its placement and connection into two separate commands. The placement and connection command (`PlaceAndConnectNodeCommand`) is executed only once the node view is ready. 
![place_and_connect_nodes](https://user-images.githubusercontent.com/5710686/95754611-4d246280-0c71-11eb-8197-b94469636048.gif)

This solution takes care of the issue of placing different sized nodes relative to the initial node but placing them vertically relative to other input nodes is still a challenge as we would need to know the size of all input nodes so that we can arrange them in a manner such that they don't overlap with each other. 

Having tried this approach, I would like to try out the auto-layout solution again but laying out only the input nodes.


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

