### PR TITLE
use existing library function to lookup previous name hints

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/ZeroTouchNodeLoader.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/ZeroTouchNodeLoader.cs
@@ -43,7 +43,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
                 string xmlSignature = nodeElement.Attributes["function"].Value;
 
                 string hintedSigniture =
-                    libraryServices.FunctionSignatureFromFunctionSignatureHint(xmlSignature);
+                    libraryServices.GetFunctionSignatureFromFunctionSignatureHint(xmlSignature);
 
                 if (hintedSigniture != null)
                 {

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -230,15 +230,13 @@ namespace Dynamo.Graph.Workspaces
             else if (typeof(DSFunctionBase).IsAssignableFrom(type))
             {
                 var mangledName = obj["FunctionSignature"].Value<string>();
-                var priorNames = libraryServices.GetPriorNames();
-                var functionDescriptor = libraryServices.GetFunctionDescriptor(mangledName);
-                string newName;
-
-                // Update the function descriptor if a newer migrated version of the node exists
-                if (priorNames.TryGetValue(mangledName, out newName))
+                var hintSignature = libraryServices.FunctionSignatureFromFunctionSignatureHint(mangledName);
+                var lookupSignature = mangledName;
+                if(hintSignature != null)
                 {
-                    functionDescriptor = libraryServices.GetFunctionDescriptor(newName);
+                    lookupSignature = hintSignature;
                 }
+                var functionDescriptor = libraryServices.GetFunctionDescriptor(lookupSignature);
 
                 // Use the functionDescriptor to try and restore the proper node if possible
                 if (functionDescriptor == null)

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -230,12 +230,7 @@ namespace Dynamo.Graph.Workspaces
             else if (typeof(DSFunctionBase).IsAssignableFrom(type))
             {
                 var mangledName = obj["FunctionSignature"].Value<string>();
-                var hintSignature = libraryServices.FunctionSignatureFromFunctionSignatureHint(mangledName);
-                var lookupSignature = mangledName;
-                if(hintSignature != null)
-                {
-                    lookupSignature = hintSignature;
-                }
+                var lookupSignature = libraryServices.GetFunctionSignatureFromFunctionSignatureHint(mangledName) ?? mangledName;
                 var functionDescriptor = libraryServices.GetFunctionDescriptor(lookupSignature);
 
                 // Use the functionDescriptor to try and restore the proper node if possible

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -305,7 +305,7 @@ namespace Dynamo.Engine
             return splitted[splitted.Length - 2] + "." + splitted[splitted.Length - 1];
         }
 
-        internal string FunctionSignatureFromFunctionSignatureHint(string functionSignature)
+        internal string GetFunctionSignatureFromFunctionSignatureHint(string functionSignature)
         {
             // if the hint is explicit, we can simply return the mapped function
             if (priorNameHints.ContainsKey(functionSignature))

--- a/test/DynamoCoreTests/MigrationTestFramework.cs
+++ b/test/DynamoCoreTests/MigrationTestFramework.cs
@@ -17,6 +17,7 @@ namespace Dynamo.Tests
             libraries.Add("DSOffice.dll");
             libraries.Add("FunctionObject.ds");
             libraries.Add("BuiltIn.ds");
+            libraries.Add("FFITarget.dll");
             base.GetLibrariesToPreload(libraries);
         }
 

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -2280,10 +2280,10 @@ namespace Dynamo.Tests
             var legacyGraph = Path.Combine(TestDirectory, "core","migration","TestMigrationFFIClass.dyn");
             TestMigration(legacyGraph);
 
-            // Verify all 4 nodes exist in the workspace and were properly loaded/opened from above
-            Assert.AreEqual(6, this.CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(8, this.CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
             AssertPreviewValue("408bd6b17f7f43b28a29175bf12fb01f", "hello");
             AssertPreviewValue("013bd08a0f574e85b1d9676ba7004990", "migrated");
+            AssertPreviewValue("df483e75085340b2a8c359a59dc8ea7a", "migrated");
         }
         #endregion
 

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -25,6 +25,7 @@ namespace Dynamo.Tests
             libraries.Add("DSOffice.dll");
             libraries.Add("FunctionObject.ds");
             libraries.Add("BuiltIn.ds");
+            libraries.Add("FFITarget.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -2270,6 +2271,19 @@ namespace Dynamo.Tests
 
             // Verify all 4 nodes exist in the workspace and were properly loaded/opened from above
             Assert.AreEqual(4, this.CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestZTNodeMigrationJSON_WithDifferentMethodNameAndParams()
+        {
+            var legacyGraph = Path.Combine(TestDirectory, "core","migration","TestMigrationFFIClass.dyn");
+            TestMigration(legacyGraph);
+
+            // Verify all 4 nodes exist in the workspace and were properly loaded/opened from above
+            Assert.AreEqual(6, this.CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            AssertPreviewValue("408bd6b17f7f43b28a29175bf12fb01f", "hello");
+            AssertPreviewValue("013bd08a0f574e85b1d9676ba7004990", "migrated");
         }
         #endregion
 

--- a/test/Engine/FFITarget/ClassWithMigratedMembers.cs
+++ b/test/Engine/FFITarget/ClassWithMigratedMembers.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFITarget
+{
+    public class ClassWithMigratedMembers
+    {
+
+        public static ClassWithMigratedMembers ByNothing()
+        {
+            return new ClassWithMigratedMembers();
+        }
+
+        //we test by opening a file that references a node with three params
+        public string AMemberWithTwoParams(string a, string b)
+        {
+            return a + b;
+        }
+        public string AMemberWithThreeParams(string a, string b,string c ="abc")
+        {
+            return "migrated";
+        }
+
+        //we test a file that uses the node AMemberWithAChangedName0
+        public string AMemberWithAChangedName2(string a)
+        {
+            return a;
+        }
+      /*  public string AMemberWithAChangedName1(string a)
+        {
+            return a;
+        }*/
+    }
+}

--- a/test/Engine/FFITarget/ClassWithMigratedMembers.cs
+++ b/test/Engine/FFITarget/ClassWithMigratedMembers.cs
@@ -32,7 +32,7 @@ namespace FFITarget
             return "migrated";
         }
 
-        //we test a file that uses the node AMemberWithAChangedName0
+        //we test a file that uses the node AMemberWithAChangedName1
         public string AMemberWithAChangedName2(string a)
         {
             return a;

--- a/test/Engine/FFITarget/ClassWithMigratedMembers.cs
+++ b/test/Engine/FFITarget/ClassWithMigratedMembers.cs
@@ -23,6 +23,14 @@ namespace FFITarget
         {
             return "migrated";
         }
+        public string AnOverloadedMember(string a, string b)
+        {
+            return "original";
+        }
+        public string AnOverloadedMember(string a, string b, string c = "abc")
+        {
+            return "migrated";
+        }
 
         //we test a file that uses the node AMemberWithAChangedName0
         public string AMemberWithAChangedName2(string a)

--- a/test/Engine/FFITarget/FFITarget.Migrations.xml
+++ b/test/Engine/FFITarget/FFITarget.Migrations.xml
@@ -8,4 +8,8 @@
     <oldName>FFITarget.ClassWithMigratedMembers.AMemberWithTwoParams@string,string</oldName>
     <newName>FFITarget.ClassWithMigratedMembers.AMemberWithThreeParams@string,string,string</newName>
   </priorNameHint>
+  <priorNameHint>
+    <oldName>FFITarget.ClassWithMigratedMembers.AnOverloadedMember@string,string</oldName>
+    <newName>FFITarget.ClassWithMigratedMembers.AnOverloadedMember@string,string,string</newName>
+  </priorNameHint>
 </migrations>

--- a/test/Engine/FFITarget/FFITarget.Migrations.xml
+++ b/test/Engine/FFITarget/FFITarget.Migrations.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0"?>
+<migrations>
+  <priorNameHint>
+    <oldName>FFITarget.ClassWithMigratedMembers.AMemberWithAChangedName1</oldName>
+    <newName>FFITarget.ClassWithMigratedMembers.AMemberWithAChangedName2</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>FFITarget.ClassWithMigratedMembers.AMemberWithTwoParams@string,string</oldName>
+    <newName>FFITarget.ClassWithMigratedMembers.AMemberWithThreeParams@string,string,string</newName>
+  </priorNameHint>
+</migrations>

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AbstractDisposeTracert.cs" />
     <Compile Include="AtLevelTestClass.cs" />
     <Compile Include="ClassFunctionality.cs" />
+    <Compile Include="ClassWithMigratedMembers.cs" />
     <Compile Include="ClassWithRefParams.cs" />
     <Compile Include="CodeCompletionClass.cs" />
     <Compile Include="CustomLabel.cs" />
@@ -97,6 +98,11 @@
       <Name>DynamoServices</Name>
       <Private>False</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="FFITarget.Migrations.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/core/migration/TestMigrationFFIClass.dyn
+++ b/test/core/migration/TestMigrationFFIClass.dyn
@@ -1,0 +1,335 @@
+{
+  "Uuid": "842b5201-dd00-4111-b207-986b131e73ca",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "TestMigrationFFIClass",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.ClassWithMigratedMembers.ByNothing",
+      "Id": "fbe24eef03a343ce888fdc5cfb61141a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "c42e788235c84766942b6e8dc026006f",
+          "Name": "ClassWithMigratedMembers",
+          "Description": "ClassWithMigratedMembers",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "ClassWithMigratedMembers.ByNothing ( ): ClassWithMigratedMembers"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.ClassWithMigratedMembers.AMemberWithAChangedName1@string",
+      "Id": "6775792fb64c4008b7b51cc5b06f3b4c",
+      "Inputs": [
+        {
+          "Id": "a5977b19471a4e0eab8dd41a1a9f9b30",
+          "Name": "classWithMigratedMembers",
+          "Description": "FFITarget.ClassWithMigratedMembers",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7a2e10eb951b4351941e7ed1916693c1",
+          "Name": "a",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "89a8a3c58f564e89a3bb9f6660f77090",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "ClassWithMigratedMembers.AMemberWithAChangedName1 (a: string): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.ClassWithMigratedMembers.AMemberWithTwoParams@string,string",
+      "Id": "db2deb1f76774d07af40dd33ab49a8ce",
+      "Inputs": [
+        {
+          "Id": "1a387533a91b4614b20601080e77b77e",
+          "Name": "classWithMigratedMembers",
+          "Description": "FFITarget.ClassWithMigratedMembers",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "74148da903804fafac1b5a569fc14fdd",
+          "Name": "a",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2dcce8cdb6284b6d8503e8d816a94d96",
+          "Name": "b",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1808ed32cf9c4b50abd462947572ebd8",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "ClassWithMigratedMembers.AMemberWithTwoParams (a: string, b: string): string"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "408bd6b17f7f43b28a29175bf12fb01f",
+      "Inputs": [
+        {
+          "Id": "af3e263d10374a68abbb774b47587f33",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9eabf28a4bf84d55bb94d59ff0340fa7",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"hello\";\n\"world\";",
+      "Id": "99c08bb549b24c91abc853d7f956f549",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "719ae5b6dc0c4b7abf85a2e541378a3a",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "010e634b76e94f99a733f085188714bc",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "013bd08a0f574e85b1d9676ba7004990",
+      "Inputs": [
+        {
+          "Id": "7e645d3aa9c94403b7127108ac042580",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ad8eae8c04354eff867764e4a1e9fa8c",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "c42e788235c84766942b6e8dc026006f",
+      "End": "a5977b19471a4e0eab8dd41a1a9f9b30",
+      "Id": "9f21548f44bf46d88fbe8dd711b5f143"
+    },
+    {
+      "Start": "c42e788235c84766942b6e8dc026006f",
+      "End": "1a387533a91b4614b20601080e77b77e",
+      "Id": "adea9c2f1fd24455a8cd42580efb9638"
+    },
+    {
+      "Start": "89a8a3c58f564e89a3bb9f6660f77090",
+      "End": "af3e263d10374a68abbb774b47587f33",
+      "Id": "eb597fda4b044fba9962eaa7e0da1751"
+    },
+    {
+      "Start": "1808ed32cf9c4b50abd462947572ebd8",
+      "End": "7e645d3aa9c94403b7127108ac042580",
+      "Id": "b7f5de277f8a415cbaddc4e01e4f2f8e"
+    },
+    {
+      "Start": "719ae5b6dc0c4b7abf85a2e541378a3a",
+      "End": "7a2e10eb951b4351941e7ed1916693c1",
+      "Id": "3f10f44c12ec4224995530d50ca79818"
+    },
+    {
+      "Start": "719ae5b6dc0c4b7abf85a2e541378a3a",
+      "End": "74148da903804fafac1b5a569fc14fdd",
+      "Id": "3cf410c133cb4f59b795ed7f445c12e0"
+    },
+    {
+      "Start": "010e634b76e94f99a733f085188714bc",
+      "End": "2dcce8cdb6284b6d8503e8d816a94d96",
+      "Id": "b3ff1f354d6e435b8402dc4be8216d2d"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.11.0.3706",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "ClassWithMigratedMembers.ByNothing",
+        "Id": "fbe24eef03a343ce888fdc5cfb61141a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 172.5,
+        "Y": 84.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "ClassWithMigratedMembers.AMemberWithAChangedName2",
+        "Id": "6775792fb64c4008b7b51cc5b06f3b4c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 525.5,
+        "Y": 224.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "ClassWithMigratedMembers.AMemberWithTwoParams",
+        "Id": "db2deb1f76774d07af40dd33ab49a8ce",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 524.5,
+        "Y": 418.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "hello",
+        "Id": "408bd6b17f7f43b28a29175bf12fb01f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1152.5,
+        "Y": 224.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "99c08bb549b24c91abc853d7f956f549",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 176.0,
+        "Y": 440.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "helloworld",
+        "Id": "013bd08a0f574e85b1d9676ba7004990",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1119.5,
+        "Y": 415.0
+      }
+    ],
+    "Annotations": [],
+    "X": -325.0,
+    "Y": -98.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/migration/TestMigrationFFIClass.dyn
+++ b/test/core/migration/TestMigrationFFIClass.dyn
@@ -202,6 +202,83 @@
       ],
       "Replication": "Disabled",
       "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.ClassWithMigratedMembers.AnOverloadedMember@string,string",
+      "Id": "1f6cc70ac940407c844c096e235bd53b",
+      "Inputs": [
+        {
+          "Id": "f61a8216a3d04a199884731d8275a4a2",
+          "Name": "classWithMigratedMembers",
+          "Description": "FFITarget.ClassWithMigratedMembers",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7384e3d4c3a949598270bbaeacff4837",
+          "Name": "a",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cb1c8b0a0e614a4c8cb756ca31a65bf8",
+          "Name": "b",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "93033c1429ce48efa89b18bdb83769f0",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "ClassWithMigratedMembers.AnOverloadedMember (a: string, b: string): string"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "df483e75085340b2a8c359a59dc8ea7a",
+      "Inputs": [
+        {
+          "Id": "721bceecdcde4932a642fb938086ad44",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "86660c1a71454595a0d7e2c0be5f13b4",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
     }
   ],
   "Connectors": [
@@ -214,6 +291,11 @@
       "Start": "c42e788235c84766942b6e8dc026006f",
       "End": "1a387533a91b4614b20601080e77b77e",
       "Id": "adea9c2f1fd24455a8cd42580efb9638"
+    },
+    {
+      "Start": "c42e788235c84766942b6e8dc026006f",
+      "End": "f61a8216a3d04a199884731d8275a4a2",
+      "Id": "edb6d3b1b9624890a4b9409ff0dd160e"
     },
     {
       "Start": "89a8a3c58f564e89a3bb9f6660f77090",
@@ -236,9 +318,24 @@
       "Id": "3cf410c133cb4f59b795ed7f445c12e0"
     },
     {
+      "Start": "719ae5b6dc0c4b7abf85a2e541378a3a",
+      "End": "7384e3d4c3a949598270bbaeacff4837",
+      "Id": "6ff489120ec64551a9465c250e85e3cc"
+    },
+    {
       "Start": "010e634b76e94f99a733f085188714bc",
       "End": "2dcce8cdb6284b6d8503e8d816a94d96",
       "Id": "b3ff1f354d6e435b8402dc4be8216d2d"
+    },
+    {
+      "Start": "010e634b76e94f99a733f085188714bc",
+      "End": "cb1c8b0a0e614a4c8cb756ca31a65bf8",
+      "Id": "179c4e5e8df44a179ce348a84758f80e"
+    },
+    {
+      "Start": "93033c1429ce48efa89b18bdb83769f0",
+      "End": "721bceecdcde4932a642fb938086ad44",
+      "Id": "db2e626a5b224c7b8742d7bea57c8e29"
     }
   ],
   "Dependencies": [],
@@ -325,11 +422,31 @@
         "Excluded": false,
         "X": 1119.5,
         "Y": 415.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "ClassWithMigratedMembers.AnOverloadedMember",
+        "Id": "1f6cc70ac940407c844c096e235bd53b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 535.967531313184,
+        "Y": 606.98434755081746
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "overload",
+        "Id": "df483e75085340b2a8c359a59dc8ea7a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1136.5271900692419,
+        "Y": 601.80741696785833
       }
     ],
     "Annotations": [],
-    "X": -325.0,
-    "Y": -98.0,
-    "Zoom": 1.0
+    "X": -108.79247816228667,
+    "Y": -37.402943935960707,
+    "Zoom": 0.8033215934625979
   }
 }

--- a/test/pkgs/Dynamo Samples/bin/SampleLibraryZeroTouch.Migrations.xml
+++ b/test/pkgs/Dynamo Samples/bin/SampleLibraryZeroTouch.Migrations.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <migrations>
   <priorNameHint>
-    <oldName>Examples.BasicExample.Create@Autodesk.DesignScript.Geometry.Point</oldName>
-    <newName>Examples.NEWBasicExample.Create@Autodesk.DesignScript.Geometry.Point</newName>
+    <oldName>Examples.BasicExample.Create</oldName>
+    <newName>Examples.NEWBasicExample.Create</newName>
   </priorNameHint>
   <priorNameHint>
     <oldName>Examples.BasicExample.Create@double,double,double</oldName>


### PR DESCRIPTION
### Purpose

I found that this PR:
https://github.com/DynamoDS/Dynamo/pull/9306

did indeed get migrations working using the migration.xml and AKA attributes - but not consistently with xml migrations.

This PR uses an existing function in library services to first check for an exact match using the full function signature (including parameter types) - and then falls back to checking for shortNames without parameters. This is more consistent with xml migration.

I've manually tested changing the name of a ZT node in the DSOffice namespace, adding that new function(without parameters) to the DSOffice.migrations.xml and all works as expected.

### TODO:
- [x] add a test for this migration
- [x] investigate how old tests pass, ~~likely they are not precise enough.~~ The tests did not include a case of migrating a type with parameters using a migration name hint that did not include those parameters - modified the test migration xml to include this case.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

