### PR TITLE
[AGD-1883] support Input Output node tooltip info

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -25,7 +25,6 @@ namespace Dynamo.Graph.Nodes
         selectionInput
     };
 
-
     /// <summary>
     /// Represents a node which acts as a UI input for the graph
     /// - may also hold a value for that input
@@ -82,6 +81,11 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
+        /// <summary>
+        /// Specifies how the input control should be rendered.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string ControlType { get; set; }
 
         private static Dictionary<Type, NodeInputTypes> dotNetTypeToNodeInputType = new Dictionary<Type, NodeInputTypes>
         {

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -911,35 +911,40 @@ namespace Dynamo.Graph.Nodes
            get { return null; }
         }
 
+        private NodeOutputData outputData;
         [JsonIgnore]
         public virtual NodeOutputData OutputData
         {
             get
             {
-                // Determine if the output type can be determined at this time
-                // Current enum supports String, Integer, Float, Boolean, and unknown
-                // When CachedValue is null, type is set to unknown
-                // When Concrete type is dictionary or other type not expressed in enum, type is set to unknown
-                object returnObj = CachedValue?.Data?? new object();
-                var returnType = NodeOutputData.getNodeOutputTypeFromType(returnObj.GetType());
-                var returnValue = String.Empty;
-
-                // IntialValue is returned when the Type enum does not equal unknown
-                if(returnType != NodeOutputTypes.unknownOutput)
+                if (outputData is null)
                 {
-                    var formattableReturnObj = returnObj as IFormattable;
-                    returnValue = formattableReturnObj != null ? formattableReturnObj.ToString(null, CultureInfo.InvariantCulture) : returnObj.ToString();
+                    // Determine if the output type can be determined at this time
+                    // Current enum supports String, Integer, Float, Boolean, and unknown
+                    // When CachedValue is null, type is set to unknown
+                    // When Concrete type is dictionary or other type not expressed in enum, type is set to unknown
+                    object returnObj = CachedValue?.Data ?? new object();
+                    var returnType = NodeOutputData.getNodeOutputTypeFromType(returnObj.GetType());
+                    var returnValue = String.Empty;
+
+                    // IntialValue is returned when the Type enum does not equal unknown
+                    if (returnType != NodeOutputTypes.unknownOutput)
+                    {
+                        var formattableReturnObj = returnObj as IFormattable;
+                        returnValue = formattableReturnObj != null ? formattableReturnObj.ToString(null, CultureInfo.InvariantCulture) : returnObj.ToString();
+                    }
+
+
+                    outputData = new NodeOutputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = returnType,
+                        Description = this.Description,
+                        InitialValue = returnValue
+                    };
                 }
-
-                
-                return new NodeOutputData()
-                {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    Type = returnType,
-                    Description = this.Description,
-                    InitialValue = returnValue
-                };
+                return outputData;
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -511,6 +511,8 @@ namespace Dynamo.Graph.Workspaces
                     {
                         matchingNode.IsSetAsInput = true;
                         matchingNode.Name = inputData.Name;
+                        if (!(matchingNode is DummyNode))
+                            matchingNode.InputData.Description = inputData.Description;
                     }
                 }
             }
@@ -528,6 +530,7 @@ namespace Dynamo.Graph.Workspaces
                     {
                         matchingNode.IsSetAsOutput = true;
                         matchingNode.Name = outputData.Name;
+                        matchingNode.OutputData.Description = outputData.Description;
                     }
                 }
             }
@@ -732,6 +735,18 @@ namespace Dynamo.Graph.Workspaces
             var outputNodeDatas = ws.Nodes.Where((node) => node.IsSetAsOutput == true && node.OutputData != null)
                 .Select(outputNode => outputNode.OutputData).ToList();
             serializer.Serialize(writer, outputNodeDatas);
+
+            // Thumbnail
+            writer.WritePropertyName("Thumbnail");
+            serializer.Serialize(writer, ws.Thumbnail);
+
+            // Validation
+            writer.WritePropertyName("Validation");
+            serializer.Serialize(writer, ws.Validation.ToString());
+
+            // Helplink
+            writer.WritePropertyName("HelpLink");
+            serializer.Serialize(writer, ws.HelpLink);
 
             // Nodes
             writer.WritePropertyName("Nodes");

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -736,18 +736,6 @@ namespace Dynamo.Graph.Workspaces
                 .Select(outputNode => outputNode.OutputData).ToList();
             serializer.Serialize(writer, outputNodeDatas);
 
