### PR TITLE
Fix custom node dialog size

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-        Title="{x:Static p:Resources.CustomNodePropertyWindowTitle}" Height="410" Width="400" WindowStartupLocation="CenterOwner"
+        Title="{x:Static p:Resources.CustomNodePropertyWindowTitle}" Height="440" Width="400" WindowStartupLocation="CenterOwner"
         Style="{DynamicResource DynamoWindowStyle}">
 
     <Window.Resources>
@@ -39,7 +39,7 @@
                     <TextBlock Text="{x:Static p:Resources.CustomNodePromptDescriptionTooltip}" />
                 </Label.ToolTip>
             </Label>
-            <TextBox Style="{DynamicResource SDarkTextBox}" MaxHeight="64" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" 
+            <TextBox Style="{DynamicResource SDarkTextBox}" Height="64" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" 
                      Name="DescriptionInput" Padding="5" MinLines="3" TextWrapping="Wrap" AcceptsReturn="True" Tag="{x:Static p:Resources.CustomNodePropertyWindowDescriptionHint}"/>
 
             <Label Content="{x:Static p:Resources.CustomNodePropertyWindowCategory}" Foreground="DarkGray" Height="28" HorizontalAlignment="Stretch" Name="label2"  />


### PR DESCRIPTION
### Purpose

Fixes the size of the custom node dialog so that buttons are not cut
outside of its boundaries when using a multi-line description.

Screenshot:
<img width="488" alt="Screen Shot 2020-12-01 at 9 17 20 AM" src="https://user-images.githubusercontent.com/10048120/100752245-5cdd3f00-33b6-11eb-9909-e99789bfc37b.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

