### PR TITLE
Dyn 3177 coverage core node models wpf 2

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -174,6 +174,7 @@
     <Compile Include="SerializationTests.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="SliderTests.cs" />
+    <Compile Include="SliderViewModelTests.cs" />
     <Compile Include="Utility\DispatcherUtil.cs" />
     <Compile Include="Utility\ViewExtensions.cs" />
     <Compile Include="UpdateManagerUITests.cs" />

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="InfoBubbleTests.cs" />
     <Compile Include="Libraries\LabelTests.cs" />
     <Compile Include="ListAtLevelTest.cs" />
+    <Compile Include="MediatoDSColorConverterTest.cs" />
     <Compile Include="NodeAutoCompleteSearchTests.cs" />
     <Compile Include="NodeHelpPromptTest.cs" />
     <Compile Include="NoteViewTests.cs" />
@@ -171,10 +172,12 @@
     <Compile Include="RunSettingsTests.cs" />
     <Compile Include="SearchSideEffects.cs" />
     <Compile Include="SearchViewModelTests.cs" />
+    <Compile Include="SelectionButtonContentConverterTest.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="SliderTests.cs" />
     <Compile Include="SliderViewModelTests.cs" />
+    <Compile Include="StringToDateTimeOffsetConverterTest.cs" />
     <Compile Include="Utility\DispatcherUtil.cs" />
     <Compile Include="Utility\ViewExtensions.cs" />
     <Compile Include="UpdateManagerUITests.cs" />

