### PR TITLE
Translate package publishing error messages

### DIFF
--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1110,6 +1110,24 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A package with the given name already exists..
+        /// </summary>
+        public static string PackageManagerPackageAlreadyExists {
+            get {
+                return ResourceManager.GetString("PackageManagerPackageAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The current user, &apos;{0}&apos;, is not a maintainer of the package &apos;{1}&apos;..
+        /// </summary>
+        public static string PackageManagerUserIsNotAMaintainer {
+            get {
+                return ResourceManager.GetString("PackageManagerUserIsNotAMaintainer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package is too large!  The package must be less than 15 MB!.
         /// </summary>
         public static string PackageTooLarge {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -733,6 +733,6 @@ Parameter name: {0}</value>
   </data>
   <data name="PackageManagerUserIsNotAMaintainer" xml:space="preserve">
     <value>The current user, '{0}', is not a maintainer of the package '{1}'.</value>
-    <comment>{0} = version (i.e. '1.2.3'), {1} = package name (i.e. 'Clockwork for Dynamo')</comment>
+    <comment>{0} = user name (i.e. 'DynamoTeam'), {1} = package name (i.e. 'Clockwork for Dynamo 1.x')</comment>
   </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -728,4 +728,11 @@ Parameter name: {0}</value>
   <data name="ModelNotFoundError" xml:space="preserve">
     <value>UpdateModelValue: Model not found</value>
   </data>
+  <data name="PackageManagerPackageAlreadyExists" xml:space="preserve">
+    <value>A package with the given name already exists.</value>
+  </data>
+  <data name="PackageManagerUserIsNotAMaintainer" xml:space="preserve">
+    <value>The current user, '{0}', is not a maintainer of the package '{1}'.</value>
+    <comment>{0} = version (i.e. '1.2.3'), {1} = package name (i.e. 'Clockwork for Dynamo')</comment>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -733,6 +733,6 @@ Parameter name: {0}</value>
   </data>
   <data name="PackageManagerUserIsNotAMaintainer" xml:space="preserve">
     <value>The current user, '{0}', is not a maintainer of the package '{1}'.</value>
-    <comment>{0} = version (i.e. '1.2.3'), {1} = package name (i.e. 'Clockwork for Dynamo')</comment>
+    <comment>{0} = user name (i.e. 'DynamoTeam'), {1} = package name (i.e. 'Clockwork for Dynamo 1.x')</comment>
   </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -728,4 +728,11 @@ Parameter name: {0}</value>
   <data name="ModelNotFoundError" xml:space="preserve">
     <value>UpdateModelValue: Model not found</value>
   </data>
+  <data name="PackageManagerPackageAlreadyExists" xml:space="preserve">
+    <value>A package with the given name already exists.</value>
+  </data>
+  <data name="PackageManagerUserIsNotAMaintainer" xml:space="preserve">
+    <value>The current user, '{0}', is not a maintainer of the package '{1}'.</value>
+    <comment>{0} = version (i.e. '1.2.3'), {1} = package name (i.e. 'Clockwork for Dynamo')</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1219,9 +1219,36 @@ namespace Dynamo.PackageManager
             catch (Exception e)
             {
                 UploadState = PackageUploadHandle.State.Error;
-                ErrorString = e.Message;
+                ErrorString = TranslatePackageManagerError(e.Message);
                 dynamoViewModel.Model.Logger.Log(e);
             }
+        }
+
+        private static readonly Regex UserIsNotAMaintainerRegex =
+            new Regex("^The user sending the new package version, ([^,]+), is not a maintainer of the package (.*)$");
+        private static readonly Regex PackageAlreadyExistsRegex =
+            new Regex("^A package with the given name and engine already exists\\.$");
+
+        /// <summary>
+        /// Inspects an error message to see if it matches a known Package Manager error message.
+        /// If it does, it returns the equivalent translated resource, otherwise returns the same.
+        /// NOTE: This function is internal for testing purposes only.
+        /// </summary>
+        /// <param name="message">Message to inspect</param>
+        /// <returns>Translated message or same as parameter</returns>
+        internal static string TranslatePackageManagerError(string message)
+        {
+            if (UserIsNotAMaintainerRegex.IsMatch(message))
+            {
+                var match = UserIsNotAMaintainerRegex.Match(message);
+                return string.Format(Properties.Resources.PackageManagerUserIsNotAMaintainer, match.Groups[1], match.Groups[2]);
+            }
+            else if (PackageAlreadyExistsRegex.IsMatch(message))
+            {
+                return Properties.Resources.PackageManagerPackageAlreadyExists;
+            }
+
+            return message;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1230,8 +1230,8 @@ namespace Dynamo.PackageManager
             new Regex("^A package with the given name and engine already exists\\.$");
 
         /// <summary>
-        /// Inspects an error message to see if it matches a known Package Manager error message.
-        /// If it does, it returns the equivalent translated resource, otherwise returns the same.
+        /// Inspects an error message to see if it matches a known Package Manager error message. If it does,
+        /// it returns the equivalent translated resource, otherwise it returns the same message.
         /// NOTE: This function is internal for testing purposes only.
         /// </summary>
         /// <param name="message">Message to inspect</param>

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="GraphLayoutTests.cs" />
     <Compile Include="NodeToCodeTests.cs" />
     <Compile Include="PackageManagerExtensionLoadingTests.cs" />
+    <Compile Include="PackageManagerUnitTests.cs" />
     <Compile Include="PackageManagerViewExtensionTests.cs" />
     <Compile Include="PresetPromptTests.cs" />
     <Compile Include="AnnotationViewModelTests.cs" />

--- a/test/DynamoCoreWpfTests/PackageManagerUnitTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUnitTests.cs
@@ -1,0 +1,40 @@
+﻿using Dynamo;
+using Dynamo.PackageManager;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    public class PackageManagerUnitTests : UnitTestBase
+    {
+        #region PackageManager error translation
+
+        [Test]
+        public void ReturnsTranslationForUserIsNotAMaintainerError()
+        {
+            var message = "The user sending the new package version, DynamoTeam, is not a maintainer of the package Clockwork for Dynamo 1.x";
+            var actual = PublishPackageViewModel.TranslatePackageManagerError(message);
+            var expected = "The current user, 'DynamoTeam', is not a maintainer of the package 'Clockwork for Dynamo 1.x'.";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ReturnsTranslationForPackageAlreadyExistsError()
+        {
+            var message = "A package with the given name and engine already exists.";
+            var actual = PublishPackageViewModel.TranslatePackageManagerError(message);
+            var expected = "A package with the given name already exists.";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ReturnsSameAsInputForUnknownMessages()
+        {
+            var message = "Unknown error";
+            var actual = PublishPackageViewModel.TranslatePackageManagerError(message);
+            Assert.AreEqual(message, actual);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
### Purpose

These errors originate from PackageManager. In order to translate them,
these are identified, parsed and then translated using local resources.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit 

