### PR TITLE
Enable subclass of AllChildrenOfType set output Name

### DIFF
--- a/src/Libraries/CoreNodeModels/Enum.cs
+++ b/src/Libraries/CoreNodeModels/Enum.cs
@@ -69,8 +69,18 @@ namespace CoreNodeModels
             RegisterAllPorts();
         }
 
+        protected AllChildrenOfType(string value) : base(value)
+        {
+            RegisterAllPorts();
+        }
+
         [JsonConstructor]
         protected AllChildrenOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts)
+        {
+        }
+
+        [JsonConstructor]
+        protected AllChildrenOfType(string value, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(value, inPorts, outPorts)
         {
         }
 

--- a/src/Libraries/CoreNodeModels/Enum.cs
+++ b/src/Libraries/CoreNodeModels/Enum.cs
@@ -69,7 +69,7 @@ namespace CoreNodeModels
             RegisterAllPorts();
         }
 
-        protected AllChildrenOfType(string value) : base(value)
+        protected AllChildrenOfType(string outputName) : base(outputName)
         {
             RegisterAllPorts();
         }
@@ -80,7 +80,7 @@ namespace CoreNodeModels
         }
 
         [JsonConstructor]
-        protected AllChildrenOfType(string value, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(value, inPorts, outPorts)
+        protected AllChildrenOfType(string outputName, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts)
         {
         }
 


### PR DESCRIPTION

### Purpose

Refer to https://github.com/DynamoDS/DynamoRevit/pull/2641 .
I want to rename the output name of "Element Types"(will be "Element Classes"). But the ` AllChildrenOfType ` can't enable that change.
This hard Code makes its inheritance very inflexible.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@Amoursol 
