### PR TITLE
Save/Load view extension size and location

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -370,6 +370,11 @@ namespace Dynamo.Configuration
         [XmlIgnore]
         public bool NamespacesToExcludeFromLibrarySpecified { get; set; }
 
+        /// <summary>
+        /// Settings that apply to view extensions.
+        /// </summary>
+        public List<ViewExtensionSettings> ViewExtensionSettings { get; set; }
+
         #endregion
 
         /// <summary>
@@ -415,6 +420,7 @@ namespace Dynamo.Configuration
             ShowTabsAndSpacesInScriptEditor = false;
             EnableNodeAutoComplete = false;
             DefaultPythonEngine = string.Empty;
+            ViewExtensionSettings = new List<ViewExtensionSettings>();
         }
 
         /// <summary>

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -50,7 +50,7 @@
         /// <summary>
         /// Identifier of the screen where this extension is shown.
         /// </summary>
-        //public string Screen { get; set; }
+        public string Screen { get; set; }
         /// <summary>
         /// Status of the window, i.e. whether it is maximized.
         /// </summary>

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -50,7 +50,7 @@
         /// <summary>
         /// Identifier of the screen where this extension is shown.
         /// </summary>
-        public string Screen { get; set; }
+        //public string Screen { get; set; }
         /// <summary>
         /// Status of the window, i.e. whether it is maximized.
         /// </summary>

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -1,0 +1,90 @@
+﻿namespace Dynamo.Configuration
+{
+    /// <summary>
+    /// Settings that apply to a view extension specifically.
+    /// </summary>
+    public class ViewExtensionSettings
+    {
+        /// <summary>
+        /// Name of the view extension.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// UniqueId of the view extension.
+        /// </summary>
+        public string UniqueId { get; set; }
+        /// <summary>
+        /// Specifies how an extension UI control should be displayed.
+        /// </summary>
+        public ViewExtensionDisplayMode DisplayMode { get; set; }
+        /// <summary>
+        /// Window settings for the extension control when displayed in FloatingWindow mode.
+        /// </summary>
+        public WindowSettings WindowSettings { get; set; }
+    }
+
+    /// <summary>
+    /// Possible display modes for an extension UI control.
+    /// </summary>
+    public enum ViewExtensionDisplayMode
+    {
+        /// <summary>
+        /// Not really a display mode but rather the absence of one.
+        /// </summary>
+        Unspecified,
+        /// <summary>
+        /// Extension control should be displayed docked to the right side.
+        /// </summary>
+        DockRight,
+        /// <summary>
+        /// Extension control should be displayed in a floating window.
+        /// </summary>
+        FloatingWindow
+    }
+
+    /// <summary>
+    /// Settings that define how to display an extension control in floating window mode.
+    /// </summary>
+    public class WindowSettings
+    {
+        /// <summary>
+        /// Identifier of the screen where this extension is shown.
+        /// </summary>
+        public string Screen { get; set; }
+        /// <summary>
+        /// Status of the window, i.e. whether it is maximized.
+        /// </summary>
+        public WindowStatus Status { get; set; }
+        /// <summary>
+        /// Coordinates of the leftmost side of the window.
+        /// </summary>
+        public int Left { get; set; }
+        /// <summary>
+        /// Coordinates of the topmost side of the window.
+        /// </summary>
+        public int Top { get; set; }
+        /// <summary>
+        /// Width of the window.
+        /// </summary>
+        public int Width { get; set; }
+        /// <summary>
+        /// Height of the window.
+        /// </summary>
+        public int Height { get; set; }
+    }
+
+    /// <summary>
+    /// Possible status of a floating window.
+    /// </summary>
+    public enum WindowStatus
+    {
+        /// <summary>
+        /// The window can be moved and resized.
+        /// </summary>
+        Normal,
+        /// <summary>
+        /// The window is maximized.
+        /// </summary>
+        Maximized
+    }
+}

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -48,10 +48,6 @@
     public class WindowSettings
     {
         /// <summary>
-        /// Identifier of the screen where this extension is shown.
-        /// </summary>
-        public string Screen { get; set; }
-        /// <summary>
         /// Status of the window, i.e. whether it is maximized.
         /// </summary>
         public WindowStatus Status { get; set; }

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -48,10 +48,6 @@
     public class WindowSettings
     {
         /// <summary>
-        /// Identifier of the screen where this extension is shown.
-        /// </summary>
-        //public string Screen { get; set; }
-        /// <summary>
         /// Status of the window, i.e. whether it is maximized.
         /// </summary>
         public WindowStatus Status { get; set; }

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -48,6 +48,10 @@
     public class WindowSettings
     {
         /// <summary>
+        /// Identifier of the screen where this extension is shown.
+        /// </summary>
+        //public string Screen { get; set; }
+        /// <summary>
         /// Status of the window, i.e. whether it is maximized.
         /// </summary>
         public WindowStatus Status { get; set; }

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -102,6 +102,7 @@ limitations under the License.
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="Configuration\ExecutionSession.cs" />
+    <Compile Include="Configuration\ViewExtensionSettings.cs" />
     <Compile Include="Core\CrashPromptArgs.cs" />
     <Compile Include="Configuration\DebugSettings.cs" />
     <Compile Include="Configuration\Context.cs" />

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -98,9 +98,9 @@ namespace Dynamo.Wpf.Extensions
         /// <returns></returns>
         public void AddToExtensionsSideBar(IViewExtension viewExtension, ContentControl contentControl)
         {
-            TabItem tabItem  = dynamoView.AddExtensionTabItem(viewExtension, contentControl);
+            bool added  = dynamoView.AddOrFocusExtensionControl(viewExtension, contentControl);
 
-            if (tabItem != null)
+            if (added)
             {
                 dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.ExtensionAdded);
             }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -287,17 +287,13 @@ namespace Dynamo.Controls
                     Width = windowSettings.Width,
                     Height = windowSettings.Height
                 };
-                var wasMaximized = windowSettings.Status == WindowStatus.Maximized;
-                if (wasMaximized)
+                window = new ExtensionWindow(this, ref windowRect);
+                if (windowSettings.Status == WindowStatus.Maximized)
                 {
                     // In case the window was maximized, its width and height will be max. That makes restore pretty
                     // useless so instead we set the size to 0 which means to restore to the default size.
-                    windowRect.Width = 0;
-                    windowRect.Height = 0;
-                }
-                window = new ExtensionWindow(this, ref windowRect);
-                if (wasMaximized)
-                {
+                    //windowRect.Width = 0;
+                    //windowRect.Height = 0;
                     window.WindowState = WindowState.Maximized;
                 }
             }
@@ -338,6 +334,13 @@ namespace Dynamo.Controls
             settings.WindowSettings.Top = (int)window.SavedWindowRect.Top;
             settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
             settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
+            // Find screen currently showing the extension
+            //var screens = System.Windows.Forms.Screen.AllScreens;
+            //var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
+            //if (currentScreen != null)
+            //{
+            //    settings.WindowSettings.Screen = currentScreen.DeviceName;
+            //}
         }
 
         private TabItem AddExtensionTab(IViewExtension viewExtension, ContentControl contentControl)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -290,13 +290,14 @@ namespace Dynamo.Controls
                 window = new ExtensionWindow(this, ref windowRect);
                 if (windowSettings.Status == WindowStatus.Maximized)
                 {
-                    var screen = System.Windows.Forms.Screen.AllScreens.FirstOrDefault(s => s.DeviceName == windowSettings.Screen);
-                    if (screen != null)
-                    {
-                        windowRect.Left = screen.WorkingArea.Left + 10;
-                        windowRect.Top = screen.WorkingArea.Top + 10;
-                    }
-                    window.WindowState = WindowState.Maximized;
+                    //var screen = System.Windows.Forms.Screen.AllScreens.FirstOrDefault(s => s.DeviceName == windowSettings.Screen);
+                    //if (screen != null)
+                    //{
+                    //    windowRect.Left = screen.WorkingArea.Left + 10;
+                    //    windowRect.Top = screen.WorkingArea.Top + 10;
+                    //}
+                    //window.WindowState = WindowState.Maximized;
+                    window.ShouldMaximize = true;
                 }
             }
             
