### PR TITLE
Do not implement props in ViewExtensionBase

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -1,13 +1,13 @@
-﻿using Dynamo.DocumentationBrowser.Properties;
-using Dynamo.Logging;
-using Dynamo.PackageManager;
-using Dynamo.ViewModels;
-using Dynamo.Wpf.Extensions;
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using Dynamo.DocumentationBrowser.Properties;
+using Dynamo.Logging;
+using Dynamo.PackageManager;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Extensions;
 
 namespace Dynamo.DocumentationBrowser
 {
@@ -27,12 +27,12 @@ namespace Dynamo.DocumentationBrowser
         /// <summary>
         /// Extension Name
         /// </summary>
-        public string Name => Properties.Resources.ExtensionName;
+        public override string Name => Properties.Resources.ExtensionName;
 
         /// <summary>
         /// GUID of the extension
         /// </summary>
-        public string UniqueId => "68B45FC0-0BD1-435C-BF28-B97CB03C71C8";
+        public override string UniqueId => "68B45FC0-0BD1-435C-BF28-B97CB03C71C8";
 
         public DocumentationBrowserViewExtension()
         {
@@ -53,12 +53,12 @@ namespace Dynamo.DocumentationBrowser
 
         #region IViewExtension lifecycle
 
-        public void Startup(ViewStartupParams viewStartupParams)
+        public override void Startup(ViewStartupParams viewStartupParams)
         {
             pmExtension = viewStartupParams.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
         }
 
-        public void Loaded(ViewLoadedParams viewLoadedParams)
+        public override void Loaded(ViewLoadedParams viewLoadedParams)
         {
             if (viewLoadedParams == null) throw new ArgumentNullException(nameof(viewLoadedParams));
 
@@ -109,11 +109,6 @@ namespace Dynamo.DocumentationBrowser
             AddToSidebar(true);
         }
 
-        public void Shutdown()
-        {
-            // Do nothing for now
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             // Cleanup
@@ -156,7 +151,6 @@ namespace Dynamo.DocumentationBrowser
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-            base.Dispose();
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionBase.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionBase.cs
@@ -17,20 +17,17 @@ namespace Dynamo.Wpf.Extensions
         /// There may be multiple instances of the same type, but the application 
         /// will *not* allow two instances to coexist with the same id.
         /// </summary>
-        public virtual string UniqueId { get; }
+        public abstract string UniqueId { get; }
 
         /// <summary>
         /// A name for the extension instance.  This is used for more user-readable logging.
         /// </summary>
-        public virtual string Name { get; }
+        public abstract string Name { get; }
 
         /// <summary>
         /// Dispose method for the view extension.
         /// </summary>
-        public virtual void Dispose()
-        {
-
-        }
+        public abstract void Dispose();
 
         /// <summary>
         /// Action to be invoked when DynamoView begins to start up.  This is guaranteed to happen

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Windows.Controls;
-using Dynamo.Controls;
 using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
@@ -32,7 +31,7 @@ namespace Dynamo.WorkspaceDependency
         /// <summary>
         /// Extension Name
         /// </summary>
-        public string Name
+        public override string Name
         {
             get
             {
@@ -43,7 +42,7 @@ namespace Dynamo.WorkspaceDependency
         /// <summary>
         /// GUID of the extension
         /// </summary>
-        public string UniqueId
+        public override string UniqueId
         {
             get
             {
@@ -54,7 +53,7 @@ namespace Dynamo.WorkspaceDependency
         /// <summary>
         /// Dispose function after extension is closed
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
             DependencyView.Dispose();
         }
@@ -65,12 +64,7 @@ namespace Dynamo.WorkspaceDependency
         {
         }
 
-        public void Shutdown()
-        {
-            // Do nothing for now
-        }
-
-        public void Startup(ViewStartupParams viewStartupParams)
+        public override void Startup(ViewStartupParams viewStartupParams)
         {
             pmExtension = viewStartupParams.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
         }
@@ -82,7 +76,7 @@ namespace Dynamo.WorkspaceDependency
             this.MessageLogged?.Invoke(msg);
         }
 
-        public void Loaded(ViewLoadedParams viewLoadedParams)
+        public override void Loaded(ViewLoadedParams viewLoadedParams)
         {
             DependencyView = new WorkspaceDependencyView(this, viewLoadedParams);
             // when a package is loaded update the DependencyView 


### PR DESCRIPTION
### Purpose

This changes the definition of ViewExtensionBase to use abstract rather
than virtual for the definition of required properties like Name and
UniqueId. The use of virtual was creating a backing field which was not
used in ViewExtensionBase and could not be assigned in the inheriting
class, making it pretty much useless.

Also the Dispose method is declared as abstract, as it was already
required to implement and having a default empty implementation could
lead developers to oversight the need to dispose resources in their
extension.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

