### PR TITLE
Avoid PATH overflow from SetupPython calls

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -178,7 +178,7 @@ namespace DSCPython
                 return null;
             }
 
-            Python.Included.Installer.SetupPython().Wait();
+            InstallPython();
 
             if (!PythonEngine.IsInitialized)
             {
@@ -243,6 +243,21 @@ namespace DSCPython
             finally
             {
                 PythonEngine.ReleaseLock(gs);
+            }
+        }
+
+        private static bool isPythonInstalled = false;
+        /// <summary>
+        /// Makes sure Python is installed on the system and it's location added to the path.
+        /// NOTE: Calling SetupPython multiple times will add the install location to the path many times,
+        /// potentially causing the environment variable to overflow.
+        /// </summary>
+        private static void InstallPython()
+        {
+            if (!isPythonInstalled)
+            {
+                Python.Included.Installer.SetupPython().Wait();
+                isPythonInstalled = true;
             }
         }
 

--- a/src/PythonMigrationViewExtension/MigrationAssistant/ScriptMigrator.cs
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/ScriptMigrator.cs
@@ -19,7 +19,7 @@ namespace Dynamo.PythonMigration.MigrationAssistant
         /// <returns></returns>
         internal static string MigrateCode(string code)
         {
-            Installer.SetupPython().Wait();
+            InstallPython();
 
             if (!PythonEngine.IsInitialized)
             {
@@ -67,6 +67,21 @@ namespace Dynamo.PythonMigration.MigrationAssistant
             finally
             {
                 PythonEngine.ReleaseLock(gs);
+            }
+        }
+
+        private static bool isPythonInstalled = false;
+        /// <summary>
+        /// Makes sure Python is installed on the system and it's location added to the path.
+        /// NOTE: Calling SetupPython multiple times will add the install location to the path many times,
+        /// potentially causing the environment variable to overflow.
+        /// </summary>
+        private static void InstallPython()
+        {
+            if (!isPythonInstalled)
+            {
+                Installer.SetupPython().Wait();
+                isPythonInstalled = true;
             }
         }
 


### PR DESCRIPTION
### Purpose

Calling Installer.SetupPython from Python.Included makes sure Python is
installed and also adds the install location to the PATH env variable.
The location is added to the PATH even if it was already there, so this
can potentially lead to an env variable overflow with the message
'Environment variable name or value is too long', after which the only
way to get CPython3 back to work would be to restart Dynamo.

The problem is avoided by remembering if Python was setup using a local
field. This should reduce the number of calls to a maximum of 2, which
is not the best (1 would be) but is far from resulting in an overflow.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
