### PR TITLE
Position node autocomplete UI against respective input port

### DIFF
--- a/src/DynamoCore/Core/DynamoSelection.cs
+++ b/src/DynamoCore/Core/DynamoSelection.cs
@@ -160,7 +160,7 @@ namespace Dynamo.Selection
         {
             foreach (var item in range)
             {
-                Items.Add(item);
+                Add(item);
             }
 
             this.OnPropertyChanged(new PropertyChangedEventArgs("Count"));

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -64,12 +64,14 @@ namespace Dynamo.Graph.Nodes
         private ObservableCollection<PortModel> inPorts = new ObservableCollection<PortModel>();
         private ObservableCollection<PortModel> outPorts = new ObservableCollection<PortModel>();
 
-        #endregion
-
-        #region public members
-
         private readonly Dictionary<int, Tuple<int, NodeModel>> inputNodes;
         private readonly Dictionary<int, HashSet<Tuple<int, NodeModel>>> outputNodes;
+
+        #endregion
+
+        internal const double NodeHeaderHeight = 25;
+
+        #region public members
 
         /// <summary>
         /// The unique name that was created the node by

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -69,7 +69,7 @@ namespace Dynamo.Graph.Nodes
 
         #endregion
 
-        internal const double NodeHeaderHeight = 25;
+        internal const double HeaderHeight = 25;
 
         #region public members
 

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -163,10 +163,9 @@ namespace Dynamo.Graph.Nodes
             get
             {
                 double halfHeight = Height * 0.5;
-                const double headerHeight = 25;
 
                 double offset = Owner.GetPortVerticalOffset(this);
-                double y = Owner.Y + headerHeight + 5 + halfHeight + offset;
+                double y = Owner.Y + NodeModel.NodeHeaderHeight + 5 + halfHeight + offset;
 
                 switch (PortType)
                 {

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -165,7 +165,7 @@ namespace Dynamo.Graph.Nodes
                 double halfHeight = Height * 0.5;
 
                 double offset = Owner.GetPortVerticalOffset(this);
-                double y = Owner.Y + NodeModel.NodeHeaderHeight + 5 + halfHeight + offset;
+                double y = Owner.Y + NodeModel.HeaderHeight + 5 + halfHeight + offset;
 
                 switch (PortType)
                 {

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -7,7 +7,7 @@
              xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
              xmlns:resx="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              mc:Ignorable="d"
-             MinWidth="250"
+             MinWidth="256"
              IsVisibleChanged="OnNodeAutoCompleteSearchControlVisibilityChanged">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -42,9 +42,9 @@ namespace Dynamo.UI.Controls
 
         private void NodeAutoCompleteSearchControl_Loaded(object sender, RoutedEventArgs e)
         {
-            if(ViewModel != null && ViewModel.PortViewModel != null)
+            if (ViewModel != null && ViewModel.PortViewModel != null)
             {
-                ViewModel.PortViewModel.PlaceNodeAutocompleteWindow(this, null);
+                ViewModel.PortViewModel.PlaceNodeAutocompleteWindow(this, e);
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -36,8 +36,8 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
+            Loaded += ViewModel.PortViewModel.PlaceNodeAutocompleteWindow;
             Unloaded += NodeAutoCompleteSearchControl_Unloaded;
-
         }
 
         private void NodeAutoCompleteSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -46,6 +46,7 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated -= currentApplicationDeactivated;
             }
+            Loaded -= ViewModel.PortViewModel.PlaceNodeAutocompleteWindow;
         }
 
         private void currentApplicationDeactivated(object sender, EventArgs e)

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -132,7 +132,6 @@ namespace Dynamo.UI.Controls
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 SearchTextBox.Focus();
-                //ViewModel.InitializeDefaultAutoCompleteCandidates();
                 ViewModel.PopulateAutoCompleteCandidates();
             }), DispatcherPriority.Loaded);
         }

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -36,8 +36,16 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
-            Loaded += ViewModel.PortViewModel.PlaceNodeAutocompleteWindow;
+            Loaded += NodeAutoCompleteSearchControl_Loaded;
             Unloaded += NodeAutoCompleteSearchControl_Unloaded;
+        }
+
+        private void NodeAutoCompleteSearchControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if(ViewModel != null && ViewModel.PortViewModel != null)
+            {
+                ViewModel.PortViewModel.PlaceNodeAutocompleteWindow(this, null);
+            }
         }
 
         private void NodeAutoCompleteSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -46,7 +54,6 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated -= currentApplicationDeactivated;
             }
