### PR TITLE
DYN-3314: Simplify html sanitization so that html sanitization always returns a valid body element

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserUtils.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserUtils.cs
@@ -65,5 +65,20 @@ namespace Dynamo.DocumentationBrowser
 
             return result;
         }
+
+        private const string SYNTAX_HIGHLIGHTING = "Dynamo.DocumentationBrowser.Docs.syntaxHighlight.html";
+
+        /// <summary>
+        /// Inject syntax highlighting into a html string.
+        /// </summary>
+        /// <param name="content"></param>
+        internal static string GetSyntaxHighlighting()
+        {
+            var syntaxHighlightingContent = DocumentationBrowserUtils.GetContentFromEmbeddedResource(SYNTAX_HIGHLIGHTING);
+            if (string.IsNullOrWhiteSpace(syntaxHighlightingContent))
+                return string.Empty;
+
+            return syntaxHighlightingContent;
+        }
     }
 }

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -249,23 +249,27 @@ namespace Dynamo.DocumentationBrowser
             {
                 writer.WriteLine(DocumentationBrowserUtils.GetContentFromEmbeddedResource(STYLE_RESOURCE));
 
-                // Get the Node info section and remove script tags if any
+                // Get the Node info section
                 var nodeDocumentation = NodeDocumentationHtmlGenerator.FromAnnotationEventArgs(e);
-                if (MarkdownHandlerInstance.SanitizeHtml(ref nodeDocumentation))
-                {
-                    LogWarning(Resources.ScriptTagsRemovalWarning, WarningLevel.Mild);
-                }
-
                 writer.WriteLine(nodeDocumentation);
 
-                // Convert the markdown file to html and remove script tags if any
-                if (MarkdownHandlerInstance.ParseToHtml(ref writer, e.MinimumQualifiedName))
+                // Convert the markdown file to html
+                MarkdownHandlerInstance.ParseToHtml(ref writer, e.MinimumQualifiedName);
+
+                writer.Flush();
+                var output = writer.ToString();
+
+                // Sanitize html and warn if any changes where made
+                if (MarkdownHandlerInstance.SanitizeHtml(ref output))
                 {
                     LogWarning(Resources.ScriptTagsRemovalWarning, WarningLevel.Mild);
                 }
 
-                writer.Flush();
-                return writer.ToString();
+                // inject the syntax highlighting script at the bottom at the document.
+                output += DocumentationBrowserUtils.GetDPIScript();
+                output += DocumentationBrowserUtils.GetSyntaxHighlighting();
+
+                return output;
             }
             finally
             {

--- a/src/DocumentationBrowserViewExtension/MarkdownHandler.cs
+++ b/src/DocumentationBrowserViewExtension/MarkdownHandler.cs
@@ -11,7 +11,6 @@ namespace Dynamo.DocumentationBrowser
     internal class MarkdownHandler : IDisposable
     {
         private const string NODE_ANNOTATION_NOT_FOUND = "Dynamo.DocumentationBrowser.Docs.NodeAnnotationNotFound.md";
-        private const string SYNTAX_HIGHLIGHTING = "Dynamo.DocumentationBrowser.Docs.syntaxHighlight.html";
         private readonly Md2Html converter = new Md2Html();
 
         /// <summary>
@@ -44,8 +43,7 @@ namespace Dynamo.DocumentationBrowser
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nodeNamespace"></param>
-        /// <returns>Returns true if any script tags was removed from the string</returns>
-        internal bool ParseToHtml(ref StringWriter writer, string nodeNamespace)
+        internal void ParseToHtml(ref StringWriter writer, string nodeNamespace)
         {
             if (writer is null)
                 throw new ArgumentNullException(nameof(writer));
@@ -53,7 +51,6 @@ namespace Dynamo.DocumentationBrowser
             var mdFilePath = PackageDocumentationManager.Instance.GetAnnotationDoc(nodeNamespace);
 
             string mdString;
-            bool scriptTagsRemoved = false;
 
             if (string.IsNullOrWhiteSpace(mdFilePath) ||
                 !File.Exists(mdFilePath))
@@ -79,21 +76,11 @@ namespace Dynamo.DocumentationBrowser
                 }
 
                 if (string.IsNullOrWhiteSpace(mdString))
-                    return false;
-
-                // Remove scripts from user content for security reasons.
-                if (SanitizeHtml(ref mdString))
-                    scriptTagsRemoved = true;
+                    return;
             }
 
             var html = converter.ParseMd2Html(mdString, mdFilePath);
             writer.WriteLine(html);
-
-            // inject the syntax highlighting script at the bottom at the document.
-            writer.WriteLine(DocumentationBrowserUtils.GetDPIScript());
-            writer.WriteLine(GetSyntaxHighlighting());
-
-            return scriptTagsRemoved;
         }
 
         /// <summary>
