### PR TITLE
Cherrypick: Add Analytics Coverage for Node AutoComplete (#11209)

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Dynamo.Logging;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
@@ -34,8 +35,16 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
+            Loaded += InCanvasSearchControl_Loaded;
             Unloaded += InCanvasSearchControl_Unloaded;
 
+        }
+
+        private void InCanvasSearchControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            Analytics.TrackEvent(
+            Dynamo.Logging.Actions.Open,
+            Dynamo.Logging.Categories.InCanvasSearchOperations);
         }
 
         private void InCanvasSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -86,6 +95,10 @@ namespace Dynamo.UI.Controls
             {
                 searchElement.Position = ViewModel.InCanvasSearchPosition;
                 searchElement.ClickedCommand.Execute(null);
+                Analytics.TrackEvent(
+                Dynamo.Logging.Actions.Select,
+                Dynamo.Logging.Categories.InCanvasSearchOperations,
+                searchElement.FullName);
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Dynamo.Logging;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
@@ -45,6 +46,9 @@ namespace Dynamo.UI.Controls
             if (ViewModel != null && ViewModel.PortViewModel != null)
             {
                 ViewModel.PortViewModel.PlaceNodeAutocompleteWindow(this, e);
+                Analytics.TrackEvent(
+                Dynamo.Logging.Actions.Open,
+                Dynamo.Logging.Categories.NodeAutoCompleteOperations);
             }
         }
 
@@ -99,6 +103,10 @@ namespace Dynamo.UI.Controls
                 if (searchElement.CreateAndConnectCommand.CanExecute(port.PortModel))
                 {
                     searchElement.CreateAndConnectCommand.Execute(port.PortModel);
+                    Analytics.TrackEvent(
+                    Dynamo.Logging.Actions.Select,
+                    Dynamo.Logging.Categories.NodeAutoCompleteOperations,
+                    searchElement.FullName);
                 }
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -85,14 +85,28 @@ namespace Dynamo.ViewModels
         {
             var elements = new List<NodeSearchElement>();
             var inputPortType = PortViewModel.PortModel.GetInputPortType();
+
+            //List of input types that are skipped temporarily, and will display list of default suggestions instead.
+            var skippedInputTypes = new List<string>() { "var", "object", "string", "bool", "int", "double" };
+
+            if (inputPortType == null)
+            {
+                return elements; 
+            }
+
             var core = dynamoViewModel.Model.LibraryServices.LibraryManagementCore;
 
-            if (inputPortType == null) return elements;
             //if inputPortType is an array, use just the typename
             var parseResult = ParserUtils.ParseWithCore($"dummyName:{ inputPortType};", core);
             var ast = parseResult.CodeBlockNode.Children().FirstOrDefault() as IdentifierNode;
             //if parsing the type failed, revert to original string.
             inputPortType = ast != null ? ast.datatype.Name : inputPortType;
+
+            //check if the input port return type is in the skipped input types list
+            if (skippedInputTypes.Any(s => s == inputPortType))
+            {
+                return elements;
+            }
 
             //gather all ztsearchelements that are visible in search and filter using inputPortType and zt return type name.
             var ztSearchElements = Model.SearchEntries.OfType<ZeroTouchSearchElement>().Where(x => x.IsVisibleInSearch);

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -56,6 +56,16 @@ namespace Dynamo.Logging
         /// Events Category related to DesignScript VM
         /// </summary>
         Engine,
+
+        /// <summary>
+        /// Events Category related to Node Auto-Complete
+        /// </summary>
+        NodeAutoCompleteOperations,
+
+        /// <summary>
+        /// Events Category related to In-Canvas search
+        /// </summary>
+        InCanvasSearchOperations
     }
 
     /// <summary>
@@ -152,6 +162,11 @@ namespace Dynamo.Logging
         /// Update Installed event
         /// </summary>
         Installed,
+
+        /// <summary>
+        /// Select event, such as node auto-complete suggestion selection or in-canvas search selection
+        /// </summary>
+        Select,
     }
 
     /// <summary>

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -164,41 +164,9 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual("string", type);
 
             var searchViewModel = (ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel);
-            searchViewModel.PortViewModel = inPorts[1];
+            searchViewModel.PortViewModel = inPorts[0];
             var suggestions = searchViewModel.GetMatchingSearchElements();
