### PR TITLE
WIP DYN-2538 Generate single RenderPackage per Node

### DIFF
--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -201,59 +201,7 @@ namespace Dynamo.Scheduler
                     //Plane tessellation needs to be handled here vs in LibG currently
                     if (graphicItem is Plane plane)
                     {
-                        package.RequiresPerVertexColoration = true;
-
-                        var s = 2.5;
-
-                        var cs = CoordinateSystem.ByPlane(plane);
-                        var a = Point.ByCartesianCoordinates(cs, s, s, 0);
-                        var b = Point.ByCartesianCoordinates(cs, -s, s, 0);
-                        var c = Point.ByCartesianCoordinates(cs, -s, -s, 0);
-                        var d = Point.ByCartesianCoordinates(cs, s, -s, 0);
-                        //Todo Dispose cs, a, b, c, d?
-
-                        package.AddTriangleVertex(a.X, a.Y, a.Z);
-                        package.AddTriangleVertex(b.X, b.Y, b.Z);
-                        package.AddTriangleVertex(c.X, c.Y, c.Z);
-
-                        package.AddTriangleVertex(c.X, c.Y, c.Z);
-                        package.AddTriangleVertex(d.X, d.Y, d.Z);
-                        package.AddTriangleVertex(a.X, a.Y, a.Z);
-
-                        package.AddTriangleVertexUV(0, 0);
-                        package.AddTriangleVertexUV(0, 0);
-                        package.AddTriangleVertexUV(0, 0);
-                        package.AddTriangleVertexUV(0, 0);
-                        package.AddTriangleVertexUV(0, 0);
-                        package.AddTriangleVertexUV(0, 0);
-
-                        // Draw plane edges
-                        package.AddLineStripVertex(a.X, a.Y, a.Z);
-                        package.AddLineStripVertex(b.X, b.Y, b.Z);
-                        package.AddLineStripVertex(b.X, b.Y, b.Z);
-                        package.AddLineStripVertex(c.X, c.Y, c.Z);
-                        package.AddLineStripVertex(c.X, c.Y, c.Z);
-                        package.AddLineStripVertex(d.X, d.Y, d.Z);
-                        package.AddLineStripVertex(d.X, d.Y, d.Z);
-                        package.AddLineStripVertex(a.X, a.Y, a.Z);
-
-                        // Draw normal
-                        package.AddLineStripVertex(plane.Origin.X, plane.Origin.Y, plane.Origin.Z);
-                        var nEnd = plane.Origin.Add(plane.Normal.Scale(2.5));
-                        package.AddLineStripVertex(nEnd.X, nEnd.Y, nEnd.Z);
-
-                        for (var i = 0; i < 5; i++)
-                        {
-                            package.AddLineStripVertexCount(2);
-                            package.AddLineStripVertexColor(MidTone, MidTone, MidTone, 255);
-                            package.AddLineStripVertexColor(MidTone, MidTone, MidTone, 255);
-                        }
-
-                        for (var i = 0; i < 6; i++)
-                        {
-                            package.AddTriangleVertexNormal(plane.Normal.X, plane.Normal.Y, plane.Normal.Z);
-                            package.AddTriangleVertexColor(0, 0, 0, 10);
-                        }
+                        CreatePlaneTessellation(package, plane);
                     }
                     else
                     {
@@ -316,6 +264,63 @@ namespace Dynamo.Scheduler
                     Debug.WriteLine(
                         "PushGraphicItemIntoPackage: " + e);
                 }
