### PR TITLE
Adding a view element to let users expand the watch node.

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -1,5 +1,6 @@
 ﻿using Dynamo.Properties;
 using Dynamo.Utilities;
+using System;
 
 namespace Dynamo.Configuration
 {
@@ -38,11 +39,13 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Maximum width of Watch Node
         /// </summary>
+        [Obsolete("This property is no longer used. Remove in Dynamo 3.0")]
         public static readonly double MaxWatchNodeWidth = 280.0;
 
         /// <summary>
         /// Maximum height of Watch Node
         /// </summary>
+        [Obsolete("This property is no longer used. Remove in Dynamo 3.0")]
         public static readonly double MaxWatchNodeHeight = 310.0;
 
         #endregion
@@ -281,8 +284,8 @@ namespace Dynamo.Configuration
 
         #region Preview Control Settings
 
-        internal static readonly double MaxExpandedPreviewWidth = MaxWatchNodeWidth;
-        internal static readonly double MaxExpandedPreviewHeight = MaxWatchNodeHeight;
+        internal static readonly double MaxExpandedPreviewWidth = 280.0;
+        internal static readonly double MaxExpandedPreviewHeight = 310.0;
         internal static readonly double MaxCondensedPreviewWidth = 280.0;
         internal static readonly double MaxCondensedPreviewHeight = 64.0;
         internal static readonly double DefCondensedContentWidth = 33.0;

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -402,10 +402,9 @@ namespace Dynamo.UI.Controls
                     }
 
                     var watchTree = largeContentGrid.Children[0] as WatchTree;