-            // Thumbnail
-            writer.WritePropertyName("Thumbnail");
-            serializer.Serialize(writer, ws.Thumbnail);
-
-            // Validation
-            writer.WritePropertyName("Validation");
-            serializer.Serialize(writer, ws.Validation.ToString());
-
-            // Helplink
-            writer.WritePropertyName("HelpLink");
-            serializer.Serialize(writer, ws.HelpLink);
-
             // Nodes
             writer.WritePropertyName("Nodes");
             serializer.Serialize(writer, ws.Nodes);

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -63,13 +63,24 @@ namespace CoreNodeModels
                 RaisePropertyChanged("Items");
             }
         }
+
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
-            //TODO There is not yet an appropriate input type
-            //defined in the cogs graph schema to support dropdowns
-            //which return arbitrary objects at some index - implement this
-            //when that exists.
-            get { return null; }
+            get
+            {
+                if (inputData is null)
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputTypes.selectionInput,
+                        Description = this.Description
+                    };
+
+                inputData.Value = SelectedString;
+                return inputData;
+            }
         }
 
         private int selectedIndex = -1;

--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -36,21 +36,29 @@ namespace CoreNodeModels.Input
                 }               
             }
         }
+
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
            
             get
             {
-                return new NodeInputData()
+                if (inputData is null)
                 {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    //use the <T> type to convert to the correct nodeTypeString defined by
-                    //the schema
-                    Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
-                    Description = this.Description,
-                    Value = Value.ToString(),
-                };
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        //use the <T> type to convert to the correct nodeTypeString defined by
+                        //the schema
+                        Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
+                        Description = this.Description
+                    };
+                }
+
+                inputData.Value = Value.ToString();
+
+                return inputData;
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
@@ -41,19 +41,25 @@ namespace CoreNodeModels.Input
             return base.UpdateValueCore(updateValueParams);
         }
 
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
-
             get
             {
-                return new NodeInputData()
+                if (inputData is null)
                 {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    Type = NodeInputData.getNodeInputTypeFromType(typeof(System.Boolean)),
-                    Description = this.Description,
-                    Value = Value.ToString().ToLower(),
-                };
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputData.getNodeInputTypeFromType(typeof(System.Boolean)),
+                        Description = this.Description
+                    };
+                }
+
+                inputData.Value = Value.ToString().ToLower();
+
+                return inputData;
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -47,22 +47,28 @@ namespace CoreNodeModels.Input
             }
         }
 
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
             get
             {
+                if(inputData is null)
+                {
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+
+                        Type = NodeInputTypes.colorInput,
+                        Description = this.Description
+                    };
+                }
+
                 //this object which we'll convert to a json string matches the format the schema expects for colors
                 var colorObj = new { Red = Convert.ToInt32(DsColor.Red), Blue = Convert.ToInt32(DsColor.Blue), Green = Convert.ToInt32(DsColor.Green), Alpha = Convert.ToInt32(DsColor.Alpha) };
+                inputData.Value = JsonConvert.SerializeObject(colorObj);
 
-                return new NodeInputData()
-                {
-                    Id = this.GUID,
-                    Name = this.Name,
-
-                    Type = NodeInputTypes.colorInput,
-                    Description = this.Description,
-                    Value = JsonConvert.SerializeObject(colorObj),
-                };
+                return inputData;
             }
         }
         /// <summary>

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -30,19 +30,26 @@ namespace CoreNodeModels.Input
             ShouldDisplayPreviewCore = false;
         }
 
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
             get
             {
-                return new NodeInputData()
+                if (inputData is null)
                 {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    Type = NodeInputData.getNodeInputTypeFromType(typeof(System.DateTime)),
-                    Description = this.Description,
-                    //format dateTime with swagger spec in mind:  ISO 8601.
-                    Value = Value.ToString("o", CultureInfo.InvariantCulture),
-                };
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputData.getNodeInputTypeFromType(typeof(System.DateTime)),
+                        Description = this.Description
+                    };
+                }
+
+                //format dateTime with swagger spec in mind:  ISO 8601.
+                inputData.Value = Value.ToString("o", CultureInfo.InvariantCulture);
+
+                return inputData;
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -41,24 +41,30 @@ namespace CoreNodeModels.Input
                 return "Double";
             }
         }
