### PR TITLE
DYN-2381 Exclude code block nodes from SetArgumentLacing

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1126,8 +1126,10 @@ namespace Dynamo.ViewModels
 
         private void SetArgumentLacing(object parameter)
         {
-            var modelGuids = DynamoSelection.Instance.Selection.
-                OfType<NodeModel>().Select(n => n.GUID);
+            var modelGuids = DynamoSelection.Instance.Selection
+                .OfType<NodeModel>()
+                .Where(n => !(n is CodeBlockNodeModel))
+                .Select(n => n.GUID);
 
             if (!modelGuids.Any())
                 return;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1128,7 +1128,7 @@ namespace Dynamo.ViewModels
         {
             var modelGuids = DynamoSelection.Instance.Selection
                 .OfType<NodeModel>()
-                .Where(n => !(n is CodeBlockNodeModel))
+                .Where(n => n.ArgumentLacing != LacingStrategy.Disabled)
                 .Select(n => n.GUID);
 
             if (!modelGuids.Any())

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -113,7 +113,64 @@ namespace Dynamo.Tests
             AssertPreviewCount(nodeIds[1].ToString(), 2);
             AssertPreviewCount(nodeIds[2].ToString(), 2);
         }
+        
+        [Test]
+        public void VerifyLacingStrategyForCodeBlockNodes()
+        {
+            var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyCodeBlockNodes.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
 
+            var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+            workspace.RunSettings.RunType = RunType.Automatic;
+
+            Guid codeBlockNodeId = Guid.Parse("5a35517215434699afe122bc51aeff7d");
+            Guid otherNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
+            var codeBlockNode = workspace.NodeFromWorkspace(codeBlockNodeId);
+            var otherNode = workspace.NodeFromWorkspace(otherNodeId);
+
+            // Verify initial lacing state is Auto and nodes return correct number of results
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 2);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
+
+            // Modify lacing strategy to Longest
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Longest, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 10);
+
+            // Modify lacing strategy to Auto
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 2);
+
+            // Modify lacing strategy to CrossProduct
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.CrossProduct, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 10);
+
+            // Change lacing back to Shortest
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Shortest, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 2);
+        }
+        
         [Test]
         public void AreGlobalLacingStrategiesInMenu()
         {

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -115,60 +115,58 @@ namespace Dynamo.Tests
         }
         
         [Test]
-        public void VerifyLacingStrategyForCodeBlockNodes()
+        public void VerifyLacingStrategyCantBeChangedOnCodeBlocks()
         {
+            // Arrange
             var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyCodeBlockNodes.dyn");
             ViewModel.OpenCommand.Execute(openPath);
-
             var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
-            workspace.RunSettings.RunType = RunType.Automatic;
-
             Guid codeBlockNodeId = Guid.Parse("5a35517215434699afe122bc51aeff7d");
-            Guid otherNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
+            Guid typicalNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
             var codeBlockNode = workspace.NodeFromWorkspace(codeBlockNodeId);
-            var otherNode = workspace.NodeFromWorkspace(otherNodeId);
+            var typicalNode = workspace.NodeFromWorkspace(typicalNodeId);
 
             // Verify initial lacing state is Auto and nodes return correct number of results
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 2);
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
+            var codeBlockNodeLacingStart = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingStart = typicalNode.ArgumentLacing;
+
+            // Act
 
             // Modify lacing strategy to Longest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
-
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Longest, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 10);
+            var codeBlockNodeLacingLongest = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingLongest = typicalNode.ArgumentLacing;
 
             // Modify lacing strategy to Auto
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
-
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 2);
+            var codeBlockNodeLacingAuto = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingAuto = typicalNode.ArgumentLacing;
 
             // Modify lacing strategy to CrossProduct
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
-
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.CrossProduct, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 10);
+            var codeBlockNodeLacingCross = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingCross = typicalNode.ArgumentLacing;
 
             // Change lacing back to Shortest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
+            var codeBlockNodeLacingShortest = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingShortest = typicalNode.ArgumentLacing;
 
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Shortest, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 2);
+            // Assert
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingStart);
+            Assert.AreEqual(LacingStrategy.Auto, typicalNodeLacingStart);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingLongest);
+            Assert.AreEqual(LacingStrategy.Longest, typicalNodeLacingLongest);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingAuto);
+            Assert.AreEqual(LacingStrategy.Auto, typicalNodeLacingAuto);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingCross);
+            Assert.AreEqual(LacingStrategy.CrossProduct, typicalNodeLacingCross);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingShortest);
+            Assert.AreEqual(LacingStrategy.Shortest, typicalNodeLacingShortest);
         }
         
         [Test]

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -115,19 +115,22 @@ namespace Dynamo.Tests
         }
         
         [Test]
