### PR TITLE
DYN-1723 Multi-line String Syntax Highlighting

### DIFF
--- a/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
+++ b/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
@@ -34,7 +34,7 @@
         <Begin>/*</Begin>
         <End>*/</End>
       </Span>
-      <Span name="String" stopateol="true" color="#885D3B" escapecharacter="\">
+      <Span name="String" stopateol="false" color="#885D3B" escapecharacter="\">
         <Begin>"</Begin>
         <End>"</End>
       </Span>


### PR DESCRIPTION
### Purpose

JIRA: [DYN-1723](https://jira.autodesk.com/browse/DYN-1723)

Apply syntax highlighting to multi-line strings.

Behaviour before:
![image](https://user-images.githubusercontent.com/193290/98841581-39bb1180-2440-11eb-83b6-5930be341e00.png)

Behaviour after:
![image](https://user-images.githubusercontent.com/193290/98841713-6c650a00-2440-11eb-8d8e-0c699a218e30.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang @mmisol

### FYIs

@Amoursol
