### PR TITLE
Cherry-pick: Updated sort order of node auto complete suggestions (#11303)

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -60,8 +60,25 @@ namespace Dynamo.ViewModels
             // If node match searchElements found, use default suggestions
             if (!searchElementsCache.Any())
             {
-                searchElementsCache =  DefaultResults.Select(e => e.Model).ToList();
-                FilteredResults = DefaultResults;
+                searchElementsCache = DefaultResults.Select(e => e.Model).ToList();
+                switch (PortViewModel.PortModel.GetInputPortType())
+                {
+                    case "int":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
+                        break;
+                    case "double":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
+                        break;
+                    case "string":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "String").ToList();
+                        break;
+                    case "bool":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "Boolean").ToList();
+                        break;
+                    default:
+                        FilteredResults = DefaultResults;
+                        break;
+                }
             }
             else
             {

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -189,8 +189,8 @@ namespace Dynamo.ViewModels
             //first sort by type distance to input port type
             elements.Sort(comparer);
             //then sort by node library group (create, action, or query node)
-            //this results in a list of elements with 3 major groups(create,action,query), each group is sub sorted into types.
-            return elements.OrderBy(x => x.Group);
+            //this results in a list of elements with 3 major groups(create,action,query), each group is sub sorted into types and then sorted by name.
+            return elements.OrderBy(x => x.Group).ThenBy(x => x.Name);
 
            
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -190,9 +190,7 @@ namespace Dynamo.ViewModels
             elements.Sort(comparer);
             //then sort by node library group (create, action, or query node)
             //this results in a list of elements with 3 major groups(create,action,query), each group is sub sorted into types and then sorted by name.
-            return elements.OrderBy(x => x.Group).ThenBy(x => x.Name);
-
-           
+            return elements.OrderBy(x => x.Group).ThenBy(x => x.OutputParameters.FirstOrDefault().ToString()).ThenBy(x => x.Name);           
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -315,8 +315,8 @@ namespace DynamoCoreWpfTests
 
             // The initial list will fill the FilteredResults with a list of default options
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(5, searchViewModel.FilteredResults.Count());
-            Assert.AreEqual("String", searchViewModel.FilteredResults.FirstOrDefault().Name);
+            Assert.AreEqual(2, searchViewModel.FilteredResults.Count());
+            Assert.AreEqual("Number Slider", searchViewModel.FilteredResults.FirstOrDefault().Name);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -38,6 +38,7 @@ namespace DynamoCoreWpfTests
             libraries.Add("BuiltIn.ds");
             libraries.Add("FFITarget.dll");
             libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DSCoreNodes.dll");
         }
 
         public override void Open(string path)
@@ -130,10 +131,7 @@ namespace DynamoCoreWpfTests
                 "FFITarget.FFITarget.ClassFunctionality.ClassFunctionality",
                 "FFITarget.FFITarget.ClassFunctionality.Instance" };
             var expectedNodes = nodes.OrderBy(s => s);
-            for (int i = 0; i < 4; i++)
-            {
-                Assert.AreEqual(expectedNodes.ElementAt(i), suggestedNodes.ElementAt(i));
-            }
+            Assert.IsTrue(expectedNodes.SequenceEqual(suggestedNodes));
         }
 
         [Test]
@@ -152,7 +150,6 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(SearchElementGroup.Create, suggestions.FirstOrDefault().Group);
             Assert.AreEqual(SearchElementGroup.Action, suggestions.ElementAt(suggestions.Count()/2).Group);
             Assert.AreEqual(SearchElementGroup.Query, suggestions.LastOrDefault().Group);
-
         }
 
         [Test]
@@ -239,7 +236,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void NodeSuggestions_DefaultSuggestions()
+        public void NodeSuggestionsAreSortedBasedOnGroupAndAlphabetically()
         {
             Open(@"UI\builtin_inputport_suggestion.dyn");
 
@@ -251,6 +248,38 @@ namespace DynamoCoreWpfTests
             var port = inPorts[0].PortModel;
             var type = port.GetInputPortType();
             Assert.AreEqual("DSCore.Color[]", type);
+
+            var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
+            searchViewModel.PortViewModel = inPorts[0];
+
+            var suggestions = searchViewModel.GetMatchingSearchElements();
+            Assert.AreEqual(6, suggestions.Count());
+
+            var suggestedNodes = suggestions.Select(s => s.FullName);
+            var expectedNodes = new[] { "DSCoreNodes.DSCore.Color.Add",
+                "DSCoreNodes.DSCore.Color.ByARGB",
+                "DSCoreNodes.DSCore.Color.Divide",
+                "DSCoreNodes.DSCore.Color.Multiply",
+                "DSCoreNodes.DSCore.ColorRange.GetColorAtParameter",
+                "DSCoreNodes.DSCore.IO.Image.Pixels"};
+
+            Assert.IsTrue(expectedNodes.SequenceEqual(suggestedNodes));
+            
+        }
+
+        [Test]
+        public void NodeSuggestions_DefaultSuggestions()
+        {
+            Open(@"UI\builtin_inputport_suggestion.dyn");
+
+            // Get the node view for a specific node in the graph
+            NodeView nodeView = NodeViewWithGuid(Guid.Parse("b6cb6ceb21df4c7fb6b186e6ff399afc").ToString());
+
+            var inPorts = nodeView.ViewModel.InPorts;
+            Assert.AreEqual(2, inPorts.Count());
+            var port = inPorts[0].PortModel;
+            var type = port.GetInputPortType();
+            Assert.AreEqual("var[]..[]", type);
 
             var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
             searchViewModel.PortViewModel = inPorts[0];
@@ -282,13 +311,11 @@ namespace DynamoCoreWpfTests
             var searchViewModel = (ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel as NodeAutoCompleteSearchViewModel);
             searchViewModel.PortViewModel = inPorts[0];
 
-            var suggestions = searchViewModel.GetMatchingSearchElements();
-
             // Get the matching node elements for the specific node port.
             searchViewModel.PopulateAutoCompleteCandidates();
 
             // Filter the node elements using the search field.
-            searchViewModel.SearchAutoCompleteCandidates("der");
+            searchViewModel.SearchAutoCompleteCandidates("ar");
             Assert.AreEqual(2 , searchViewModel.FilteredResults.Count());
         }
 


### PR DESCRIPTION
Purpose
Updated sort order of the suggestions to first sort by groups, followed by output parameters and finally by name.

Reviewers
@DynamoDS/dynamo