### PR TITLE
Fix node autocomplete popup placement

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Controls.Primitives;
 using Dynamo.Configuration;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Graph;
@@ -31,6 +32,8 @@ namespace Dynamo.ViewModels
         public delegate void NodeDialogEventHandler(object sender, NodeDialogEventArgs e);
         public delegate void SnapInputEventHandler(PortViewModel portViewModel);
         public delegate void PreviewPinStatusHandler(bool pinned);
+
+        internal delegate void NodeAutoCompletePopupEventHandler(Popup popup);
         #endregion
 
         #region events
@@ -563,6 +566,14 @@ namespace Dynamo.ViewModels
         #endregion
 
         #region events
+
+        internal event NodeAutoCompletePopupEventHandler RequestAutoCompletePopupPlacementTarget;
+
+        internal void OnRequestAutoCompletePopupPlacementTarget(Popup popup)
+        {
+            RequestAutoCompletePopupPlacementTarget?.Invoke(popup);
+        }
+
         public event NodeDialogEventHandler RequestShowNodeHelp;
         public virtual void OnRequestShowNodeHelp(Object sender, NodeDialogEventArgs e)
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -18,7 +18,7 @@ namespace Dynamo.ViewModels
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
-        private const double autocompleteUISpacing = 5.0;
+        private const double autocompleteUISpacing = 2.5;
 
         /// <summary>
         /// Port model.

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -18,7 +18,7 @@ namespace Dynamo.ViewModels
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
-        private const double autocompleteUISpacing = 2.5;
+        private const double autocompleteUISpacing = 5.0;
 
         /// <summary>
         /// Port model.
@@ -242,23 +242,12 @@ namespace Dynamo.ViewModels
             var control = sender as NodeAutoCompleteSearchControl;
             var popup = control.Parent as Popup;
 
-            double x;
-            if (PortModel.PortType == PortType.Input)
-            {
-                // Position node autocomplete UI offset left by its width from X position of node.
-                // Note: MinWidth property of the control is set to a constant value in the XAML
-                // for the ActualWidth to return a consistent value.
-                x = _node.X - (control.ActualWidth + autocompleteUISpacing);
-            }
-            else
-            {
-                // Position node autocomplete UI offset right by node width from X position of node.
-                x = _node.X + _node.NodeModel.Width + autocompleteUISpacing;
-            }
-            // Position UI down from the top of the node but offset down by the node header and against the respective port.
-            var y = _node.Y + NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
+            _node.OnRequestAutoCompletePopupPlacementTarget(popup);
 
-            popup.PlacementRectangle = new Rect(x, y, 0, 0);
+            popup.Placement = PortModel.PortType == PortType.Input ? PlacementMode.Left : PlacementMode.Right;
+
+            popup.HorizontalOffset = -autocompleteUISpacing;
+            popup.VerticalOffset = NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
         }
 
         private void Workspace_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -16,7 +18,10 @@ using Dynamo.UI.Controls;
 using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
+using Binding = System.Windows.Data.Binding;
 using DynCmd = Dynamo.Models.DynamoModel;
+using MouseEventArgs = System.Windows.Input.MouseEventArgs;
+using Panel = System.Windows.Controls.Panel;
 
 namespace Dynamo.Controls
 {
@@ -134,6 +139,7 @@ namespace Dynamo.Controls
             ViewModel.RequestShowNodeHelp -= ViewModel_RequestShowNodeHelp;
             ViewModel.RequestShowNodeRename -= ViewModel_RequestShowNodeRename;
             ViewModel.RequestsSelection -= ViewModel_RequestsSelection;
+            ViewModel.RequestAutoCompletePopupPlacementTarget -= ViewModel_RequestAutoCompletePopupPlacementTarget;
             ViewModel.NodeLogic.PropertyChanged -= NodeLogic_PropertyChanged;
             ViewModel.NodeModel.ConnectorAdded -= NodeModel_ConnectorAdded;
             MouseLeave -= NodeView_MouseLeave;
@@ -209,6 +215,7 @@ namespace Dynamo.Controls
             ViewModel.RequestShowNodeHelp += ViewModel_RequestShowNodeHelp;
             ViewModel.RequestShowNodeRename += ViewModel_RequestShowNodeRename;
             ViewModel.RequestsSelection += ViewModel_RequestsSelection;
+            ViewModel.RequestAutoCompletePopupPlacementTarget += ViewModel_RequestAutoCompletePopupPlacementTarget;
             ViewModel.NodeLogic.PropertyChanged += NodeLogic_PropertyChanged;
             ViewModel.NodeModel.ConnectorAdded += NodeModel_ConnectorAdded;
             MouseLeave += NodeView_MouseLeave;
@@ -279,6 +286,11 @@ namespace Dynamo.Controls
 
                 previewControl.BindToDataSource();
             }));
+        }
+
+        private void ViewModel_RequestAutoCompletePopupPlacementTarget(Popup popup)
+        {
+            popup.PlacementTarget = this;
         }
 
         void ViewModel_RequestsSelection(object sender, EventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -18,10 +17,8 @@ using Dynamo.UI.Controls;
 using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
-using Binding = System.Windows.Data.Binding;
 using DynCmd = Dynamo.Models.DynamoModel;
-using MouseEventArgs = System.Windows.Input.MouseEventArgs;
-using Panel = System.Windows.Controls.Panel;
+
 
 namespace Dynamo.Controls
 {


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/DYN-3215
Fixes node autocomplete popup placement w.r.t the node and makes it zoom invariant.

![autocomplete_ui_placement](https://user-images.githubusercontent.com/5710686/97098424-23950f00-1653-11eb-9799-9805242fac5e.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Fyi
@Amoursol 