### PR TITLE
DYN-1078 Prevent `-` Button Removing Required Ports

### DIFF
--- a/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
+++ b/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Dynamo.Core;
+using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 
 namespace Dynamo.Graph.Nodes
@@ -173,13 +174,17 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public virtual void RemoveInputFromModel()
         {
-            var count = model.InPorts.Count;
-            if (count > 0)
+            int count = model.InPorts.Count;
+            bool countIsDefaultOrFewer = model is DSVarArgFunction dSVarArgFunction && count <= dSVarArgFunction.DefaultNumInputs;
+            if (count == 0 || countIsDefaultOrFewer)
             {
-                var port = model.InPorts[count - 1];
-                port.DestroyConnectors();
-                model.InPorts.Remove(port);
+                MarkNodeDirty();
+                return;
             }
+
+            var port = model.InPorts[count - 1];
+            port.DestroyConnectors();
+            model.InPorts.Remove(port);
 
             MarkNodeDirty();
         }

--- a/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
+++ b/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
@@ -175,17 +175,13 @@ namespace Dynamo.Graph.Nodes
         public virtual void RemoveInputFromModel()
         {
             int count = model.InPorts.Count;
-            bool countIsDefaultOrFewer = model is DSVarArgFunction dSVarArgFunction && count <= dSVarArgFunction.DefaultNumInputs;
-            if (count == 0 || countIsDefaultOrFewer)
+            bool countIsGreaterThanDefault = model is DSVarArgFunction dSVarArgFunction && count > dSVarArgFunction.DefaultNumInputs;
+            if (count != 0 && countIsGreaterThanDefault)
             {
-                MarkNodeDirty();
-                return;
+                var port = model.InPorts[count - 1];
+                port.DestroyConnectors();
+                model.InPorts.Remove(port);
             }
-
-            var port = model.InPorts[count - 1];
-            port.DestroyConnectors();
-            model.InPorts.Remove(port);
-
             MarkNodeDirty();
         }
 

--- a/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
+++ b/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
@@ -175,7 +175,9 @@ namespace Dynamo.Graph.Nodes
         public virtual void RemoveInputFromModel()
         {
             int count = model.InPorts.Count;
-            bool countIsGreaterThanDefault = model is DSVarArgFunction dSVarArgFunction && count > dSVarArgFunction.DefaultNumInputs;
+            // Do not remove input port if there aren't any
+            // or if the node is a DSVarArgFunction and doing so would remove a default port
+            bool countIsGreaterThanDefault = !(model is DSVarArgFunction dSVarArgFunction) || count > dSVarArgFunction.DefaultNumInputs;
             if (count != 0 && countIsGreaterThanDefault)
             {
                 var port = model.InPorts[count - 1];

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -1136,5 +1136,28 @@ namespace Dynamo.Tests
             Assert.AreEqual(1, this.CurrentDynamoModel.CurrentWorkspace.Annotations.Count());
             Assert.AreEqual(1, this.CurrentDynamoModel.CurrentWorkspace.Notes.Count());
         }
+
+        [Test]
+        public void CannotRemoveDefaultDSVarArgFunctionPorts()
+        {
+            // Arrange
+            string openPath = Path.Combine(TestDirectory, @"core\dsfunction\StringSplit.dyn");
+            OpenModel(openPath);
+            var nodeGuid = Guid.Parse("c969eca6005a4273aee4ed8ddd73f3ab");
+            var node = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSVarArgFunction>(nodeGuid);
+            int portCountBefore = node.InPorts.Count;
+
+            // Act
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.ModelEventCommand(nodeGuid, "AddInPort", 1));
+            int portCountAfterAdd = node.InPorts.Count;
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.ModelEventCommand(nodeGuid, "RemoveInPort", 1));
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.ModelEventCommand(nodeGuid, "RemoveInPort", 1));
+            int portCountAfterRemove = node.InPorts.Count;
+
+            // Assert
+            Assert.AreEqual(2, portCountBefore);
+            Assert.AreEqual(3, portCountAfterAdd);
+            Assert.AreEqual(2, portCountAfterRemove);
+        }
     }
 }

--- a/test/core/dsfunction/StringSplit.dyn
+++ b/test/core/dsfunction/StringSplit.dyn
@@ -1,0 +1,95 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "StringSplit",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction, DynamoCore",
+      "FunctionSignature": "DSCore.String.Split@string,string[]",
+      "FunctionType": "VariableArgument",
+      "NodeType": "FunctionNode",
+      "Id": "c969eca6005a4273aee4ed8ddd73f3ab",
+      "Inputs": [
+        {
+          "Id": "62d1f2df984d4e9582ced830f4dfffef",
+          "Name": "str",
+          "Description": "String to split up.\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "69a292c7fe2c49218e65f42a46f69d2f",
+          "Name": "separator0",
+          "Description": "Strings that, if present, determine the end and start of a split.\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4e3f4bb242a242ac988282c170cb6da7",
+          "Name": "strings",
+          "Description": "List of strings made from the input string.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Divides a single string into a list of strings, with divisions determined by the given separator strings.\n\nString.Split (str: string, separators: string[]): string[]"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.7.0.9206",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "String.Split",
+        "Id": "c969eca6005a4273aee4ed8ddd73f3ab",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 210.40000000000003,
+        "Y": 217.6
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

JIRA: [DYN-1078]( https://jira.autodesk.com/browse/DYN-1078)

Issue: https://github.com/DynamoDS/Dynamo/issues/8741

Prevent the user from being able to remove default ports using the `-` button on `DSVarArgFunction` nodes

Behaviour before:

![DYN-1078-Remove-Default-Inputs-Before-v2](https://user-images.githubusercontent.com/193290/98712937-dae19380-237e-11eb-90f2-2506422b04e4.gif)


Behaviour after:

![DYN-1078-Remove-Default-Inputs-Completed](https://user-images.githubusercontent.com/193290/98711472-ef249100-237c-11eb-850f-f86e702c829a.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @ QilongTang @mmisol

### FYIs

@Amoursol