### PR TITLE
Add analytics tracking events on extension load

### DIFF
--- a/src/DynamoCore/Extensions/ExtensionLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLoader.cs
@@ -33,6 +33,11 @@ namespace Dynamo.Extensions
                 var assembly = Assembly.LoadFrom(extension.AssemblyPath);
                 var result = assembly.CreateInstance(extension.TypeName) as IExtension;
                 ExtensionLoading?.Invoke(result);
+                
+                Logging.Analytics.TrackEvent(
+                Actions.Load,
+                Categories.ExtensionOperations, extension.TypeName);
+
                 return result;
             }
             catch(Exception ex)

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionLoader.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionLoader.cs
@@ -23,6 +23,11 @@ namespace Dynamo.Wpf.Extensions
                     var assembly = Assembly.LoadFrom(viewExtension.AssemblyPath);
                     var result = assembly.CreateInstance(viewExtension.TypeName) as IViewExtension;
                     ExtensionLoading?.Invoke(result);
+
+                    Analytics.TrackEvent(
+                    Actions.Load,
+                    Categories.ExtensionOperations, viewExtension.TypeName);
+
                     return result;
                 }
                 return null;

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -71,6 +71,16 @@ namespace Dynamo.Logging
         /// Events Category related to Python operations
         /// </summary>
         PythonOperations,
+
+        /// <summary>
+        /// Events Category related to Extensions operations
+        /// </summary>
+        ExtensionOperations,
+
+        /// <summary>
+        /// Events Category related to View Extensions operations
+        /// </summary>
+        ViewExtensionOperations,
     }
 
     /// <summary>
@@ -187,6 +197,11 @@ namespace Dynamo.Logging
         /// Run event, such as Python node run clicked, Graph run Clicked
         /// </summary>
         Run,
+
+        /// <summary>
+        /// Load event, such as extensions loaded
+        /// </summary>
+        Load,
     }
 
     /// <summary>


### PR DESCRIPTION
### Purpose
[DYN-1994](https://jira.autodesk.com/browse/DYN-1994)
Added analytics events for Extensions and View Extensions load event.

Related PR: https://git.autodesk.com/Dynamo/Analytics.NET/pull/24

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@DynamoDS/dynamo 
