### PR TITLE
Fix for inconsistent placement of node autocomplete popup 

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -249,12 +249,17 @@ namespace Dynamo.ViewModels
             double x;
             if (PortModel.PortType == PortType.Input)
             {
+                // Offset popup left by its width from X position of left edge of node.
+                // Note: MinWidth property of the control is set to a constant value in the XAML
+                // for the ActualWidth to return a consistent value.
                 x = -autocompleteUISpacing - control.ActualWidth / zoom;
             }
             else
             {
+                // Offset popup right by node width from X position of left edge of node.
                 x = autocompleteUISpacing + PortModel.Owner.Width;
             }
+            // Offset popup down from the upper edge of the node by the node header and corresponding to the respective port.
             var y = NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
             popup.PlacementRectangle = new Rect(x, y, 0, 0);
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -246,7 +246,15 @@ namespace Dynamo.ViewModels
 
             var zoom = _node.WorkspaceViewModel.Zoom;
 
-            var x = -autocompleteUISpacing - control.ActualWidth / zoom;
+            double x;
+            if (PortModel.PortType == PortType.Input)
+            {
+                x = -autocompleteUISpacing - control.ActualWidth / zoom;
+            }
+            else
+            {
+                x = autocompleteUISpacing + PortModel.Owner.Width;
+            }
             var y = NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
             popup.PlacementRectangle = new Rect(x, y, 0, 0);
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -244,10 +244,11 @@ namespace Dynamo.ViewModels
 
             _node.OnRequestAutoCompletePopupPlacementTarget(popup);
 
-            popup.Placement = PortModel.PortType == PortType.Input ? PlacementMode.Left : PlacementMode.Right;
+            var zoom = _node.WorkspaceViewModel.Zoom;
 
-            popup.HorizontalOffset = -autocompleteUISpacing;
-            popup.VerticalOffset = NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
+            var x = _node.X -autocompleteUISpacing - control.ActualWidth / zoom;
+            var y = _node.Y + NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
+            popup.PlacementRectangle = new Rect(x, y, 0, 0);
         }
 
         private void Workspace_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -249,14 +249,14 @@ namespace Dynamo.ViewModels
             double x;
             if (PortModel.PortType == PortType.Input)
             {
-                // Offset popup left by its width from X position of left edge of node.
+                // Offset popup to the left by its width from left edge of node and constant spacing.
                 // Note: MinWidth property of the control is set to a constant value in the XAML
                 // for the ActualWidth to return a consistent value.
                 x = -autocompleteUISpacing - control.ActualWidth / zoom;
             }
             else
             {
-                // Offset popup right by node width from X position of left edge of node.
+                // Offset popup to the right by node width from left edge of node.
                 x = autocompleteUISpacing + PortModel.Owner.Width;
             }
             // Offset popup down from the upper edge of the node by the node header and corresponding to the respective port.

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -246,8 +246,8 @@ namespace Dynamo.ViewModels
 
             var zoom = _node.WorkspaceViewModel.Zoom;
 
-            var x = _node.X -autocompleteUISpacing - control.ActualWidth / zoom;
-            var y = _node.Y + NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
+            var x = -autocompleteUISpacing - control.ActualWidth / zoom;
+            var y = NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
             popup.PlacementRectangle = new Rect(x, y, 0, 0);
         }
 


### PR DESCRIPTION
### Purpose

Fix for inconsistent placement of node autocomplete popup. Removed setting of `popup.Placement` property to `Left` or `Right` as it could be[ inconsistent on different machines](https://stackoverflow.com/questions/4043878/why-is-my-popup-showing-opposite-the-placement-property-on-some-machines). Resorted to using `PlacementRectangle` again.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs

@zeusongit for testing