### PR TITLE
crash when undoing  deletion of function definition code blocks

### DIFF
--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -1022,7 +1022,7 @@ namespace ProtoCore
 
                 bool hasThisSymbol;
                 AddressType addressType;
-                symbolIndex = ClassUtils.GetSymbolIndex(thisClass, name, classScope, functionScope, currentCodeBlock.codeBlockId, core.CompleteCodeBlockList, out hasThisSymbol, out addressType);
+                symbolIndex = ClassUtils.GetSymbolIndex(thisClass, name, classScope, functionScope, currentCodeBlock.codeBlockId, core.CompleteCodeBlockDict, out hasThisSymbol, out addressType);
                 if (Constants.kInvalidIndex != symbolIndex)
                 {
                     // It is static member, then get node from code block
@@ -1080,7 +1080,7 @@ namespace ProtoCore
             ProtoCore.DSASM.AddressType addressType;
             ProtoCore.DSASM.ClassNode classnode = core.ClassTable.ClassNodes[globalClassIndex];
 
-            int symbolIndex = ClassUtils.GetSymbolIndex(classnode, name, globalClassIndex, globalProcIndex, 0, core.CompleteCodeBlockList, out hasThisSymbol, out addressType);
+            int symbolIndex = ClassUtils.GetSymbolIndex(classnode, name, globalClassIndex, globalProcIndex, 0, core.CompleteCodeBlockDict, out hasThisSymbol, out addressType);
             if (symbolIndex == ProtoCore.DSASM.Constants.kInvalidIndex)
             {
                 return false;

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -214,7 +214,12 @@ namespace ProtoCore
         public List<CodeBlock> CodeBlockList { get; set; }
         // The Complete Code Block list contains all the code blocks
         // unlike the codeblocklist which only stores the outer most code blocks
-        public SortedDictionary<int, CodeBlock> CompleteCodeBlockList { get; set; }
+        public List<CodeBlock> CompleteCodeBlockList
+        {
+            get { return CompleteCodeBlockDict.Select(x => x.Value).ToList(); }
+            set { value.ForEach(x => CompleteCodeBlockDict.Add(x.codeBlockId, x)); }
+        }
+        internal SortedDictionary<int, CodeBlock> CompleteCodeBlockDict { get; set; }
 
         /// <summary>
         /// ForLoopBlockIndex tracks the current number of new for loop blocks created at compile time for every new compile phase
@@ -347,7 +352,7 @@ namespace ProtoCore
                 // Remove codeblock defined in procNode from CodeBlockList and CompleteCodeBlockList
                 foreach (int cbID in procNode.ChildCodeBlocks)
                 {
-                    CompleteCodeBlockList.Remove(cbID);
+                    CompleteCodeBlockDict.Remove(cbID);
 
                     foreach (CodeBlock cb in CodeBlockList)
                     {
@@ -438,7 +443,7 @@ namespace ProtoCore
             CodeBlockIndex = 0;
             RuntimeTableIndex = 0;
             CodeBlockList = new List<CodeBlock>();
-            CompleteCodeBlockList = new SortedDictionary<int, CodeBlock>();
+            CompleteCodeBlockDict = new SortedDictionary<int, CodeBlock>();
             CallsiteGuidMap = new Dictionary<Guid, int>();
 
             AssocNode = null;
@@ -717,7 +722,7 @@ namespace ProtoCore
             // Create the code block list data
             DSExecutable.CodeBlocks = new List<CodeBlock>();
             DSExecutable.CodeBlocks.AddRange(CodeBlockList);
-            DSExecutable.CompleteCodeBlocks = new SortedDictionary<int, CodeBlock>(CompleteCodeBlockList);
+            DSExecutable.CompleteCodeBlockDict = new SortedDictionary<int, CodeBlock>(CompleteCodeBlockDict);
 
             // Retrieve the class table directly since it is a global table
             DSExecutable.classTable = ClassTable;
@@ -768,7 +773,7 @@ namespace ProtoCore
         internal int GetRuntimeTableSize()
         {
             // Due to the way this list is constructed, the largest id is the one of the last block.
-            var lastBlock = CompleteCodeBlockList.LastOrDefault().Value;
+            var lastBlock = CompleteCodeBlockDict.LastOrDefault().Value;
             // If there are no code blocks yet, then the required size for tables is 0.
             // This happens when the first code block is being created and its id is being generated.
             if (lastBlock == null)

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -214,6 +214,7 @@ namespace ProtoCore
         public List<CodeBlock> CodeBlockList { get; set; }
         // The Complete Code Block list contains all the code blocks
         // unlike the codeblocklist which only stores the outer most code blocks
+        [Obsolete("Property will be deprecated in Dynamo 3.1")]
         public List<CodeBlock> CompleteCodeBlockList
         {
             get { return CompleteCodeBlockDict.Select(x => x.Value).ToList(); }

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -214,7 +214,7 @@ namespace ProtoCore
         public List<CodeBlock> CodeBlockList { get; set; }
         // The Complete Code Block list contains all the code blocks
         // unlike the codeblocklist which only stores the outer most code blocks
-        [Obsolete("Property will be deprecated in Dynamo 3.1")]
+        [Obsolete("Property will be deprecated in Dynamo 3.0")]
         public List<CodeBlock> CompleteCodeBlockList
         {
             get { return CompleteCodeBlockDict.Select(x => x.Value).ToList(); }

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -214,7 +214,7 @@ namespace ProtoCore
         public List<CodeBlock> CodeBlockList { get; set; }
         // The Complete Code Block list contains all the code blocks
         // unlike the codeblocklist which only stores the outer most code blocks
-        public List<CodeBlock> CompleteCodeBlockList { get; set; }
+        public SortedDictionary<int, CodeBlock> CompleteCodeBlockList { get; set; }
 
         /// <summary>
         /// ForLoopBlockIndex tracks the current number of new for loop blocks created at compile time for every new compile phase
@@ -347,7 +347,7 @@ namespace ProtoCore
                 // Remove codeblock defined in procNode from CodeBlockList and CompleteCodeBlockList
                 foreach (int cbID in procNode.ChildCodeBlocks)
                 {
-                    CompleteCodeBlockList.RemoveAll(x => x.codeBlockId == cbID);
+                    CompleteCodeBlockList.Remove(cbID);
 
                     foreach (CodeBlock cb in CodeBlockList)
                     {
@@ -438,7 +438,7 @@ namespace ProtoCore
             CodeBlockIndex = 0;
             RuntimeTableIndex = 0;
             CodeBlockList = new List<CodeBlock>();
-            CompleteCodeBlockList = new List<CodeBlock>();
+            CompleteCodeBlockList = new SortedDictionary<int, CodeBlock>();
             CallsiteGuidMap = new Dictionary<Guid, int>();
 
             AssocNode = null;
@@ -717,9 +717,7 @@ namespace ProtoCore
             // Create the code block list data
             DSExecutable.CodeBlocks = new List<CodeBlock>();
             DSExecutable.CodeBlocks.AddRange(CodeBlockList);
-            DSExecutable.CompleteCodeBlocks = new List<CodeBlock>();
-            DSExecutable.CompleteCodeBlocks.AddRange(CompleteCodeBlockList);
-
+            DSExecutable.CompleteCodeBlocks = new SortedDictionary<int, CodeBlock>(CompleteCodeBlockList);
 
             // Retrieve the class table directly since it is a global table
             DSExecutable.classTable = ClassTable;
@@ -770,7 +768,7 @@ namespace ProtoCore
         internal int GetRuntimeTableSize()
         {
             // Due to the way this list is constructed, the largest id is the one of the last block.
-            var lastBlock = CompleteCodeBlockList.LastOrDefault();
+            var lastBlock = CompleteCodeBlockList.LastOrDefault().Value;
             // If there are no code blocks yet, then the required size for tables is 0.
             // This happens when the first code block is being created and its id is being generated.
             if (lastBlock == null)

--- a/src/Engine/ProtoCore/DSASM/Executable.cs
+++ b/src/Engine/ProtoCore/DSASM/Executable.cs
@@ -48,7 +48,7 @@ namespace ProtoCore.DSASM
 
         public List<CodeBlock> CodeBlocks { get; set; }
 
-        [Obsolete("Property will be deprecated in Dynamo 3.1")]
+        [Obsolete("Property will be deprecated in Dynamo 3.0")]
         public List<CodeBlock> CompleteCodeBlocks { 
             get { return CompleteCodeBlockDict.Select(x => x.Value).ToList(); } 
             set { value.ForEach(x => CompleteCodeBlockDict.Add(x.codeBlockId, x)); }

--- a/src/Engine/ProtoCore/DSASM/Executable.cs
+++ b/src/Engine/ProtoCore/DSASM/Executable.cs
@@ -46,7 +46,7 @@ namespace ProtoCore.DSASM
         public TypeSystem TypeSystem { get; set; }
 
         public List<CodeBlock> CodeBlocks { get; set; }
-        public List<CodeBlock> CompleteCodeBlocks { get; set; }
+        public SortedDictionary<int, CodeBlock> CompleteCodeBlocks { get; set; }
 
         public InstructionStream[] instrStreamList { get; set; } 
         public InstructionStream iStreamCanvas { get; set; }
@@ -156,7 +156,7 @@ namespace ProtoCore.DSASM
 
             isBreakable = isBreakableBlock;
             codeBlockId = core.GetRuntimeTableSize();
-            core.CompleteCodeBlockList.Add(this);
+            core.CompleteCodeBlockList.Add(codeBlockId, this);
 
             symbols.RuntimeIndex = codeBlockId;
 

--- a/src/Engine/ProtoCore/DSASM/Executable.cs
+++ b/src/Engine/ProtoCore/DSASM/Executable.cs
@@ -47,6 +47,8 @@ namespace ProtoCore.DSASM
         public TypeSystem TypeSystem { get; set; }
 
         public List<CodeBlock> CodeBlocks { get; set; }
+
+        [Obsolete("Property will be deprecated in Dynamo 3.1")]
         public List<CodeBlock> CompleteCodeBlocks { 
             get { return CompleteCodeBlockDict.Select(x => x.Value).ToList(); } 
             set { value.ForEach(x => CompleteCodeBlockDict.Add(x.codeBlockId, x)); }

--- a/src/Engine/ProtoCore/DSASM/Executable.cs
+++ b/src/Engine/ProtoCore/DSASM/Executable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using ProtoCore.AssociativeGraph;
 using ProtoCore.Lang;
 using ProtoFFI;
@@ -46,7 +47,11 @@ namespace ProtoCore.DSASM
         public TypeSystem TypeSystem { get; set; }
 
         public List<CodeBlock> CodeBlocks { get; set; }
-        public SortedDictionary<int, CodeBlock> CompleteCodeBlocks { get; set; }
+        public List<CodeBlock> CompleteCodeBlocks { 
+            get { return CompleteCodeBlockDict.Select(x => x.Value).ToList(); } 
+            set { value.ForEach(x => CompleteCodeBlockDict.Add(x.codeBlockId, x)); }
+        }
+        internal SortedDictionary<int, CodeBlock> CompleteCodeBlockDict { get; set; }
 
         public InstructionStream[] instrStreamList { get; set; } 
         public InstructionStream iStreamCanvas { get; set; }
@@ -94,7 +99,7 @@ namespace ProtoCore.DSASM
             instrStreamList = null;
             iStreamCanvas = null;
             CodeBlocks = null;
-            CompleteCodeBlocks = null;
+            CompleteCodeBlockDict = null;
             ContextDataMngr = null;
             CodeToLocation = null;
             CurrentDSFileName = string.Empty;
@@ -156,7 +161,7 @@ namespace ProtoCore.DSASM
 
             isBreakable = isBreakableBlock;
             codeBlockId = core.GetRuntimeTableSize();
-            core.CompleteCodeBlockList.Add(codeBlockId, this);
+            core.CompleteCodeBlockDict.Add(codeBlockId, this);
 
             symbols.RuntimeIndex = codeBlockId;
 

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1519,7 +1519,9 @@ namespace ProtoCore.DSASM
                             }
 
                             var cb = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, currentLangBlock);
-                            if (cb != null && cb.IsMyAncestorBlock(graphNode.languageBlockId))
+                            Validity.Assert(cb != null, $"Could not find code block with codeBlockId {currentLangBlock}");
+
+                            if (cb.IsMyAncestorBlock(graphNode.languageBlockId))
                             {
                                 continue;
                             }
@@ -2910,10 +2912,8 @@ namespace ProtoCore.DSASM
         public void ReturnSiteGC(int blockId, int classIndex, int functionIndex)
         {
             CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
-            if (codeBlock == null)
-            {
-                throw new RuntimeException($"Could find CodeBlock with id {blockId}");
-            }
+            Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
+
             foreach (CodeBlock cb in exe.CompleteCodeBlocks[blockId].children)
             {
                 if (cb.blockType == CodeBlockType.Construct)
@@ -4420,10 +4420,8 @@ namespace ProtoCore.DSASM
             int blockId = op1.BlockIndex;
 
             CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
-            if (codeBlock == null)
-            {
-                throw new RuntimeException($"Could find CodeBlock with id {blockId}");
-            }
+            Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
+
             runtimeVerify(codeBlock.blockType == CodeBlockType.Construct);
             GCCodeBlock(blockId);
             pc++;

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2914,7 +2914,7 @@ namespace ProtoCore.DSASM
             CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
             Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
 
-            foreach (CodeBlock cb in exe.CompleteCodeBlocks[blockId].children)
+            foreach (CodeBlock cb in codeBlock.children)
             {
                 if (cb.blockType == CodeBlockType.Construct)
                     GCCodeBlock(cb.codeBlockId, functionIndex, classIndex);

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1518,7 +1518,7 @@ namespace ProtoCore.DSASM
                                 continue;
                             }
 
-                            bool found = exe.CompleteCodeBlocks.TryGetValue(currentLangBlock, out CodeBlock cb);
+                            bool found = exe.CompleteCodeBlockDict.TryGetValue(currentLangBlock, out CodeBlock cb);
                             Validity.Assert(found, $"Could not find code block with codeBlockId {currentLangBlock}");
 
                             if (cb.IsMyAncestorBlock(graphNode.languageBlockId))
@@ -2715,7 +2715,7 @@ namespace ProtoCore.DSASM
                     SymbolNode node = null;
                     bool isStatic = false;
                     ClassNode classNode = exe.classTable.ClassNodes[type];
-                    int symbolIndex = ClassUtils.GetSymbolIndex(classNode, procName, type, Constants.kGlobalScope, runtimeCore.RunningBlock, exe.CompleteCodeBlocks, out hasThisSymbol, out addressType);
+                    int symbolIndex = ClassUtils.GetSymbolIndex(classNode, procName, type, Constants.kGlobalScope, runtimeCore.RunningBlock, exe.CompleteCodeBlockDict, out hasThisSymbol, out addressType);
 
                     if (Constants.kInvalidIndex != symbolIndex)
                     {
@@ -2911,7 +2911,7 @@ namespace ProtoCore.DSASM
 
         public void ReturnSiteGC(int blockId, int classIndex, int functionIndex)
         {
-            bool found = exe.CompleteCodeBlocks.TryGetValue(blockId, out CodeBlock codeBlock);
+            bool found = exe.CompleteCodeBlockDict.TryGetValue(blockId, out CodeBlock codeBlock);
             Validity.Assert(found, $"Could find code block with codeBlockId {blockId}");
 
             foreach (CodeBlock cb in codeBlock.children)
@@ -4423,7 +4423,7 @@ namespace ProtoCore.DSASM
             StackValue op1 = instruction.op1;
             int blockId = op1.BlockIndex;
 
-            bool found = exe.CompleteCodeBlocks.TryGetValue(blockId, out CodeBlock codeBlock);
+            bool found = exe.CompleteCodeBlockDict.TryGetValue(blockId, out CodeBlock codeBlock);
             Validity.Assert(found, $"Could find code block with codeBlockId {blockId}");
 
             runtimeVerify(codeBlock.blockType == CodeBlockType.Construct);

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1518,8 +1518,8 @@ namespace ProtoCore.DSASM
                                 continue;
                             }
 
-                            var cb = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, currentLangBlock);
-                            Validity.Assert(cb != null, $"Could not find code block with codeBlockId {currentLangBlock}");
+                            bool found = exe.CompleteCodeBlocks.TryGetValue(currentLangBlock, out CodeBlock cb);
+                            Validity.Assert(found, $"Could not find code block with codeBlockId {currentLangBlock}");
 
                             if (cb.IsMyAncestorBlock(graphNode.languageBlockId))
                             {
@@ -2911,8 +2911,8 @@ namespace ProtoCore.DSASM
 
         public void ReturnSiteGC(int blockId, int classIndex, int functionIndex)
         {
-            CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
-            Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
+            bool found = exe.CompleteCodeBlocks.TryGetValue(blockId, out CodeBlock codeBlock);
+            Validity.Assert(found, $"Could find code block with codeBlockId {blockId}");
 
             foreach (CodeBlock cb in codeBlock.children)
             {
@@ -4423,8 +4423,8 @@ namespace ProtoCore.DSASM
             StackValue op1 = instruction.op1;
             int blockId = op1.BlockIndex;
 
-            CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
-            Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
+            bool found = exe.CompleteCodeBlocks.TryGetValue(blockId, out CodeBlock codeBlock);
+            Validity.Assert(found, $"Could find code block with codeBlockId {blockId}");
 
             runtimeVerify(codeBlock.blockType == CodeBlockType.Construct);
             GCCodeBlock(blockId);

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1513,8 +1513,13 @@ namespace ProtoCore.DSASM
                         // happens. 
                         if (graphNode.isLanguageBlock && currentLangBlock != Constants.kInvalidIndex)
                         {
-                            if (graphNode.languageBlockId == currentLangBlock
-                                || exe.CompleteCodeBlocks[currentLangBlock].IsMyAncestorBlock(graphNode.languageBlockId))
+                            if (graphNode.languageBlockId == currentLangBlock)
+                            {
+                                continue;
+                            }
+
+                            var cb = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, currentLangBlock);
+                            if (cb != null && cb.IsMyAncestorBlock(graphNode.languageBlockId))
                             {
                                 continue;
                             }
@@ -2904,6 +2909,11 @@ namespace ProtoCore.DSASM
 
         public void ReturnSiteGC(int blockId, int classIndex, int functionIndex)
         {
+            CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
+            if (codeBlock == null)
+            {
+                throw new RuntimeException($"Could find CodeBlock with id {blockId}");
+            }
             foreach (CodeBlock cb in exe.CompleteCodeBlocks[blockId].children)
             {
                 if (cb.blockType == CodeBlockType.Construct)
@@ -4409,7 +4419,11 @@ namespace ProtoCore.DSASM
             StackValue op1 = instruction.op1;
             int blockId = op1.BlockIndex;
 
-            CodeBlock codeBlock = exe.CompleteCodeBlocks[blockId];
+            CodeBlock codeBlock = CoreUtils.GetCodeBlock(exe.CompleteCodeBlocks, blockId);
+            if (codeBlock == null)
+            {
+                throw new RuntimeException($"Could find CodeBlock with id {blockId}");
+            }
             runtimeVerify(codeBlock.blockType == CodeBlockType.Construct);
             GCCodeBlock(blockId);
             pc++;

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2937,6 +2937,10 @@ namespace ProtoCore.DSASM
             for (int n = 0; n < exe.instrStreamList.Length; ++n)
             {
                 InstructionStream stream = exe.instrStreamList[n];
+                if (stream == null)
+                {
+                    continue;
+                }
                 for (int i = 0; i < stream.dependencyGraph.GraphList.Count; ++i)
                 {
                     AssociativeGraph.GraphNode node = stream.dependencyGraph.GraphList[i];

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -332,8 +332,11 @@ namespace ProtoCore.DSASM.Mirror
             }
             else
             {
-                CodeBlock searchBlock = runtimeCore.DSExecutable.CompleteCodeBlocks[block];
-
+                CodeBlock searchBlock = CoreUtils.GetCodeBlock(runtimeCore.DSExecutable.CompleteCodeBlocks, block);
+                if (searchBlock != null)
+                {
+                    throw new NameNotFoundException { Name = name };
+                }
                 // To detal with the case that a language block defined in a function
                 //
                 // def foo()
@@ -718,10 +721,15 @@ namespace ProtoCore.DSASM.Mirror
 
             for (int block = startBlock; block < exe.runtimeSymbols.Length; block++)
             {
-                int index = exe.runtimeSymbols[block].IndexOf(name, Constants.kInvalidIndex, Constants.kGlobalScope);
+                var symbolTable = exe.runtimeSymbols[block];
+                if (symbolTable == null)
+                {
+                    continue;
+                }
+                int index = symbolTable.IndexOf(name, Constants.kInvalidIndex, Constants.kGlobalScope);
                 if (Constants.kInvalidIndex != index)
                 {
-                    SymbolNode symNode = exe.runtimeSymbols[block].symbolList[index];
+                    SymbolNode symNode = symbolTable.symbolList[index];
                     if (symNode.absoluteFunctionIndex == Constants.kGlobalScope)
                     {
                         return MirrorTarget.rmem.GetAtRelative(symNode.index);
@@ -738,11 +746,16 @@ namespace ProtoCore.DSASM.Mirror
 
             for (int block = startBlock; block < exe.runtimeSymbols.Length; block++)
             {
-                int index = exe.runtimeSymbols[block].IndexOf(name, classcope, Constants.kGlobalScope);
+                var symbolTable = exe.runtimeSymbols[block];
+                if (symbolTable == null)
+                {
+                    continue;
+                }
+                int index = symbolTable.IndexOf(name, classcope, Constants.kGlobalScope);
                 if (Constants.kInvalidIndex != index)
                 {
                     //Q(Luke): This seems to imply that the LHS is an array index?
-                    var symbol = exe.runtimeSymbols[block].symbolList[index];
+                    var symbol = symbolTable.symbolList[index];
                     return MirrorTarget.rmem.GetSymbolValue(symbol);
                 }
             }

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -332,8 +332,8 @@ namespace ProtoCore.DSASM.Mirror
             }
             else
             {
-                CodeBlock searchBlock = CoreUtils.GetCodeBlock(runtimeCore.DSExecutable.CompleteCodeBlocks, block);
-                Validity.Assert(searchBlock != null, $"Could not find code block with codeBlockId {block}");
+                bool found = runtimeCore.DSExecutable.CompleteCodeBlocks.TryGetValue(block, out CodeBlock searchBlock);
+                Validity.Assert(found, $"Could not find code block with codeBlockId {block}");
 
                 // To detal with the case that a language block defined in a function
                 //

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -332,7 +332,7 @@ namespace ProtoCore.DSASM.Mirror
             }
             else
             {
-                bool found = runtimeCore.DSExecutable.CompleteCodeBlocks.TryGetValue(block, out CodeBlock searchBlock);
+                bool found = runtimeCore.DSExecutable.CompleteCodeBlockDict.TryGetValue(block, out CodeBlock searchBlock);
                 Validity.Assert(found, $"Could not find code block with codeBlockId {block}");
 
                 // To detal with the case that a language block defined in a function

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -333,10 +333,8 @@ namespace ProtoCore.DSASM.Mirror
             else
             {
                 CodeBlock searchBlock = CoreUtils.GetCodeBlock(runtimeCore.DSExecutable.CompleteCodeBlocks, block);
-                if (searchBlock != null)
-                {
-                    throw new NameNotFoundException { Name = name };
-                }
+                Validity.Assert(searchBlock != null, $"Could not find code block with codeBlockId {block}");
+
                 // To detal with the case that a language block defined in a function
                 //
                 // def foo()

--- a/src/Engine/ProtoCore/FunctionPointerTable.cs
+++ b/src/Engine/ProtoCore/FunctionPointerTable.cs
@@ -40,10 +40,9 @@ namespace ProtoCore.DSASM
                 else
                 {
                     var codeBlock = CoreUtils.GetCodeBlock(runtimeCore.DSExecutable.CompleteCodeBlocks, blockId);
-                    if (codeBlock != null)
-                    {
-                        procNode = codeBlock.procedureTable.Procedures[functionIndex];
-                    }
+                    Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
+
+                    procNode = codeBlock.procedureTable.Procedures[functionIndex];
                 }
 
                 return true;

--- a/src/Engine/ProtoCore/FunctionPointerTable.cs
+++ b/src/Engine/ProtoCore/FunctionPointerTable.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ProtoCore.Utils;
+using System;
 using System.Collections.Generic;
 
 namespace ProtoCore.DSASM
@@ -38,7 +39,11 @@ namespace ProtoCore.DSASM
                 }
                 else
                 {
-                    procNode = runtimeCore.DSExecutable.CompleteCodeBlocks[blockId].procedureTable.Procedures[functionIndex];
+                    var codeBlock = CoreUtils.GetCodeBlock(runtimeCore.DSExecutable.CompleteCodeBlocks, blockId);
+                    if (codeBlock != null)
+                    {
+                        procNode = codeBlock.procedureTable.Procedures[functionIndex];
+                    }
                 }
 
                 return true;

--- a/src/Engine/ProtoCore/FunctionPointerTable.cs
+++ b/src/Engine/ProtoCore/FunctionPointerTable.cs
@@ -39,7 +39,7 @@ namespace ProtoCore.DSASM
                 }
                 else
                 {
-                    bool found = runtimeCore.DSExecutable.CompleteCodeBlocks.TryGetValue(blockId, out CodeBlock codeBlock);
+                    bool found = runtimeCore.DSExecutable.CompleteCodeBlockDict.TryGetValue(blockId, out CodeBlock codeBlock);
                     Validity.Assert(found, $"Could find code block with codeBlockId {blockId}");
 
                     procNode = codeBlock.procedureTable.Procedures[functionIndex];

--- a/src/Engine/ProtoCore/FunctionPointerTable.cs
+++ b/src/Engine/ProtoCore/FunctionPointerTable.cs
@@ -39,8 +39,8 @@ namespace ProtoCore.DSASM
                 }
                 else
                 {
-                    var codeBlock = CoreUtils.GetCodeBlock(runtimeCore.DSExecutable.CompleteCodeBlocks, blockId);
-                    Validity.Assert(codeBlock != null, $"Could find code block with codeBlockId {blockId}");
+                    bool found = runtimeCore.DSExecutable.CompleteCodeBlocks.TryGetValue(blockId, out CodeBlock codeBlock);
+                    Validity.Assert(found, $"Could find code block with codeBlockId {blockId}");
 
                     procNode = codeBlock.procedureTable.Procedures[functionIndex];
                 }

--- a/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
+++ b/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
@@ -14,4 +14,5 @@ using System.Runtime.CompilerServices;
 [assembly:InternalsVisibleTo("DynamoCore")]
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
 [assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
-
+[assembly: InternalsVisibleTo("ProtoImperative")]
+[assembly: InternalsVisibleTo("ProtoScript")]

--- a/src/Engine/ProtoCore/Utils/ClassUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ClassUtils.cs
@@ -156,13 +156,14 @@ namespace ProtoCore.Utils
 
         public static List<int> GetAncestorBlockIdsOfBlock(int blockId, List<CodeBlock> codeblockList)
         {
-            if (blockId >= codeblockList.Count || blockId < 0)
-            {
-                return new List<int>();
-            }
-            CodeBlock thisBlock = codeblockList[blockId];
-
             var ancestors = new List<int>();
+
+            CodeBlock thisBlock = CoreUtils.GetCodeBlock(codeblockList, blockId);
+            if (thisBlock == null)
+            {
+                return ancestors;
+            }
+            
             CodeBlock codeBlock = thisBlock.parent;
             while (codeBlock != null)
             {

--- a/src/Engine/ProtoCore/Utils/ClassUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ClassUtils.cs
@@ -69,7 +69,7 @@ namespace ProtoCore.Utils
         // 
         //     2.3 Otherwise, classScope == kInvalidIndex && functionScope == kInvalidIndex
         //         Return public member in derived class, or public member in base classes 
-        public static int GetSymbolIndex(ClassNode classNode, string name, int classScope, int functionScope, int blockId, List<CodeBlock> codeblockList, out bool hasThisSymbol, out ProtoCore.DSASM.AddressType addressType)
+        public static int GetSymbolIndex(ClassNode classNode, string name, int classScope, int functionScope, int blockId, SortedDictionary<int, CodeBlock> codeblocks, out bool hasThisSymbol, out ProtoCore.DSASM.AddressType addressType)
         {
             hasThisSymbol = false;
             addressType = ProtoCore.DSASM.AddressType.Invalid;
@@ -92,7 +92,7 @@ namespace ProtoCore.Utils
                 classNode.ProcTable.Procedures[functionScope].IsStatic;
 
             // Try for member function variables
-            var blocks = GetAncestorBlockIdsOfBlock(blockId, codeblockList);
+            var blocks = GetAncestorBlockIdsOfBlock(blockId, codeblocks);
             blocks.Insert(0, blockId);
 
             Dictionary<int, SymbolNode> symbolOfBlockScope = new Dictionary<int, SymbolNode>();
@@ -154,12 +154,10 @@ namespace ProtoCore.Utils
             return Constants.kInvalidIndex;
         }
 
-        public static List<int> GetAncestorBlockIdsOfBlock(int blockId, List<CodeBlock> codeblockList)
+        public static List<int> GetAncestorBlockIdsOfBlock(int blockId, SortedDictionary<int, CodeBlock> codeblocks)
         {
             var ancestors = new List<int>();
-
-            CodeBlock thisBlock = CoreUtils.GetCodeBlock(codeblockList, blockId);
-            if (thisBlock == null)
+            if (!codeblocks.TryGetValue(blockId, out CodeBlock thisBlock))
             {
                 return ancestors;
             }

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -2,13 +2,14 @@
 using System.Linq;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
+using System.Diagnostics;
 
 namespace ProtoCore.Utils
 {
     public static class CoreUtils
     {
 
-
+        static Stopwatch timer = Stopwatch.StartNew();
         public static void InsertPredefinedAndBuiltinMethods(Core core, CodeBlockNode root)
         {
             if (DSASM.InterpreterMode.Normal == core.Options.RunMode)
@@ -806,6 +807,7 @@ namespace ProtoCore.Utils
         /// <returns></returns>
         public static CodeBlock GetCodeBlock(List<CodeBlock> blockList, int blockId)
         {
+            timer.Start();
             CodeBlock codeblock = null;
             codeblock = blockList.Find(x => x.codeBlockId == blockId);
             if (codeblock == null)
@@ -819,6 +821,9 @@ namespace ProtoCore.Utils
                     }
                 }
             }
+            timer.Stop();
+            var seconds = timer.Elapsed.TotalSeconds;
+            System.Console.WriteLine(seconds);
             return codeblock;
         }
         

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -2,14 +2,11 @@
 using System.Linq;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
-using System.Diagnostics;
 
 namespace ProtoCore.Utils
 {
     public static class CoreUtils
     {
-
-        static Stopwatch timer = Stopwatch.StartNew();
         public static void InsertPredefinedAndBuiltinMethods(Core core, CodeBlockNode root)
         {
             if (DSASM.InterpreterMode.Normal == core.Options.RunMode)
@@ -807,7 +804,6 @@ namespace ProtoCore.Utils
         /// <returns></returns>
         public static CodeBlock GetCodeBlock(List<CodeBlock> blockList, int blockId)
         {
-            timer.Start();
             CodeBlock codeblock = null;
             codeblock = blockList.Find(x => x.codeBlockId == blockId);
             if (codeblock == null)
@@ -821,9 +817,6 @@ namespace ProtoCore.Utils
                     }
                 }
             }
-            timer.Stop();
-            var seconds = timer.Elapsed.TotalSeconds;
-            System.Console.WriteLine(seconds);
             return codeblock;
         }
         

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -881,8 +881,8 @@ namespace ProtoImperative
                 if (propogateUpdateGraphNode != null)
                 {
                     propogateUpdateGraphNode.languageBlockId = blockId;
-                    CodeBlock childBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, blockId);
-                    Validity.Assert(childBlock != null, $"Could find code block with codeBlockId {blockId}");
+                    bool foundChild = core.CompleteCodeBlockList.TryGetValue(blockId, out CodeBlock childBlock);
+                    Validity.Assert(foundChild, $"Could find code block with codeBlockId {blockId}");
 
                     foreach (var subGraphNode in childBlock.instrStream.dependencyGraph.GraphList)
                     {
@@ -895,8 +895,8 @@ namespace ProtoImperative
                             {
                                 SymbolNode dependentSymbol = depentNode.updateNodeRefList[0].nodeList[0].symbol;
                                 int symbolBlockId = dependentSymbol.codeBlockId;
-                                CodeBlock symbolBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, symbolBlockId);
-                                if (symbolBlock != null && !symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
+                                if (core.CompleteCodeBlockList.TryGetValue(symbolBlockId, out CodeBlock symbolBlock) && 
+                                    !symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
                                 {
                                     propogateUpdateGraphNode.PushDependent(depentNode);
                                 }

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -882,24 +882,23 @@ namespace ProtoImperative
                 {
                     propogateUpdateGraphNode.languageBlockId = blockId;
                     CodeBlock childBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, blockId);
-                    if (childBlock != null)
+                    Validity.Assert(childBlock != null, $"Could find code block with codeBlockId {blockId}");
+
+                    foreach (var subGraphNode in childBlock.instrStream.dependencyGraph.GraphList)
                     {
-                        foreach (var subGraphNode in childBlock.instrStream.dependencyGraph.GraphList)
+                        foreach (var depentNode in subGraphNode.dependentList)
                         {
-                            foreach (var depentNode in subGraphNode.dependentList)
+                            if (depentNode.updateNodeRefList != null
+                                && depentNode.updateNodeRefList.Count > 0
+                                && depentNode.updateNodeRefList[0].nodeList != null
+                                && depentNode.updateNodeRefList[0].nodeList.Count > 0)
                             {
-                                if (depentNode.updateNodeRefList != null
-                                    && depentNode.updateNodeRefList.Count > 0
-                                    && depentNode.updateNodeRefList[0].nodeList != null
-                                    && depentNode.updateNodeRefList[0].nodeList.Count > 0)
+                                SymbolNode dependentSymbol = depentNode.updateNodeRefList[0].nodeList[0].symbol;
+                                int symbolBlockId = dependentSymbol.codeBlockId;
+                                CodeBlock symbolBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, symbolBlockId);
+                                if (symbolBlock != null && !symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
                                 {
-                                    SymbolNode dependentSymbol = depentNode.updateNodeRefList[0].nodeList[0].symbol;
-                                    int symbolBlockId = dependentSymbol.codeBlockId;
-                                    CodeBlock symbolBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, symbolBlockId);
-                                    if (symbolBlock != null && !symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
-                                    {
-                                        propogateUpdateGraphNode.PushDependent(depentNode);
-                                    }
+                                    propogateUpdateGraphNode.PushDependent(depentNode);
                                 }
                             }
                         }

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -881,7 +881,7 @@ namespace ProtoImperative
                 if (propogateUpdateGraphNode != null)
                 {
                     propogateUpdateGraphNode.languageBlockId = blockId;
-                    bool foundChild = core.CompleteCodeBlockList.TryGetValue(blockId, out CodeBlock childBlock);
+                    bool foundChild = core.CompleteCodeBlockDict.TryGetValue(blockId, out CodeBlock childBlock);
                     Validity.Assert(foundChild, $"Could find code block with codeBlockId {blockId}");
 
                     foreach (var subGraphNode in childBlock.instrStream.dependencyGraph.GraphList)
@@ -895,7 +895,7 @@ namespace ProtoImperative
                             {
                                 SymbolNode dependentSymbol = depentNode.updateNodeRefList[0].nodeList[0].symbol;
                                 int symbolBlockId = dependentSymbol.codeBlockId;
-                                if (core.CompleteCodeBlockList.TryGetValue(symbolBlockId, out CodeBlock symbolBlock) && 
+                                if (core.CompleteCodeBlockDict.TryGetValue(symbolBlockId, out CodeBlock symbolBlock) && 
                                     !symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
                                 {
                                     propogateUpdateGraphNode.PushDependent(depentNode);

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -881,22 +881,22 @@ namespace ProtoImperative
                 if (propogateUpdateGraphNode != null)
                 {
                     propogateUpdateGraphNode.languageBlockId = blockId;
-                    CodeBlock childBlock = core.CompleteCodeBlockList[blockId];
-                    foreach (var subGraphNode in childBlock.instrStream.dependencyGraph.GraphList)
+                    CodeBlock childBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, blockId);
+                    if (childBlock != null)
                     {
-                        foreach (var depentNode in subGraphNode.dependentList)
+                        foreach (var subGraphNode in childBlock.instrStream.dependencyGraph.GraphList)
                         {
-                            if (depentNode.updateNodeRefList != null 
-                                && depentNode.updateNodeRefList.Count > 0 
-                                && depentNode.updateNodeRefList[0].nodeList != null
-                                && depentNode.updateNodeRefList[0].nodeList.Count > 0)
+                            foreach (var depentNode in subGraphNode.dependentList)
                             {
-                                SymbolNode dependentSymbol = depentNode.updateNodeRefList[0].nodeList[0].symbol;
-                                int symbolBlockId = dependentSymbol.codeBlockId;
-                                if (symbolBlockId != Constants.kInvalidIndex)
+                                if (depentNode.updateNodeRefList != null
+                                    && depentNode.updateNodeRefList.Count > 0
+                                    && depentNode.updateNodeRefList[0].nodeList != null
+                                    && depentNode.updateNodeRefList[0].nodeList.Count > 0)
                                 {
-                                    CodeBlock symbolBlock = core.CompleteCodeBlockList[symbolBlockId];
-                                    if (!symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
+                                    SymbolNode dependentSymbol = depentNode.updateNodeRefList[0].nodeList[0].symbol;
+                                    int symbolBlockId = dependentSymbol.codeBlockId;
+                                    CodeBlock symbolBlock = CoreUtils.GetCodeBlock(core.CompleteCodeBlockList, symbolBlockId);
+                                    if (symbolBlock != null && !symbolBlock.IsMyAncestorBlock(codeBlock.codeBlockId))
                                     {
                                         propogateUpdateGraphNode.PushDependent(depentNode);
                                     }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -324,10 +324,8 @@ namespace ProtoScript.Runners
                     core.CodeBlockList.RemoveAll(x => x.guid == bnode.guid);// && x.AstID == bnode.OriginalAstID);
 
                     // Remove from the runtime codeblocks
-                    foreach (var key in core.CompleteCodeBlockDict.Where(x => x.Value.guid == bnode.guid).Select(x => x.Key).ToArray())
-                    {
-                        core.CompleteCodeBlockDict.Remove(key);
-                    }
+                    var keysToRemove = core.CompleteCodeBlockDict.Where(x => x.Value.guid == bnode.guid).Select(x => x.Key).ToList();
+                    keysToRemove.ForEach(key => core.CompleteCodeBlockDict.Remove(key));
                 }
             }
         }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -315,6 +315,7 @@ namespace ProtoScript.Runners
                 bnode = node as BinaryExpressionNode;
                 if (bnode.RightNode is LanguageBlockNode)
                 {
+                    // Tibi: core.CodeBlockList[0] should be the global scope (should always exist ?)
                     if (core.CodeBlockList[0].children != null)
                     {
                         core.CodeBlockList[0].children.RemoveAll(x => x.guid == bnode.guid);

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -324,9 +324,9 @@ namespace ProtoScript.Runners
                     core.CodeBlockList.RemoveAll(x => x.guid == bnode.guid);// && x.AstID == bnode.OriginalAstID);
 
                     // Remove from the runtime codeblocks
-                    foreach (var key in core.CompleteCodeBlockList.Where(x => x.Value.guid == bnode.guid).Select(x => x.Key).ToArray())
+                    foreach (var key in core.CompleteCodeBlockDict.Where(x => x.Value.guid == bnode.guid).Select(x => x.Key).ToArray())
                     {
-                        core.CompleteCodeBlockList.Remove(key);
+                        core.CompleteCodeBlockDict.Remove(key);
                     }
                 }
             }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -322,8 +322,12 @@ namespace ProtoScript.Runners
 
                     // Remove from the global codeblocks
                     core.CodeBlockList.RemoveAll(x => x.guid == bnode.guid);// && x.AstID == bnode.OriginalAstID);
+
                     // Remove from the runtime codeblocks
-                    core.CompleteCodeBlockList.RemoveAll(x => x.guid == bnode.guid);// && x.AstID == bnode.OriginalAstID);
+                    foreach (var key in core.CompleteCodeBlockList.Where(x => x.Value.guid == bnode.guid).Select(x => x.Key).ToArray())
+                    {
+                        core.CompleteCodeBlockList.Remove(key);
+                    }
                 }
             }
         }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -315,7 +315,6 @@ namespace ProtoScript.Runners
                 bnode = node as BinaryExpressionNode;
                 if (bnode.RightNode is LanguageBlockNode)
                 {
-                    // Tibi: core.CodeBlockList[0] should be the global scope (should always exist ?)
                     if (core.CodeBlockList[0].children != null)
                     {
                         core.CodeBlockList[0].children.RemoveAll(x => x.guid == bnode.guid);

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5984,13 +5984,19 @@ k = i[""a""];
             removed.Add(TestFrameWork.CreateSubTreeFromCode(guidFuncDef, codes[0]));
   
             syncData = new GraphSyncData(removed, null, null);
-            liveRunner.UpdateGraph(syncData);
+            Assert.DoesNotThrow(() =>
+            {
+                liveRunner.UpdateGraph(syncData);
+            });
 
             List<Subtree> undoRemove = new List<Subtree>();
             undoRemove.Add(TestFrameWork.CreateSubTreeFromCode(guidFuncDef, codes[0]));
 
             syncData = new GraphSyncData(null, undoRemove, null);
-            liveRunner.UpdateGraph(syncData);
+            Assert.DoesNotThrow(() =>
+            {
+                liveRunner.UpdateGraph(syncData);
+            });
         }
 
         [Test]

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5931,6 +5931,69 @@ k = i[""a""];
         }
 
         [Test]
+        public void CrashOnUndoDelFuncDef()
+        {
+            List<string> codes = new List<string>()
+            {
+                @"
+                    def foo(a, b)
+                    {
+	                    return [Imperative]
+	                    {
+		                    list = a..b;
+		                    x = [];
+		                    count = 0;
+		                    for(i in list)
+		                    {
+			                    x[count] = i;
+			                    count = count+1;
+		                    }
+		                    return x;
+	                    }
+                    };      
+                ",
+                @"
+                    x = false;
+                    l1 = foo(1, 10);
+                    l2 = foo(10, 20);
+                    [Imperative]
+                    {
+	                    if(x==true)
+	                    {
+		                    return l1;
+	                    }
+	                    else
+	                    {
+		                    return l2;
+	                    }
+                    };      
+                "
+            };
+
+            Guid guidFuncDef = Guid.NewGuid();
+            Guid guidOther = Guid.NewGuid();
+
+            List<Subtree> added = new List<Subtree>();
+            added.Add(TestFrameWork.CreateSubTreeFromCode(guidFuncDef, codes[0]));
+            added.Add(TestFrameWork.CreateSubTreeFromCode(guidOther, codes[1]));
+
+            var syncData = new GraphSyncData(null, added, null);
+            liveRunner.UpdateGraph(syncData);
+
+            List<Subtree> removed = new List<Subtree>();
+            removed.Add(TestFrameWork.CreateSubTreeFromCode(guidFuncDef, codes[0]));
+  
+            syncData = new GraphSyncData(removed, null, null);
+            liveRunner.UpdateGraph(syncData);
+
+            List<Subtree> undoRemove = new List<Subtree>();
+            undoRemove.Add(TestFrameWork.CreateSubTreeFromCode(guidFuncDef, codes[0]));
+
+            syncData = new GraphSyncData(null, undoRemove, null);
+            liveRunner.UpdateGraph(syncData);
+        }
+
+        [Test]
         public void RegressMAGN7759()
         {
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7759

--- a/test/Engine/ProtoTestFx/DebugTestFx.cs
+++ b/test/Engine/ProtoTestFx/DebugTestFx.cs
@@ -190,10 +190,15 @@ namespace ProtoTestFx
 
             for (int symTableIndex = 0; symTableIndex < rtcore1.DSExecutable.runtimeSymbols.Length; symTableIndex++)
             {
-                foreach (SymbolNode symNode in rtcore1.DSExecutable.runtimeSymbols[symTableIndex].symbolList.Values)
+                var rtc1Symbols = rtcore1.DSExecutable.runtimeSymbols[symTableIndex];
+                if (rtc1Symbols == null)
+                {
+                    continue;
+                }
+                foreach (SymbolNode symNode in rtc1Symbols.symbolList.Values)
                 {
 
-                    ExecutionMirror runExecMirror = new ExecutionMirror(rtcore1.CurrentExecutive.CurrentDSASMExec,rtcore1);
+                    ExecutionMirror runExecMirror = new ExecutionMirror(rtcore1.CurrentExecutive.CurrentDSASMExec, rtcore1);
                     ExecutionMirror debugExecMirror = new ExecutionMirror(rtcore2.CurrentExecutive.CurrentDSASMExec, rtcore2);
 
                     bool lookupOk = false;


### PR DESCRIPTION
### Purpose
Fix crash when deleting/modifying codeblocks

What is causing the crash:
1. There is code that assumes that Lists of` CodeBLocks` should have their indexes correspond to the `CodeBlock.codeBlockId`. 
   Basically code that does the following: `CodeBlockList[someCodeBlockId]`
   This assumptions is wrong because CodeBlockLists can be altered (items removed at any index in the list). For example when you delete a code block that contains a function declaration (see https://github.com/DynamoDS/Dynamo/blob/81df8a93517f6bc99a3377ade94f1e81a42c7bbe/src/Engine/ProtoCore/Core.cs#L350 )
2. Not having null checks on arrays of symbolTables or ProcedureTables (or instruction streams) that can contain null items.

More than the crash:
There is code that is error prone (multiple arrays that have to kept in sync, array indexes passed/stored in different objects).
I propose to create a new task to refactor the code - maybe add a Dictionary to hold all data that needs to be in sync. Also maybe change the data type of codeblockIds (currently integer - CodeBlock.codeBlockId) to a GUID or a dedicated class so that there will be no confusion that codeblockIds can be used as indexes in arrays or keys in Dictionaries.

My proposed solution:
Minimal changes that resole the crash. 
1. Null checks when iterating on arrays of SymbolTables, ProcedureTables and InstructionStreams.
2. Swap out all code that assumed CodeBlockArrays can use codeblockIds as their indexes with the `CoreUtil.GetCodeBlock()` . 
`CoreUtil.GetCodeBlock()` basically iterates the codeblock arrays and tries to match each one with the code block id.

Potential issues with proposal:
`CoreUtil.GetCodeBlock(codeBlockList, codeBlockId)` may cause performance degradation - although, from my experiments/measurements, I only noticed insignificant increases. Only tested on hundreds of codeblocks.
--Update-- performance should not be an issue, because CompleteCodeBlocks contains a flat list of all code blocks. When searching for a code block through `CoreUtil.GetCodeBlock` no recursive calls should be made if the blockId is valid.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