-        public void VerifyLacingStrategyCantBeChangedOnCodeBlocks()
+        public void VerifyLacingStrategyDisabledCantBeChanged()
         {
             // Arrange
-            var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyCodeBlockNodes.dyn");
+            var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyDisabled.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
             Guid codeBlockNodeId = Guid.Parse("5a35517215434699afe122bc51aeff7d");
+            Guid pythonNodeId = Guid.Parse("cd679ac2203f42c18b30e44bb6c5238e");
             Guid typicalNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
             var codeBlockNode = workspace.NodeFromWorkspace(codeBlockNodeId);
+            var pythonNode = workspace.NodeFromWorkspace(pythonNodeId);
             var typicalNode = workspace.NodeFromWorkspace(typicalNodeId);
 
-            // Verify initial lacing state is Auto and nodes return correct number of results
+            // Verify initial lacing state is Auto
             var codeBlockNodeLacingStart = codeBlockNode.ArgumentLacing;
+            var pythonNodeLacingStart = pythonNode.ArgumentLacing;
             var typicalNodeLacingStart = typicalNode.ArgumentLacing;
 
             // Act
@@ -136,36 +139,45 @@ namespace Dynamo.Tests
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
             var codeBlockNodeLacingLongest = codeBlockNode.ArgumentLacing;
+            var pythonNodeLacingLongest = pythonNode.ArgumentLacing;
             var typicalNodeLacingLongest = typicalNode.ArgumentLacing;
 
             // Modify lacing strategy to Auto
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
             var codeBlockNodeLacingAuto = codeBlockNode.ArgumentLacing;
+            var pythonNodeLacingAuto = pythonNode.ArgumentLacing;
             var typicalNodeLacingAuto = typicalNode.ArgumentLacing;
 
             // Modify lacing strategy to CrossProduct
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
             var codeBlockNodeLacingCross = codeBlockNode.ArgumentLacing;
+            var pythonNodeLacingCross = pythonNode.ArgumentLacing;
             var typicalNodeLacingCross = typicalNode.ArgumentLacing;
 
             // Change lacing back to Shortest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
             var codeBlockNodeLacingShortest = codeBlockNode.ArgumentLacing;
+            var pythonNodeLacingShortest = pythonNode.ArgumentLacing;
             var typicalNodeLacingShortest = typicalNode.ArgumentLacing;
 
             // Assert
             Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingStart);
+            Assert.AreEqual(LacingStrategy.Disabled, pythonNodeLacingStart);
             Assert.AreEqual(LacingStrategy.Auto, typicalNodeLacingStart);
             Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingLongest);
+            Assert.AreEqual(LacingStrategy.Disabled, pythonNodeLacingLongest);
             Assert.AreEqual(LacingStrategy.Longest, typicalNodeLacingLongest);
             Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingAuto);
+            Assert.AreEqual(LacingStrategy.Disabled, pythonNodeLacingAuto);
             Assert.AreEqual(LacingStrategy.Auto, typicalNodeLacingAuto);
             Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingCross);
+            Assert.AreEqual(LacingStrategy.Disabled, pythonNodeLacingCross);
             Assert.AreEqual(LacingStrategy.CrossProduct, typicalNodeLacingCross);
             Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingShortest);
+            Assert.AreEqual(LacingStrategy.Disabled, pythonNodeLacingShortest);
             Assert.AreEqual(LacingStrategy.Shortest, typicalNodeLacingShortest);
         }
         

