### PR TITLE
DYN-3243: HTML Sanitizer fixes

### DIFF
--- a/src/Tools/Md2Html/Md2Html.cs
+++ b/src/Tools/Md2Html/Md2Html.cs
@@ -97,8 +97,17 @@ namespace Md2Html
         /// <returns>return sanitized content string or an empty string if no sanitizing happened</returns>
         internal static string Sanitize(string content)
         {
+            string output;
             HtmlSanitizer.ContentWasUpdated = false;
-            var output = HtmlSanitizer.Sanitize(content);
+            if (content.Contains(@"<body "))
+            {
+                output = HtmlSanitizer.SanitizeDocument(content);
+
+            }
+            else
+            {
+                output = HtmlSanitizer.Sanitize(content);
+            }
             if (HtmlSanitizer.ContentWasUpdated)
             {
                 return output;

--- a/src/Tools/Md2Html/Md2Html.cs
+++ b/src/Tools/Md2Html/Md2Html.cs
@@ -102,7 +102,6 @@ namespace Md2Html
             if (content.Contains(@"<body "))
             {
                 output = HtmlSanitizer.SanitizeDocument(content);
-
             }
             else
             {

--- a/src/Tools/Md2Html/Md2HtmlSanitizer.cs
+++ b/src/Tools/Md2Html/Md2HtmlSanitizer.cs
@@ -15,9 +15,16 @@ namespace Md2Html
 
         internal Md2HtmlSanitizer()
         {
+            AllowedTags.Add(@"meta");
+            AllowedTags.Add(@"style");
+
+            AllowedAttributes.Add(@"content");
+            AllowedAttributes.Add(@"http-equiv");
+
+            AllowedCssProperties.Add(@"src");
+
             RemovingAtRule += ChangedEvent;
             RemovingAttribute += ChangedEvent;
-            RemovingComment += ChangedEvent;
             RemovingCssClass += ChangedEvent;
             RemovingStyle += ChangedEvent;
             RemovingTag += ChangedEvent;


### PR DESCRIPTION
### Purpose

HTML Sanitizer fixes

This pull request does:
* allow html content with a `body` to Sanitize as a document (e.g. `head` tags are allowed)
* allow `meta` tags
* allow `style` tags
* allow `content` attributes
* allow `http-equiv` attributes
* allow `src` css properties
* stop consider comments as a content change

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 

### FYIs
