### PR TITLE
Make IntegerSlider the only AKA for migration

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -22,7 +22,6 @@ namespace CoreNodeModels.Input
     [OutPortTypes("int")]
     [SupressImportIntoVM]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.Input.IntegerSlider")]
     [IsVisibleInDynamoLibrary(false)]
     public class IntegerSlider : SliderBase<int>
     {

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -23,6 +23,7 @@ namespace CoreNodeModels.Input
     [SupressImportIntoVM]
     [IsDesignScriptCompatible]
     [IsVisibleInDynamoLibrary(false)]
+    [AlsoKnownAs("DSCoreNodesUI.Input.IntegerSlider")]
     public class IntegerSlider : SliderBase<int>
     {
         /// <summary>
@@ -217,7 +218,6 @@ namespace CoreNodeModels.Input
     [OutPortTypes("int")]
     [SupressImportIntoVM]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.Input.IntegerSlider")]
     public class IntegerSlider64Bit : SliderBase<long>
     {
         /// <summary>


### PR DESCRIPTION
### Purpose

There were two classes that were declaring an 'AlsoKnownAs' attribute
for 'DSCoreNodesUI.Input.IntegerSlider' in 'CoreNodeModels.Input':
'IntegerSlider' and 'IntegerSlider64Bit'. While the latter obsoletes
the former, it is not possible to migrate to it from XML, so only 
'IntegerSlider' should continue declaring an 'AlsoKnownAs' attribute.
Note that currently both classes are trying to be registered, which
results in only one of them being registered but not really making any
guarantees of which one it is. This also generates an exception catched
internally but shown in the console.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