-            Loaded -= ViewModel.PortViewModel.PlaceNodeAutocompleteWindow;
         }
 
         private void currentApplicationDeactivated(object sender, EventArgs e)

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -22,7 +22,7 @@ namespace Dynamo.UI.Controls
     {
         ListBoxItem HighlightedItem;
 
-        internal event Action<PortViewModel, ShowHideFlags> RequestShowNodeAutoCompleteSearch;
+        internal event Action<ShowHideFlags> RequestShowNodeAutoCompleteSearch;
 
         public NodeAutoCompleteSearchViewModel ViewModel
         {
@@ -57,7 +57,7 @@ namespace Dynamo.UI.Controls
         {
             if (RequestShowNodeAutoCompleteSearch != null)
             {
-                RequestShowNodeAutoCompleteSearch(null, flags);
+                RequestShowNodeAutoCompleteSearch(flags);
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -22,7 +22,7 @@ namespace Dynamo.UI.Controls
     {
         ListBoxItem HighlightedItem;
 
-        internal event Action<ShowHideFlags> RequestShowNodeAutoCompleteSearch;
+        internal event Action<PortViewModel, ShowHideFlags> RequestShowNodeAutoCompleteSearch;
 
         public NodeAutoCompleteSearchViewModel ViewModel
         {
@@ -57,7 +57,7 @@ namespace Dynamo.UI.Controls
         {
             if (RequestShowNodeAutoCompleteSearch != null)
             {
-                RequestShowNodeAutoCompleteSearch(flags);
+                RequestShowNodeAutoCompleteSearch(null, flags);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Controls.Primitives;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.UI.Commands;
@@ -217,6 +218,7 @@ namespace Dynamo.ViewModels
             _port.PropertyChanged += _port_PropertyChanged;
             _node.PropertyChanged += _node_PropertyChanged;
             _node.WorkspaceViewModel.PropertyChanged += Workspace_PropertyChanged;
+            _node.WorkspaceViewModel.RequestNodeAutocompleteWindowPlacement += PlaceNodeAutocompleteWindow;
         }
 
         public override void Dispose()
@@ -224,6 +226,15 @@ namespace Dynamo.ViewModels
             _port.PropertyChanged -= _port_PropertyChanged;
             _node.PropertyChanged -= _node_PropertyChanged;
             _node.WorkspaceViewModel.PropertyChanged -= Workspace_PropertyChanged;
+            _node.WorkspaceViewModel.RequestNodeAutocompleteWindowPlacement -= PlaceNodeAutocompleteWindow;
+        }
+
+        private void PlaceNodeAutocompleteWindow(object sender, EventArgs e)
+        {
+            var popup = (e as NodeAutocompleteEventArgs).NodeAutocompleteSearchBar;
+            var x = Center.X;
+            var y = Center.Y - PortModel.Height * 0.5;
+            popup.PlacementRectangle = new Rect(x, y, 100, 100);
         }
 
         private void Workspace_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -235,6 +246,18 @@ namespace Dynamo.ViewModels
                     break;
             }
         }
+
+        //internal CustomPopupPlacement[] PlaceNodeAutoCompleteSearchBar(Size popupSize,
+        //    Size targetSize, Point offset)
+        //{
+        //    var x = Center.X;
+        //    var y = Center.Y;
+        //    var pt1 = new Point(x, y);
+        //    var placement1 = new CustomPopupPlacement(pt1, PopupPrimaryAxis.None);
+        //    var placement2 = new CustomPopupPlacement(pt1, PopupPrimaryAxis.None);
+
+        //    return new[] {placement1, placement2};
+        //}
 
         void _node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
@@ -367,10 +390,10 @@ namespace Dynamo.ViewModels
         // Handler to invoke node Auto Complete
         private void AutoComplete(object parameter)
         {
-            DynamoViewModel dynamoViewModel = _node.DynamoViewModel;
-            var svm = dynamoViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel;
-            svm.PortViewModel = parameter as PortViewModel;
-            dynamoViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
+            var wsViewModel = _node.WorkspaceViewModel;
+            var svm = wsViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel;
+            svm.PortViewModel = this;
+            wsViewModel.OnRequestNodeAutoCompleteSearch(this, ShowHideFlags.Show);
         }
 
         private bool CanAutoComplete(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -19,7 +19,6 @@ namespace Dynamo.ViewModels
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
         private const double autocompleteUISpacing = 2.5;
-        private const double autocompleteUIWidth = 256;
 
         /// <summary>
         /// Port model.
@@ -247,10 +246,10 @@ namespace Dynamo.ViewModels
             if (PortModel.PortType == PortType.Input)
             {
                 // Position node autocomplete UI offset left by its width from X position of node.
-                // TODO: control.ActualWidth gives the correct value except for the first time the control is launched.
-                // This probably has to do with the autocomplete suggestions not being populated in the 
-                // NodeAutoCompleteSearchViewModel the first time.
-                x = _node.X - (/*control.ActualWidth*/ autocompleteUIWidth + autocompleteUISpacing);
+                // Note: Width property of the control is set to a constant value in the WorkspaceView XAML.
+                // Without setting the Width explicitly control.ActualWidth gives the correct value
+                // except for the first time the control is launched. 
+                x = _node.X - (control.ActualWidth + autocompleteUISpacing);
             }
             else
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -19,6 +19,7 @@ namespace Dynamo.ViewModels
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
         private const double autocompleteUISpacing = 2.5;
+        private const double autocompleteUIWidth = 256;
 
         /// <summary>
         /// Port model.
@@ -246,7 +247,10 @@ namespace Dynamo.ViewModels
             if (PortModel.PortType == PortType.Input)
             {
                 // Position node autocomplete UI offset left by its width from X position of node.
-                x = _node.X - (control.ActualWidth + autocompleteUISpacing);
+                // TODO: control.ActualWidth gives the correct value except for the first time the control is launched.
+                // This probably has to do with the autocomplete suggestions not being populated in the 
+                // NodeAutoCompleteSearchViewModel the first time.
+                x = _node.X - (/*control.ActualWidth*/ autocompleteUIWidth + autocompleteUISpacing);
             }
             else
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -393,7 +393,7 @@ namespace Dynamo.ViewModels
             var wsViewModel = _node.WorkspaceViewModel;
             var svm = wsViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel;
             svm.PortViewModel = this;
-            wsViewModel.OnRequestNodeAutoCompleteSearch(this, ShowHideFlags.Show);
+            wsViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
         }
 
         private bool CanAutoComplete(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls.Primitives;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.UI.Commands;
+using Dynamo.UI.Controls;
 using Dynamo.Utilities;
 
 namespace Dynamo.ViewModels
@@ -218,7 +219,6 @@ namespace Dynamo.ViewModels
             _port.PropertyChanged += _port_PropertyChanged;
             _node.PropertyChanged += _node_PropertyChanged;
             _node.WorkspaceViewModel.PropertyChanged += Workspace_PropertyChanged;
-            _node.WorkspaceViewModel.RequestNodeAutocompleteWindowPlacement += PlaceNodeAutocompleteWindow;
         }
 
         public override void Dispose()
@@ -226,15 +226,14 @@ namespace Dynamo.ViewModels
             _port.PropertyChanged -= _port_PropertyChanged;
             _node.PropertyChanged -= _node_PropertyChanged;
             _node.WorkspaceViewModel.PropertyChanged -= Workspace_PropertyChanged;
-            _node.WorkspaceViewModel.RequestNodeAutocompleteWindowPlacement -= PlaceNodeAutocompleteWindow;
         }
 
-        private void PlaceNodeAutocompleteWindow(object sender, EventArgs e)
+        internal void PlaceNodeAutocompleteWindow(object sender, EventArgs e)
         {
-            var popup = (e as NodeAutocompleteEventArgs).NodeAutocompleteSearchBar;
-            var x = Center.X;
-            var y = Center.Y - PortModel.Height * 0.5;
-            popup.PlacementRectangle = new Rect(x, y, 100, 100);
+            var popup = sender as NodeAutoCompleteSearchControl;
+            var x = _node.X - popup.ActualWidth;
+            var y = _node.Y + 25 + PortModel.Index * PortModel.Height;
+            (popup.Parent as Popup).PlacementRectangle = new Rect(x, y, 0, 0);
         }
 
         private void Workspace_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -246,18 +245,6 @@ namespace Dynamo.ViewModels
                     break;
             }
         }
-
-        //internal CustomPopupPlacement[] PlaceNodeAutoCompleteSearchBar(Size popupSize,
-        //    Size targetSize, Point offset)
-        //{
-        //    var x = Center.X;
-        //    var y = Center.Y;
-        //    var pt1 = new Point(x, y);
-        //    var placement1 = new CustomPopupPlacement(pt1, PopupPrimaryAxis.None);
-        //    var placement2 = new CustomPopupPlacement(pt1, PopupPrimaryAxis.None);
-
-        //    return new[] {placement1, placement2};
-        //}
 
         void _node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
@@ -393,7 +380,12 @@ namespace Dynamo.ViewModels
             var wsViewModel = _node.WorkspaceViewModel;
             var svm = wsViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel;
             svm.PortViewModel = this;
+
+            //wsViewModel.RequestNodeAutocompleteWindowPlacement += PlaceNodeAutocompleteWindow;
+
             wsViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
+
+            //wsViewModel.RequestNodeAutocompleteWindowPlacement -= PlaceNodeAutocompleteWindow;
         }
 
         private bool CanAutoComplete(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -231,8 +231,21 @@ namespace Dynamo.ViewModels
         internal void PlaceNodeAutocompleteWindow(object sender, EventArgs e)
         {
             var popup = sender as NodeAutoCompleteSearchControl;
-            var x = _node.X - popup.ActualWidth;
-            var y = _node.Y + 25 + PortModel.Index * PortModel.Height;
+
+            double x;
+            if (PortModel.PortType == PortType.Input)
+            {
+                // Position node autocomplete UI offset left from X position of node by its width.
+                x = _node.X - popup.ActualWidth;
+            }
+            else
+            {
+                // Position node autocomplete UI offset right from X position of node by node width.
+                x = _node.X + _node.NodeModel.Width;
+            }
+            // Position UI down from the top of the node but offset by the node header and against the respective port.
+            var y = _node.Y + NodeModel.NodeHeaderHeight + PortModel.Index * PortModel.Height;
+
             (popup.Parent as Popup).PlacementRectangle = new Rect(x, y, 0, 0);
         }
 
@@ -381,11 +394,7 @@ namespace Dynamo.ViewModels
             var svm = wsViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel;
             svm.PortViewModel = this;
 
-            //wsViewModel.RequestNodeAutocompleteWindowPlacement += PlaceNodeAutocompleteWindow;
-
             wsViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
-
-            //wsViewModel.RequestNodeAutocompleteWindowPlacement -= PlaceNodeAutocompleteWindow;
         }
 
         private bool CanAutoComplete(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -246,9 +246,8 @@ namespace Dynamo.ViewModels
             if (PortModel.PortType == PortType.Input)
             {
                 // Position node autocomplete UI offset left by its width from X position of node.
-                // Note: Width property of the control is set to a constant value in the WorkspaceView XAML.
-                // Without setting the Width explicitly control.ActualWidth gives the correct value
-                // except for the first time the control is launched. 
+                // Note: MinWidth property of the control is set to a constant value in the XAML
+                // for the ActualWidth to return a consistent value.
                 x = _node.X - (control.ActualWidth + autocompleteUISpacing);
             }
             else

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -18,7 +18,7 @@ namespace Dynamo.ViewModels
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
-        private const double autocompleteUIWidth = 2.5;
+        private const double autocompleteUISpacing = 2.5;
 
         /// <summary>
         /// Port model.
@@ -246,12 +246,12 @@ namespace Dynamo.ViewModels
             if (PortModel.PortType == PortType.Input)
             {
                 // Position node autocomplete UI offset left by its width from X position of node.
-                x = _node.X - (control.ActualWidth + autocompleteUIWidth);
+                x = _node.X - (control.ActualWidth + autocompleteUISpacing);
             }
             else
             {
                 // Position node autocomplete UI offset right by node width from X position of node.
-                x = _node.X + _node.NodeModel.Width + autocompleteUIWidth;
+                x = _node.X + _node.NodeModel.Width + autocompleteUISpacing;
             }
             // Position UI down from the top of the node but offset down by the node header and against the respective port.
             var y = _node.Y + NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -18,6 +18,7 @@ namespace Dynamo.ViewModels
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
+        private const double autocompleteUIWidth = 2.5;
 
         /// <summary>
         /// Port model.
@@ -228,25 +229,34 @@ namespace Dynamo.ViewModels
             _node.WorkspaceViewModel.PropertyChanged -= Workspace_PropertyChanged;
         }
 
