### PR TITLE
Add Analytics Coverage for Node AutoComplete

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -35,8 +35,16 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
+            Loaded += InCanvasSearchControl_Loaded;
             Unloaded += InCanvasSearchControl_Unloaded;
 
+        }
+
+        private void InCanvasSearchControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            Analytics.TrackEvent(
+            Dynamo.Logging.Actions.Open,
+            Dynamo.Logging.Categories.InCanvasSearchOperations);
         }
 
         private void InCanvasSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -89,7 +97,7 @@ namespace Dynamo.UI.Controls
                 searchElement.ClickedCommand.Execute(null);
                 Analytics.TrackEvent(
                 Dynamo.Logging.Actions.Select,
-                Dynamo.Logging.Categories.NodeOperations,
+                Dynamo.Logging.Categories.InCanvasSearchOperations,
                 searchElement.FullName);
             }
         }

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Dynamo.Logging;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
@@ -86,6 +87,10 @@ namespace Dynamo.UI.Controls
             {
                 searchElement.Position = ViewModel.InCanvasSearchPosition;
                 searchElement.ClickedCommand.Execute(null);
+                Analytics.TrackEvent(
+                Dynamo.Logging.Actions.Select,
+                Dynamo.Logging.Categories.NodeOperations,
+                searchElement.FullName);
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -103,11 +103,11 @@ namespace Dynamo.UI.Controls
                 if (searchElement.CreateAndConnectCommand.CanExecute(port.PortModel))
                 {
                     searchElement.CreateAndConnectCommand.Execute(port.PortModel);
+                    Analytics.TrackEvent(
+                    Dynamo.Logging.Actions.Select,
+                    Dynamo.Logging.Categories.NodeAutoCompleteOperations,
+                    searchElement.FullName);
                 }
-                Analytics.TrackEvent(
-                Dynamo.Logging.Actions.Select,
-                Dynamo.Logging.Categories.NodeAutoCompleteOperations,
-                searchElement.FullName);
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Dynamo.Logging;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
@@ -45,6 +46,9 @@ namespace Dynamo.UI.Controls
             if (ViewModel != null && ViewModel.PortViewModel != null)
             {
                 ViewModel.PortViewModel.PlaceNodeAutocompleteWindow(this, e);
+                Analytics.TrackEvent(
+                Dynamo.Logging.Actions.Open,
+                Dynamo.Logging.Categories.NodeAutoCompleteOperations);
             }
         }
 
@@ -100,6 +104,10 @@ namespace Dynamo.UI.Controls
                 {
                     searchElement.CreateAndConnectCommand.Execute(port.PortModel);
                 }
+                Analytics.TrackEvent(
+                Dynamo.Logging.Actions.Select,
+                Dynamo.Logging.Categories.NodeAutoCompleteOperations,
+                searchElement.FullName);
             }
         }
 

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -61,6 +61,11 @@ namespace Dynamo.Logging
         /// Events Category related to Node Auto-Complete
         /// </summary>
         NodeAutoCompleteOperations,
+
+        /// <summary>
+        /// Events Category related to In-Canvas search
+        /// </summary>
+        InCanvasSearchOperations
     }
 
     /// <summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -56,6 +56,11 @@ namespace Dynamo.Logging
         /// Events Category related to DesignScript VM
         /// </summary>
         Engine,
+
+        /// <summary>
+        /// Events Category related to Node Auto-Complete
+        /// </summary>
+        NodeAutoCompleteOperations,
     }
 
     /// <summary>
@@ -152,6 +157,11 @@ namespace Dynamo.Logging
         /// Update Installed event
         /// </summary>
         Installed,
+
+        /// <summary>
+        /// Select event, such as node auto-complete suggestion selection
+        /// </summary>
+        Select,
     }
 
     /// <summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -159,7 +159,7 @@ namespace Dynamo.Logging
         Installed,
 
         /// <summary>
-        /// Select event, such as node auto-complete suggestion selection
+        /// Select event, such as node auto-complete suggestion selection or in-canvas search selection
         /// </summary>
         Select,
     }


### PR DESCRIPTION
### Purpose

[DYN-3178](https://jira.autodesk.com/browse/DYN-3178)
Added tracking events for coverage of node autocomplete feature and in-canvas search.
Events covered:
- Opening a node-autocomplete window
- Placing a node using node-autocomplete window
- Opening an in-canvas search window
- Placing a node using in-canvas search window

Related PR to add waypoints to Analytics: [#23](https://git.autodesk.com/Dynamo/Analytics.NET/pull/23)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@DynamoDS/dynamo 