@@ -112,19 +99,6 @@ namespace Dynamo.DocumentationBrowser
 
             content = sanitizedContent;
             return true;
-        }
-
-        /// <summary>
-        /// Inject syntax highlighting into a html string.
-        /// </summary>
-        /// <param name="content"></param>
-        private static string GetSyntaxHighlighting()
-        {
-            var syntaxHighlightingContent = DocumentationBrowserUtils.GetContentFromEmbeddedResource(SYNTAX_HIGHLIGHTING);
-            if (string.IsNullOrWhiteSpace(syntaxHighlightingContent))
-                return string.Empty;
-
-            return syntaxHighlightingContent;
         }
     }
 }

--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -44,43 +44,41 @@ namespace Dynamo.DocumentationBrowser
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendLine($"<h2>{Resources.NodeDocumentationNodeInfo}</h2>");
-            sb.AppendLine("<table>");
-            sb.AppendLine("<tbody>");
-            sb.AppendLine("<tr>");
-            sb.AppendLine($"<td>{Resources.NodeDocumentationNodeType}</td>");
-            sb.AppendLine($"<td>{e.Type}</td>");
-            sb.AppendLine("</tr>");
-            sb.AppendLine("<tr>");
-            sb.AppendLine($"<td>{Resources.NodeDocumentationDescription}</td>");
-            sb.AppendLine($"<td>{Regex.Replace(e.Description, @"\r\n?|\n", "<br>")}</td>");
-            sb.AppendLine("</tr>");
-            sb.AppendLine("<tr>");
-            sb.AppendLine($"<td>{Resources.NodeDocumentationCategory}</td>");
-            sb.AppendLine($"<td>{e.Category}</td>");
-            sb.AppendLine("</tr>");
-            sb.AppendLine("<tr>");
-            sb.AppendLine($"<td>{Resources.NodeDocumentationInputs}</td>");
-            sb.AppendLine("<td>");
+            sb.AppendLine("<table class=\"table--noborder\">");
+            sb.AppendLine("<tr class=\"table--noborder\">");
+            sb.AppendLine($"<td class=\"table--noborder\">{Resources.NodeDocumentationNodeType}</td>");
+            sb.AppendLine($"<td class=\"table--noborder\">{e.Type}</td>");
+            sb.AppendLine(@"</tr>");
+            sb.AppendLine("<tr class=\"table--noborder\">");
+            sb.AppendLine($"<td class=\"table--noborder\">{Resources.NodeDocumentationDescription}</td>");
+            sb.AppendLine($"<td class=\"table--noborder\">{Regex.Replace(e.Description, @"\r\n?|\n", "<br>")}</td>");
+            sb.AppendLine(@"</tr>");
+            sb.AppendLine("<tr class=\"table--noborder\">");
+            sb.AppendLine($"<td class=\"table--noborder\">{Resources.NodeDocumentationCategory}</td>");
+            sb.AppendLine($"<td class=\"table--noborder\">{e.Category}</td>");
+            sb.AppendLine(@"</tr>");
+            sb.AppendLine("<tr class=\"table--noborder\">");
+            sb.AppendLine($"<td class=\"table--noborder\">{Resources.NodeDocumentationInputs}</td>");
+            sb.AppendLine("<td class=\"table--noborder\">");
             for (int i = 0; i < e.InputNames.Count(); i++)
             {
                 sb.AppendLine(
                     $"<li style=\"margin-bottom: 5px\"><b><u>{e.InputNames.ElementAt(i)}</u></b><br>{Regex.Replace(e.InputDescriptions.ElementAt(i), @"\r\n?|\n", "<br>")}</li>");
             }