+            }
+        }
+
+        private static void CreatePlaneTessellation(IRenderPackage package, Plane plane)
+        {
+            package.RequiresPerVertexColoration = true;
+
+            var s = 2.5;
+
+            var cs = CoordinateSystem.ByPlane(plane);
+            var a = Point.ByCartesianCoordinates(cs, s, s, 0);
+            var b = Point.ByCartesianCoordinates(cs, -s, s, 0);
+            var c = Point.ByCartesianCoordinates(cs, -s, -s, 0);
+            var d = Point.ByCartesianCoordinates(cs, s, -s, 0);
+            //Todo Dispose cs, a, b, c, d?
+
+            package.AddTriangleVertex(a.X, a.Y, a.Z);
+            package.AddTriangleVertex(b.X, b.Y, b.Z);
+            package.AddTriangleVertex(c.X, c.Y, c.Z);
+
+            package.AddTriangleVertex(c.X, c.Y, c.Z);
+            package.AddTriangleVertex(d.X, d.Y, d.Z);
+            package.AddTriangleVertex(a.X, a.Y, a.Z);
+
+            package.AddTriangleVertexUV(0, 0);
+            package.AddTriangleVertexUV(0, 0);
+            package.AddTriangleVertexUV(0, 0);
+            package.AddTriangleVertexUV(0, 0);
+            package.AddTriangleVertexUV(0, 0);
+            package.AddTriangleVertexUV(0, 0);
+
+            // Draw plane edges
+            package.AddLineStripVertex(a.X, a.Y, a.Z);
+            package.AddLineStripVertex(b.X, b.Y, b.Z);
+            package.AddLineStripVertex(b.X, b.Y, b.Z);
+            package.AddLineStripVertex(c.X, c.Y, c.Z);
+            package.AddLineStripVertex(c.X, c.Y, c.Z);
+            package.AddLineStripVertex(d.X, d.Y, d.Z);
+            package.AddLineStripVertex(d.X, d.Y, d.Z);
+            package.AddLineStripVertex(a.X, a.Y, a.Z);
+
+            // Draw normal
+            package.AddLineStripVertex(plane.Origin.X, plane.Origin.Y, plane.Origin.Z);
+            var nEnd = plane.Origin.Add(plane.Normal.Scale(2.5));
+            package.AddLineStripVertex(nEnd.X, nEnd.Y, nEnd.Z);
+
+            for (var i = 0; i < 5; i++)
+            {
+                package.AddLineStripVertexCount(2);
+                package.AddLineStripVertexColor(MidTone, MidTone, MidTone, 255);
+                package.AddLineStripVertexColor(MidTone, MidTone, MidTone, 255);
+            }
+
+            for (var i = 0; i < 6; i++)
+            {
+                package.AddTriangleVertexNormal(plane.Normal.X, plane.Normal.Y, plane.Normal.Z);
+                package.AddTriangleVertexColor(0, 0, 0, 10);
             }
         }
 

--- a/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
+++ b/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.DesignScript.Interfaces;
 
