### PR TITLE
Fix sorting for number keys in List.SortByKey

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -465,7 +465,7 @@ namespace DSCore
             var pairs = list.Cast<object>()
                     .Zip(keys.Cast<object>(), (item, key) => new { item, key });
 
-            var numberKeyPairs = pairs.Where(pair => pair.key is double || pair.key is int || pair.key is float);
+            var numberKeyPairs = pairs.Where(pair => pair.key is double || pair.key is int || pair.key is float || pair.key is long);
             // We don't use Except, because Except doesn't return duplicates.
             var keyPairs = pairs.Where(
                 pair =>

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -663,6 +663,31 @@ namespace Dynamo.Tests
 			SelectivelyAssertPreviewValues("9e2c84e6-b9b8-4bdf-b82e-868b2436b865", validationData1);
 
 		}
+
+        [Test]
+        public void SortByKey_SimpleTest()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\list\ListSortByKey.dyn");
+            RunModel(openPath);
+
+            // First and last element in the list before sorting
+            var validationData = new []
+            {
+                "Zack",
+				"Ian",
+				"Anna",
+				"Neal"
+            };
+            AssertPreviewValue("aaf179d9-71a5-4c30-b603-e41cee521dff", validationData);
+
+            // First and last element in the list after sorting
+            var validationData1 = new object[]
+            {
+                -3, 1.6, 5, "abc"
+            };
+            AssertPreviewValue("ef7368e4-5fe4-426d-9c58-27f250a1b040", validationData1);
+
+        }
 		#endregion
 
 		#region Reverse Test Cases  

--- a/test/core/list/ListSortByKey.dyn
+++ b/test/core/list/ListSortByKey.dyn
@@ -1,0 +1,262 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "ListSortByKey",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.SortByKey@var[]..[],var[]..[]",
+      "Id": "aeff4f246990441aae2cea89cd5d2d5d",
+      "Inputs": [
+        {
+          "Id": "496ce45912ae4178a10d2b1eeeede378",
+          "Name": "list",
+          "Description": "list to be sorted\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dfd6fb927b2446c0bf2014259e3bc7be",
+          "Name": "keys",
+          "Description": "list of keys, keys have to be sortable (e.g. numbers,strings)\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "080467e0daa5463c806b789ce5f5424c",
+          "Name": "sortedList",
+          "Description": "type: var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0ced997499ad442e8068622bcb567bc1",
+          "Name": "sortedKeys",
+          "Description": "type: var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Sort list based on its keys\n\nList.SortByKey (list: var[]..[], keys: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\"Zack\",\n        \"Ian\",\n        \"Neal\",\n        \"Anna\"];",
+      "Id": "6a570493e8cc4b33ae1aec199b366dde",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "fa6580ad9a5b4ae4b33dd5cd5422b8e6",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[-3,\n        1.6,\n        \"abc\",5];",
+      "Id": "5490581cd07147699e9b895764274ef8",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d6911c819ee942618c930b7d0b6e0d78",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "ef7368e45fe4426d9c5827f250a1b040",
+      "Inputs": [
+        {
+          "Id": "73fd808a004d4e67b7d66ce8ad888a54",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6422c725c7d44cf28232844c451f6e47",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "aaf179d971a54c30b603e41cee521dff",
+      "Inputs": [
+        {
+          "Id": "554320adf0144c6c961abb3842a9daf1",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a94896972f7442319534fbcf42ffbb77",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "080467e0daa5463c806b789ce5f5424c",
+      "End": "554320adf0144c6c961abb3842a9daf1",
+      "Id": "98598957df2641b1ab77685fc52efdc8"
+    },
+    {
+      "Start": "0ced997499ad442e8068622bcb567bc1",
+      "End": "73fd808a004d4e67b7d66ce8ad888a54",
+      "Id": "e64f9af715be4ec8b520e17eea1714ec"
+    },
+    {
+      "Start": "fa6580ad9a5b4ae4b33dd5cd5422b8e6",
+      "End": "496ce45912ae4178a10d2b1eeeede378",
+      "Id": "1db00d2bcf4e45d4a69eaa7697fb2b86"
+    },
+    {
+      "Start": "d6911c819ee942618c930b7d0b6e0d78",
+      "End": "dfd6fb927b2446c0bf2014259e3bc7be",
+      "Id": "88a66942c48449518a99f82484fb27da"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.10.0.3156",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "List.SortByKey",
+        "Id": "aeff4f246990441aae2cea89cd5d2d5d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 466.5,
+        "Y": 138.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6a570493e8cc4b33ae1aec199b366dde",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 157.5,
+        "Y": -3.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "5490581cd07147699e9b895764274ef8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 194.0,
+        "Y": 277.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "ef7368e45fe4426d9c5827f250a1b040",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 804.0,
+        "Y": 263.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "aaf179d971a54c30b603e41cee521dff",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 861.0,
+        "Y": 55.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

https://autodesk.slack.com/archives/C0W60575Z/p1604848871192600

After fix:
![image](https://user-images.githubusercontent.com/5710686/98849706-a1159900-2421-11eb-9f81-828a464f6f2e.png)

Previously the integer keys were not sorted along with the doubles as they didn't pass the number key check in line 468 and the result in the watch node was: `[1.2, 4.8, 1, 2, 3]`, which was incorrect.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate 
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