-            sb.AppendLine("</td>");
-            sb.AppendLine("</tr>");
-            sb.AppendLine("<tr>");
-            sb.AppendLine($"<td>{Resources.NodeDocumentationOutputs}</td>");
-            sb.AppendLine("<td>");
+            sb.AppendLine(@"</td>");
+            sb.AppendLine(@"</tr>");
+            sb.AppendLine("<tr class=\"table--noborder\">");
+            sb.AppendLine($"<td class=\"table--noborder\">{Resources.NodeDocumentationOutputs}</td>");
+            sb.AppendLine("<td class=\"table--noborder\">");
             for (int i = 0; i < e.OutputNames.Count(); i++)
             {
                 sb.AppendLine(
                     $"<li style=\"margin-bottom: 5px\"><b><u>{e.OutputNames.ElementAt(i)}</u></b><br>{Regex.Replace(e.OutputDescriptions.ElementAt(i), @"\r\n?|\n", "<br>")}</li>");
             }
-            sb.AppendLine("</td>");
-            sb.AppendLine("</tr>");
-            sb.AppendLine("</tbody>");
-            sb.AppendLine("</table>");
-            sb.Append("<hr>");
+            sb.AppendLine(@"</td>");
+            sb.AppendLine(@"</tr>");
+            sb.AppendLine(@"</table>");
+            sb.Append(@"<hr>");
 
             return sb.ToString();
         }