+        /// <summary>
+        /// Places the node autocomplete window relative to the respective port 
+        /// once the control is loaded and when its actual width is known.
+        /// The UI is first placed w.r.t to the X, Y position of the node (to which the port belongs),
+        /// then offset from that based on the port, the width of the UI itself and in some cases, the node width.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         internal void PlaceNodeAutocompleteWindow(object sender, EventArgs e)
         {
-            var popup = sender as NodeAutoCompleteSearchControl;
+            var control = sender as NodeAutoCompleteSearchControl;
+            var popup = control.Parent as Popup;
 
             double x;
             if (PortModel.PortType == PortType.Input)
             {
-                // Position node autocomplete UI offset left from X position of node by its width.
-                x = _node.X - popup.ActualWidth;
+                // Position node autocomplete UI offset left by its width from X position of node.
+                x = _node.X - (control.ActualWidth + autocompleteUIWidth);
             }
             else
             {
-                // Position node autocomplete UI offset right from X position of node by node width.
-                x = _node.X + _node.NodeModel.Width;
+                // Position node autocomplete UI offset right by node width from X position of node.
+                x = _node.X + _node.NodeModel.Width + autocompleteUIWidth;
             }
-            // Position UI down from the top of the node but offset by the node header and against the respective port.
-            var y = _node.Y + NodeModel.NodeHeaderHeight + PortModel.Index * PortModel.Height;
+            // Position UI down from the top of the node but offset down by the node header and against the respective port.
+            var y = _node.Y + NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
 
-            (popup.Parent as Popup).PlacementRectangle = new Rect(x, y, 0, 0);
+            popup.PlacementRectangle = new Rect(x, y, 0, 0);
         }
 
         private void Workspace_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using Dynamo.Configuration;