@@ -337,12 +338,12 @@ namespace Dynamo.Controls
             settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
             settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
             // Find screen currently showing the extension
-            var screens = System.Windows.Forms.Screen.AllScreens;
-            var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
-            if (currentScreen != null)
-            {
-                settings.WindowSettings.Screen = currentScreen.DeviceName;
-            }
+            //var screens = System.Windows.Forms.Screen.AllScreens;
+            //var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
+            //if (currentScreen != null)
+            //{
+            //    settings.WindowSettings.Screen = currentScreen.DeviceName;
+            //}
         }
 
         private TabItem AddExtensionTab(IViewExtension viewExtension, ContentControl contentControl)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -290,10 +290,12 @@ namespace Dynamo.Controls
                 window = new ExtensionWindow(this, ref windowRect);
                 if (windowSettings.Status == WindowStatus.Maximized)
                 {
-                    // In case the window was maximized, its width and height will be max. That makes restore pretty
-                    // useless so instead we set the size to 0 which means to restore to the default size.
-                    //windowRect.Width = 0;
-                    //windowRect.Height = 0;
+                    var screen = System.Windows.Forms.Screen.AllScreens.FirstOrDefault(s => s.DeviceName == windowSettings.Screen);
+                    if (screen != null)
+                    {
+                        windowRect.Left = screen.WorkingArea.Left + 10;
+                        windowRect.Top = screen.WorkingArea.Top + 10;
+                    }
                     window.WindowState = WindowState.Maximized;
                 }
             }
