### PR TITLE
CP: Save/Load view extension size and location

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -370,6 +370,11 @@ namespace Dynamo.Configuration
         [XmlIgnore]
         public bool NamespacesToExcludeFromLibrarySpecified { get; set; }
 
+        /// <summary>
+        /// Settings that apply to view extensions.
+        /// </summary>
+        public List<ViewExtensionSettings> ViewExtensionSettings { get; set; }
+
         #endregion
 
         /// <summary>
@@ -415,6 +420,7 @@ namespace Dynamo.Configuration
             ShowTabsAndSpacesInScriptEditor = false;
             EnableNodeAutoComplete = false;
             DefaultPythonEngine = string.Empty;
+            ViewExtensionSettings = new List<ViewExtensionSettings>();
         }
 
         /// <summary>

--- a/src/DynamoCore/Configuration/ViewExtensionSettings.cs
+++ b/src/DynamoCore/Configuration/ViewExtensionSettings.cs
@@ -1,0 +1,86 @@
+﻿namespace Dynamo.Configuration
+{
+    /// <summary>
+    /// Settings that apply to a view extension specifically.
+    /// </summary>
+    public class ViewExtensionSettings
+    {
+        /// <summary>
+        /// Name of the view extension.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// UniqueId of the view extension.
+        /// </summary>
+        public string UniqueId { get; set; }
+        /// <summary>
+        /// Specifies how an extension UI control should be displayed.
+        /// </summary>
+        public ViewExtensionDisplayMode DisplayMode { get; set; }
+        /// <summary>
+        /// Window settings for the extension control when displayed in FloatingWindow mode.
+        /// </summary>
+        public WindowSettings WindowSettings { get; set; }
+    }
+
+    /// <summary>
+    /// Possible display modes for an extension UI control.
+    /// </summary>
+    public enum ViewExtensionDisplayMode
+    {
+        /// <summary>
+        /// Not really a display mode but rather the absence of one.
+        /// </summary>
+        Unspecified,
+        /// <summary>
+        /// Extension control should be displayed docked to the right side.
+        /// </summary>
+        DockRight,
+        /// <summary>
+        /// Extension control should be displayed in a floating window.
+        /// </summary>
+        FloatingWindow
+    }
+
+    /// <summary>
+    /// Settings that define how to display an extension control in floating window mode.
+    /// </summary>
+    public class WindowSettings
+    {
+        /// <summary>
+        /// Status of the window, i.e. whether it is maximized.
+        /// </summary>
+        public WindowStatus Status { get; set; }
+        /// <summary>
+        /// Coordinates of the leftmost side of the window.
+        /// </summary>
+        public int Left { get; set; }
+        /// <summary>
+        /// Coordinates of the topmost side of the window.
+        /// </summary>
+        public int Top { get; set; }
+        /// <summary>
+        /// Width of the window.
+        /// </summary>
+        public int Width { get; set; }
+        /// <summary>
+        /// Height of the window.
+        /// </summary>
+        public int Height { get; set; }
+    }
+
+    /// <summary>
+    /// Possible status of a floating window.
+    /// </summary>
+    public enum WindowStatus
+    {
+        /// <summary>
+        /// The window can be moved and resized.
+        /// </summary>
+        Normal,
+        /// <summary>
+        /// The window is maximized.
+        /// </summary>
+        Maximized
+    }
+}

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -102,6 +102,7 @@ limitations under the License.
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="Configuration\ExecutionSession.cs" />
+    <Compile Include="Configuration\ViewExtensionSettings.cs" />
     <Compile Include="Core\CrashPromptArgs.cs" />
     <Compile Include="Configuration\DebugSettings.cs" />
     <Compile Include="Configuration\Context.cs" />

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -98,9 +98,9 @@ namespace Dynamo.Wpf.Extensions
         /// <returns></returns>
         public void AddToExtensionsSideBar(IViewExtension viewExtension, ContentControl contentControl)
         {
-            TabItem tabItem  = dynamoView.AddExtensionTabItem(viewExtension, contentControl);
+            bool added  = dynamoView.AddOrFocusExtensionControl(viewExtension, contentControl);
 
-            if (tabItem != null)
+            if (added)
             {
                 dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.ExtensionAdded);
             }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -212,71 +212,165 @@ namespace Dynamo.Controls
         }
 
         /// <summary>
