### PR TITLE
DYN-3320: Add basic standard library support

### DIFF
--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -76,9 +76,20 @@ namespace Dynamo.PackageManager
 
         private readonly List<string> packagesDirectoriesToVerifyCertificates = new List<string>();
 
+        // The standard library directory is located in the same directory as the DynamoPackages.dll
+        private string StandardLibraryDirectory =>
+            Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(GetType()).Location),
+                @"Standard Library", @"Packages");
+
         public PackageLoader(string overridePackageDirectory)
-            : this(new[] { overridePackageDirectory })
         {
+            if (overridePackageDirectory == null)
+                throw new ArgumentNullException("overridePackageDirectory");
+
+            packagesDirectories.Add(overridePackageDirectory);
+            this.packagesDirectories.Add(StandardLibraryDirectory);
+
+            this.packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
         }
 
         public PackageLoader(IEnumerable<string> packagesDirectories)
@@ -87,10 +98,14 @@ namespace Dynamo.PackageManager
                 throw new ArgumentNullException("packagesDirectories");
 
             this.packagesDirectories.AddRange(packagesDirectories);
+            this.packagesDirectories.Add(StandardLibraryDirectory);
+            
             var error = PathHelper.CreateFolderIfNotExist(DefaultPackagesDirectory);
 
             if (error != null)
                 Log(error);
+
+            this.packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
         }
 
         /// <summary>
@@ -99,11 +114,22 @@ namespace Dynamo.PackageManager
         /// <param name="packagesDirectories">Default package directories</param>
         /// <param name="packageDirectoriesToVerify">Default package directories where node library files require certificate verification before loading</param>
         public PackageLoader(IEnumerable<string> packagesDirectories, IEnumerable<string> packageDirectoriesToVerify)
-            : this(packagesDirectories)
         {
+            if (packagesDirectories == null)
+                throw new ArgumentNullException("packagesDirectories");
+
             if (packageDirectoriesToVerify == null)
                 throw new ArgumentNullException("packageDirectoriesToVerify");
 
+            this.packagesDirectories.AddRange(packagesDirectories);
+            this.packagesDirectories.Add(StandardLibraryDirectory);
+
+            var error = PathHelper.CreateFolderIfNotExist(DefaultPackagesDirectory);
+
+            if (error != null)
+                Log(error);
+
+            this.packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
             this.packagesDirectoriesToVerifyCertificates.AddRange(packageDirectoriesToVerify);
         }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -77,7 +77,7 @@ namespace Dynamo.PackageManager
         private readonly List<string> packagesDirectoriesToVerifyCertificates = new List<string>();
 
         // The standard library directory is located in the same directory as the DynamoPackages.dll
-        private string StandardLibraryDirectory =>
+        internal string StandardLibraryDirectory =>
             Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(GetType()).Location),
                 @"Standard Library", @"Packages");
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -82,14 +82,8 @@ namespace Dynamo.PackageManager
                 @"Standard Library", @"Packages");
 
         public PackageLoader(string overridePackageDirectory)
+            : this(new[] { overridePackageDirectory })
         {
-            if (overridePackageDirectory == null)
-                throw new ArgumentNullException("overridePackageDirectory");
-
-            packagesDirectories.Add(overridePackageDirectory);
-            this.packagesDirectories.Add(StandardLibraryDirectory);
-
-            this.packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
         }
 
         public PackageLoader(IEnumerable<string> packagesDirectories)
@@ -114,22 +108,11 @@ namespace Dynamo.PackageManager
         /// <param name="packagesDirectories">Default package directories</param>
         /// <param name="packageDirectoriesToVerify">Default package directories where node library files require certificate verification before loading</param>
         public PackageLoader(IEnumerable<string> packagesDirectories, IEnumerable<string> packageDirectoriesToVerify)
+            : this(packagesDirectories)
         {
-            if (packagesDirectories == null)
-                throw new ArgumentNullException("packagesDirectories");
-
             if (packageDirectoriesToVerify == null)
                 throw new ArgumentNullException("packageDirectoriesToVerify");
 
-            this.packagesDirectories.AddRange(packagesDirectories);
-            this.packagesDirectories.Add(StandardLibraryDirectory);
-
-            var error = PathHelper.CreateFolderIfNotExist(DefaultPackagesDirectory);
-
-            if (error != null)
-                Log(error);
-
-            this.packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
             this.packagesDirectoriesToVerifyCertificates.AddRange(packageDirectoriesToVerify);
         }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -99,7 +99,7 @@ namespace Dynamo.PackageManager
             if (error != null)
                 Log(error);
 