@@ -335,12 +337,12 @@ namespace Dynamo.Controls
             settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
             settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
             // Find screen currently showing the extension
-            //var screens = System.Windows.Forms.Screen.AllScreens;
-            //var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
-            //if (currentScreen != null)
-            //{
-            //    settings.WindowSettings.Screen = currentScreen.DeviceName;
-            //}
+            var screens = System.Windows.Forms.Screen.AllScreens;
+            var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
+            if (currentScreen != null)
+            {
+                settings.WindowSettings.Screen = currentScreen.DeviceName;
+            }
         }
 
         private TabItem AddExtensionTab(IViewExtension viewExtension, ContentControl contentControl)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -338,13 +338,6 @@ namespace Dynamo.Controls
             settings.WindowSettings.Top = (int)window.SavedWindowRect.Top;
             settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
             settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
-            // Find screen currently showing the extension
-            var screens = System.Windows.Forms.Screen.AllScreens;
-            var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
-            if (currentScreen != null)
-            {
-                settings.WindowSettings.Screen = currentScreen.DeviceName;
-            }
         }
 
         private TabItem AddExtensionTab(IViewExtension viewExtension, ContentControl contentControl)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -290,13 +290,8 @@ namespace Dynamo.Controls
                 window = new ExtensionWindow(this, ref windowRect);
                 if (windowSettings.Status == WindowStatus.Maximized)
                 {
-                    //var screen = System.Windows.Forms.Screen.AllScreens.FirstOrDefault(s => s.DeviceName == windowSettings.Screen);
-                    //if (screen != null)
-                    //{
-                    //    windowRect.Left = screen.WorkingArea.Left + 10;
-                    //    windowRect.Top = screen.WorkingArea.Top + 10;
-                    //}
-                    //window.WindowState = WindowState.Maximized;
+                    // Rather than setting the WindowState here, this is delayed to the Loaded event.
+                    // This helps overcome a bug which makes the window appear always on the primary screen.
                     window.ShouldMaximize = true;
                 }
             }
@@ -337,13 +332,6 @@ namespace Dynamo.Controls
             settings.WindowSettings.Top = (int)window.SavedWindowRect.Top;
             settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
             settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
-            // Find screen currently showing the extension
-            //var screens = System.Windows.Forms.Screen.AllScreens;
-            //var currentScreen = screens.FirstOrDefault(s => window.Left >= s.WorkingArea.Left && window.Left < s.WorkingArea.Right);
-            //if (currentScreen != null)
-            //{
-            //    settings.WindowSettings.Screen = currentScreen.DeviceName;
-            //}
         }
 
         private TabItem AddExtensionTab(IViewExtension viewExtension, ContentControl contentControl)

--- a/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml
+++ b/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml
@@ -7,6 +7,8 @@
                            xmlns:ui="clr-namespace:Dynamo.UI"
                            mc:Ignorable="d" 
                            d:DesignHeight="450" d:DesignWidth="800"
+                           MinHeight="32"
+                           MinWidth="160"
                            WindowStyle="None"
                            StateChanged="ExtensionWindow_StateChanged"
                            Loaded="ExtensionWindow_Loaded">

--- a/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
@@ -19,6 +19,12 @@ namespace Dynamo.Wpf.Windows
             InitializeComponent();
         }
 