-        /// Adds a tab item to the extension bar and sets the extension window/control as the tab
-        /// content. It also makes sure the extension is visible.
+        /// Adds an extension control or if it already exists it makes sure it is focused.
+        /// The control may be added as a window or a tab in the extension bar depending on settings.
         /// </summary>
         /// <param name="viewExtension">View extension adding the content</param>
-        /// <param name="contentControl">Control being added to the extension bar</param>
-        /// <returns>The tab item if it was added, otherwise null</returns>
-        internal TabItem AddExtensionTabItem(IViewExtension viewExtension, ContentControl contentControl)
+        /// <param name="contentControl">Control being added</param>
+        /// <returns>True if the control was added, false if it already existed</returns>
+        internal bool AddOrFocusExtensionControl(IViewExtension viewExtension, ContentControl contentControl)
         {
-            // If the extension is showing as a window, shift focus there.
-            if (ExtensionWindows.ContainsKey(viewExtension.Name))
-            {
-                var window = ExtensionWindows[viewExtension.Name];
-                window.Focus();
-                return null;
-            }
-
+            var window = ExtensionWindows.ContainsKey(viewExtension.Name) ? ExtensionWindows[viewExtension.Name] : null;
             var tab = FindExtensionTab(viewExtension);
-            if (tab == null)
+            var addExtensionControl = window == null && tab == null;
+
+            if (addExtensionControl)
             {
-                tabDynamic.DataContext = null;
-
-                // creates a new tab item
-                tab = new TabItem();
-                tab.Header = viewExtension.Name;
-                tab.Tag = viewExtension;
-                tab.Uid = viewExtension.UniqueId;
-                tab.HeaderTemplate = tabDynamic.FindResource("TabHeader") as DataTemplate;
-
-                // setting the extension UI to the current tab content 
-                // based on whether it is a UserControl element or window element. 
-                if (contentControl is UserControl)
+                var settings = this.dynamoViewModel.PreferenceSettings.ViewExtensionSettings.Find(s => s.UniqueId == viewExtension.UniqueId);
+                // Create default settings if they do not currently exist
+                if (settings == null)
                 {
-                    tab.Content = contentControl;
+                    settings = new ViewExtensionSettings()
+                    {
+                        Name = viewExtension.Name,
+                        UniqueId = viewExtension.UniqueId,
+                        DisplayMode = ViewExtensionDisplayMode.DockRight
+                    };
+                    this.dynamoViewModel.PreferenceSettings.ViewExtensionSettings.Add(settings);
+                }
+
+                if (settings.DisplayMode == ViewExtensionDisplayMode.FloatingWindow)
+                {
+                    window = AddExtensionWindow(viewExtension, contentControl, settings.WindowSettings);
                 }
                 else
                 {
-                    if (contentControl != null)
-                    {
-                        tab.Content = contentControl.Content;
-                    }
-                    var extensionWindow = contentControl as Window;
-                    if (extensionWindow != null)
-                    {
-                        // Make sure the extension window closes with Dynamo
-                        extensionWindow.Owner = this;
-                    }
+                    tab = AddExtensionTab(viewExtension, contentControl);
                 }
-
-                //Insert the tab at the end
-                ExtensionTabItems.Insert(ExtensionTabItems.Count, tab);
-
-                tabDynamic.DataContext = ExtensionTabItems;
-                tabDynamic.SelectedItem = tab;
-
-                return tab;
             }
-
-            // Make sure the extension bar is visible
-            if (ExtensionsCollapsed)
+            else
             {
-                ToggleExtensionBarCollapseStatus();
+                // Set focus on the existing control
+                if (window != null)
+                {
+                    window.Focus();
+                }
+                else if (tab != null)
+                {
+                    // Make sure the extension bar is visible
+                    if (ExtensionsCollapsed)
+                    {
+                        ToggleExtensionBarCollapseStatus();
+                    }
+
+                    tabDynamic.SelectedItem = tab;
+                }
             }
 
+            return addExtensionControl;
+        }
+
+        private ExtensionWindow AddExtensionWindow(IViewExtension viewExtension, ContentControl contentControl, WindowSettings windowSettings)
+        {
+            ExtensionWindow window;
+            if (windowSettings == null)
+            {
+                window = new ExtensionWindow();
+                window.Owner = this;
+            }
+            else
+            {
+                var windowRect = new ModelessChildWindow.WindowRect()
+                {
+                    Left = windowSettings.Left,
+                    Top = windowSettings.Top,
+                    Width = windowSettings.Width,
+                    Height = windowSettings.Height
+                };
+                window = new ExtensionWindow(this, ref windowRect);
+                if (windowSettings.Status == WindowStatus.Maximized)
+                {
+                    // Rather than setting the WindowState here, this is delayed to the Loaded event.
+                    // This helps overcome a bug which makes the window appear always on the primary screen.
+                    window.ShouldMaximize = true;
+                }
+            }
+            
+            // Icon is passed from DynamoView (respecting Host integrator icon)
+            SetApplicationIcon();
+            window.Icon = this.Icon;
+            window.ExtensionContent.Content = contentControl;
+            window.Title = viewExtension.Name;
+            window.Tag = viewExtension;
+            window.Uid = viewExtension.UniqueId;
+            window.Closing += ExtensionWindow_Closing;
+            window.Closed += ExtensionWindow_Closed;
+
+            window.Show();
+
+            ExtensionWindows.Add(viewExtension.Name, window);
+
+            return window;
+        }
+
+        private void ExtensionWindow_Closing(object sender, CancelEventArgs e)
+        {
+            var window = sender as ExtensionWindow;
+            SaveExtensionWindowSettings(window);
+        }
+
+        private void SaveExtensionWindowSettings(ExtensionWindow window)
+        {
+            var extension = window.Tag as IViewExtension;
+            var settings = this.dynamoViewModel.Model.PreferenceSettings.ViewExtensionSettings.Find(ext => ext.UniqueId == extension.UniqueId);
+            if (settings.WindowSettings == null)
+            {
+                settings.WindowSettings = new WindowSettings();
+            }
+            settings.WindowSettings.Status = window.WindowState == WindowState.Maximized ? WindowStatus.Maximized : WindowStatus.Normal;
+            settings.WindowSettings.Left = (int)window.SavedWindowRect.Left;
+            settings.WindowSettings.Top = (int)window.SavedWindowRect.Top;
+            settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
+            settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
+        }
+
+        private TabItem AddExtensionTab(IViewExtension viewExtension, ContentControl contentControl)
+        {
+            tabDynamic.DataContext = null;
+
+            // creates a new tab item
+            var tab = new TabItem();
+            tab.Header = viewExtension.Name;
+            tab.Tag = viewExtension;
+            tab.Uid = viewExtension.UniqueId;
+            tab.HeaderTemplate = tabDynamic.FindResource("TabHeader") as DataTemplate;
+
+            // setting the extension UI to the current tab content 
+            // based on whether it is a UserControl element or window element. 
+            if (contentControl is UserControl)
+            {
+                tab.Content = contentControl;
+            }
+            else
+            {
+                if (contentControl != null)
+                {
+                    tab.Content = contentControl.Content;
+                }
+                if (contentControl is Window contentContainer)
+                {
+                    // Make sure the extension window closes with Dynamo
+                    contentContainer.Owner = this;
+                }
+            }
+
+            //Insert the tab at the end
+            ExtensionTabItems.Insert(ExtensionTabItems.Count, tab);
+
+            tabDynamic.DataContext = ExtensionTabItems;
             tabDynamic.SelectedItem = tab;
-            return null;
+
+            return tab;
         }
 
         /// <summary>