-            Assert.AreEqual(22, suggestions.Count());
-            var suggestedNodes = suggestions.Select(s => s.FullName).OrderBy(s => s);
-            var nodes = new[]
-            {
-                "Core.Input.File Path",
-                "Core.String.String from Array",
-                "Core.String.String from Object",
-                "FFITarget.DupTargetTest.Bar",
-                "FFITarget.FFITarget.AtLevelTestClass.sumAndConcat",
-                "FFITarget.FFITarget.AtLevelTestClass.SumAndConcat",
-                "FFITarget.FFITarget.FirstNamespace.AnotherClassWithNameConflict.PropertyA",
-                "FFITarget.FFITarget.FirstNamespace.AnotherClassWithNameConflict.PropertyB",
-                "FFITarget.FFITarget.FirstNamespace.AnotherClassWithNameConflict.PropertyC",
-                "FFITarget.FFITarget.FirstNamespace.ClassWithNameConflict.PropertyA",
-                "FFITarget.FFITarget.FirstNamespace.ClassWithNameConflict.PropertyB",
-                "FFITarget.FFITarget.FirstNamespace.ClassWithNameConflict.PropertyC",
-                "FFITarget.FFITarget.SecondNamespace.ClassWithNameConflict.PropertyD",
-                "FFITarget.FFITarget.SecondNamespace.ClassWithNameConflict.PropertyE",
-                "FFITarget.FFITarget.SecondNamespace.ClassWithNameConflict.PropertyF",
-                "FFITarget.FFITarget.TestData.GetStringValue",
-                "FFITarget.FFITarget.TestRankReduce.Method",
-                "FFITarget.FFITarget.TestRankReduce.Property",
-                "FFITarget.FFITarget.TestRankReduce.RankReduceMethod",
-                "FFITarget.FFITarget.TestRankReduce.RankReduceProperty",
-                "ProtoGeometry.Autodesk.DesignScript.Geometry.Geometry.ExportToSAT",
-                "ProtoGeometry.Autodesk.DesignScript.Geometry.Geometry.ToSolidDef"
-
-            };
-            var expectedNodes = nodes.OrderBy(s => s);
-            for (int i = 0; i < 5; i++)
-            {
-                Assert.AreEqual(expectedNodes.ElementAt(i), suggestedNodes.ElementAt(i));
-            }
+            Assert.AreEqual(0, suggestions.Count());
         }
 
         [Test]
@@ -280,6 +248,33 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, suggestions.Count());
 
             // The initial list will fill the FilteredResults with a few options - all basic input types
+            searchViewModel.PopulateAutoCompleteCandidates();
+            Assert.AreEqual(5, searchViewModel.FilteredResults.Count());
+            Assert.AreEqual("String", searchViewModel.FilteredResults.FirstOrDefault().Name);
+        }
+
+        [Test]
+        public void NodeSuggestions_SkippedSuggestions()
+        {
+            Open(@"UI\builtin_inputport_suggestion.dyn");
+
+            // Get the node view for a specific node in the graph
+            NodeView nodeView = NodeViewWithGuid(Guid.Parse("1a0f89fdd3ce4214ba81c08934706452").ToString());
+
+            var inPorts = nodeView.ViewModel.InPorts;
+            Assert.AreEqual(1, inPorts.Count());
+            var port = inPorts[0].PortModel;
+            var type = port.GetInputPortType();
+            Assert.AreEqual("double", type);
+
+            var searchViewModel = (ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel);
+            searchViewModel.PortViewModel = inPorts[0];
+
+            // Running the algorithm against skipped nodes should return no suggestions
+            var suggestions = searchViewModel.GetMatchingSearchElements();
+            Assert.AreEqual(0, suggestions.Count());
+
+            // The initial list will fill the FilteredResults with a list of default options
             searchViewModel.PopulateAutoCompleteCandidates();
             Assert.AreEqual(5, searchViewModel.FilteredResults.Count());
             Assert.AreEqual("String", searchViewModel.FilteredResults.FirstOrDefault().Name);

--- a/test/UI/builtin_inputport_suggestion.dyn
+++ b/test/UI/builtin_inputport_suggestion.dyn
@@ -86,6 +86,36 @@
       ],
       "Replication": "Auto",
       "Description": "Create a ColorRange by supplying lists of colors and UVs.\n\nColorRange.ByColorsAndParameters (colors: Color[], parameters: UV[]): ColorRange"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Math.Log@double",
+      "Id": "1a0f89fdd3ce4214ba81c08934706452",
+      "Inputs": [
+        {
+          "Id": "353f0248b261405ab58bddbe06d58fa8",
+          "Name": "number",
+          "Description": "Number greater than 0.\n\ndouble",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "575de58425ee4edd99e5ce50761fb8d8",
+          "Name": "double",
+          "Description": "Natural log of the number.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Finds the natural logarithm of a number in the range (0, ∞).\n\nMath.Log (number: double): double"
     }
   ],
   "Connectors": [],
@@ -133,6 +163,16 @@
         "Excluded": false,
         "X": 498.0,
         "Y": 68.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Math.Log",
+        "Id": "1a0f89fdd3ce4214ba81c08934706452",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 504.0,
+        "Y": 452.0
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

Cherry-picking #11209 
Added tracking events for coverage of node autocomplete feature and in-canvas search.
Events covered:

Opening a node-autocomplete window
Placing a node using node-autocomplete window
Opening an in-canvas search window
Placing a node using in-canvas search window
### Declarations

### Reviewers
@QilongTang 
