### PR TITLE
CP: Handle errors when loading application icon

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2259,6 +2259,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occurred when loading the application icon: {0}.
+        /// </summary>
+        public static string ErrorLoadingIcon {
+            get {
+                return ResourceManager.GetString("ErrorLoadingIcon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extension tab added to the extensions side bar..
         /// </summary>
         public static string ExtensionAdded {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2277,4 +2277,8 @@ Uninstall the following packages: {0}?</value>
     <value>Enable Node Auto Complete</value>
     <comment>Setting menu | Experimental | Enable Node Auto Complete</comment>
   </data>
+  <data name="ErrorLoadingIcon" xml:space="preserve">
+    <value>An error occurred when loading the application icon: {0}</value>
+    <comment>{0} = detailed error message</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2279,4 +2279,8 @@ Uninstall the following packages: {0}?</value>
     <value>Enable Node Auto Complete</value>
     <comment>Setting menu | Experimental | Enable Node Auto Complete</comment>
   </data>
+  <data name="ErrorLoadingIcon" xml:space="preserve">
+    <value>An error occurred when loading the application icon: {0}</value>
+    <comment>{0} = detailed error message</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -488,13 +488,21 @@ namespace Dynamo.Controls
         {
             if (this.Icon == null && !DynamoModel.IsTestMode)
             {
-                var icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetEntryAssembly().Location);
-                var bmp = icon.ToBitmap();
-                MemoryStream stream = new MemoryStream();
-                bmp.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-                stream.Seek(0, SeekOrigin.Begin);
-                PngBitmapDecoder pngDecoder = new PngBitmapDecoder(stream, BitmapCreateOptions.None, BitmapCacheOption.Default);
-                this.Icon = pngDecoder.Frames[0];
+                var applicationPath = Process.GetCurrentProcess().MainModule.FileName;
+                try
+                {
+                    var icon = System.Drawing.Icon.ExtractAssociatedIcon(applicationPath);
+                    var bmp = icon.ToBitmap();
+                    MemoryStream stream = new MemoryStream();
+                    bmp.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                    stream.Seek(0, SeekOrigin.Begin);
+                    PngBitmapDecoder pngDecoder = new PngBitmapDecoder(stream, BitmapCreateOptions.None, BitmapCacheOption.Default);
+                    this.Icon = pngDecoder.Frames[0];
+                }
+                catch (Exception ex)
+                {
+                    Log(string.Format(Dynamo.Wpf.Properties.Resources.ErrorLoadingIcon, ex.Message));
+                }
             }
         }
 


### PR DESCRIPTION
When loading the application icon to be displayed in the extension
windows, the method used would result in an unhandled error when the
application was started from a network folder. This error is now
handled, resulting only in the absence of the icon for the extension
window. Also, the method used to get the application path is changed
for a more reliable one.