-            this.packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
+            packagesDirectoriesToVerifyCertificates.Add(StandardLibraryDirectory);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Dynamo.PackageManager
             if (packageDirectoriesToVerify == null)
                 throw new ArgumentNullException("packageDirectoriesToVerify");
 
-            this.packagesDirectoriesToVerifyCertificates.AddRange(packageDirectoriesToVerify);
+            packagesDirectoriesToVerifyCertificates.AddRange(packageDirectoriesToVerify);
         }
 
         private void OnPackageAdded(Package pkg)
@@ -134,9 +134,9 @@ namespace Dynamo.PackageManager
 
         internal void Add(Package pkg)
         {
-            if (!this.localPackages.Contains(pkg))
+            if (!localPackages.Contains(pkg))
             {
-                this.localPackages.Add(pkg);
+                localPackages.Add(pkg);
                 pkg.MessageLogged += OnPackageMessageLogged;
                 OnPackageAdded(pkg);
             }
@@ -144,9 +144,9 @@ namespace Dynamo.PackageManager
 
         internal void Remove(Package pkg)
         {
-            if (this.localPackages.Contains(pkg))
+            if (localPackages.Contains(pkg))
             {
-                this.localPackages.Remove(pkg);
+                localPackages.Remove(pkg);
                 pkg.MessageLogged -= OnPackageMessageLogged;
                 OnPackageRemoved(pkg);
             }
@@ -187,7 +187,7 @@ namespace Dynamo.PackageManager
         /// <param name="package"></param>
         internal void TryLoadPackageIntoLibrary(Package package)
         {
-            this.Add(package);
+            Add(package);
 
             // Prevent duplicate loads
             if (package.Loaded) return;
@@ -225,11 +225,11 @@ namespace Dynamo.PackageManager
                     {
                         RequestAddExtension?.Invoke(extension);
                     }
-                    this.requestedExtensions.Add(extension);
+                    requestedExtensions.Add(extension);
                 }
 
                 package.Loaded = true;
-                this.PackgeLoaded?.Invoke(package);
+                PackgeLoaded?.Invoke(package);
             }
             catch (CustomNodePackageLoadException e)
             {
@@ -325,9 +325,9 @@ namespace Dynamo.PackageManager
             foreach (var path in loadPackageParams.Preferences.CustomPackageFolders)
             {
                 customNodeManager.AddUninitializedCustomNodesInPath(path, false, false);
-                if (!this.packagesDirectories.Contains(path))
+                if (!packagesDirectories.Contains(path))
                 {
-                    this.packagesDirectories.Add(path);
+                    packagesDirectories.Add(path);
                 }
             }
             LoadAll(loadPackageParams);
@@ -360,7 +360,7 @@ namespace Dynamo.PackageManager
                         return;
                     }
 
-                    this.Log(string.Format(Resources.InvalidPackageFolderWarning, root));
+                    Log(string.Format(Resources.InvalidPackageFolderWarning, root));
                     return;
                 }
 
@@ -424,7 +424,7 @@ namespace Dynamo.PackageManager
                 // prevent duplicates
                 if (LocalPackages.All(pkg => pkg.Name != discoveredPkg.Name))
                 {
-                    this.Add(discoveredPkg);
+                    Add(discoveredPkg);
                     return discoveredPkg; // success
                 }
                 throw new LibraryLoadFailedException(directory, String.Format(Properties.Resources.DulicatedPackage, discoveredPkg.Name, discoveredPkg.RootDirectory));

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Dynamo.Engine;
+using System.Reflection;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
@@ -641,6 +641,22 @@ namespace Dynamo.PackageManager.Tests
         //        }
         //    }
         //}
+
+        [Test]
+        public void HasValidStandardLibraryPath()
+        {
+            // Arrange
+            var loader = new PackageLoader(new[] { PackagesDirectory }, new[] { PackagesDirectorySigned });
+            var directory = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(loader.GetType()).Location),
+                @"Standard Library", @"Packages");
+
+            // Act
+            var standardDirectory = loader.StandardLibraryDirectory;
+
+            // Assert
+            Assert.IsNotNullOrEmpty(standardDirectory);
+            Assert.AreEqual(standardDirectory, directory);
+        }
 
         [Test]
         public void IsUnderPackageControlIsCorrectForValidFunctionDefinition()


### PR DESCRIPTION
### Purpose

Packages should be loadable/shippable with core runtime zip and daily builds. 

This pull request does:
* introduce a new `Standard Library\Packages` folder that lives in the same folder as the `DynamoPackages.dll`
* add this folder as a folder to load packages from in each `PackageLoader` constructor.
* require that packages loaded from this location is signed.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
