### PR TITLE
Do not aggregate node execution analytics anymore

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1044,18 +1044,18 @@ namespace Dynamo.Models
 
                         if (Logging.Analytics.ReportingAnalytics)
                         {
-                            var modifiedNodes = "";
                             if (updateTask.ModifiedNodes != null && updateTask.ModifiedNodes.Any())
                             {
-                                modifiedNodes = updateTask.ModifiedNodes
-                                    .Select(n => n.GetOriginalName())
-                                    .Aggregate((x, y) => string.Format("{0}, {1}", x, y));
+                                // Send analytics for each of modified nodes so they are counted individually
+                                foreach (var node in updateTask.ModifiedNodes)
+                                {
+                                    // Notice the executionTimeSpan is still for the whole delta computation
+                                    Dynamo.Logging.Analytics.TrackTimedEvent(
+                                        Categories.Performance,
+                                        e.Task.GetType().Name,
+                                        executionTimeSpan, node.GetOriginalName());
+                                }
                             }
-
-                            Dynamo.Logging.Analytics.TrackTimedEvent(
-                                Categories.Performance,
-                                e.Task.GetType().Name,
-                                executionTimeSpan, modifiedNodes);
                         }
 
                         Debug.WriteLine(String.Format(Resources.EvaluationCompleted, executionTimeSpan));

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1049,11 +1049,12 @@ namespace Dynamo.Models
                                 // Send analytics for each of modified nodes so they are counted individually
                                 foreach (var node in updateTask.ModifiedNodes)
                                 {
-                                    // Notice the executionTimeSpan is still for the whole delta computation
-                                    Dynamo.Logging.Analytics.TrackTimedEvent(
-                                        Categories.Performance,
-                                        e.Task.GetType().Name,
-                                        executionTimeSpan, node.GetOriginalName());
+                                    // Starting from Dynamo 2.11.0, tracking node execution as generic event so
+                                    // it is distinguished with the previous aggregated performance event
+                                    Dynamo.Logging.Analytics.TrackEvent(
+                                        Actions.Run, 
+                                        Categories.NodeOperations,
+                                        node.GetOriginalName());
                                 }
                             }
                         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1049,8 +1049,8 @@ namespace Dynamo.Models
                                 // Send analytics for each of modified nodes so they are counted individually
                                 foreach (var node in updateTask.ModifiedNodes)
                                 {
-                                    // Starting from Dynamo 2.11.0, tracking node execution as generic event so
-                                    // it is distinguished with the previous aggregated performance event
+                                    // Tracking node execution as generic event
+                                    // it is distinguished with the legacy aggregated performance event
                                     Dynamo.Logging.Analytics.TrackEvent(
                                         Actions.Run, 
                                         Categories.NodeOperations,

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -194,7 +194,7 @@ namespace Dynamo.Logging
         Switch,
 
         /// <summary>
-        /// Run event, such as Python node run clicked, Graph run Clicked
+        /// Run event, such as Python node run clicked, Graph run Clicked, generic node run during graph execution
         /// </summary>
         Run,
 


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Example Graph
![image](https://user-images.githubusercontent.com/3942418/101956860-4f9e2c80-3bce-11eb-815e-30fdcc59443f.png)

Previously, node execution analytics data was aggregated with comma, e.g.

```
Code Block, String from Array, Watch
```

This makes data much less straight forward on backend with all kinds of combos of modified nodes during execution.

After this PR, each executed node will be tracked individually and no longer using timed event. Here are the cases:

1. Adding a new node, `ModifiedNodes` only contains the new node
2. Deleting a node, depending on which node we are deleting, `ModifiedNodes` only contains the downstream subgraph
3. Moving a node, no graph run will be triggered
4. Undo moving a node, `ModifiedNodes` only contains the node moved and downstream subgraph. This is a bug tracked.
5. Modifying a node, `ModifiedNodes` only contains the node modified and downstream subgraph

Individual node execution event will be tracked as `DYN.NodeOperations.Run` instead of the previous aggregated `DYN.Performance.UpdateGraphAsyncTask`. See related PR: https://git.autodesk.com/Dynamo/Analytics.NET/pull/26

About performance impact, I used DotTrace by Jetbrains to profile with a file with ~760 nodes, I did file opening and some other actions above which would trigger rerun with a lot of nodes executed. The profiling results did not mark any hot spots on analytics call but marked Python node view customization as hot spots. Since the analytics call do not involve system I/O by default which matches my expectation, I think adding this loop should be safe. FYI: @mmisol 
![image](https://user-images.githubusercontent.com/3942418/102112460-bb1e0f00-3e05-11eb-8fe5-7d70be14beb6.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