+
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
             get
             {
-                return new NodeInputData()
+                if(inputData is null)
                 {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    Type = NodeInputTypes.numberInput,
-                    Description = this.Description,
-                    Value = Value.ToString(CultureInfo.InvariantCulture),
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputTypes.numberInput,
+                        NumberType = this.NumberType,
+                        Description = this.Description
+                    };
+                }
 
-                    MinimumValue = this.Min,
-                    MaximumValue = this.Max,
-                    StepValue = this.Step,
-                    NumberType = this.NumberType,
+                inputData.Value = Value.ToString(CultureInfo.InvariantCulture);
+                inputData.MinimumValue = this.Min;
+                inputData.MaximumValue = this.Max;
+                inputData.StepValue = this.Step;
 
-                };
+                return inputData;
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -46,24 +46,30 @@ namespace CoreNodeModels.Input
                 return "Integer";
             }
         }
+
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
             get
             {
-                return new NodeInputData()
+                if (inputData is null)
                 {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    Type = NodeInputTypes.numberInput,
-                    Description = this.Description,
-                    Value = Value.ToString(CultureInfo.InvariantCulture),
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputTypes.numberInput,
+                        NumberType = this.NumberType,
+                        Description = this.Description
+                    };
+                }
 
-                    MinimumValue = this.Min,
-                    MaximumValue = this.Max,
-                    StepValue = this.Step,
-                    NumberType = this.NumberType,
+                inputData.Value = Value.ToString(CultureInfo.InvariantCulture);
+                inputData.MinimumValue = this.Min;
+                inputData.MaximumValue = this.Max;
+                inputData.StepValue = this.Step;
 
-                };
+                return inputData;
             }
         }
 
@@ -241,27 +247,31 @@ namespace CoreNodeModels.Input
             }
         }
 
+        private NodeInputData inputData;
         public override NodeInputData InputData
         {
-           get
+            get
             {
-                return new NodeInputData()
+                if (inputData is null)
                 {
-                    Id = this.GUID,
-                    Name = this.Name,
-                    Type = NodeInputTypes.numberInput,
-                    Description = this.Description,
-                    Value = Value.ToString(CultureInfo.InvariantCulture),
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputTypes.numberInput,
+                        NumberType = this.NumberType,
+                        Description = this.Description
+                    };
+                }
 
-                    MinimumValue = this.Min,
-                    MaximumValue = this.Max,
-                    StepValue = this.Step,
-                    NumberType = this.NumberType,
-
-                };
+                inputData.Value = Value.ToString(CultureInfo.InvariantCulture);
+                inputData.MinimumValue = this.Min;
+                inputData.MaximumValue = this.Max;
+                inputData.StepValue = this.Step;
+               
+                return inputData;
             }
         }
-
 
         [JsonConstructor]
         private IntegerSlider64Bit(IEnumerable<PortModel> inPorts,

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -32,7 +32,26 @@ namespace CoreNodeModels
         
         #region public properties
 
-        public IEnumerable<TSelection> Selection { get { return selection; } } 
+        public IEnumerable<TSelection> Selection { get { return selection; } }
+
+        private NodeInputData inputData;
+        public override NodeInputData InputData
+        {
+            get
+            {
+                if(inputData is null)
+                    inputData = new NodeInputData()
+                    {
+                        Id = this.GUID,
+                        Name = this.Name,
+                        Type = NodeInputTypes.selectionInput,
+                        Description = this.Description
+                    };
+
+                inputData.Value = string.Join(",", selectionIdentifier.ToArray());
+                return inputData;
+            }
+        }
 
         /// <summary>
         /// A list of selected model objects


### PR DESCRIPTION
### Purpose

JIRA: [AGD-1883](https://jira.autodesk.com/browse/AGD-1883)

This PR changes how `NodeInputData` is used on input nodes. Instead of creating a new `NodeInputData` instance whenever a nodes `inputData` is called we only create it if it dosent exist. This makes it possible to store a special description for input nodes using `InputData.Description`.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@saintentropy @nate-peters 

### FYIs
@mjkkirschner @mmisol @QilongTang 

Still a few things that needs to be decided on this, opening this as a draft so its easier to discuss.

**Tests are on the todo list.**