@@ -333,7 +427,8 @@ namespace Dynamo.Controls
                 // clear tab control binding and bind to the new tab-list. 
                 tabDynamic.DataContext = null;
                 ExtensionTabItems.Remove(tabToBeRemoved);
-                ExtensionTabItems = ExtensionTabItems;
+                // Disconnect content from tab to allow it to be moved.
+                tabToBeRemoved.Content = null;
                 tabDynamic.DataContext = ExtensionTabItems;
 
                 // Highlight previously selected tab. if that is removed then Highlight the first tab
@@ -354,6 +449,8 @@ namespace Dynamo.Controls
             {
                 var extension = ExtensionWindows[name];
                 extension.Close();
+                // Disconnect content to allow it to be moved.
+                extension.ExtensionContent.Content = null;
                 ExtensionWindows.Remove(name);
             }
         }
@@ -375,24 +472,12 @@ namespace Dynamo.Controls
         internal void UndockExtension(string name)
         {
             var tabItem = ExtensionTabItems.OfType<TabItem>().SingleOrDefault(tab => tab.Header.ToString() == name);
-            CloseExtensionTab(tabItem);
-
-            var ext = new ExtensionWindow();
-            // Icon is passed from DynamoView (respecting Host integrator icon)
-            SetApplicationIcon();
-            ext.Icon = this.Icon;
-            ext.Owner = this;
             var content = tabItem.Content as ContentControl;
-            // Disconnect from previous parent to avoid error
-            tabItem.Content = null;
-            ext.ExtensionContent.Content = content;
-            ext.Title = name;
-            ext.Tag = tabItem.Tag;
-            ext.Uid = tabItem.Uid;
-            ext.Closed += ExtensionWindow_Closed;
-            ext.Show();
-
-            ExtensionWindows.Add(name, ext);
+            CloseExtensionTab(tabItem);
+            var extension = tabItem.Tag as IViewExtension;
+            var settings = this.dynamoViewModel.PreferenceSettings.ViewExtensionSettings.Find(s => s.UniqueId == extension.UniqueId);
+            AddExtensionWindow(extension, content, settings.WindowSettings);
+            settings.DisplayMode = ViewExtensionDisplayMode.FloatingWindow;
         }
 
         /// <summary>
