### PR TITLE
Dock and Undock view extension with Dynamic extension ID as edge case

### DIFF
--- a/src/DynamoCoreWpf/Extensions/ViewExtensionManager.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionManager.cs
@@ -98,7 +98,7 @@ namespace Dynamo.Wpf.Extensions
                 // with a consistent UniqueId. This may result in unexpected Dynamo behavior.
                 if (extension.UniqueId != extension.UniqueId)
                 {
-                    Log("Inconsistent UniqueId for " + extension.Name + " view extension.");
+                    Log("Inconsistent UniqueId for " + extension.Name + " view extension. This may result in unexpected Dynamo behavior.");
                 }
 
                 if (ExtensionAdded != null)

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionManager.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionManager.cs
@@ -94,6 +94,12 @@ namespace Dynamo.Wpf.Extensions
             {
                 viewExtensions.Add(extension);
                 Log(fullName + " view extension is added");
+                // Inform view extension author and consumer that the view extension does not come 
+                // with a consistent UniqueId. This may result in unexpected Dynamo behavior.
+                if (extension.UniqueId != extension.UniqueId)
+                {
+                    Log("Inconsistent UniqueId for " + extension.Name + " view extension.");
+                }
 
                 if (ExtensionAdded != null)
                 {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -296,6 +296,7 @@ namespace Dynamo.Controls
                 }
             }
             
+            // Setting the content of the undocked window
             // Icon is passed from DynamoView (respecting Host integrator icon)
             SetApplicationIcon();
             window.Icon = this.Icon;
@@ -328,15 +329,18 @@ namespace Dynamo.Controls
         {
             var extension = window.Tag as IViewExtension;
             var settings = this.dynamoViewModel.Model.PreferenceSettings.ViewExtensionSettings.Find(ext => ext.UniqueId == extension.UniqueId);
-            if (settings.WindowSettings == null)
+            if (settings != null)
             {
-                settings.WindowSettings = new WindowSettings();
+                if (settings.WindowSettings == null)
+                {
+                    settings.WindowSettings = new WindowSettings();
+                }
+                settings.WindowSettings.Status = window.WindowState == WindowState.Maximized ? WindowStatus.Maximized : WindowStatus.Normal;
+                settings.WindowSettings.Left = (int)window.SavedWindowRect.Left;
+                settings.WindowSettings.Top = (int)window.SavedWindowRect.Top;
+                settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
+                settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
             }
-            settings.WindowSettings.Status = window.WindowState == WindowState.Maximized ? WindowStatus.Maximized : WindowStatus.Normal;
-            settings.WindowSettings.Left = (int)window.SavedWindowRect.Left;
-            settings.WindowSettings.Top = (int)window.SavedWindowRect.Top;
-            settings.WindowSettings.Width = (int)window.SavedWindowRect.Width;
-            settings.WindowSettings.Height = (int)window.SavedWindowRect.Height;
         }
 
         private TabItem AddExtensionTab(IViewExtension viewExtension, UIElement content)
@@ -472,8 +476,11 @@ namespace Dynamo.Controls
             CloseExtensionTab(tabItem);
             var extension = tabItem.Tag as IViewExtension;
             var settings = this.dynamoViewModel.PreferenceSettings.ViewExtensionSettings.Find(s => s.UniqueId == extension.UniqueId);
-            AddExtensionWindow(extension, content, settings.WindowSettings);
-            settings.DisplayMode = ViewExtensionDisplayMode.FloatingWindow;
+            AddExtensionWindow(extension, content, settings?.WindowSettings);
+            if (settings != null)
+            {
+                settings.DisplayMode = ViewExtensionDisplayMode.FloatingWindow;
+            }
         }
 
         /// <summary>
@@ -516,8 +523,10 @@ namespace Dynamo.Controls
                 AddExtensionTab(extension, content);
 
                 var settings = this.dynamoViewModel.PreferenceSettings.ViewExtensionSettings.Find(s => s.UniqueId == extension.UniqueId);
-                settings.DisplayMode = ViewExtensionDisplayMode.DockRight;
-
+                if (settings != null)
+                {
+                    settings.DisplayMode = ViewExtensionDisplayMode.DockRight;
+                }
                 Analytics.TrackEvent(Actions.Dock, Categories.ViewExtensionOperations, extName);
             }
             else

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -227,6 +227,23 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void ExtensionDockAndUndockWithRandomGUID()
+        {
+            RaiseLoadedEvent(this.View);
+
+            // Add extension, default state is docked immediately
+            View.viewExtensionManager.Add(extensionsSideBarViewExtension);
+
+            // Extension bar is shown
+            Assert.AreEqual(1, View.ExtensionTabItems.Count);
+            Assert.IsFalse(View.ExtensionsCollapsed);
+
+            // Undock extension which return a new UniqueId, this should not crash Dynamo
+            extensionsSideBarViewExtension.UniqueId = "NewRandomGuid1";
+            Assert.DoesNotThrow(() => View.UndockExtension(extensionsSideBarViewExtension.Name));
+        }
+
+        [Test]
         public void ExtensionCannotBeAddedAsBothWindowAndTab()
         {
             RaiseLoadedEvent(this.View);


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

@nate-peters and @saintentropy found that docking and undocking view extensions with dynamic unique id will lead to hard crash in Dynamo. Although it is not recommended to do that, the baseline is Dynamo should no crash.

TODO:
- [x] Warning user in console that the view extension does not have static id
![image](https://user-images.githubusercontent.com/3942418/104226832-6a0a3680-5416-11eb-8d4e-18b129d22ce7.png)

- [x] Unit test

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