@@ -161,12 +162,17 @@ namespace Dynamo.ViewModels
             RequestShowInCanvasSearch?.Invoke(flag);
         }
 
-        internal event Action<ShowHideFlags> RequestNodeAutoCompleteSearch;
+        internal event Action<PortViewModel, ShowHideFlags> RequestNodeAutoCompleteSearch;
 
-        internal void OnRequestNodeAutoCompleteSearch(object param)
+        internal void OnRequestNodeAutoCompleteSearch(PortViewModel pvm, ShowHideFlags flag)
         {
-            var flag = (ShowHideFlags)param;
-            RequestNodeAutoCompleteSearch?.Invoke(flag);
+            RequestNodeAutoCompleteSearch?.Invoke(pvm, flag);
+        }
+
+        internal event EventHandler RequestNodeAutocompleteWindowPlacement;
+        internal void OnRequestNodeAutoCompleteWindowPlacement(Popup nodeAutocompletePopup)
+        {
+            RequestNodeAutocompleteWindowPlacement?.Invoke(this, new NodeAutocompleteEventArgs(nodeAutocompletePopup));
         }
 
         #endregion
@@ -1400,6 +1406,17 @@ namespace Dynamo.ViewModels
             RaisePropertyChanged("IsGeometryOperationEnabled");
             RaisePropertyChanged("AnyNodeVisible");
             RaisePropertyChanged("SelectionArgumentLacing");            