@@ -415,22 +500,25 @@ namespace Dynamo.Controls
 
         private void ExtensionWindow_Closed(object sender, EventArgs e)
         {
-            var ext = sender as ExtensionWindow;
-            var extName = ext.Title;
-            var content = ext.ExtensionContent.Content as ContentControl;
+            var window = sender as ExtensionWindow;
+            var extName = window.Title;
+            var content = window.ExtensionContent.Content as ContentControl;
             // Release content from window
-            ext.ExtensionContent.Content = null;
+            window.ExtensionContent.Content = null;
             ExtensionWindows.Remove(extName);
-            if (ext.DockRequested)
+            var extension = window.Tag as IViewExtension;
+            if (window.DockRequested)
             {
-                AddExtensionTabItem((IViewExtension)ext.Tag, content);
-                Logging.Analytics.TrackEvent(
-                   Actions.Dock,
-                   Categories.ViewExtensionOperations, extName);
+                AddExtensionTab(extension, content);
+
+                var settings = this.dynamoViewModel.PreferenceSettings.ViewExtensionSettings.Find(s => s.UniqueId == extension.UniqueId);
+                settings.DisplayMode = ViewExtensionDisplayMode.DockRight;
+
+                Analytics.TrackEvent(Actions.Dock, Categories.ViewExtensionOperations, extName);
             }
             else
             {
-                if (ext.Tag is ViewExtensionBase viewExtensionBase)
+                if (extension is ViewExtensionBase viewExtensionBase)
                 {
                     viewExtensionBase.Closed();
                 }
@@ -1404,6 +1492,8 @@ namespace Dynamo.Controls
 
         private void WindowClosing(object sender, CancelEventArgs e)
         {
+            SaveExtensionWindowsState();
+
             if (!PerformShutdownSequenceOnViewModel() && !DynamoModel.IsTestMode)
             {
                 e.Cancel = true;
@@ -1411,6 +1501,18 @@ namespace Dynamo.Controls
             else
             {
                 isPSSCalledOnViewModelNoCancel = true;
+            }
+        }
+
+        /// <summary>
+        /// Saves the state of currently displayed extension windows. This is needed because the closing event is
+        /// not called on child windows: https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.closing
+        /// </summary>
+        private void SaveExtensionWindowsState()
+        {
+            foreach (var window in ExtensionWindows.Values)
+            {
+                SaveExtensionWindowSettings(window);
             }
         }
 

--- a/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml
+++ b/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml
@@ -7,6 +7,8 @@
                            xmlns:ui="clr-namespace:Dynamo.UI"
                            mc:Ignorable="d" 
                            d:DesignHeight="450" d:DesignWidth="800"
+                           MinHeight="32"
+                           MinWidth="160"
                            WindowStyle="None"
                            StateChanged="ExtensionWindow_StateChanged"
                            Loaded="ExtensionWindow_Loaded">

--- a/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Windows/ExtensionWindow.xaml.cs
@@ -13,8 +13,27 @@ namespace Dynamo.Wpf.Windows
         /// Note: Setter is internal for testing purposes only.
         /// </summary>
         public bool DockRequested { get; internal set; }
+        /// <summary>
+        /// Indicates if the window should be maximized when it is loaded.
+        /// </summary>
+        public bool ShouldMaximize { get; set; }
 
+        /// <summary>
+        /// Creates a window with an initially empty window rectangle.
+        /// Note: This constructor assumes Owner is set externally.
+        /// </summary>
         public ExtensionWindow()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Creates a window with the specified owner and window rectangle.
+        /// </summary>
+        /// <param name="viewParent">A UI object in the Dynamo visual tree.</param>
+        /// <param name="rect">A reference to the Rect object that will store the window's position during this session.</param>
+        public ExtensionWindow(DependencyObject viewParent, ref WindowRect rect)
+            : base(viewParent, ref rect)
         {
             InitializeComponent();
         }
@@ -65,6 +84,12 @@ namespace Dynamo.Wpf.Windows
         {
             // This can't be done using markup, so we do it here.
             iconImage.Source = Icon;
+            // The window is maximized at this point to make sure it appears on the right screen.
+            if (ShouldMaximize)
+            {
+                WindowState = WindowState.Maximized;
+            }
+            RefreshMaximizeRestoreButton();
         }
     }
 }

--- a/src/DynamoCoreWpf/Windows/ModelessChildWindow.cs
+++ b/src/DynamoCoreWpf/Windows/ModelessChildWindow.cs
@@ -115,8 +115,11 @@ namespace Dynamo.Wpf.Windows
 
         private void ModelessChildWindow_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            SavedWindowRect.Width = e.NewSize.Width;
-            SavedWindowRect.Height = e.NewSize.Height;
+            if (WindowState != WindowState.Maximized)
+            {
+                SavedWindowRect.Width = e.NewSize.Width;
+                SavedWindowRect.Height = e.NewSize.Height;
+            }
         }
 
         private void ModelessChildWindow_LocationChanged(object sender, EventArgs e)

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -59,6 +59,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.EnableNodeAutoComplete, false);
             Assert.AreEqual(settings.DefaultPythonEngine, string.Empty);
             Assert.AreEqual(settings.MaxNumRecentFiles, PreferenceSettings.DefaultMaxNumRecentFiles);
