### PR TITLE
[SPIKE] Use Helix instancing to save memory for large number of mesh geometry

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoMesh.hlsl
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoMesh.hlsl
@@ -53,7 +53,7 @@ PSInput main(VSInput input)
             input.mr2,
             input.mr3
         };
-        inputp = mul(input.p, mInstance);
+        inputp = mul(inputp, mInstance);
         inputn = mul(inputn, (float3x3) mInstance);
     }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoMesh.hlsl
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/shaderSource/vsDynamoMesh.hlsl
@@ -26,9 +26,11 @@ PSInput main(VSInput input)
     bool requiresPerVertexColoration = flags & 32;
      
     float4 inputp;
+    float3 inputn;
     float3 nudge = normalize(input.n) * 0.0001;
 
     inputp = input.p;
+    inputn = input.n;
     if (requiresPerVertexColoration)
     {
         // Nudge the vertex out slightly along its normal a tiny bit.
@@ -41,6 +43,19 @@ PSInput main(VSInput input)
         inputp = float4(inputp.x + nudge.x, inputp.y + nudge.y, inputp.z + nudge.z, inputp.w);
     }
     
+    // compose instance matrix
+    if (bHasInstances)
+    {
+        matrix mInstance =
+        {
+            input.mr0,
+            input.mr1,
+            input.mr2,
+            input.mr3
+        };
+        inputp = mul(input.p, mInstance);
+        inputn = mul(inputn, (float3x3) mInstance);
+    }
 
     //set position into world space
     output.p = mul(inputp, mWorld);
@@ -53,7 +68,7 @@ PSInput main(VSInput input)
     output.c = input.c;
 
     //set normal for interpolation	
-    output.n = normalize(mul(input.n, (float3x3)mWorld));
+    output.n = normalize(mul(inputn, (float3x3)mWorld));
 
     return output;
 }


### PR DESCRIPTION
### Purpose

Trial implementation exploring using Helix instancing to render large number of mesh geometry.
This goes hand-in-hand with corresponding LibG changes here: https://git.autodesk.com/Dynamo/LibG/pull/1080

#### Assumptions
- This assumes that any node producing mesh geometry (solids and surfaces) and participating in replication can potentially benefit from instancing while being rendered.

#### Issues
- Instances do not currently display in the background preview for some reason
- Geometry transforms are incorrect in LibG (e.g. if a Sphere is located away from the origin, it's transform matrix does not reflect its exact position)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