+        }
+
+    }
+
+    internal class NodeAutocompleteEventArgs : EventArgs
+    {
+        internal Popup NodeAutocompleteSearchBar { get; }
+
+        internal NodeAutocompleteEventArgs(Popup nodeAutocompletePopup)
+        {
+            NodeAutocompleteSearchBar = nodeAutocompletePopup;
         }
     }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -162,11 +162,11 @@ namespace Dynamo.ViewModels
             RequestShowInCanvasSearch?.Invoke(flag);
         }
 
-        internal event Action<PortViewModel, ShowHideFlags> RequestNodeAutoCompleteSearch;
+        internal event Action<ShowHideFlags> RequestNodeAutoCompleteSearch;
 
-        internal void OnRequestNodeAutoCompleteSearch(PortViewModel pvm, ShowHideFlags flag)
+        internal void OnRequestNodeAutoCompleteSearch(ShowHideFlags flag)
         {
-            RequestNodeAutoCompleteSearch?.Invoke(pvm, flag);
+            RequestNodeAutoCompleteSearch?.Invoke(flag);
         }
 
         internal event EventHandler RequestNodeAutocompleteWindowPlacement;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -169,12 +169,6 @@ namespace Dynamo.ViewModels
             RequestNodeAutoCompleteSearch?.Invoke(flag);
         }
 
-        //internal event EventHandler RequestNodeAutocompleteWindowPlacement;
-        //internal void OnRequestNodeAutoCompleteWindowPlacement(Popup nodeAutocompletePopup)
-        //{
-        //    RequestNodeAutocompleteWindowPlacement?.Invoke(this, new NodeAutocompleteEventArgs(nodeAutocompletePopup));
-        //}
-
         #endregion
 
         #region Properties and Fields
@@ -1409,16 +1403,6 @@ namespace Dynamo.ViewModels
         }
 
     }