+            Assert.AreEqual(settings.ViewExtensionSettings.Count, 0);
 
             // Save
             settings.Save(tempPath);
@@ -72,6 +73,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.EnableNodeAutoComplete, false);
             Assert.AreEqual(settings.DefaultPythonEngine, string.Empty);
             Assert.AreEqual(settings.MaxNumRecentFiles, PreferenceSettings.DefaultMaxNumRecentFiles);
+            Assert.AreEqual(settings.ViewExtensionSettings.Count, 0);
 
             // Change setting values
             settings.SetIsBackgroundPreviewActive("MyBackgroundPreview", false);
@@ -81,6 +83,20 @@ namespace Dynamo.Tests.Configuration
             settings.DefaultPythonEngine = "CP3";
             settings.MaxNumRecentFiles = 24;
             settings.EnableNodeAutoComplete = true;
+            settings.ViewExtensionSettings.Add(new ViewExtensionSettings()
+            {
+                Name = "MyExtension",
+                UniqueId = "1234",
+                DisplayMode = ViewExtensionDisplayMode.FloatingWindow,
+                WindowSettings = new WindowSettings()
+                {
+                    Left = 123,
+                    Top = 456,
+                    Height = 321,
+                    Width = 654,
+                    Status = WindowStatus.Maximized
+                }
+            });
 
             // Save
             settings.Save(tempPath);
