### PR TITLE
update developer docs testing information

### DIFF
--- a/04-Testing/4-0-testing.html
+++ b/04-Testing/4-0-testing.html
@@ -475,7 +475,7 @@
 <span class="hljs-tag">&lt;<span class="hljs-name">configuration</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">appSettings</span>&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-name">add</span> <span class="hljs-attr">key</span>=<span class="hljs-string">&quot;DynamoBasePath&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;C:\Program Files\Dynamo\Dynamo Core\1.3&quot;</span>/&gt;</span>
-    <span class="hljs-tag">&lt;<span class="hljs-name">add</span> <span class="hljs-attr">key</span>=<span class="hljs-string">&quot;RequestedLibraryVersion&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;Version221&quot;</span>/&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">add</span> <span class="hljs-attr">key</span>=<span class="hljs-string">&quot;RequestedLibraryVersion2&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;226.0.0&quot;</span>/&gt;</span>
   <span class="hljs-tag">&lt;/<span class="hljs-name">appSettings</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">configuration</span>&gt;</span>
 </code></pre>


### PR DESCRIPTION
this PR updates the dev docs site to use the new `RequestedLibraryVersion2` config key for testing. this is required for ASM 224 and up.