### PR TITLE
Turn off hit testing visibility for render package geometry created for DM manipulator

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1891,7 +1891,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var manipulator = model as DynamoGeometryModel3D;
                     if (null == manipulator)
                     {
-                        manipulator = CreateDynamoGeometryModel3D(rp);
+                        manipulator = CreateDynamoGeometryModel3D(rp, false);
                         AttachedProperties.SetIsSpecialRenderPackage(manipulator, true);
                     }
                     
@@ -1912,7 +1912,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var centerline = model as DynamoLineGeometryModel3D;
                     if (null == centerline)
                     {
-                        centerline = CreateLineGeometryModel3D(rp, 0.3);
+                        centerline = CreateLineGeometryModel3D(rp, 0.3, false);
                         AttachedProperties.SetIsSpecialRenderPackage(centerline, true);
                     }
                     centerline.Geometry = rp.Lines;
@@ -1922,7 +1922,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var plane = model as DynamoLineGeometryModel3D;
                     if (null == plane)
                     {
-                        plane = CreateLineGeometryModel3D(rp, 0.7);
+                        plane = CreateLineGeometryModel3D(rp, 0.7, false);
                         AttachedProperties.SetIsSpecialRenderPackage(plane, true);
                     }
                     plane.Geometry = rp.Lines;
@@ -2029,14 +2029,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                pt + defaultLabelOffset));
         }
 
-        private DynamoGeometryModel3D CreateDynamoGeometryModel3D(HelixRenderPackage rp)
+        private DynamoGeometryModel3D CreateDynamoGeometryModel3D(HelixRenderPackage rp, bool isHitTestVisible = true)
         {
           
             var meshGeometry3D = new DynamoGeometryModel3D()
             {
                 Transform = new MatrixTransform3D(rp.Transform.ToMatrix3D()),
                 Material = WhiteMaterial,
-                IsHitTestVisible = true,
+                IsHitTestVisible = isHitTestVisible,
                 RequiresPerVertexColoration = rp.RequiresPerVertexColoration,
             };
 
@@ -2070,7 +2070,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             return meshGeometry3D;
         }
 
-        private DynamoLineGeometryModel3D CreateLineGeometryModel3D(HelixRenderPackage rp, double thickness = 1.0)
+        private DynamoLineGeometryModel3D CreateLineGeometryModel3D(HelixRenderPackage rp, double thickness = 1.0, 
+            bool isHitTestVisible = true)
         {
             var lineGeometry3D = new DynamoLineGeometryModel3D()
             {
@@ -2078,7 +2079,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 Transform = new MatrixTransform3D(rp.Transform.ToMatrix3D()),
                 Color = Colors.White,
                 Thickness = thickness,
-                IsHitTestVisible = true,
+                IsHitTestVisible = isHitTestVisible,
                 IsSelected = rp.IsSelected
             };
             return lineGeometry3D;


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3219

TL;DR:
Hit testing was turned on for Helix line and mesh geometry during the helix updates that went into release 2.7. This interfered with the custom hit testing logic implemented in the DirectManipulation extension for manipulator geometry. This has therefore been fixed by disabling the hit test visibility specifically for manipulator geometry.

After enabling hit test visibility for mesh and line geometry in Helix, any mouse click events were being handled by `HelixWatch3DViewModel.HandleViewClick`. This method detects if there are any hits on scene geometry with the mouse pointer. If there are, then it finds the corresponding node that created that geometry and selects it. Selection of a `Point.ByCoordinates` node automatically draws a manipulator gizmo at the location of the point it creates.

Previously this method wouldn't return any hits, and therefore not find any nodes. However, after enabling hit-testing, this method began to find hits and tried to match the hit geometry with workspace nodes. This logic was never intended to work with manipulator geometry, and due to the current logic, the matched node returned would always be the first node added to the workspace. In the case where there are two `Point.ByCoordinate` nodes, for example, clicking on the second manipulator would therefore result in the first node being selected instead, which is why the manipulator gizmo would be drawn (appear to jump) on the first node instead of staying with the second.

This has been fixed by simply disabling hit test visibility just for manipulator geometry as hit testing on manipulators is
implemented separately in and specifically for the DirectManipulation view extension (see `NodeManipulator.MouseDown`).

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs

@QilongTang 