@@ -94,6 +110,18 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.DefaultPythonEngine, "CP3");
             Assert.AreEqual(settings.MaxNumRecentFiles, 24);
             Assert.AreEqual(settings.EnableNodeAutoComplete, true);
+            Assert.AreEqual(settings.ViewExtensionSettings.Count, 1);
+            var extensionSettings = settings.ViewExtensionSettings[0];
+            Assert.AreEqual(extensionSettings.Name, "MyExtension");
+            Assert.AreEqual(extensionSettings.UniqueId, "1234");
+            Assert.AreEqual(extensionSettings.DisplayMode, ViewExtensionDisplayMode.FloatingWindow);
+            Assert.IsNotNull(extensionSettings.WindowSettings);
+            var windowSettings = extensionSettings.WindowSettings;
+            Assert.AreEqual(windowSettings.Left, 123);
+            Assert.AreEqual(windowSettings.Top, 456);
+            Assert.AreEqual(windowSettings.Height, 321);
+            Assert.AreEqual(windowSettings.Width, 654);
+            Assert.AreEqual(windowSettings.Status, WindowStatus.Maximized);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -106,7 +106,7 @@ namespace DynamoCoreWpfTests
 
             // Simulate the extension activating the tab content again.
             // The content here should not matter because it won't be used.
-            View.AddExtensionTabItem(viewExtension, new UserControl());
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
 
             // Extension bar is shown
             Assert.IsFalse(View.ExtensionsCollapsed);
@@ -223,11 +223,76 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, View.ExtensionWindows.Count);
 
             // Attempt to open the extension in the side bar when it's open as a window
-            View.AddExtensionTabItem(viewExtension, new UserControl());
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
 
             // Extension is not added to the sidebar
             Assert.AreEqual(0, View.ExtensionTabItems.Count);
             Assert.IsTrue(View.ExtensionsCollapsed);
+        }
+
+        [Test]
+        public void ExtensionLocationIsRemembered()
+        {
+            RaiseLoadedEvent(this.View);
+
+            // Add extension
+            View.viewExtensionManager.Add(viewExtension);
+
+            // Extension bar is shown
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+
+            // Undock extension 
+            View.UndockExtension(viewExtension.Name);
+
+            // Extension is no longer in the side bar (now collapsed)
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            // Extension is in a window now
+            Assert.AreEqual(1, View.ExtensionWindows.Count);
+
+            // Close the window without docking
+            var window = View.ExtensionWindows[viewExtension.Name];
+            window.Close();
+
+            // Extension is not in the sidebar nor as a window
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+
+            // Re-open the extension
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
+
+            // Extension is remembered to be opened as a window
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            Assert.AreEqual(1, View.ExtensionWindows.Count);
+
+            // Dock the extension to the sidebar
+            window = View.ExtensionWindows[viewExtension.Name];
+            window.DockRequested = true;
+            window.Close();
+
+            // Extension is in the sidebar now
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+
+            // Close the extension tab in the sidebar
+            View.CloseExtensionControl(viewExtension);
+
+            // Extension is closed
+            Assert.AreEqual(0, View.ExtensionTabItems.Count);
+            Assert.IsTrue(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
+
+            // Re-open the extension again
+            View.AddOrFocusExtensionControl(viewExtension, new UserControl());
+
+            // Extension is remembered to be opened in the sidebar
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+            Assert.AreEqual(0, View.ExtensionWindows.Count);
         }
 
         public static void RaiseLoadedEvent(FrameworkElement element)


### PR DESCRIPTION
Information of where an extension control was last shown is saved and
retrieved as preference settings. These are actually not directly
visible for the user and are updating automatically, just like the main
Dynamo window size. These settings are used when showing the extension
control, to restore it to how it used to be before closing it.

The available information for each view extension is:

1. How it is shown. For now this can be either as a floating window or
docked to the right-side panel.

2. In case it is shown as a floating window, the following information
about the window is saved:
- Location by Top/Left coordinates
- Size by Width/Height
- Whether the window is maximized
