### PR TITLE
don't mark variableInputNode dirty

### DIFF
--- a/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
+++ b/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
@@ -183,8 +183,9 @@ namespace Dynamo.Graph.Nodes
                 var port = model.InPorts[count - 1];
                 port.DestroyConnectors();
                 model.InPorts.Remove(port);
+                MarkNodeDirty();
             }
-            MarkNodeDirty();
+            
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose
don't mark variableInputNode dirty  if port was not removed

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