--- a/test/DynamoCoreWpfTests/MediatoDSColorConverterTest.cs
+++ b/test/DynamoCoreWpfTests/MediatoDSColorConverterTest.cs
@@ -1,0 +1,41 @@
+﻿using System.Windows.Media;
+using CoreNodeModelsWpf.Converters;
+using Dynamo.Tests;
+using NUnit.Framework;
+using DSColor = DSCore.Color;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    class MediatoDSColorConverterTest
+    {
+        /// <summary>
+        /// This test method will validate the Convert() and ConvertBack() methods from the MediatoDSColorConverterConvertConvertBack class.
+        /// </summary>
+        [Test]
+        public void MediatoDSColorConverterConvertConvertBackTest()
+        {
+            //Red DSColor
+            var redDSColor = DSColor.ByARGB(255, 255, 0, 0);
+
+            var dsColorConverter = new MediatoDSColorConverter();
+
+            //Convert from DSColor to Color
+            var colorConverted = (Color)dsColorConverter.Convert(redDSColor, null, null, null);
+
+            //Validates that the convertion to Color was successful
+            Assert.IsNotNull(colorConverted);
+            Assert.AreEqual(colorConverted.GetType(), typeof(Color));
+            Assert.AreEqual(colorConverted.ToString(), "#FFFF0000");
+
+            //Convert back from Color to DSColor
+            var dsColorBack = (DSColor)dsColorConverter.ConvertBack(colorConverted, null, null, null);
+
+            //Validates that the convertion to DSColor was successful
+            Assert.IsNotNull(dsColorBack);
+            Assert.AreEqual(dsColorBack.GetType(), typeof(DSColor));
+            Assert.AreEqual(dsColorBack.ToString(), "Color(Red = 255, Green = 0, Blue = 0, Alpha = 255)");
+
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/SelectionButtonContentConverterTest.cs
+++ b/test/DynamoCoreWpfTests/SelectionButtonContentConverterTest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CoreNodeModelsWpf.Converters;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    class SelectionButtonContentConverterTest
+    {
+        /// <summary>
+        /// This test method will validate the Convert() and ConvertBack() methods from the SelectionButtonContentConverter class.
+        /// </summary>
+        [Test]
+        public void SelectionButtonContentConverter_ConvertConvertBackStringTest()
+        {
+
+            var list = new List<object>();
+            var buttonContentConverter = new SelectionButtonContentConverter();
+
+            var selectConverted = buttonContentConverter.Convert(list, null, null, null);
+
+            //Validates that the Convert function returned the expected result when passing a IEnumerable<object>.
+            Assert.IsNotNull(selectConverted);
+            Assert.AreEqual(selectConverted.ToString(), "Select");
+
+            //Validates that the Convert function returned the expected result when passing a string object.
+            var changeConterted = buttonContentConverter.Convert("test1", null, null, null);
+            Assert.IsNotNull(changeConterted);
+            Assert.AreEqual(changeConterted.ToString(), "Change");
+
+            //Validates that the ConvertBack function return null no matter the parameter passed
+            Assert.IsNull(buttonContentConverter.ConvertBack(list, null, null, null));
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/SliderViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SliderViewModelTests.cs
@@ -69,7 +69,10 @@ namespace DynamoCoreWpfTests
         }
 
         /// <summary>
-        /// This test method will 
+        /// This test method will validate the next properties from the SliderViewModel class:
+        ///  public T Max
+        ///  public T Min
+        ///  public T Step
         /// </summary>
         [Test]
         public void SliderViewModel_PropertiesTest()
@@ -103,26 +106,28 @@ namespace DynamoCoreWpfTests
             expander.IsExpanded = true;
 
             DispatcherUtil.DoEvents();
+            //Get the current min, max y step values in the TextBoxes
             var textBoxes = expander.ChildrenOfType<DynamoTextBox>();
             var minTextBox = (from textBox in textBoxes where textBox.Name.Equals("MinTb") select textBox).FirstOrDefault();
             var maxTextBox = (from textBox in textBoxes where textBox.Name.Equals("MaxTb") select textBox).FirstOrDefault();
             var stepTextBox = (from textBox in textBoxes where textBox.Name.Equals("StepTb") select textBox).FirstOrDefault();
 
+            //Validate that the TextBoxes have the right value according to the Model
             Assert.IsNotNull(WatchNode);
             Assert.AreEqual("0", minTextBox.Text);
             Assert.AreEqual("200", maxTextBox.Text);
             Assert.AreEqual("10", stepTextBox.Text);
 
+            //Validates the result gotten from the Watch node
             Assert.AreEqual("20", WatchNode.CachedValue.ToString());
         }
 
         /// <summary>
-        /// 
+        /// This test method will validate the "public T Value" property in SliderViewModel.cs
         /// </summary>
         [Test]
         public void SliderViewModel_ValueTest()
         {
-
             Open(@"core\library\NumberSliderNodeTest.dyn");
             Run();
 
@@ -132,6 +137,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
 
             var dynamoSlider = nodeView.grid.ChildrenOfType<DynamoSlider>().FirstOrDefault();
+            //Setting the Value property from the SliderViewModel
             var sliderBaseModel = dynamoSlider.DataContext as SliderViewModel<double>;
             sliderBaseModel.Value = 200.0;//Set the Max value
             sliderBaseModel.Value = -200.0;//Set the Min value
@@ -141,11 +147,13 @@ namespace DynamoCoreWpfTests
             expander.IsExpanded = true;
 
             DispatcherUtil.DoEvents();
+            //Get the current min, max y step values in the TextBoxes
             var textBoxes = expander.ChildrenOfType<DynamoTextBox>();
             var minTextBox = (from textBox in textBoxes where textBox.Name.Equals("MinTb") select textBox).FirstOrDefault();
             var maxTextBox = (from textBox in textBoxes where textBox.Name.Equals("MaxTb") select textBox).FirstOrDefault();
             var stepTextBox = (from textBox in textBoxes where textBox.Name.Equals("StepTb") select textBox).FirstOrDefault();
 
+            //Validates that the max and min values were set correctly when setting the Value property (SliderViewModel)
             Assert.IsNotNull(WatchNode);
             Assert.AreEqual("-200", minTextBox.Text);
             Assert.AreEqual("200", maxTextBox.Text);

--- a/test/DynamoCoreWpfTests/SliderViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SliderViewModelTests.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using CoreNodeModels;
+using CoreNodeModels.Input;
+using CoreNodeModelsWpf;
+using CoreNodeModelsWpf.Controls;
+using Dynamo.Nodes;
+using Dynamo.Tests;
+using Dynamo.Utilities;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    class SliderViewModelTests : DynamoTestUIBase
+    {
+        private AssemblyHelper assemblyHelper;
+
+        public override void Open(string path)
+        {
+            base.Open(path);
+
+            DispatcherUtil.DoEvents();
+        }
+
+        public override void Run()
+        {
+            base.Run();
+
+            DispatcherUtil.DoEvents();
+        }
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            SetupTests();
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("CoreNodeModelsWpf.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        public void SetupTests()
+        {
+            var assemblyPath = Assembly.GetExecutingAssembly().Location;
+            var moduleRootFolder = Path.GetDirectoryName(assemblyPath);
+
+            var resolutionPaths = new[]
+            {
+                // The CoreNodeModelsWpf.dll needed is under "nodes" folder.
+                Path.Combine(moduleRootFolder, "nodes")
+            };
+
+            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths);
+            AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
+        }
+
+        [TearDown]
+        public void RunAfterAllTests()
+        {
+            assemblyHelper = null;
+        }
+
+        /// <summary>
+        /// This test method will 
+        /// </summary>
+        [Test]
+        public void SliderViewModel_PropertiesTest()
+        {
+            Open(@"core\library\NumberSliderNodeTest.dyn");
+
+            var nodeView = NodeViewWithGuid("17ef3a6e-4742-45b6-8a2e-7ec3901e7726");//NodeViewOf<DoubleSlider>();
+            var WatchNode = Model.CurrentWorkspace.NodeFromWorkspace<Watch>("213fc6a3f4ff415d95747fdd2d385dfd");
+
+            Run();
+
+            DispatcherUtil.DoEvents();
+
+            var dynamoSlider = nodeView.grid.ChildrenOfType<DynamoSlider>().FirstOrDefault();
+            var sliderBaseModel = dynamoSlider.DataContext as SliderViewModel<double>;
+
+            //Getting the model using reflection
+            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+            FieldInfo field = sliderBaseModel.GetType().GetField("model", bindFlags);
+            SliderBase<double> sliderModel = (SliderBase<double>)field.GetValue(sliderBaseModel);
+
+            //Setting the model values
+            sliderModel.Max = 200.0;
+            sliderModel.Min = 0.0;
+            sliderModel.Step = 10;
+
+            sliderBaseModel.Value = 0;
+            sliderBaseModel.Value += 20;
+
+            var expander = nodeView.inputGrid.ChildrenOfType<Expander>().FirstOrDefault();
+            expander.IsExpanded = true;
+
+            DispatcherUtil.DoEvents();
+            var textBoxes = expander.ChildrenOfType<DynamoTextBox>();
+            var minTextBox = (from textBox in textBoxes where textBox.Name.Equals("MinTb") select textBox).FirstOrDefault();
+            var maxTextBox = (from textBox in textBoxes where textBox.Name.Equals("MaxTb") select textBox).FirstOrDefault();
+            var stepTextBox = (from textBox in textBoxes where textBox.Name.Equals("StepTb") select textBox).FirstOrDefault();
+
+            Assert.IsNotNull(WatchNode);
+            Assert.AreEqual("0", minTextBox.Text);
+            Assert.AreEqual("200", maxTextBox.Text);
+            Assert.AreEqual("10", stepTextBox.Text);
+
+            Assert.AreEqual("20", WatchNode.CachedValue.ToString());
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void SliderViewModel_ValueTest()
+        {
+
+            Open(@"core\library\NumberSliderNodeTest.dyn");
+            Run();
+
+            var nodeView = NodeViewWithGuid("17ef3a6e-4742-45b6-8a2e-7ec3901e7726");//NodeViewOf<DoubleSlider>();
+            var WatchNode = Model.CurrentWorkspace.NodeFromWorkspace<Watch>("213fc6a3f4ff415d95747fdd2d385dfd");
+
+            DispatcherUtil.DoEvents();
+
+            var dynamoSlider = nodeView.grid.ChildrenOfType<DynamoSlider>().FirstOrDefault();
+            var sliderBaseModel = dynamoSlider.DataContext as SliderViewModel<double>;
+            sliderBaseModel.Value = 200.0;//Set the Max value
+            sliderBaseModel.Value = -200.0;//Set the Min value
+            sliderBaseModel.Value = 0.0;//Set the Value
+
+            var expander = nodeView.inputGrid.ChildrenOfType<Expander>().FirstOrDefault();
+            expander.IsExpanded = true;
+
+            DispatcherUtil.DoEvents();
+            var textBoxes = expander.ChildrenOfType<DynamoTextBox>();
+            var minTextBox = (from textBox in textBoxes where textBox.Name.Equals("MinTb") select textBox).FirstOrDefault();
+            var maxTextBox = (from textBox in textBoxes where textBox.Name.Equals("MaxTb") select textBox).FirstOrDefault();
+            var stepTextBox = (from textBox in textBoxes where textBox.Name.Equals("StepTb") select textBox).FirstOrDefault();
+
+            Assert.IsNotNull(WatchNode);
+            Assert.AreEqual("-200", minTextBox.Text);
+            Assert.AreEqual("200", maxTextBox.Text);
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/SliderViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SliderViewModelTests.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Input;
 using CoreNodeModels;
 using CoreNodeModels.Input;
 using CoreNodeModelsWpf;
@@ -40,32 +35,9 @@ namespace DynamoCoreWpfTests
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
-            SetupTests();
             libraries.Add("VMDataBridge.dll");
             libraries.Add("DSCoreNodes.dll");
-            libraries.Add("CoreNodeModelsWpf.dll");
             base.GetLibrariesToPreload(libraries);
-        }
-
-        public void SetupTests()
-        {
-            var assemblyPath = Assembly.GetExecutingAssembly().Location;
-            var moduleRootFolder = Path.GetDirectoryName(assemblyPath);
-
-            var resolutionPaths = new[]
-            {
-                // The CoreNodeModelsWpf.dll needed is under "nodes" folder.
-                Path.Combine(moduleRootFolder, "nodes")
-            };
-
-            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths);
-            AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
-        }
-
-        [TearDown]
-        public void RunAfterAllTests()
-        {
-            assemblyHelper = null;
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/StringToDateTimeOffsetConverterTest.cs
+++ b/test/DynamoCoreWpfTests/StringToDateTimeOffsetConverterTest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using CoreNodeModelsWpf.Converters;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+
+    [TestFixture]
+    class StringToDateTimeOffsetConverterTest
+    {
+        private const string DefaultDateFormat = "MMMM dd, yyyy h:mm tt";
+
+        /// <summary>
+        /// This test method will validate the Convert() and ConvertBack() methods from the StringToDateTimeOffsetConverter class.
+        /// </summary>
+        [Test]
+        public void StringToDateTimeOffsetConverter_ConvertConvertBackStringDateTest()
+        {
+
+            var dateConverter = new StringToDateTimeConverter();
+            var testDate = new DateTime(2020, 12, 12, 5, 50, 00);
+
+            //Passing a DateTime to the Convert() method
+            var dateConverted = (String)dateConverter.Convert(testDate, null, null, null);
+
+            //Validates that the conversion from DateTime to String was successful
+            Assert.IsNotNull(dateConverted);
+            Assert.AreEqual(dateConverted.GetType(), typeof(String));
+            Assert.AreEqual(dateConverted.ToString(), "December 12, 2020 5:50 AM");
+
+            //Passing a string with a specific data format to the ConvertBack() method
+            var dateContertedBack = (DateTime)dateConverter.ConvertBack("December 12, 2020 5:50 AM", null, null, null);
+
+            //Validates that the conversion from String to DateTime was successful
+            Assert.IsNotNull(dateContertedBack);
+            Assert.AreEqual(dateContertedBack.GetType(), typeof(DateTime));
+            Assert.AreEqual(dateContertedBack.ToString(DefaultDateFormat), testDate.ToString(DefaultDateFormat));
+
+        }
+    }
+}

--- a/test/core/library/NumberSliderNodeTest.dyn
+++ b/test/core/library/NumberSliderNodeTest.dyn
@@ -1,0 +1,124 @@
+{
+  "Uuid": "2d6dae19-245a-49c2-85f4-666fe3b16dd3",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "NumberSliderNodeTest",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "MaximumValue": 100.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "InputValue": 1.0,
+      "Id": "17ef3a6e474245b68a2e7ec3901e7726",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f097ccc95ea84a9dbabc2d78000ef84f",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces numeric values."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "213fc6a3f4ff415d95747fdd2d385dfd",
+      "Inputs": [
+        {
+          "Id": "b08c1233e61f4e638b4ff344d196b079",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "13787c1747fc47cb8b24976d25021d96",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "f097ccc95ea84a9dbabc2d78000ef84f",
+      "End": "b08c1233e61f4e638b4ff344d196b079",
+      "Id": "f7fe438b18304625b507ba3ca70876a7"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.9.0.2745",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Number Slider",
+        "Id": "17ef3a6e474245b68a2e7ec3901e7726",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 360.5,
+        "Y": 203.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "213fc6a3f4ff415d95747fdd2d385dfd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 775.5,
+        "Y": 197.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose
Increase the code coverage in the CoreNodeModelsWpf folder (second pull request).

2 test methods added for covering the class SliderViewModel.cs

Added several tests for the next converters:
- MediatoDSColorConverter
- SelectionButtonContentConverter
- StringToDateTimeOffsetConverter

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @aparajit-pratap 

### FYIs

@alfredo-pozo 