-
-    //internal class NodeAutocompleteEventArgs : EventArgs
-    //{
-    //    internal Popup NodeAutocompleteSearchBar { get; }
-
-    //    internal NodeAutocompleteEventArgs(Popup nodeAutocompletePopup)
-    //    {
-    //        NodeAutocompleteSearchBar = nodeAutocompletePopup;
-    //    }
-    //}
 
     public class ViewModelEventArgs : EventArgs
     {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -169,11 +169,11 @@ namespace Dynamo.ViewModels
             RequestNodeAutoCompleteSearch?.Invoke(flag);
         }
 
-        internal event EventHandler RequestNodeAutocompleteWindowPlacement;
-        internal void OnRequestNodeAutoCompleteWindowPlacement(Popup nodeAutocompletePopup)
-        {
-            RequestNodeAutocompleteWindowPlacement?.Invoke(this, new NodeAutocompleteEventArgs(nodeAutocompletePopup));
-        }
+        //internal event EventHandler RequestNodeAutocompleteWindowPlacement;
+        //internal void OnRequestNodeAutoCompleteWindowPlacement(Popup nodeAutocompletePopup)
+        //{
+        //    RequestNodeAutocompleteWindowPlacement?.Invoke(this, new NodeAutocompleteEventArgs(nodeAutocompletePopup));
+        //}
 
         #endregion
 
@@ -1410,15 +1410,15 @@ namespace Dynamo.ViewModels
 
     }
 