--- a/src/DynamoUtilities/Properties/AssemblyInfo.cs
+++ b/src/DynamoUtilities/Properties/AssemblyInfo.cs
@@ -12,4 +12,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fdd60a60-c6e4-4f11-b583-8a417061c043")]
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
+[assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
 [assembly: InternalsVisibleTo("DocumentationBrowserViewExtension")]

--- a/src/Tools/Md2Html/Md2Html.cs
+++ b/src/Tools/Md2Html/Md2Html.cs
@@ -99,14 +99,9 @@ namespace Md2Html
         {
             string output;
             HtmlSanitizer.ContentWasUpdated = false;
-            if (content.Contains(@"<body "))
-            {
-                output = HtmlSanitizer.SanitizeDocument(content);
-            }
-            else
-            {
-                output = HtmlSanitizer.Sanitize(content);
-            }
+
+            output = HtmlSanitizer.SanitizeDocument(content);
+
             if (HtmlSanitizer.ContentWasUpdated)
             {
                 return output;

--- a/src/Tools/Md2Html/Md2HtmlSanitizer.cs
+++ b/src/Tools/Md2Html/Md2HtmlSanitizer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AngleSharp.Css.Dom;
 using Ganss.XSS;
 
 namespace Md2Html
@@ -20,8 +21,24 @@ namespace Md2Html
 
             AllowedAttributes.Add(@"content");
             AllowedAttributes.Add(@"http-equiv");
+            AllowedAttributes.Add(@"id");
 
             AllowedCssProperties.Add(@"src");
+            AllowedCssProperties.Add(@"word-break");
+            AllowedCssProperties.Add(@"word-wrap");
+            AllowedCssProperties.Add(@"-moz-tab-size");
+            AllowedCssProperties.Add(@"-o-tab-size");
+            AllowedCssProperties.Add(@"tab-size");
+            AllowedCssProperties.Add(@"-webkit-hyphens");
+            AllowedCssProperties.Add(@"-moz-hyphens");
+            AllowedCssProperties.Add(@"-ms-hyphens");
+            AllowedCssProperties.Add(@"hyphens");
+            AllowedCssProperties.Add(@"background-position-x");
+            AllowedCssProperties.Add(@"background-position-y");
+
+            AllowedSchemes.Add(@"file");
+
+            AllowedAtRules.Add(CssRuleType.Media);
 
             RemovingAtRule += ChangedEvent;
             RemovingAttribute += ChangedEvent;

--- a/src/Tools/Md2Html/Md2HtmlSanitizer.cs
+++ b/src/Tools/Md2Html/Md2HtmlSanitizer.cs
@@ -22,6 +22,7 @@ namespace Md2Html
             AllowedAttributes.Add(@"content");
             AllowedAttributes.Add(@"http-equiv");
             AllowedAttributes.Add(@"id");
+            AllowedAttributes.Add(@"class");
 
             AllowedCssProperties.Add(@"src");
             AllowedCssProperties.Add(@"word-break");
@@ -35,10 +36,18 @@ namespace Md2Html
             AllowedCssProperties.Add(@"hyphens");
             AllowedCssProperties.Add(@"background-position-x");
             AllowedCssProperties.Add(@"background-position-y");
+            AllowedCssProperties.Add(@"transition-property");
+            AllowedCssProperties.Add(@"transition-duration");
+            AllowedCssProperties.Add(@"transition-timing-function");
+            AllowedCssProperties.Add(@"transition-delay");
+            AllowedCssProperties.Add(@"box-shadow");
 
             AllowedSchemes.Add(@"file");
+            AllowedSchemes.Add(@"data");
 
             AllowedAtRules.Add(CssRuleType.Media);
+            AllowedAtRules.Add(CssRuleType.Keyframe);
+            AllowedAtRules.Add(CssRuleType.Keyframes);
 
             RemovingAtRule += ChangedEvent;
             RemovingAttribute += ChangedEvent;

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -29,10 +29,10 @@ namespace DynamoCoreWpfTests
         private const string excelDocsFileHtmlHeader = "<h2>Excel not installed </h2>";
         private const string fileMissingHtmlHeader = "<h3>Error 404</h3>";
         private const string nodeDocumentationInfoHeader = "<h2>Node Info</h2>";
-        private const string nodeDocumentationInfoNodeType = "<td>Node Type</td>";
-        private const string nodeDocumentationInfoNodeDescription = "<td>Description</td>";
-        private const string nodeDocumentationInfoNodeInputs = "<td>Inputs</td>";
-        private const string nodeDocumentationInfoNodeOutputs = "<td>Outputs</td>";
+        private const string nodeDocumentationInfoNodeType = "<td class=\"table--noborder\">Node Type</td>";
+        private const string nodeDocumentationInfoNodeDescription = "<td class=\"table--noborder\">Description</td>";
+        private const string nodeDocumentationInfoNodeInputs = "<td class=\"table--noborder\">Inputs</td>";
+        private const string nodeDocumentationInfoNodeOutputs = "<td class=\"table--noborder\">Outputs</td>";
 
         private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), @"core\docbrowser\pkgs"); } }
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -386,7 +386,7 @@ namespace DynamoCoreWpfTests
                 Assert.IsFalse(docsEvent.IsRemoteResource);
                 Assert.AreEqual(0, tabsBeforeExternalEventTrigger);
                 Assert.AreEqual(1, tabsAfterExternalEventTrigger);
-                Assert.IsTrue(htmlContent.Contains(@"<h2>Division by zero</h2>"));
+                Assert.IsTrue(htmlContent.Contains("<h2 id=\"heading\">Division by zero</h2>"));
                 Assert.False(htmlContent.Contains("document.getElementById(\"heading\").innerHTML = \"Script1\";"));
             }
         }


### PR DESCRIPTION
### Purpose

[DYN-3314](https://jira.autodesk.com/browse/DYN-3314) simplify html sanitization so that html sanitization always returns a valid body element

This pull request does:
* change the markdown to html conversion so it always returns a full html document.
* change the `md2html` tool so it only sanitize full documents.
* allow some new schemes/attributes/properties when sanitizing that reflects how our embedded content is setup.
* force the use of the `table--noborder` class when generating the node info doc table in a way that I think always works.
* add dynamic tests that checks if anything gets removed when sanitizing our embedded content 

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 