### PR TITLE
Fix for regression in multi-output node preview 

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -62,7 +62,7 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// The string lable visibile in the watch.
+        /// The string label visible in the watch.
         /// </summary>
         public string NodeLabel
         {

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using Dynamo.Configuration;
 using Dynamo.Controls;
+using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.Scheduler;
@@ -368,8 +369,17 @@ namespace Dynamo.UI.Controls
             RunOnSchedulerSync(
                 () =>
                 {
-                    var preferredDictionaryOrdering = 
-                    nodeViewModel.NodeModel.OutPorts.Select(p => p.Name).Where(n => !String.IsNullOrEmpty(n));
+                    IEnumerable<string> preferredDictionaryOrdering;
+                    if (nodeViewModel.NodeModel is DSFunction dsFunction)
+                    {
+                        preferredDictionaryOrdering = dsFunction.Controller.ReturnKeys;
+                    }
+                    else
+                    {
+                        preferredDictionaryOrdering =
+                            nodeViewModel.NodeModel.OutPorts.Select(p => p.Name).Where(n => !string.IsNullOrEmpty(n));
+                    }
+
                     newViewModel = nodeViewModel.DynamoViewModel.WatchHandler.GenerateWatchViewModelForData(
                         nodeViewModel.NodeModel.CachedValue, preferredDictionaryOrdering,
                         null, nodeViewModel.NodeModel.AstIdentifierForPreview.Name, false);

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -444,7 +444,7 @@ namespace DSCore
         /// <returns name="sortedList">type: var[]..[]</returns>
         /// <returns name="sortedKeys">type: var[]..[]</returns>
         /// <search>sort;key</search>
-        [MultiReturn(new[] { "sorted list", "sorted keys" })]
+        [MultiReturn("sortedList", "sortedKeys")]
         [IsVisibleInDynamoLibrary(true)]
         public static IDictionary SortByKey(IList list, IList keys)
         {
@@ -484,8 +484,8 @@ namespace DSCore
 
             return new Dictionary<object, object>
             {
-                { "sorted list", sortedList },
-                { "sorted keys", sortedKeys }
+                { "sortedList", sortedList },
+                { "sortedKeys", sortedKeys }
             };
         }
 

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -32,6 +32,7 @@ namespace DynamoCoreWpfTests
         {
             libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSCoreNodes.dll");
+            libraries.Add("FFITarget.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -335,6 +336,30 @@ namespace DynamoCoreWpfTests
         {
             Open(@"core\DetailedPreviewMargin_Test.dyn");
             var nodeView = NodeViewWithGuid("7828a9dd-88e6-49f4-9ed3-72e355f89bcc");
+
+            var previewBubble = nodeView.PreviewControl;
+            previewBubble.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+            previewBubble.bubbleTools.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            // open preview bubble
+            RaiseMouseEnterOnNode(nodeView);
+            Assert.IsTrue(previewBubble.IsCondensed, "Compact preview bubble should be shown");
+            Assert.AreEqual(Visibility.Collapsed, previewBubble.bubbleTools.Visibility, "Pin icon should not be shown");
+
+            // hover preview bubble to see pin icon
+            RaiseMouseEnterOnNode(previewBubble);
+            Assert.AreEqual(Visibility.Visible, previewBubble.bubbleTools.Visibility, "Pin icon should be shown");
+
+            // expand preview bubble
+            RaiseMouseEnterOnNode(previewBubble.bubbleTools);
+            Assert.IsTrue(previewBubble.IsExpanded, "Expanded preview bubble should be shown");
+        }
+
+        [Test]
+        public void PreviewBubble_ShowExpandedPreview_MultiReturnNode()
+        {
+            Open(@"core\multireturnnode_preview.dyn");
+            var nodeView = NodeViewWithGuid("587d7494-e764-41fb-8b5d-a4229f7294ee");
 
             var previewBubble = nodeView.PreviewControl;
             previewBubble.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\..\..\bin\AnyCPU\Debug\en-US\FFITarget.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -432,7 +432,7 @@ namespace FFITarget
         /// <returns name="wt">weight</returns>
         /// <returns name="ok">okay</returns>
         [MultiReturn("color", "dict", "nums", "weight", "ok")]
-        public static IDictionary ReturnNestedDictionary()
+        public static Dictionary<string, object> ReturnNestedDictionary()
         {
             return new Dictionary<string, object>() 
             {

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -432,7 +432,7 @@ namespace FFITarget
         /// <returns name="wt">weight</returns>
         /// <returns name="ok">okay</returns>
         [MultiReturn("color", "dict", "nums", "weight", "ok")]
-        public static Dictionary<string, object> ReturnNestedDictionary()
+        public Dictionary<string, object> ReturnNestedDictionary()
         {
             return new Dictionary<string, object>() 
             {

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -423,8 +423,16 @@ namespace FFITarget
             return x.GetValue();
         }
 
+        /// <summary>
+        /// Return nested dictionary.
+        /// </summary>
+        /// <returns name="col">column</returns>
+        /// <returns name="dict">dictionary</returns>
+        /// <returns name="num">number</returns>
+        /// <returns name="wt">weight</returns>
+        /// <returns name="ok">okay</returns>
         [MultiReturn("color", "dict", "nums", "weight", "ok")]
-        public Dictionary<string, object> ReturnNestedDictionary()
+        public static IDictionary ReturnNestedDictionary()
         {
             return new Dictionary<string, object>() 
             {

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -1097,8 +1097,8 @@ namespace DSCoreNodesTests
             var result = List.SortByKey(list, keys);
             var expected = new Dictionary<string, object>
             {
-                { "sorted list", new object[] { "item2", "item1" } },
-                { "sorted keys", new object[] { "key1", "key2" } }
+                { "sortedList", new object[] { "item2", "item1" } },
+                { "sortedKeys", new object[] { "key1", "key2" } }
             };
 
             Assert.AreEqual(expected, result);
@@ -1142,8 +1142,8 @@ namespace DSCoreNodesTests
             var result = List.SortByKey(list, keys);
             var expected = new Dictionary<string, object>
             {
-                { "sorted list", new object[] { "Neal", "Matt", "Ian", "Zack", "Colin" } },
-                { "sorted keys", new object[] { "Burnham", "Jezyk", "Keough", "Kron", "McCrone" } }
+                { "sortedList", new object[] { "Neal", "Matt", "Ian", "Zack", "Colin" } },
+                { "sortedKeys", new object[] { "Burnham", "Jezyk", "Keough", "Kron", "McCrone" } }
             };
 
             Assert.AreEqual(expected, result);
@@ -1165,8 +1165,8 @@ namespace DSCoreNodesTests
             var result = List.SortByKey(list, keys);
             var expected = new Dictionary<string, object>
             {
-                { "sorted list", new object[] { "Zack", "Ian", "Anna", "Neal" } },
-                { "sorted keys", new object[] { -3, 1.6, 5, "abc" } }
+                { "sortedList", new object[] { "Zack", "Ian", "Anna", "Neal" } },
+                { "sortedKeys", new object[] { -3, 1.6, 5, "abc" } }
             };
 
             Assert.AreEqual(expected, result);
@@ -1182,8 +1182,8 @@ namespace DSCoreNodesTests
             var result = List.SortByKey(list, keys);
             var expected = new Dictionary<string, object>
             {
-                { "sorted list", new object[] { 2, 3, 1 }},
-                { "sorted keys", new object[] { 1.20, 1.2001, 1.21 } }
+                { "sortedList", new object[] { 2, 3, 1 }},
+                { "sortedKeys", new object[] { 1.20, 1.2001, 1.21 } }
             };
 
             Assert.AreEqual(expected, result);

--- a/test/core/multireturnnode_preview.dyn
+++ b/test/core/multireturnnode_preview.dyn
@@ -14,7 +14,17 @@
       "NodeType": "FunctionNode",
       "FunctionSignature": "FFITarget.TestData.ReturnNestedDictionary",
       "Id": "587d7494e76441fb8b5da4229f7294ee",
-      "Inputs": [],
+      "Inputs": [
+        {
+          "Id": "0e6050e8916a454eab7cf2d87861cb07",
+          "Name": "testData",
+          "Description": "FFITarget.TestData",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
       "Outputs": [
         {
           "Id": "fddbb030b56041bf88ee3b0f0b44c493",
@@ -64,9 +74,35 @@
       ],
       "Replication": "Auto",
       "Description": "Return nested dictionary.\n\nTestData.ReturnNestedDictionary ( ): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.TestData.TestData",
+      "Id": "e64dd6ca741c4a09b722c7fb231cf474",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1404145039bf4ffbb2f648eecdce0928",
+          "Name": "TestData",
+          "Description": "TestData",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "TestData.TestData ( ): TestData"
     }
   ],
-  "Connectors": [],
+  "Connectors": [
+    {
+      "Start": "1404145039bf4ffbb2f648eecdce0928",
+      "End": "0e6050e8916a454eab7cf2d87861cb07",
+      "Id": "e9da6bf89a1f4ff98b09a22a57585115"
+    }
+  ],
   "Dependencies": [],
   "NodeLibraryDependencies": [],
   "Bindings": [],
@@ -99,8 +135,18 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 472.836288832632,
-        "Y": 312.25508075583207
+        "X": 587.591972524768,
+        "Y": 366.80443744047426
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "TestData.TestData",
+        "Id": "e64dd6ca741c4a09b722c7fb231cf474",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 396.92609744922186,
+        "Y": 383.40302487798539
       }
     ],
     "Annotations": [],

--- a/test/core/multireturnnode_preview.dyn
+++ b/test/core/multireturnnode_preview.dyn
@@ -1,0 +1,111 @@
+{
+  "Uuid": "cdab5b52-304f-4b23-8a5e-4a93ebdcafb9",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "multireturnnode_preview",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.TestData.ReturnNestedDictionary",
+      "Id": "587d7494e76441fb8b5da4229f7294ee",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "fddbb030b56041bf88ee3b0f0b44c493",
+          "Name": "col",
+          "Description": "column",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0f381b0e745e4604856705582cf0231c",
+          "Name": "dict",
+          "Description": "dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "421f2476bb444d8ba1330c9fd8d6e4fd",
+          "Name": "num",
+          "Description": "number",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "fc3fbe47234a4e0f8d4fa4385e301419",
+          "Name": "wt",
+          "Description": "weight",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8d8682c503d84a0f8da77833247df6a8",
+          "Name": "ok",
+          "Description": "okay",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Return nested dictionary.\n\nTestData.ReturnNestedDictionary ( ): var[]..[]"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.10.0.3246",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "TestData.ReturnNestedDictionary",
+        "Id": "587d7494e76441fb8b5da4229f7294ee",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 472.836288832632,
+        "Y": 312.25508075583207
+      }
+    ],
+    "Annotations": [],
+    "X": -201.66090832590237,
+    "Y": -282.42730312803474,
+    "Zoom": 1.2374114765500794
+  }
+}


### PR DESCRIPTION
### Purpose

Fixes:
https://jira.autodesk.com/browse/DYN-3255
https://jira.autodesk.com/browse/DYN-1016 (GH issue: https://github.com/DynamoDS/Dynamo/issues/8885)

Node previews such as that for `List.SortByKey` had regressed after Martin Stacey's port renaming PR's.

Output port names are aligned with the names of the XML return tags specified on the node/method and the objective of Martin's work was to rename the port names by modifying the XML tag names. That was fine. However, for multi-return nodes, the multi-output node preview logic for ZT nodes (which is based on keys of a dictionary returned from the node) also followed the output port names, and these were therefore affected by the XML tag renaming changes, which is why this caused the node preview to break.

The fix is to make the returned dictionary keys to be based on the multi-return attribute inputs and not the output port names (aka XML tags).

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs
@QilongTang 