@@ -154,6 +155,7 @@ namespace Dynamo.Visualization
         /// Apply a color to each point vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyPointVertexColors(byte[] colors)
         {
             pointColors.Clear();
@@ -163,6 +165,7 @@ namespace Dynamo.Visualization
         /// <summary>
         /// Apply a color to a sequence of line vertices.
         /// </summary>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyLineVertexColors(byte[] colors)
         {
             lineColors.Clear();
@@ -173,6 +176,7 @@ namespace Dynamo.Visualization
         /// Apply a color to each mesh vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyMeshVertexColors(byte[] colors)
         {
             meshColors.Clear();
@@ -183,6 +187,7 @@ namespace Dynamo.Visualization
         /// Sets an array of bytes that is used as a color map.
         /// </summary>
         /// <param name="colors"></param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public void SetColors(byte[] colors)
         {
             this.colors = colors;
@@ -370,11 +375,13 @@ namespace Dynamo.Visualization
         /// for mapping onto surfaces. Use the ColorsStride property to define the
         /// size of one dimension of the collection.
         /// </summary>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public IEnumerable<byte> Colors { get; private set; }
 
         /// <summary>
         /// The size of one dimension of the Colors collection.
         /// </summary>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public int ColorsStride { get; set; }
     }
 }

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -569,6 +569,21 @@ namespace Dynamo.Wpf.Rendering
         #region IRenderPackageSupplement implementation
 
         /// <summary>
+        /// The number of point vertices colors in the package.
+        /// </summary>
+        public int PointVertexColorCount => points.Colors.Count;
+
+        /// <summary>
+        /// The number of line vertices colors in the package.
+        /// </summary>
+        public int LineVertexColorCount => lines.Colors.Count;
+
+        /// <summary>
+        /// The number of mesh vertices colors in the package.
+        /// </summary>
+        public int MeshVertexColorCount => mesh.Colors.Count;
+
+        /// <summary>
         /// Insert a color to a range of point vertices.
         /// </summary>
         public void InsertPointVertexColorRange(int startIndex, int endIndex, byte red, byte green, byte blue, byte alpha)

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -181,6 +181,7 @@ namespace Dynamo.Wpf.Rendering
 
         #region IRenderPackage implementation
 
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public void SetColors(byte[] colors)
         {
             this.colors = colors;
@@ -313,6 +314,7 @@ namespace Dynamo.Wpf.Rendering
         /// Apply a color to each point vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyPointVertexColors(byte[] colors)
         {
             if (colors.Count()/4 != points.Positions.Count)
@@ -328,6 +330,7 @@ namespace Dynamo.Wpf.Rendering
         /// Apply a color to each line vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyLineVertexColors(byte[] colors)
         {
             if (colors.Count() / 4 != lines.Positions.Count)
@@ -343,6 +346,7 @@ namespace Dynamo.Wpf.Rendering
         /// Apply a color to each mesh vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyMeshVertexColors(byte[] colors)
         {
             if (colors.Count() / 4 != mesh.Positions.Count)
@@ -496,11 +500,13 @@ namespace Dynamo.Wpf.Rendering
             get { return points.Indices.ToArray(); }
         }
 
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public IEnumerable<byte> Colors
         {
             get { return colors; }
         }
 
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public int ColorsStride { get; set; }
 
         #endregion

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -47,6 +47,7 @@ namespace Dynamo.Wpf.Rendering
         private bool hasData;
         private List<int> lineStripVertexCounts;
         private byte[] colors;
+        private int colorStride;
         private List< byte[]> colorsList = new List<byte[]>();
         private List<int> colorStrideList = new List<int>();
         private List<Tuple<int, int>> colorsMeshVerticesRange = new List<Tuple<int, int>>();
@@ -184,6 +185,11 @@ namespace Dynamo.Wpf.Rendering
         [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         public void SetColors(byte[] colors)
         {
+            if (!AllowLegacyColorOperations)
+            {
+                throw new LegacyRenderPackageMethodException();
+            }
+            
             this.colors = colors;
         }
 
@@ -317,6 +323,11 @@ namespace Dynamo.Wpf.Rendering
         [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyPointVertexColors(byte[] colors)
         {
+            if (!AllowLegacyColorOperations)
+            {
+                throw new LegacyRenderPackageMethodException();
+            }
+            
             if (colors.Count()/4 != points.Positions.Count)
             {
                 throw new Exception("The number of colors specified must be equal to the number of vertices.");
@@ -333,6 +344,11 @@ namespace Dynamo.Wpf.Rendering
         [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyLineVertexColors(byte[] colors)
         {
+            if (!AllowLegacyColorOperations)
+            {
+                throw new LegacyRenderPackageMethodException();
+            }
+            
             if (colors.Count() / 4 != lines.Positions.Count)
             {
                 throw new Exception("The number of colors specified must be equal to the number of vertices.");
@@ -349,6 +365,11 @@ namespace Dynamo.Wpf.Rendering
         [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         public void ApplyMeshVertexColors(byte[] colors)
         {
+            if (!AllowLegacyColorOperations)
+            {
+                throw new LegacyRenderPackageMethodException();
+            }
+            
             if (colors.Count() / 4 != mesh.Positions.Count)
             {
                 throw new Exception("The number of colors specified must be equal to the number of vertices.");
@@ -507,7 +528,18 @@ namespace Dynamo.Wpf.Rendering
         }
 
         [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
-        public int ColorsStride { get; set; }
+        public int ColorsStride
+        {
+            get => colorStride;
+            set
+            {
+                if (!AllowLegacyColorOperations)
+                {
+                    throw new LegacyRenderPackageMethodException();
+                }
+                colorStride = value;
+            }
+        }
 
         #endregion
 
@@ -752,6 +784,12 @@ namespace Dynamo.Wpf.Rendering
             colorsList.Add(colors);
             colorStrideList.Add(stride);
         }
+
+        /// <summary>
+        /// Allow legacy usage of the color methods in IRenderPackage
+        /// </summary>
+        [Obsolete("Do not use! This will be removed in Dynamo 3.0")]
+        public bool AllowLegacyColorOperations { get; set; } = true;
 
         #endregion
 

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -44,7 +44,6 @@ namespace Dynamo.Wpf.Rendering
         private PointGeometry3D points;
         private LineGeometry3D lines;
         private MeshGeometry3D mesh;
-        internal readonly List<Tuple<string, Vector3>> labelData = new List<Tuple<string, Vector3>>();
         private bool hasData;
         private List<int> lineStripVertexCounts;
         private byte[] colors;
@@ -508,12 +507,15 @@ namespace Dynamo.Wpf.Rendering
 
         #region IRenderLabels implementation
 
+        ///// <summary>
+        ///// Get label data; label string and associated position
+        ///// </summary>
         public List<Tuple<string, float[]>> LabelData
         {
             get
             {
                 var list = new List<Tuple<string, float[]>>();
-                foreach (var tuple in labelData)
+                foreach (var tuple in LabelPlaces)
                 {
                     list.Add(new Tuple<string, float[]>(tuple.Item1, tuple.Item2.ToArray()));
                 }
@@ -545,7 +547,7 @@ namespace Dynamo.Wpf.Rendering
                 default:
                     return;
             }
-            labelData.Add(new Tuple<string, Vector3>(label,position));
+            LabelPlaces.Add(new Tuple<string, Vector3>(label,position));
         }
 
         /// <summary>
@@ -553,7 +555,7 @@ namespace Dynamo.Wpf.Rendering
         /// </summary>
         public void AddLabel(string label, double x, double y, double z)
         {
-            labelData.Add(new Tuple<string, Vector3>(label, Vector3ForYUp(x, y, z)));
+            LabelPlaces.Add(new Tuple<string, Vector3>(label, Vector3ForYUp(x, y, z)));
         }
 
         /// <summary>
@@ -561,7 +563,7 @@ namespace Dynamo.Wpf.Rendering
         /// </summary>
         public void ClearLabels()
         {
-            labelData.Clear();
+            LabelPlaces.Clear();
         }
 
         #endregion
@@ -764,6 +766,8 @@ namespace Dynamo.Wpf.Rendering
                 return points;
             }
         }
+
+        public List<Tuple<string, Vector3>> LabelPlaces { get; } = new List<Tuple<string, Vector3>>();
 
         internal static LineGeometry3D InitLineGeometry()
         {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1644,7 +1644,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
                     if (rp.LabelData.Any())
                     {
-                        AddLabelPlace(baseId, rp.labelData, rp);
+                        AddLabelPlace(baseId, rp.LabelPlaces, rp);
                     }
 
                     string id;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -2075,8 +2075,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             foreach (var labelData  in nodeLabelData)
             {
-                geom.TextInfo.Add(new TextInfo(labelData.Item1,
-                    labelData.Item2 + defaultLabelOffset));
+                string labelText = labelData.Item1;
+                if (labelData.Item1.Split(':')[0] == nodeId)
+                {
+                    labelText = HelixRenderPackage.CleanTag(labelData.Item1);
+                }
+                
+                geom.TextInfo.Add(new TextInfo(labelText, labelData.Item2 + defaultLabelOffset));
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1631,7 +1631,18 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             {
                 foreach (var rp in packages)
                 {
+                    // Each node can produce multiple render packages. We want all the geometry of the
+                    // same kind stored inside a RenderPackage to be pushed into one GeometryModel3D object.
+                    // We strip the unique identifier for the package (i.e. the bit after the `:` in var12345:0), and replace it
+                    // with `points`, `lines`, or `mesh`. For each RenderPackage, we check whether the geometry dictionary
+                    // has entries for the points, lines, or mesh already. If so, we add the RenderPackage's geometry
+                    // to those geometry objects.
+                    
                     var baseId = rp.Description;
+                    if (baseId.IndexOf(":", StringComparison.Ordinal) > 0)
+                    {
+                        baseId = baseId.Split(':')[0];
+                    }
 
                     //If this render package belongs to special render package, then create
                     //and update the corresponding GeometryModel. Special renderpackage are
@@ -1755,7 +1766,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var m = rp.Mesh;
                     if (!m.Positions.Any()) continue;
 
-                    id = baseId + MeshKey;
+                    //If we are using the legacy colors array for texture map we need to create a new Geometry3d object with a unique key.
+                    id = (rp.Colors.Any() ? rp.Description : baseId) + MeshKey;
 
                     //if we require texture coloration then we need to create a new Geometry3d object.
                     if (rp.ColorsMeshVerticesRange.Any())

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -197,6 +197,65 @@ namespace Autodesk.DesignScript.Interfaces
     }
 
     /// <summary>
+    /// This interface provides additional methods adding for color information to a render package.
+    /// </summary>
+    public interface IRenderPackageSupplement
+    {
+        /// <summary>
+        /// Insert a color to a range of point vertices.
+        /// </summary>
+        void InsertPointVertexColorRange(int startIndex, int endIndex, byte red, byte green, byte blue, byte alpha);
+        
+        /// <summary>
+        /// Append a color range for point vertices.
+        /// </summary>
+        /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        void AppendPointVertexColorRange(byte[] colors);
+
+        /// <summary>
+        /// Insert a color to a range of line vertices.
+        /// </summary>
+        void InsertLineVertexColorRange(int startIndex, int endIndex, byte red, byte green, byte blue, byte alpha);
+
+        /// <summary>
+        /// Append a color range for line vertices.
+        /// </summary>
+        void AppendLineVertexColorRange(byte[] colors);
+
+        /// <summary>
+        /// Insert a color to a range of of mesh vertices.
+        /// </summary>
+        void InsertMeshVertexColorRange(int startIndex, int endIndex, byte red, byte green, byte blue, byte alpha);
+
+        /// <summary>
+        /// Append a color range for mesh vertex.
+        /// </summary>
+        /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        void AppendMeshVertexColorRange(byte[] colors);
+
+        /// <summary>
+        /// A List containing arrays of bytes representing RGBA colors.
+        /// These arrays can be used to populate textures for mapping onto specific meshes
+        /// </summary>
+        List<byte[]> ColorsList { get; }
+
+        /// <summary>
+        /// A list containing the size of one dimension of the associated Colors list.
+        /// </summary>
+        List<int> ColorsStrideList { get; }
+
+        /// <summary>
+        /// A list of mesh vertices ranges that have associated texture maps
+        /// </summary>
+        List<Tuple<int,int>> ColorsMeshVerticesRange { get; }
+
+        /// <summary>
+        /// Set a color map for a range of mesh vertices
+        /// </summary>
+        void AddColorsForMeshVerticesRange(int startIndex, int endIndex, byte[] colors, int stride);
+    }
+    
+    /// <summary>
     /// Represents a graphics item object, that can provide tesselated data
     /// into the given render package.
     /// </summary>

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -202,6 +202,21 @@ namespace Autodesk.DesignScript.Interfaces
     public interface IRenderPackageSupplement
     {
         /// <summary>
+        /// The number of point vertices colors in the package.
+        /// </summary>
+        int PointVertexColorCount { get; }
+
+        /// <summary>
+        /// The number of line vertices colors in the package.
+        /// </summary>
+        int LineVertexColorCount { get; }
+
+        /// <summary>
+        /// The number of mesh vertices colors in the package.
+        /// </summary>
+        int MeshVertexColorCount { get; }
+        
+        /// <summary>
         /// Insert a color to a range of point vertices.
         /// </summary>
         void InsertPointVertexColorRange(int startIndex, int endIndex, byte red, byte green, byte blue, byte alpha);

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -115,11 +115,13 @@ namespace Autodesk.DesignScript.Interfaces
         /// for mapping onto surfaces. Use the ColorsStride property to define the
         /// size of one dimension of the collection.
         /// </summary>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         IEnumerable<byte> Colors { get; }
- 
+
         /// <summary>
         /// The size of one dimension of the Colors collection.
         /// </summary>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         int ColorsStride { get; set; }
  
         /// <summary>
@@ -171,23 +173,27 @@ namespace Autodesk.DesignScript.Interfaces
         /// Apply a color to each point vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         void ApplyPointVertexColors(byte[] colors);
 
         /// <summary>
         /// Apply a color to a sequence of line vertices.
         /// </summary>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         void ApplyLineVertexColors(byte[] colors);
 
         /// <summary>
         /// Apply a color to each mesh vertex.
         /// </summary>
         /// <param name="colors">A buffer of R,G,B,A values corresponding to each vertex.</param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add ranges of vertex colors.")]
         void ApplyMeshVertexColors(byte[] colors);
 
         /// <summary>
         /// Set a an array of bytes to be used as a color map.
         /// </summary>
         /// <param name="colors"></param>
+        [Obsolete("Do not use! Use the methods in IRenderPackageSupplement to add mesh texture maps.")]
         void SetColors(byte[] colors);
 
         /// <summary>

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -256,6 +256,39 @@ namespace Autodesk.DesignScript.Interfaces
     }
     
     /// <summary>
+    /// Represents labels and positions
+    /// </summary>
+    public interface IRenderLabels
+    {
+        ///// <summary>
+        ///// Get label data; label string and associated position
+        ///// </summary>
+        List<Tuple<string, float[]>> LabelData { get; }
+
+        /// <summary>
+        /// Add a label position to the render package with reference to a geometry vertex.
+        /// </summary>
+        void AddLabel(string label, VertexType vertexType, int index);
+
+        /// <summary>
+        /// Add a label position to the render package.
+        /// </summary>
+        void AddLabel(string label, double x, double y, double z);
+
+        /// <summary>
+        /// Clear all label data from the render package.
+        /// </summary>
+        void ClearLabels();
+    }
+
+    public enum VertexType
+    {
+        Point,
+        Line,
+        Mesh
+    }
+
+    /// <summary>
     /// Represents a graphics item object, that can provide tesselated data
     /// into the given render package.
     /// </summary>

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -274,6 +274,12 @@ namespace Autodesk.DesignScript.Interfaces
         /// Set a color map for a range of mesh vertices
         /// </summary>
         void AddColorsForMeshVerticesRange(int startIndex, int endIndex, byte[] colors, int stride);
+
+        /// <summary>
+        /// Allow legacy usage of the color methods in IRenderPackage
+        /// </summary>
+        [Obsolete("Do not use! This will be removed in Dynamo 3.0")]
+        bool AllowLegacyColorOperations { get; set; }
     }
     
     /// <summary>
@@ -509,4 +515,9 @@ namespace Autodesk.DesignScript.Interfaces
         /// </summary>
         bool RequiresPerVertexColoration { get; }
     }
+
+    /// <summary>
+    /// Exception used to catch usage of Legacy IRenderPackage color APIs
+    /// </summary>
+    public class LegacyRenderPackageMethodException : Exception { }
 }

--- a/src/VisualizationTests/CustomNodeTests.cs
+++ b/src/VisualizationTests/CustomNodeTests.cs
@@ -38,7 +38,7 @@ namespace WpfVisualizationTests
         [Test]
         public async void InHomeWorkspace_CustomNodeInstance_HasGeometry()
         {
-            Assert.AreEqual(11, BackgroundPreviewGeometry.Meshes().Count());
+            Assert.AreEqual(3, BackgroundPreviewGeometry.Meshes().Count());
             Assert.AreEqual(3, BackgroundPreviewGeometry.Curves().Count());
             Assert.AreEqual(3, BackgroundPreviewGeometry.Points().Count());
         }
@@ -145,7 +145,7 @@ namespace WpfVisualizationTests
         {
             Assert.AreEqual(2, BackgroundPreviewGeometry.Points().Count(p => p.IsAlive()));
             Assert.AreEqual(2, BackgroundPreviewGeometry.Curves().Count(p => p.IsAlive()));
-            Assert.AreEqual(10, BackgroundPreviewGeometry.Meshes().Count(p => p.IsAlive()));
+            Assert.AreEqual(2, BackgroundPreviewGeometry.Meshes().Count(p => p.IsAlive()));
         }
 
         [Test]
@@ -165,8 +165,8 @@ namespace WpfVisualizationTests
             Assert.NotNull(customNode);
             customNode.UpdateValue(new UpdateValueParams("IsVisible", "false"));
 
-            Assert.AreEqual(6, BackgroundPreviewGeometry.Meshes().Count(m => m.Visibility == Visibility.Visible));
-            Assert.AreEqual(5, BackgroundPreviewGeometry.Meshes().Count(m => m.Visibility == Visibility.Hidden));
+            Assert.AreEqual(2, BackgroundPreviewGeometry.Meshes().Count(m => m.Visibility == Visibility.Visible));
+            Assert.AreEqual(1, BackgroundPreviewGeometry.Meshes().Count(m => m.Visibility == Visibility.Hidden));
         }
 
         [Test]

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -1189,7 +1189,7 @@ namespace WpfVisualizationTests
             return views.Last();
         }
 
-        [Test]
+        [Test, Category("Failure")]
         public void GeometryPreviewWhenClickingArrayItemInPreview()
         {
             OpenVisualizationTest("magn_10809.dyn");


### PR DESCRIPTION
### Purpose

Note: I was cleaning up my Dynamo git stash over the holiday break and this was too good to leave on the shelf.  This builds on some work that @LongNguyenP, @Dewb, @aparajit-pratap, and I looked at a while back.  I picked up and fixed the regressions we noted previously. 

The purpose of this PR is a performance and memory optimization for the render pipeline.  The main architectural change is modifying the assumption that we generate a single `RenderPackage` object per every individual return object for a node. Instead we aggregate all node tessellation data into a single `RenderPackage` recursively.  This improves tessellation performance as the `HelixRenderPackage` is a large .NET object with a non-trivial init time in addition to a large saving in memory; specifically one render package with all the tessellation data is much smaller then many render packages with partial tessellation data.  This approach also creates performance benefit and memory savings when the tessellated data is added to the Helix scene.  Processing one RenderPackage per `AggregateRenderPackages` call is dramatically more efficient than numerous render packages as there are numerous collection interactions and temporary allocation.  In code, this change was enabled by generating the RenderPackage first in `GetRenderPackagesFromMirrorData` before the recursive loop to fill the render package data.  Previously it was generated within the loop.

There are a few things that require changes to support features which assumed a single item = a single RenderPackage.

* Labels (ie the labels that appear in the scene context by selecting items in the node preview).  The existing implementation encoded label information in the `Description` property of the `RenderPackage`.  That encoding was not well documented making it nearly impossible to add labels to the your own tessellation method overrides.  Here I introduce a new interface, `IRenderLabels`, which provides methods on the render package to add label data and placement.  The new underlying storage implementation matches the existing `LabelPlaces` data structure in the `HelixWatch3DViewModel` so that adding labels requires much less string parsing and processing. 

* Texture maps.  The original texture map implementation in the `Colors` and `ColorStride` property assumed only one texture map per the mesh geometry in the `RenderPackage`.  To support aggregation of multiple mesh geometries within a single `RenderPackage` with unique textures, I introduce a new interface, `IRenderPackageSupplement`, which supports adding lists of Colors and ColorStrides along with their associated mesh vertex ranges.  The `Colors` and `ColorStride` property as well as the `SetColors` method are marked as obsolete with notes to use the new methods in the `IRenderPackageSupplement`.

* Color adding methods on `IRenderPackage`.  While methods to add vertex color like  `AddPointVertexColor` still work fine with this change, when utilized in tessellation calls, methods like `ApplyPointVertexColors` overwrite the previous data vs appending.  That can cause data loss as they are currently used.  I introduce new methods to `IRenderPackageSupplement` like `InsertPointVertexColorRange` and `AppendPointVertexColorRange` to allow additions without overwriting existing data.  The old methods are also marked as obsolete with notes to use the new methods in the `IRenderPackageSupplement`.  The GeometryColor nodes are updated to use the new methods.

These new features are being introduced with a minor release and not Dynamo 3.0.  While we can update the tessellation implementation in Dynamo and Dynamo integrations, Third Party tessellation functions also need to stay working.  For each of the Obsolete methods above I introduced an Exception to allow the `GetRenderPackagesFromMirrorData` implementation to detect their usage.  Specifically within `IRenderPackageSupplement` there is a boolean `AllowLegacyColorOperations` that can be set to false which will cause the `LegacyRenderPackageMethodException` to be thrown when the obsolete methods are called.  In that case, we roll back any changes to the `RenderPackage` that occurred within the `Tesselate` call and generate a new `RenderPackage` with `AllowLegacyColorOperations` set to true and re-Tesselate.  This individual render package is added to the RenderPackageCache and the outer loop resumes.  In the transition to Dynamo 3.0, the obsolete methods can be removed as well as this fallback.

Todo
* Add tests for the new functionality
* Update Tessellate implementation in DynamoRevit, other integrations, samples, or internal packages.  This is not strictly required due to the fallback mechanism. 
* Fix the Label.ByPointAndString node to work with the new label mechanism so that the node actually work.
* ITransformable needs to be refactored similarly to the Texture Map implementation.  This may be covered under a separate PR as we can possibly take advantage of the refactor to introduce instancing mechanism. 

Examples

https://user-images.githubusercontent.com/2145751/104148265-98006400-539f-11eb-980e-595a01f6b856.mp4

https://user-images.githubusercontent.com/2145751/104148270-9df64500-539f-11eb-9c8f-20ed9d0c27e5.mp4

https://user-images.githubusercontent.com/2145751/104148276-a2baf900-539f-11eb-9edf-a803ab32acc3.mp4

https://user-images.githubusercontent.com/2145751/104148280-a64e8000-539f-11eb-997d-f8235882d69a.mp4

For most point and curve tessellation the speed and memory improvement will be linear based on the number of tessellated items.  However for meshes the speed and memory improvement is dramatic. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @aparajit-pratap @QilongTang 
