### PR TITLE
Implement ToString for DS Dictionary

### DIFF
--- a/src/Libraries/DesignScriptBuiltin/Dictionary.cs
+++ b/src/Libraries/DesignScriptBuiltin/Dictionary.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 using Autodesk.DesignScript.Runtime;
 
 namespace DesignScript
@@ -102,6 +104,28 @@ namespace DesignScript
             public object ValueAtKey(string key)
             {
                 return D[key];
+            }
+
+            /// <summary>
+            /// Returns a friendly string representation of the dictionary.
+            /// </summary>
+            /// <returns>String representation of the dictionary.</returns>
+            public override string ToString()
+            {
+                var result = new StringBuilder();
+                result.Append("{");
+                foreach (var key in D.Keys)
+                {
+                    result.Append($"{key}:{D[key]},");
+                }
+
+                if (D.Any())
+                {
+                    result.Length -= 1;
+                }
+
+                result.Append("}");
+                return result.ToString();
             }
         }
     }

--- a/test/DynamoCoreTests/Nodes/DictionaryTests.cs
+++ b/test/DynamoCoreTests/Nodes/DictionaryTests.cs
@@ -58,5 +58,25 @@ namespace Dynamo.Tests.Nodes
             AssertPreviewValue("756519ff963e4353a68535047fd50756", validationData1);
             AssertPreviewValue("48a84d7d9af14873a76a9e76df4f6058", validationData1);
         }
+
+        [Test]
+        public void DictionaryToString()
+        {
+            var dict = Dictionary.ByKeysValues(new string[] { "A", "B", "C", "D" }, new object[] { 1, 2, 3, 4 });
+            var dictAsString = dict.ToString();
+            // Entries can be in any order, so this is a safe way to assert the result.
+            StringAssert.Contains("A:1", dictAsString);
+            StringAssert.Contains("B:2", dictAsString);
+            StringAssert.Contains("C:3", dictAsString);
+            StringAssert.Contains("D:4", dictAsString);
+            StringAssert.IsMatch(@"\{\w:\d,\w:\d,\w:\d,\w:\d\}", dictAsString);
+        }
+
+        [Test]
+        public void EmptyDictionaryToString()
+        {
+            var dict = Dictionary.ByKeysValues(new string[0], new object[0]);
+            Assert.AreEqual(dict.ToString(), "{}");
+        }
     }
 }

--- a/test/Engine/ProtoTest/TD/MultiLangTests/BuiltinFunction_FromOldLang.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/BuiltinFunction_FromOldLang.cs
@@ -54,10 +54,16 @@ namespace ProtoTest.TD.MultiLangTests
 	}
 	def testToString()
 	{
-		a = [true,[false,false],true];
+		a = [true,[false,false],true,{""a"":1}];
 		b = __ToStringFromArray(a);
 		return = b;
 	}
+    def testToStringFromObject()
+    {
+        a = {""a"":1};
+		b = __ToStringFromObject(a);
+		return = b;
+    }
 	def testTranspose()
 	{
 		a = [[3,-4],[4,5]];
@@ -79,6 +85,7 @@ t6 = testSomeFalse();
 t7 = testSomeTrue();
 t8 = testToString();
 t9 = testTranspose();
+t10 = testToStringFromObject();
 t15 = testNormalizeDepth();
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
@@ -98,8 +105,9 @@ t15 = testNormalizeDepth();
             thisTest.Verify("t5", 2);
             thisTest.Verify("t6", true);
             thisTest.Verify("t7", true);
-            thisTest.Verify("t8", "[true,[false,false],true]");
+            thisTest.Verify("t8", "[true,[false,false],true,{a:1}]");
             thisTest.Verify("t9", v4);
+            thisTest.Verify("t10", "{a:1}");
             thisTest.Verify("t15", v9);
         }
 

--- a/test/Engine/ProtoTest/TD/MultiLangTests/BuiltinFunction_FromOldLang.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/BuiltinFunction_FromOldLang.cs
@@ -58,12 +58,12 @@ namespace ProtoTest.TD.MultiLangTests
 		b = __ToStringFromArray(a);
 		return = b;
 	}
-    def testToStringFromObject()
-    {
-        a = {""a"":1};
+	def testToStringFromObject()
+	{
+		a = {""a"":1};
 		b = __ToStringFromObject(a);
 		return = b;
-    }
+	}
 	def testTranspose()
 	{
 		a = [[3,-4],[4,5]];


### PR DESCRIPTION
### Purpose

This is done to provide meaningful output when a dictionary is provided
to nodes like 'String from Array' and 'String from Object'. These nodes
call built-in DS functions that end up calling ToString on the
dictionary, which until now used the default implementation inherited
from Object which just returned the class name.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
