### PR TITLE
 DYN-3177-Coverage-CoreNodeModelsWpf-CodeReview

### DIFF
--- a/test/DynamoCoreWpfTests/ConverterViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterViewModelTests.cs
@@ -1,25 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Windows.Controls;
 using CoreNodeModels;
 using CoreNodeModels.Input;
+using CoreNodeModelsWpf;
 using CoreNodeModelsWpf.Controls;
 using Dynamo.Tests;
 using Dynamo.Utilities;
-using DynamoCoreWpfTests;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 
-namespace CoreNodeModelsWpf
+namespace DynamoCoreWpfTests
 {
     [TestFixture]
     public class ConverterViewModelTests : DynamoTestUIBase
     {
-        private AssemblyHelper assemblyHelper;
-
         public override void Open(string path)
         {
             base.Open(path);
@@ -36,35 +31,11 @@ namespace CoreNodeModelsWpf
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
-            SetupTests();
             libraries.Add("VMDataBridge.dll");
             libraries.Add("DSCoreNodes.dll");
             libraries.Add("DynamoConversions.dll");
             libraries.Add("DynamoUnits.dll");
-            libraries.Add("CoreNodeModelsWpf.dll");
             base.GetLibrariesToPreload(libraries);
-        }
-
-        public void SetupTests()
-        {
-            var assemblyPath = Assembly.GetExecutingAssembly().Location;
-            var moduleRootFolder = Path.GetDirectoryName(assemblyPath);
-
-            var resolutionPaths = new[]
-            {
-                // The CoreNodeModelsWpf.dll needed is under "nodes" folder.
-                Path.Combine(moduleRootFolder, "nodes")
-            };
-
-            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths);
-            AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
-        }
-
-        [TestFixtureTearDown]
-        public void RunAfterAllTests()
-        {
-            AppDomain.CurrentDomain.AssemblyResolve -= assemblyHelper.ResolveAssembly;
-            assemblyHelper = null;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Based on the comments that Aparajit did on my previous pull request (https://github.com/DynamoDS/Dynamo/pull/11191) after was merged I did some changes to avoid loading the CoreNodeModelsWpf.dll and also remove the methods used for adding the nodes folder.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @aparajit-pratap 

### FYIs

@alfredo-pozo 