+        public ExtensionWindow(DependencyObject viewParent, ref WindowRect rect)
+            : base(viewParent, ref rect)
+        {
+            InitializeComponent();
+        }
+
         private void OnDockButtonClick(object sender, RoutedEventArgs e)
         {
             DockRequested = true;
@@ -65,6 +71,7 @@ namespace Dynamo.Wpf.Windows
         {
             // This can't be done using markup, so we do it here.
             iconImage.Source = Icon;
+            RefreshMaximizeRestoreButton();
         }
     }
 }

--- a/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
@@ -13,6 +13,10 @@ namespace Dynamo.Wpf.Windows
         /// Note: Setter is internal for testing purposes only.
         /// </summary>
         public bool DockRequested { get; internal set; }
+        /// <summary>
+        /// Indicates if the window should be maximized when it is loaded.
+        /// </summary>
+        public bool ShouldMaximize { get; set; }
 
         public ExtensionWindow()
         {
@@ -71,6 +75,10 @@ namespace Dynamo.Wpf.Windows
         {
             // This can't be done using markup, so we do it here.
             iconImage.Source = Icon;
+            if (ShouldMaximize)
+            {
+                WindowState = WindowState.Maximized;
+            }
             RefreshMaximizeRestoreButton();
         }
     }

--- a/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
@@ -18,11 +18,20 @@ namespace Dynamo.Wpf.Windows
         /// </summary>
         public bool ShouldMaximize { get; set; }
 
+        /// <summary>
+        /// Creates a window with an initially empty window rectangle.
+        /// Note: This constructor assumes Owner is set externally.
+        /// </summary>
         public ExtensionWindow()
         {
             InitializeComponent();
         }
 
+        /// <summary>
+        /// Creates a window with the specified owner and window rectangle.
+        /// </summary>
+        /// <param name="viewParent">A UI object in the Dynamo visual tree.</param>
+        /// <param name="rect">A reference to the Rect object that will store the window's position during this session.</param>
         public ExtensionWindow(DependencyObject viewParent, ref WindowRect rect)
             : base(viewParent, ref rect)
         {
@@ -75,6 +84,7 @@ namespace Dynamo.Wpf.Windows
         {
             // This can't be done using markup, so we do it here.
             iconImage.Source = Icon;
+            // The window is maximized at this point to make sure it appears on the right screen.
             if (ShouldMaximize)
             {
                 WindowState = WindowState.Maximized;

--- a/src/DynamoCoreWpf/Windows/ModelessChildWindow.cs
+++ b/src/DynamoCoreWpf/Windows/ModelessChildWindow.cs
@@ -115,8 +115,11 @@ namespace Dynamo.Wpf.Windows
 
         private void ModelessChildWindow_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            SavedWindowRect.Width = e.NewSize.Width;
-            SavedWindowRect.Height = e.NewSize.Height;
+            if (WindowState != WindowState.Maximized)
+            {
+                SavedWindowRect.Width = e.NewSize.Width;
+                SavedWindowRect.Height = e.NewSize.Height;
+            }
         }
 
         private void ModelessChildWindow_LocationChanged(object sender, EventArgs e)

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -59,6 +59,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.EnableNodeAutoComplete, false);
             Assert.AreEqual(settings.DefaultPythonEngine, string.Empty);
             Assert.AreEqual(settings.MaxNumRecentFiles, PreferenceSettings.DefaultMaxNumRecentFiles);
+            Assert.AreEqual(settings.ViewExtensionSettings.Count, 0);
 
             // Save
             settings.Save(tempPath);
@@ -72,6 +73,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.EnableNodeAutoComplete, false);
             Assert.AreEqual(settings.DefaultPythonEngine, string.Empty);
             Assert.AreEqual(settings.MaxNumRecentFiles, PreferenceSettings.DefaultMaxNumRecentFiles);
+            Assert.AreEqual(settings.ViewExtensionSettings.Count, 0);
 
             // Change setting values
             settings.SetIsBackgroundPreviewActive("MyBackgroundPreview", false);
@@ -81,6 +83,20 @@ namespace Dynamo.Tests.Configuration
             settings.DefaultPythonEngine = "CP3";
             settings.MaxNumRecentFiles = 24;
             settings.EnableNodeAutoComplete = true;