-
                     if (watchTree != null)
                     {
-                        var rootDataContext = watchTree.DataContext as WatchViewModel; 
+                        var rootDataContext = watchTree.DataContext as WatchViewModel;
 
                         cachedLargeContent = newViewModel;
 
@@ -414,7 +413,6 @@ namespace Dynamo.UI.Controls
                             rootDataContext.IsOneRowContent = cachedLargeContent.Children.Count == 0;
                             rootDataContext.Children.Clear();
                             rootDataContext.Children.Add(cachedLargeContent);
-
                             rootDataContext.CountNumberOfItems(); //count the total number of items in the list
                             if (!rootDataContext.IsOneRowContent)
                             {

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -281,12 +281,6 @@ namespace Dynamo.UI.Controls
             var watchTree = largeContentGrid.Children[0] as WatchTree;
             var rootDataContext = watchTree.DataContext as WatchViewModel;
 
-            watchTree.Width = Double.NaN;
-            watchTree.Height = Double.NaN;
-
-            var thumbElement = watchTree.ChildrenOfType<Thumb>().Where(x => x.Name.ToString() == "resizeThumb").FirstOrDefault();
-            thumbElement.Visibility = Visibility.Hidden;
-
             // Unbind the view from data context, then clear the data context.
             BindingOperations.ClearAllBindings(watchTree.treeView1);
             BindingOperations.ClearAllBindings(watchTree.ListLevelsDisplay);
@@ -408,12 +402,6 @@ namespace Dynamo.UI.Controls
                     }
 
                     var watchTree = largeContentGrid.Children[0] as WatchTree;
-
-                    watchTree.Width = Double.NaN;
-                    watchTree.Height = Double.NaN;
-
-                    var resizeThumbElement = watchTree.ChildrenOfType<Thumb>().Where(x => x.Name.ToString() == "resizeThumb").FirstOrDefault();
-                    if(resizeThumbElement != null) resizeThumbElement.Visibility = Visibility.Hidden;
 
                     if (watchTree != null)
                     {
@@ -660,14 +648,6 @@ namespace Dynamo.UI.Controls
 
         private void RefreshExpandedDisplayAction()
         {
-            var watchTree = largeContentGrid.Children[0] as WatchTree;
-
-            watchTree.Width = Double.NaN;
-            watchTree.Height = Double.NaN;
-
-            var resizeThumbElement = watchTree.ChildrenOfType<Thumb>().Where(x => x.Name.ToString() == "resizeThumb").FirstOrDefault();
-            if (resizeThumbElement != null) resizeThumbElement.Visibility = Visibility.Hidden;
-
             smallContentGrid.Visibility = Visibility.Collapsed;
             largeContentGrid.Visibility = Visibility.Visible;
 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -281,6 +281,12 @@ namespace Dynamo.UI.Controls
             var watchTree = largeContentGrid.Children[0] as WatchTree;
             var rootDataContext = watchTree.DataContext as WatchViewModel;
 
+            watchTree.Width = Double.NaN;
+            watchTree.Height = Double.NaN;
+
+            var thumbElement = watchTree.ChildrenOfType<Thumb>().Where(x => x.Name.ToString() == "resizeThumb").FirstOrDefault();
+            thumbElement.Visibility = Visibility.Hidden;
+
             // Unbind the view from data context, then clear the data context.
             BindingOperations.ClearAllBindings(watchTree.treeView1);
             BindingOperations.ClearAllBindings(watchTree.ListLevelsDisplay);
@@ -402,9 +408,16 @@ namespace Dynamo.UI.Controls
                     }
 
                     var watchTree = largeContentGrid.Children[0] as WatchTree;
+
+                    watchTree.Width = Double.NaN;
+                    watchTree.Height = Double.NaN;
+
+                    var resizeThumbElement = watchTree.ChildrenOfType<Thumb>().Where(x => x.Name.ToString() == "resizeThumb").FirstOrDefault();
+                    if(resizeThumbElement != null) resizeThumbElement.Visibility = Visibility.Hidden;
+
                     if (watchTree != null)
                     {
-                        var rootDataContext = watchTree.DataContext as WatchViewModel;
+                        var rootDataContext = watchTree.DataContext as WatchViewModel; 
 
                         cachedLargeContent = newViewModel;
 
@@ -413,6 +426,7 @@ namespace Dynamo.UI.Controls
                             rootDataContext.IsOneRowContent = cachedLargeContent.Children.Count == 0;
                             rootDataContext.Children.Clear();
                             rootDataContext.Children.Add(cachedLargeContent);
+
                             rootDataContext.CountNumberOfItems(); //count the total number of items in the list
                             if (!rootDataContext.IsOneRowContent)
                             {
@@ -646,6 +660,14 @@ namespace Dynamo.UI.Controls
 
         private void RefreshExpandedDisplayAction()
         {
+            var watchTree = largeContentGrid.Children[0] as WatchTree;
+
+            watchTree.Width = Double.NaN;
+            watchTree.Height = Double.NaN;
+
+            var resizeThumbElement = watchTree.ChildrenOfType<Thumb>().Where(x => x.Name.ToString() == "resizeThumb").FirstOrDefault();
+            if (resizeThumbElement != null) resizeThumbElement.Visibility = Visibility.Hidden;
+
             smallContentGrid.Visibility = Visibility.Collapsed;
             largeContentGrid.Visibility = Visibility.Visible;
 

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -240,7 +240,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid Name ="inputGrid" MinHeight="100" MinWidth="100">
+    <Grid Name ="inputGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height ="*" />
             <RowDefinition Height="Auto" />

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -17,7 +17,6 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
             <Style x:Key="BorderlessButton"
                    TargetType="{x:Type Button}">
                 <Setter Property="Padding"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -7,8 +7,6 @@
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:controls="clr-namespace:Dynamo.Controls"
              mc:Ignorable="d"
-             Width="300"
-             Height="300"
              HorizontalAlignment="Stretch"
              VerticalAlignment="Stretch"
              BorderBrush="Black">
@@ -392,7 +390,7 @@
                HorizontalAlignment="Right"
                Margin="5"
                DragDelta="ThumbResizeThumbOnDragDeltaHandler"
-               Visibility="{Binding IsResizable, Converter={StaticResource BoolToVisibilityCollapsedConverter}}"/>
+               Visibility="Hidden"/>
           </Grid>
         </Border>
     </Grid>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -19,7 +19,6 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <controls:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
             <Style x:Key="BorderlessButton"
                    TargetType="{x:Type Button}">

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -335,7 +335,7 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             
             <!-- Shows counts of all items in List -->
@@ -388,10 +388,9 @@
                 </ListView.ItemTemplate>
             </ListView>
 
-            <Thumb Name ="resizeThumb" Grid.Column ="1"
+            <Thumb Name ="resizeThumb" Grid.Column ="3"
                Width="10" Height="10" 
-               HorizontalAlignment="Right" 
-               VerticalAlignment="Bottom" 
+               HorizontalAlignment="Right"
                Margin="5"
                DragDelta="ThumbResizeThumbOnDragDeltaHandler"
                Visibility="{Binding IsResizable, Converter={StaticResource BoolToVisibilityCollapsedConverter}}"/>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -5,13 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModels="clr-namespace:Dynamo.ViewModels"
              xmlns:ui="clr-namespace:Dynamo.UI"
+             xmlns:controls="clr-namespace:Dynamo.Controls"
              mc:Ignorable="d"
-             d:DesignHeight="161"
-             d:DesignWidth="410"
+             Width="300"
+             Height="300"
              HorizontalAlignment="Stretch"
              VerticalAlignment="Stretch"
-             BorderBrush="Black"
-             MaxHeight="300">
+             BorderBrush="Black">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -19,6 +19,8 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
+            <controls:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+            <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
             <Style x:Key="BorderlessButton"
                    TargetType="{x:Type Button}">
                 <Setter Property="Padding"
@@ -240,8 +242,8 @@
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid>
 
+    <Grid Name ="inputGrid" MinHeight="100" MinWidth="100">
         <Grid.RowDefinitions>
             <RowDefinition Height ="*" />
             <RowDefinition Height="Auto" />
@@ -385,7 +387,15 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-        </Grid>
+
+            <Thumb Name ="resizeThumb" Grid.Column ="1"
+               Width="10" Height="10" 
+               HorizontalAlignment="Right" 
+               VerticalAlignment="Bottom" 
+               Margin="5"
+               DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+               Visibility="{Binding IsResizable, Converter={StaticResource BoolToVisibilityCollapsedConverter}}"/>
+          </Grid>
         </Border>
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Dynamo.ViewModels;
 
 namespace Dynamo.Controls
@@ -99,6 +100,21 @@ namespace Dynamo.Controls
             if (_vm.FindNodeForPathCommand.CanExecute(node.Path))
             {
                 _vm.FindNodeForPathCommand.Execute(node.Path);
+            }
+        }
+        private void ThumbResizeThumbOnDragDeltaHandler(object sender, DragDeltaEventArgs e)
+        {
+            var yAdjust = ActualHeight + e.VerticalChange;
+            var xAdjust = ActualWidth + e.HorizontalChange;
+
+            if (xAdjust >= inputGrid.MinWidth)
+            {
+                Width = xAdjust;
+            }
+
+            if (yAdjust >= inputGrid.MinHeight)
+            {
+                Height = yAdjust;
             }
         }
     }

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -31,6 +31,8 @@ namespace Dynamo.Controls
             resizeThumb.Visibility = Visibility.Visible;
             this.Width = 200;
             this.Height = 200;
+            inputGrid.MinHeight = 100;
+            inputGrid.MinWidth = 100;
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -26,6 +26,13 @@ namespace Dynamo.Controls
             _vm = this.DataContext as WatchViewModel;
         }
 
+        internal void SetWatchNodeProperties() 
+        {
+            resizeThumb.Visibility = Visibility.Visible;
+            this.Width = 200;
+            this.Height = 200;
+        }
+
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             //find the element which was clicked

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -14,6 +14,8 @@ namespace Dynamo.Controls
     {
         private WatchViewModel _vm;
         private WatchViewModel prevWatchViewModel;
+        private readonly int defaultSize = 200;
+        private readonly int minSize = 100;
 
         public WatchTree()
         {
@@ -29,10 +31,10 @@ namespace Dynamo.Controls
         internal void SetWatchNodeProperties() 
         {
             resizeThumb.Visibility = Visibility.Visible;
-            this.Width = 200;
-            this.Height = 200;
-            inputGrid.MinHeight = 100;
-            inputGrid.MinWidth = 100;
+            this.Width = defaultSize;
+            this.Height = defaultSize;
+            inputGrid.MinHeight = minSize;
+            inputGrid.MinWidth = minSize;
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -45,7 +45,6 @@ namespace CoreNodeModelsWpf.Nodes
             // make empty watchViewModel
             rootWatchViewModel = new WatchViewModel(dynamoViewModel.BackgroundPreviewViewModel.AddLabelForPath);
 
-            // Fix the maximum width/height of watch node.
             nodeView.PresentationGrid.Children.Add(watchTree);
             nodeView.PresentationGrid.Visibility = Visibility.Visible;
             // disable preview control

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -44,8 +44,6 @@ namespace CoreNodeModelsWpf.Nodes
             rootWatchViewModel = new WatchViewModel(dynamoViewModel.BackgroundPreviewViewModel.AddLabelForPath);
 
             // Fix the maximum width/height of watch node.
-            nodeView.PresentationGrid.MaxWidth = Configurations.MaxWatchNodeWidth;
-            nodeView.PresentationGrid.MaxHeight = Configurations.MaxWatchNodeHeight;
             nodeView.PresentationGrid.Children.Add(watchTree);
             nodeView.PresentationGrid.Visibility = Visibility.Visible;
             // disable preview control

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -40,6 +40,8 @@ namespace CoreNodeModelsWpf.Nodes
 
             var watchTree = new WatchTree();
 
+            watchTree.SetWatchNodeProperties();
+
             // make empty watchViewModel
             rootWatchViewModel = new WatchViewModel(dynamoViewModel.BackgroundPreviewViewModel.AddLabelForPath);
 


### PR DESCRIPTION
### Purpose

This PR adds a functionality to let the users expand the watch node so that they can view the whole content. 

Task: https://jira.autodesk.com/browse/DYN-2457

After discussing with @Amoursol and @QilongTang, we thought it would be useful to add a thumb control to expand the watch node to a desirable size. This thumb control to similar to the one, that is present in watch3D node. 

![watch node expansion](https://user-images.githubusercontent.com/43763136/101690523-6102ff80-3a3b-11eb-9ff6-1bed1580b456.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