-    internal class NodeAutocompleteEventArgs : EventArgs
-    {
-        internal Popup NodeAutocompleteSearchBar { get; }
+    //internal class NodeAutocompleteEventArgs : EventArgs
+    //{
+    //    internal Popup NodeAutocompleteSearchBar { get; }
 
-        internal NodeAutocompleteEventArgs(Popup nodeAutocompletePopup)
-        {
-            NodeAutocompleteSearchBar = nodeAutocompletePopup;
-        }
-    }
+    //    internal NodeAutocompleteEventArgs(Popup nodeAutocompletePopup)
+    //    {
+    //        NodeAutocompleteSearchBar = nodeAutocompletePopup;
+    //    }
+    //}
 
     public class ViewModelEventArgs : EventArgs
     {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows;
-using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using Dynamo.Configuration;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Dynamo.Controls;
 using Dynamo.Search.SearchElements;
 using Dynamo.Wpf.ViewModels;
 
@@ -12,6 +11,7 @@ namespace Dynamo.ViewModels
     public class NodeAutoCompleteSearchViewModel : SearchViewModel
     {
         internal PortViewModel PortViewModel { get; set; }
+
 
         internal NodeAutoCompleteSearchViewModel(DynamoViewModel dynamoViewModel) : base(dynamoViewModel)
         {

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -12,7 +12,6 @@ namespace Dynamo.ViewModels
     {
         internal PortViewModel PortViewModel { get; set; }
 
-
         internal NodeAutoCompleteSearchViewModel(DynamoViewModel dynamoViewModel) : base(dynamoViewModel)
         {
             // Do nothing for now, but we may off load some time consuming operation here later

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -290,10 +290,7 @@ namespace Dynamo.Wpf.ViewModels
             DynamoSelection.Instance.ClearSelection();
             var inputNodes = initialNode.InputNodes.Values.Where(x => x != null).Select(y => y.Item2);
 
-            foreach (var inputNode in inputNodes)
-            {
-                DynamoSelection.Instance.Selection.AddUnique(inputNode);
-            }
+            DynamoSelection.Instance.Selection.AddRange(inputNodes);
         }
 
         protected virtual bool CanCreateAndConnectToPort(object parameter)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -346,6 +346,7 @@
         </Popup>
 
         <Popup Name="NodeAutoCompleteSearchBar"
+               Width="256"
                StaysOpen="True"
                AllowsTransparency="True"
                IsOpen="False"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -349,8 +349,6 @@
                StaysOpen="True"
                AllowsTransparency="True"
                IsOpen="False"
-               Placement="MousePoint"
-               HorizontalOffset="-290"
                DataContext="{Binding NodeAutoCompleteSearchViewModel}">
             <ui:NodeAutoCompleteSearchControl RequestShowNodeAutoCompleteSearch="ShowHideNodeAutoCompleteControl" />
         </Popup>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -346,7 +346,6 @@
         </Popup>
 
         <Popup Name="NodeAutoCompleteSearchBar"
-               Width="256"
                StaysOpen="True"
                AllowsTransparency="True"
                IsOpen="False"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -146,6 +146,7 @@ namespace Dynamo.Views
             ViewModel.Model.RequestNodeCentered -= vm_RequestNodeCentered;
             ViewModel.Model.RequestNodeCentered -= vm_RequestNodeCentered;
             ViewModel.Model.CurrentOffsetChanged -= vm_CurrentOffsetChanged;
+            ViewModel.RequestNodeAutoCompleteSearch -= ShowHideNodeAutoCompleteControl;
         }
 
         void OnWorkspaceViewUnloaded(object sender, RoutedEventArgs e)
@@ -155,7 +156,6 @@ namespace Dynamo.Views
             if (ViewModel != null)
             {
                 removeViewModelsubscriptions(ViewModel);
-                ViewModel.RequestNodeAutoCompleteSearch -= ShowHideNodeAutoCompleteControl;
             }
 
             infiniteGridView.DetachFromZoomBorder(zoomBorder);
@@ -187,7 +187,6 @@ namespace Dynamo.Views
                 case ShowHideFlags.Show:
                     // Show InCanvas search just in case, when mouse is over workspace.
                     popup.IsOpen = DynamoModel.IsTestMode || IsMouseOver;
-                    
                     ViewModel.InCanvasSearchViewModel.SearchText = string.Empty;
                     ViewModel.InCanvasSearchViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
                     break;
@@ -366,7 +365,7 @@ namespace Dynamo.Views
                 oldViewModel.RequestAddViewToOuterCanvas -= vm_RequestAddViewToOuterCanvas;
                 oldViewModel.WorkspacePropertyEditRequested -= VmOnWorkspacePropertyEditRequested;
                 oldViewModel.RequestSelectionBoxUpdate -= VmOnRequestSelectionBoxUpdate;
-                this.removeViewModelsubscriptions(oldViewModel);
+                removeViewModelsubscriptions(oldViewModel);
             }
 
             if (ViewModel != null)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -155,6 +155,7 @@ namespace Dynamo.Views
             if (ViewModel != null)
             {
                 removeViewModelsubscriptions(ViewModel);
+                ViewModel.RequestNodeAutoCompleteSearch -= ShowHideNodeAutoCompleteControl;
             }
 
             infiniteGridView.DetachFromZoomBorder(zoomBorder);
@@ -163,27 +164,11 @@ namespace Dynamo.Views
 
         private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
         {
-            if (flag == ShowHideFlags.Show)
-            {
-                
-                //if (pvm != null && NodeAutoCompleteSearchBar.CustomPopupPlacementCallback == null)
-                //{
-                //    NodeAutoCompleteSearchBar.CustomPopupPlacementCallback += pvm.PlaceNodeAutoCompleteSearchBar;
-                //}
-            }
-            //else
-            //{
-            //    if (pvm != null && NodeAutoCompleteSearchBar.CustomPopupPlacementCallback != null)
-            //    {
-            //        NodeAutoCompleteSearchBar.CustomPopupPlacementCallback -= pvm.PlaceNodeAutoCompleteSearchBar;
-            //        NodeAutoCompleteSearchBar.CustomPopupPlacementCallback = null;
-            //    }
-            //}
             ShowHidePopup(flag, NodeAutoCompleteSearchBar);
-            if (flag == ShowHideFlags.Show)
-            {
-                ViewModel.OnRequestNodeAutoCompleteWindowPlacement(NodeAutoCompleteSearchBar);
-            }
+            //if (flag == ShowHideFlags.Show)
+            //{
+            //    ViewModel.OnRequestNodeAutoCompleteWindowPlacement(NodeAutoCompleteSearchBar);
+            //}
         }
 
         private void ShowHideInCanvasControl(ShowHideFlags flag)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -161,7 +161,7 @@ namespace Dynamo.Views
             
         }
 
-        private void ShowHideNodeAutoCompleteControl(PortViewModel pvm, ShowHideFlags flag)
+        private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
         {
             if (flag == ShowHideFlags.Show)
             {
@@ -229,7 +229,7 @@ namespace Dynamo.Views
                 // in Dynamo window will forcefully shutdown all the open SearchBars
                 if ((new TimeSpan(DateTime.Now.Ticks - ViewModel.GetLastStateTimestamp().Ticks)).TotalSeconds > 0.2)
                 {
-                    ShowHideNodeAutoCompleteControl(null, ShowHideFlags.Hide);
+                    ShowHideNodeAutoCompleteControl(ShowHideFlags.Hide);
                     ViewModel.CancelActiveState();
                 }
             }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -161,9 +161,29 @@ namespace Dynamo.Views
             
         }
 
-        private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
+        private void ShowHideNodeAutoCompleteControl(PortViewModel pvm, ShowHideFlags flag)
         {
+            if (flag == ShowHideFlags.Show)
+            {
+                
+                //if (pvm != null && NodeAutoCompleteSearchBar.CustomPopupPlacementCallback == null)
+                //{
+                //    NodeAutoCompleteSearchBar.CustomPopupPlacementCallback += pvm.PlaceNodeAutoCompleteSearchBar;
+                //}
+            }
+            //else
+            //{
+            //    if (pvm != null && NodeAutoCompleteSearchBar.CustomPopupPlacementCallback != null)
+            //    {
+            //        NodeAutoCompleteSearchBar.CustomPopupPlacementCallback -= pvm.PlaceNodeAutoCompleteSearchBar;
+            //        NodeAutoCompleteSearchBar.CustomPopupPlacementCallback = null;
+            //    }
+            //}
             ShowHidePopup(flag, NodeAutoCompleteSearchBar);
+            if (flag == ShowHideFlags.Show)
+            {
+                ViewModel.OnRequestNodeAutoCompleteWindowPlacement(NodeAutoCompleteSearchBar);
+            }
         }
 
         private void ShowHideInCanvasControl(ShowHideFlags flag)
@@ -186,6 +206,7 @@ namespace Dynamo.Views
                 case ShowHideFlags.Show:
                     // Show InCanvas search just in case, when mouse is over workspace.
                     popup.IsOpen = DynamoModel.IsTestMode || IsMouseOver;
+                    
                     ViewModel.InCanvasSearchViewModel.SearchText = string.Empty;
                     ViewModel.InCanvasSearchViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
                     break;
@@ -208,7 +229,7 @@ namespace Dynamo.Views
                 // in Dynamo window will forcefully shutdown all the open SearchBars
                 if ((new TimeSpan(DateTime.Now.Ticks - ViewModel.GetLastStateTimestamp().Ticks)).TotalSeconds > 0.2)
                 {
-                    ShowHideNodeAutoCompleteControl(ShowHideFlags.Hide);
+                    ShowHideNodeAutoCompleteControl(null, ShowHideFlags.Hide);
                     ViewModel.CancelActiveState();
                 }
             }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -165,10 +165,6 @@ namespace Dynamo.Views
         private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
         {
             ShowHidePopup(flag, NodeAutoCompleteSearchBar);
-            //if (flag == ShowHideFlags.Show)
-            //{
-            //    ViewModel.OnRequestNodeAutoCompleteWindowPlacement(NodeAutoCompleteSearchBar);
-            //}
         }
 
         private void ShowHideInCanvasControl(ShowHideFlags flag)

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -893,7 +893,7 @@ namespace DynamoCoreWpfTests
             var currentWs = View.ChildOfType<WorkspaceView>();
 
             // Show Node AutoCompleteSearchBar