+            settings.ViewExtensionSettings.Add(new ViewExtensionSettings()
+            {
+                Name = "MyExtension",
+                UniqueId = "1234",
+                DisplayMode = ViewExtensionDisplayMode.FloatingWindow,
+                WindowSettings = new WindowSettings()
+                {
+                    Left = 123,
+                    Top = 456,
+                    Height = 321,
+                    Width = 654,
+                    Status = WindowStatus.Maximized
+                }
+            });
 
             // Save
             settings.Save(tempPath);
@@ -94,6 +110,18 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.DefaultPythonEngine, "CP3");
             Assert.AreEqual(settings.MaxNumRecentFiles, 24);
             Assert.AreEqual(settings.EnableNodeAutoComplete, true);
+            Assert.AreEqual(settings.ViewExtensionSettings.Count, 1);
+            var extensionSettings = settings.ViewExtensionSettings[0];
+            Assert.AreEqual(extensionSettings.Name, "MyExtension");
+            Assert.AreEqual(extensionSettings.UniqueId, "1234");
+            Assert.AreEqual(extensionSettings.DisplayMode, ViewExtensionDisplayMode.FloatingWindow);
+            Assert.IsNotNull(extensionSettings.WindowSettings);
+            var windowSettings = extensionSettings.WindowSettings;
+            Assert.AreEqual(windowSettings.Left, 123);
+            Assert.AreEqual(windowSettings.Top, 456);
+            Assert.AreEqual(windowSettings.Height, 321);
+            Assert.AreEqual(windowSettings.Width, 654);
+            Assert.AreEqual(windowSettings.Status, WindowStatus.Maximized);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -210,6 +210,71 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(View.ExtensionsCollapsed);
         }
 
+        [Test]
+        public void ExtensionLocationIsRemembered()
+        {
+            RaiseLoadedEvent(this.View);
+
+            // Add extension
+            View.viewExtensionManager.Add(viewExtension);
+
+            // Extension bar is shown
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+
+            // Undock extension 
+            View.UndockExtension(viewExtension.Name);
+
+            // Extension is no longer in the side bar (now collapsed)
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            // Extension is in a window now
+            Assert.AreEqual(1, View.ExtensionWindows.Count);
+
+            // Close the window without docking
+            var window = View.ExtensionWindows[viewExtension.Name];
+            window.Close();
+
+            // Extension is not in the sidebar nor as a window
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+
+            // Re-open the extension
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
+
+            // Extension is remembered to be opened as a window
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            Assert.AreEqual(1, View.ExtensionWindows.Count);
+
+            // Dock the extension to the sidebar
+            window = View.ExtensionWindows[viewExtension.Name];
+            window.DockRequested = true;
+            window.Close();
+
+            // Extension is in the sidebar now
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+
+            // Close the extension tab in the sidebar
+            View.CloseExtensionControl(viewExtension);
+
+            // Extension is closed
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+
+            // Re-open the extension again
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
+
+            // Extension is remembered to be opened in the sidebar
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+        }
+
         public static void RaiseLoadedEvent(FrameworkElement element)
         {
             MethodInfo eventMethod = typeof(FrameworkElement).GetMethod("OnLoaded",

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -86,7 +86,7 @@ namespace DynamoCoreWpfTests
 
             // Simulate the extension activating the tab content again.
             // The content here should not matter because it won't be used.
-            View.AddExtensionTabItem(viewExtension, new UserControl());
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
 
             // Extension bar is shown
             Assert.IsFalse(View.ExtensionsCollapsed);
@@ -203,7 +203,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, View.ExtensionWindows.Count);
 
             // Attempt to open the extension in the side bar when it's open as a window
-            View.AddExtensionTabItem(viewExtension, new UserControl());
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
 
             // Extension is not added to the sidebar
             Assert.AreEqual(0, View.ExtensionTabItems.Count);


### PR DESCRIPTION
### Purpose

Information of where an extension control was last shown is saved and
retrieved as preference settings. These are actually not directly
visible for the user and are updating automatically, just like the main
Dynamo window size. These settings are used when showing the extension
control, to restore it to how it used to be before closing it.

The available information for each view extension is:

1. How it is shown. For now this can be either as a floating window or
docked to the right-side panel.

2. In case it is shown as a floating window, the following information
about the window is saved:
- Location by Top/Left coordinates
- Size by Width/Height
- Whether the window is maximized

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
