### PR TITLE
DYN-3177-Coverage-CoreNodeModelsWpf

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/ConverterViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/ConverterViewModel.cs
@@ -58,7 +58,7 @@ namespace CoreNodeModelsWpf
             get { return dynamoConvertModel.SelectedToConversionSource; }
             set
             {
-                dynamoConvertModel.SelectedFromConversionSource = value;             
+                dynamoConvertModel.SelectedToConversionSource = value;             
             }
         }
 

--- a/test/DynamoCoreWpfTests/ConverterViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterViewModelTests.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Controls;
+using CoreNodeModels;
+using CoreNodeModels.Input;
+using CoreNodeModelsWpf.Controls;
+using Dynamo.Tests;
+using Dynamo.Utilities;
+using DynamoCoreWpfTests;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+
+namespace CoreNodeModelsWpf
+{
+    [TestFixture]
+    public class ConverterViewModelTests : DynamoTestUIBase
+    {
+        private AssemblyHelper assemblyHelper;
+
+        public override void Open(string path)
+        {
+            base.Open(path);
+
+            DispatcherUtil.DoEvents();
+        }
+
+        public override void Run()
+        {
+            base.Run();
+
+            DispatcherUtil.DoEvents();
+        }
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            SetupTests();
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("DynamoConversions.dll");
+            libraries.Add("DynamoUnits.dll");
+            libraries.Add("CoreNodeModelsWpf.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        public void SetupTests()
+        {
+            var assemblyPath = Assembly.GetExecutingAssembly().Location;
+            var moduleRootFolder = Path.GetDirectoryName(assemblyPath);
+
+            var resolutionPaths = new[]
+            {
+                // The CoreNodeModelsWpf.dll needed is under "nodes" folder.
+                Path.Combine(moduleRootFolder, "nodes")
+            };
+
+            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths);
+            AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
+        }
+
+        [TearDown]
+        public void RunAfterAllTests()
+        {
+            assemblyHelper = null;
+        }
+
+        /// <summary>
+        /// This test method will execute the next methods/properties from the ConverterViewModel.cs file:
+        /// public ConverterViewModel(DynamoConvert model,NodeView nodeView)
+        /// public ConversionMetricUnit SelectedMetricConversion
+        /// public ConversionUnit SelectedFromConversion
+        /// public ConversionUnit SelectedToConversion
+        /// private void model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        /// </summary>
+        [Test]
+        public void ConverterViewModel_LengthInchesToCentimetersTest()
+        {
+            float inchesToCmFactor = (float)2.54;
+            // open file
+            Open(@"core\library\converterNodeTest.dyn");
+            Run();
+
+            var NumberNode = Model.CurrentWorkspace.NodeFromWorkspace<DoubleInput>("d6b824d37d1741b6ba6b9e15a7bf14ab");
+            NumberNode.Value = "200";
+            var WatchNode = Model.CurrentWorkspace.NodeFromWorkspace<Watch>("6805c0f154474e539b7c7cb0d1bf4de0");
+
+            var nodeView = NodeViewWithGuid("b30c51f0-00ce-4fa3-96cf-dd43b0db45a6");//NodeViewOf<DynamoConverterControl>();
+
+            //Get the list of all the comboboxes
+            var comboBoxes = nodeView.inputGrid.ChildrenOfType<ComboBox>();
+
+            var selectConversionMetricCombo = (from combo in comboBoxes where combo.Name.Equals("SelectConversionMetric") select combo).FirstOrDefault();
+            var selectConversionFrom = (from combo in comboBoxes where combo.Name.Equals("SelectConversionFrom") select combo).FirstOrDefault();
+            var selectConversionTo = (from combo in comboBoxes where combo.Name.Equals("SelectConversionTo") select combo).FirstOrDefault();
+
+            selectConversionMetricCombo.SelectedItem = DynamoConversions.ConversionMetricUnit.Length;
+            selectConversionFrom.SelectedItem = DynamoConversions.ConversionUnit.Inches;
+            selectConversionTo.SelectedItem = DynamoConversions.ConversionUnit.Centimeters;
+
+            //Validates that the ComboBox items were selected correctly
+            Assert.AreEqual(selectConversionMetricCombo.SelectedItem, DynamoConversions.ConversionMetricUnit.Length);
+            Assert.AreEqual(selectConversionFrom.SelectedItem, DynamoConversions.ConversionUnit.Inches);
+            Assert.AreEqual(selectConversionTo.SelectedItem, DynamoConversions.ConversionUnit.Centimeters);
+
+            //Validates that the conversion from Inches to Centimeters was successful
+            Assert.AreEqual(inchesToCmFactor * float.Parse(NumberNode.Value), float.Parse(WatchNode.CachedValue.ToString()));
+        }
+
+        /// <summary>
+        /// This test method will execute the next methods/properties from the ConverterViewModel.cs file:
+        /// public bool IsSelectionFromBoxEnabled
+        /// public string SelectionFromBoxToolTip
+        /// </summary>
+        [Test]
+        public void ConverterViewModel_TooltipTest()
+        {
+            float inchesToCmFactor = (float)2.54;
+            // open file
+            Open(@"core\library\converterNodeTest.dyn");
+
+            var WatchNode = Model.CurrentWorkspace.NodeFromWorkspace<Watch>("6805c0f154474e539b7c7cb0d1bf4de0");
+
+            var nodeView = NodeViewWithGuid("b30c51f0-00ce-4fa3-96cf-dd43b0db45a6");//NodeViewOf<DynamoConverterControl>();
+            var NumberNode = Model.CurrentWorkspace.NodeFromWorkspace<DoubleInput>("d6b824d37d1741b6ba6b9e15a7bf14ab");
+            NumberNode.Value = "200";
+
+            var dynamoConverterControl = nodeView.grid.ChildrenOfType<DynamoConverterControl>().FirstOrDefault();
+            //Get the list of all the comboboxes
+            var comboBoxes = nodeView.inputGrid.ChildrenOfType<ComboBox>();
+
+            var selectConversionMetricCombo = (from combo in comboBoxes where combo.Name.Equals("SelectConversionMetric") select combo).FirstOrDefault();
+            var selectConversionFrom = (from combo in comboBoxes where combo.Name.Equals("SelectConversionFrom") select combo).FirstOrDefault();
+            var selectConversionTo = (from combo in comboBoxes where combo.Name.Equals("SelectConversionTo") select combo).FirstOrDefault();
+
+            var directionButton = nodeView.inputGrid.ChildrenOfType<Button>().FirstOrDefault();
+
+            //Getting the ConverterViewModel fromn the WPF DynamoConververControl
+            var converterViewModel = dynamoConverterControl.DataContext as ConverterViewModel;
+            converterViewModel.IsSelectionFromBoxEnabled = false;
+            converterViewModel.SelectionFromBoxToolTip = "Testing Tooltip";
+
+            selectConversionMetricCombo.SelectedItem = DynamoConversions.ConversionMetricUnit.Length;
+            selectConversionFrom.SelectedItem = DynamoConversions.ConversionUnit.Inches;
+            selectConversionTo.SelectedItem = DynamoConversions.ConversionUnit.Centimeters;
+
+            Assert.IsFalse(selectConversionFrom.IsEnabled);
+            Assert.AreEqual(selectConversionFrom.ToolTip.ToString(), "Testing Tooltip");
+
+            //Validates that the conversion from Inches to Centimeters was successful
+            Assert.AreEqual(inchesToCmFactor * float.Parse(NumberNode.Value), float.Parse(WatchNode.CachedValue.ToString()));
+        }
+
+        /// <summary>
+        /// This test method will execute the next methods/properties from the ConverterViewModel.cs file:
+        /// public List<ConversionUnit> SelectedFromConversionSource
+        /// public List<ConversionUnit> SelectedToConversionSource
+        /// </summary>
+        [Test]
+        public void ConverterViewModel_ItemsSourceCentimetersToMetersTest()
+        {
+            Open(@"core\library\converterNodeTest.dyn");
+
+            var WatchNode = Model.CurrentWorkspace.NodeFromWorkspace<Watch>("6805c0f154474e539b7c7cb0d1bf4de0");
+
+            var nodeView = NodeViewWithGuid("b30c51f0-00ce-4fa3-96cf-dd43b0db45a6");//NodeViewOf<DynamoConverterControl>();
+            var NumberNode = Model.CurrentWorkspace.NodeFromWorkspace<DoubleInput>("d6b824d37d1741b6ba6b9e15a7bf14ab");
+            NumberNode.Value = "200";
+            //Get the list of all the comboboxes
+            var comboBoxes = nodeView.inputGrid.ChildrenOfType<ComboBox>();
+
+            var selectConversionMetricCombo = (from combo in comboBoxes where combo.Name.Equals("SelectConversionMetric") select combo).FirstOrDefault();
+            var selectConversionFrom = (from combo in comboBoxes where combo.Name.Equals("SelectConversionFrom") select combo).FirstOrDefault();
+            var selectConversionTo = (from combo in comboBoxes where combo.Name.Equals("SelectConversionTo") select combo).FirstOrDefault();
+           
+            var dynamoConverterControl = nodeView.grid.ChildrenOfType<DynamoConverterControl>().FirstOrDefault();
+
+            //Getting the ConverterViewModel fromn the WPF DynamoConververControl
+            var converterViewModel = dynamoConverterControl.DataContext as ConverterViewModel;
+            
+            converterViewModel.SelectedFromConversionSource = new List<DynamoConversions.ConversionUnit>() { DynamoConversions.ConversionUnit.Centimeters };
+            converterViewModel.SelectedFromConversion = DynamoConversions.ConversionUnit.Centimeters;
+
+            converterViewModel.SelectedToConversionSource = new List<DynamoConversions.ConversionUnit>() { DynamoConversions.ConversionUnit.Meters };
+            converterViewModel.SelectedToConversion = DynamoConversions.ConversionUnit.Meters;
+
+            Run();
+
+            //Validates that the convertion from Centimeters to Meters was correctly
+            Assert.AreEqual(selectConversionFrom.SelectedItem, DynamoConversions.ConversionUnit.Centimeters);
+            Assert.AreEqual(selectConversionTo.SelectedItem, DynamoConversions.ConversionUnit.Meters);
+            Assert.AreEqual(float.Parse(NumberNode.Value)/100, float.Parse(WatchNode.CachedValue.ToString()));
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/ConverterViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterViewModelTests.cs
@@ -60,9 +60,10 @@ namespace CoreNodeModelsWpf
             AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void RunAfterAllTests()
         {
+            AppDomain.CurrentDomain.AssemblyResolve -= assemblyHelper.ResolveAssembly;
             assemblyHelper = null;
         }
 

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -123,6 +123,7 @@
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="ColorPaletteTests.cs" />
+    <Compile Include="ConverterViewModelTests.cs" />
     <Compile Include="InfoBubbleTests.cs" />
     <Compile Include="Libraries\LabelTests.cs" />
     <Compile Include="ListAtLevelTest.cs" />

--- a/test/core/library/converterNodeTest.dyn
+++ b/test/core/library/converterNodeTest.dyn
@@ -1,0 +1,168 @@
+{
+  "Uuid": "841dedc9-db6f-4484-b84a-8b9fd3c20a9a",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "converter_node_test",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.DynamoConvert, CoreNodeModels",
+      "NodeType": "ConvertBetweenUnitsNode",
+      "MeasurementType": "Length",
+      "FromConversion": "Inches",
+      "ToConversion": "Meters",
+      "Id": "b30c51f000ce4fa396cfdd43b0db45a6",
+      "Inputs": [
+        {
+          "Id": "5f7a73fe74ce41b699c2e7f3c682103e",
+          "Name": "",
+          "Description": "A numeric value for conversion.",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1afd01292aa64317bc0379cd77e61cd4",
+          "Name": "",
+          "Description": "A converted numeric value.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Convert between units of measure."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 34.0,
+      "Id": "d6b824d37d1741b6ba6b9e15a7bf14ab",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1fed05ce6e0b482ba88a710f270f4c11",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "6805c0f154474e539b7c7cb0d1bf4de0",
+      "Inputs": [
+        {
+          "Id": "36a3b31ee4a64c6095587398262d6f5b",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "be7393754b774da8acd8d1ecbc83fc93",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "1afd01292aa64317bc0379cd77e61cd4",
+      "End": "36a3b31ee4a64c6095587398262d6f5b",
+      "Id": "51d31a9d2a0f4d03b0527c1514aa18b7"
+    },
+    {
+      "Start": "1fed05ce6e0b482ba88a710f270f4c11",
+      "End": "5f7a73fe74ce41b699c2e7f3c682103e",
+      "Id": "c48e32cd6829465e923ffba4a6042e06"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.9.0.2856",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Convert Between Units",
+        "Id": "b30c51f000ce4fa396cfdd43b0db45a6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 217.5,
+        "Y": 310.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "d6b824d37d1741b6ba6b9e15a7bf14ab",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 45.5,
+        "Y": 216.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "6805c0f154474e539b7c7cb0d1bf4de0",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 757.5,
+        "Y": 230.5
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION

### Purpose

I added three test methods for increasing code coverage in the CoreNodeModelsWpf\ConverterViewModel.cs file.
Also I modified the ConverterViewModel.cs due that is not consistent to the behavior in the SelectedToConversionSource property (ComboBox).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@alfredo-pozo 


