### PR TITLE
Change analytics code block position for both controls, Nodeautocomplete and Incanvas search

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -35,16 +35,8 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
-            Loaded += InCanvasSearchControl_Loaded;
             Unloaded += InCanvasSearchControl_Unloaded;
 
-        }
-
-        private void InCanvasSearchControl_Loaded(object sender, RoutedEventArgs e)
-        {
-            Analytics.TrackEvent(
-            Dynamo.Logging.Actions.Open,
-            Dynamo.Logging.Categories.InCanvasSearchOperations);
         }
 
         private void InCanvasSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -125,6 +117,10 @@ namespace Dynamo.UI.Controls
 
             // Select text in text box.
             SearchTextBox.SelectAll();
+
+            Analytics.TrackEvent(
+            Dynamo.Logging.Actions.Open,
+            Dynamo.Logging.Categories.InCanvasSearchOperations);
 
             // Visibility of textbox changed, but text box has not been initialized(rendered) yet.
             // Call asynchronously focus, when textbox will be ready.

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -37,18 +37,7 @@ namespace Dynamo.UI.Controls
             {
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
-            Loaded += NodeAutoCompleteSearchControl_Loaded;
             Unloaded += NodeAutoCompleteSearchControl_Unloaded;
-        }
-
-        private void NodeAutoCompleteSearchControl_Loaded(object sender, RoutedEventArgs e)
-        {
-            if (ViewModel != null && ViewModel.PortViewModel != null)
-            {
-                Analytics.TrackEvent(
-                    Dynamo.Logging.Actions.Open,
-                    Dynamo.Logging.Categories.NodeAutoCompleteOperations);
-            }
         }
 
         private void NodeAutoCompleteSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -133,6 +122,10 @@ namespace Dynamo.UI.Controls
 
             // When launching this control, always start with clear search term.
             SearchTextBox.Clear();
+
+            Analytics.TrackEvent(
+            Dynamo.Logging.Actions.Open,
+            Dynamo.Logging.Categories.NodeAutoCompleteOperations);
 
             // Visibility of textbox changed, but text box has not been initialized(rendered) yet.
             // Call asynchronously focus, when textbox will be ready.


### PR DESCRIPTION
### Purpose

ADP tracking for in-canvas search control was being recorded incorrectly as it was also triggered right after startup.
Therefore, it is now moved to the function that handles visibility change for both the controls to maintain uniformity and accurate hits.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@DynamoDS/dynamo 