--- a/test/core/visualization/LacingStrategyCodeBlockNodes.dyn
+++ b/test/core/visualization/LacingStrategyCodeBlockNodes.dyn
@@ -1,0 +1,224 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "DYN-2381 CBN Lacing Multiplication",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..2;",
+      "Id": "a96c9d6d6f494c34a6f8321ba7701caf",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4e373052d56644dc93483c5a4138cdbb",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..10;",
+      "Id": "23c514fbf53c456882fcc34b2641b2ef",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d5d76f7e2f5946ed922f32b38298252a",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "*@var[]..[],var[]..[]",
+      "Id": "ab8afb7c1dfe4dd0994662f3306fc530",
+      "Inputs": [
+        {
+          "Id": "4cc2d7cc1a4944a6aa1aef91cdefaa2d",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a2e85ae1e0df4ea6be73aa31b753a30a",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b299d917224744e380837fe6a584e389",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Multiplies x by y.\n\n* (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "x*y;",
+      "Id": "5a35517215434699afe122bc51aeff7d",
+      "Inputs": [
+        {
+          "Id": "b15891aff6d44d0182145ccbace97e4b",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c926eafa523143eba0a5b186828cdc0f",
+          "Name": "y",
+          "Description": "y",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8547b6f7c4144781bc91c5c95bb90be2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4e373052d56644dc93483c5a4138cdbb",
+      "End": "a2e85ae1e0df4ea6be73aa31b753a30a",
+      "Id": "8f470ec93f294f7fa4b67d8f7609f5e0"
+    },
+    {
+      "Start": "4e373052d56644dc93483c5a4138cdbb",
+      "End": "c926eafa523143eba0a5b186828cdc0f",
+      "Id": "f1f8c13bcb9b456cbf1b39fa466f7945"
+    },
+    {
+      "Start": "d5d76f7e2f5946ed922f32b38298252a",
+      "End": "4cc2d7cc1a4944a6aa1aef91cdefaa2d",
+      "Id": "27ab27ccd35a48bea33178bab8bdd808"
+    },
+    {
+      "Start": "d5d76f7e2f5946ed922f32b38298252a",
+      "End": "b15891aff6d44d0182145ccbace97e4b",
+      "Id": "1bb9252b158e44aebdb9ef3450687922"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.8.0.2471",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "a96c9d6d6f494c34a6f8321ba7701caf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 387.4,
+        "Y": 483.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "23c514fbf53c456882fcc34b2641b2ef",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 383.8,
+        "Y": 329.59999999999991
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "*",
+        "Id": "ab8afb7c1dfe4dd0994662f3306fc530",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 665.6,
+        "Y": 276.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "5a35517215434699afe122bc51aeff7d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 699.0,
+        "Y": 513.2
+      }
+    ],
+    "Annotations": [],
+    "X": -9.6000000000001364,
+    "Y": 2.3999999999999773,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/visualization/LacingStrategyDisabled.dyn
+++ b/test/core/visualization/LacingStrategyDisabled.dyn
@@ -2,7 +2,7 @@
   "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
   "IsCustomNode": false,
   "Description": "",
-  "Name": "DYN-2381 CBN Lacing Multiplication",
+  "Name": "LacingStrategyDisabled",
   "ElementResolver": {
     "ResolutionMap": {}
   },
@@ -126,6 +126,38 @@
       ],
       "Replication": "Disabled",
       "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\nclr.AddReference('ProtoGeometry')\r\nfrom Autodesk.DesignScript.Geometry import *\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = 0",
+      "Engine": "CPython3",
+      "VariableInputPorts": true,
+      "Id": "cd679ac2203f42c18b30e44bb6c5238e",
+      "Inputs": [
+        {
+          "Id": "dfdfb4ccd98144ce9c2fe4e0df0e7b5b",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "71f838eee0e44ddcbedaf5623e447614",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded Python script."
     }
   ],
   "Connectors": [
@@ -138,6 +170,11 @@
       "Start": "4e373052d56644dc93483c5a4138cdbb",
       "End": "c926eafa523143eba0a5b186828cdc0f",
       "Id": "f1f8c13bcb9b456cbf1b39fa466f7945"
+    },
+    {
+      "Start": "4e373052d56644dc93483c5a4138cdbb",
+      "End": "dfdfb4ccd98144ce9c2fe4e0df0e7b5b",
+      "Id": "70a4225c53e94be0a0eaa875206bc740"
     },
     {
       "Start": "d5d76f7e2f5946ed922f32b38298252a",
@@ -158,7 +195,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.8.0.2471",
+      "Version": "2.10.0.3355",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -214,6 +251,16 @@
         "Excluded": false,
         "X": 699.0,
         "Y": 513.2
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "cd679ac2203f42c18b30e44bb6c5238e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 696.00000000000023,
+        "Y": 667.19999999999993
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

JIRA: [DYN-2381](https://jira.autodesk.com/browse/DYN-2381)

Exclude Code Block Nodes when setting the lacing by selecting multiple nodes and right clicking on the canvas.

The previous behaviour did nothing but causes some visual anomalies and can be confusing to a user.

Previous Behaviour:

![DYN-2381-CBN-Lacing-Before](https://user-images.githubusercontent.com/193290/98557593-50286800-229c-11eb-8747-795ef350bdd9.gif)

Revised Behaviour

![DYN-2381-CBN-Lacing-Complete](https://user-images.githubusercontent.com/193290/98557603-53235880-229c-11eb-916d-7aea90942072.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang @mmisol

### FYIs

@Amoursol 