-            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
+            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(null, ShowHideFlags.Show);
             Assert.IsTrue(currentWs.NodeAutoCompleteSearchBar.IsOpen);
 
             RightClick(currentWs.zoomBorder);
@@ -902,7 +902,7 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(currentWs.NodeAutoCompleteSearchBar.IsOpen);
 
             // Hide Node AutoCompleteSearchBar
-            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Hide);
+            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(null, ShowHideFlags.Hide);
             Assert.IsFalse(currentWs.NodeAutoCompleteSearchBar.IsOpen);
         }
 

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -893,7 +893,7 @@ namespace DynamoCoreWpfTests
             var currentWs = View.ChildOfType<WorkspaceView>();
 
             // Show Node AutoCompleteSearchBar
-            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(null, ShowHideFlags.Show);
+            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);
             Assert.IsTrue(currentWs.NodeAutoCompleteSearchBar.IsOpen);
 
             RightClick(currentWs.zoomBorder);
@@ -902,7 +902,7 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(currentWs.NodeAutoCompleteSearchBar.IsOpen);
 
             // Hide Node AutoCompleteSearchBar
-            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(null, ShowHideFlags.Hide);
+            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Hide);
             Assert.IsFalse(currentWs.NodeAutoCompleteSearchBar.IsOpen);
         }
 


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3174

Attempt at placing the node autocomplete UI aligned with the respective port. 

This works as expected **except for the first time you bring up the UI**, for some reason. As can be seen in the gif, the first time, the UI is not spaced correctly from the port. It was observed that the reason for this is that the `ActualWidth` of the control is 250 the first time and subsequently it is 256. I'm not sure why this is the case 😕 

![place_autocomplete_ui](https://user-images.githubusercontent.com/5710686/96521246-d5d96a80-123e-11eb-83d8-8ba2a3f448f0.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### FYIs

@Amoursol 
