### PR TITLE
Update licenses and about box for 2.10 and master branch changes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ Apache license 2.0
 
 ## Dynamo License
 
-Copyright 2013-2020 Autodesk
+Copyright 2013-2021 Autodesk
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
@@ -12,6 +12,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 
 ## Third Party Licenses ##
+
+### AngleSharp
+https://github.com/AngleSharp/AngleSharp
+https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE
+	(MIT license)
 
 ### Avalon Edit
 http://avalonedit.net/
@@ -52,6 +57,11 @@ https://github.com/helix-toolkit/helix-toolkit
 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE
   (MIT license)
 
+### HTMLSanitizer
+https://github.com/mganss/HtmlSanitizer
+https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md
+	(MIT license)
+
 ### Immutable (System.Immutable)
 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
   (MIT License)
@@ -59,6 +69,11 @@ https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
 ### Iron Python, Dynamic Language Runtime
 http://ironpython.net/
 http://opensource.org/licenses/apache2.0.php
+
+### ILMerge
+https://github.com/dotnet/ILMerge
+https://github.com/dotnet/ILMerge/blob/master/LICENSE
+  (MIT License)
 
 ### libiconv
 https://www.gnu.org/software/libiconv/
@@ -138,6 +153,26 @@ https://unlicense.org/
 ### StarMath
 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE
   (MIT license)
+
+### System.Buffers
+https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+  (MIT License)
+
+### System.Memory
+https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+  (MIT License)
+
+### System.Numerics.Vectors
+https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+  (MIT License)
+
+### System.Runtime.CompilerServices.Unsafe
+https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+  (MIT License)
+
+### System.Text.Encoding.CodePages
+https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+  (MIT License)
 
 ### Xceed Extended WPF Toolkit
 https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -89,12 +89,11 @@ http://miconvexhull.codeplex.com/
 http://miconvexhull.codeplex.com/license
   (MIT license)
 
-### Microsoft 2013 C Runtime DLLs, msvcp120.dll, msvcr120.dll
-http://msdn.microsoft.com/en-us/vstudio/dn501987
-https://docs.microsoft.com/en-us/visualstudio/productinfo/2013-redistribution-vs
-
 ### Microsoft 2015 C Runtime DLLs, msvcp140.dll, msvcr140.dll
 https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs
+
+### Microsoft 2019 C Runtime DLLs, msvcp142.dll, msvcr142.dll
+https://visualstudio.microsoft.com/license-terms/mlt031619/
 
 ### Moq
 http://www.nuget.org/packages/Moq/
@@ -175,6 +174,6 @@ https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
   (MIT License)
 
 ### Xceed Extended WPF Toolkit
-https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md
+https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md
   (Microsoft Public License)
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 ### AngleSharp
 https://github.com/AngleSharp/AngleSharp
 https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE
-	(MIT license)
+  (MIT license)
 
 ### Avalon Edit
 http://avalonedit.net/
@@ -60,7 +60,7 @@ https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE
 ### HTMLSanitizer
 https://github.com/mganss/HtmlSanitizer
 https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md
-	(MIT license)
+  (MIT license)
 
 ### Immutable (System.Immutable)
 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -1,365 +1,541 @@
-{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang2057\deflangfe2057\themelang2057\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f1\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Arial;}
+{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang2057\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f1\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Arial;}
 {\f4\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Helvetica;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
 {\f43\fbidi \fswiss\fcharset0\fprq0{\*\panose 00000000000000000000}Helvetica-Bold{\*\falt Helvetica};}{\f44\fbidi \froman\fcharset0\fprq0{\*\panose 00000000000000000000}TimesNewRomanPS-BoldMT{\*\falt Times New Roman};}
 {\f45\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}TimesNewRomanPSMT{\*\falt Times New Roman};}{\f46\fbidi \fswiss\fcharset0\fprq2{\*\panose 00000000000000000000}Tahoma;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f510\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\f511\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f513\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f514\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f515\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\f516\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f517\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f518\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f520\fbidi \fswiss\fcharset238\fprq2 Arial CE;}
-{\f521\fbidi \fswiss\fcharset204\fprq2 Arial Cyr;}{\f523\fbidi \fswiss\fcharset161\fprq2 Arial Greek;}{\f524\fbidi \fswiss\fcharset162\fprq2 Arial Tur;}{\f525\fbidi \fswiss\fcharset177\fprq2 Arial (Hebrew);}
-{\f526\fbidi \fswiss\fcharset178\fprq2 Arial (Arabic);}{\f527\fbidi \fswiss\fcharset186\fprq2 Arial Baltic;}{\f528\fbidi \fswiss\fcharset163\fprq2 Arial (Vietnamese);}{\f550\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}
-{\f551\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}{\f553\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f554\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f555\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}
-{\f556\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}{\f557\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f558\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f850\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
-{\f851\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f853\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f854\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f857\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
-{\f858\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f970\fbidi \fswiss\fcharset238\fprq2 Tahoma CE;}{\f971\fbidi \fswiss\fcharset204\fprq2 Tahoma Cyr;}{\f973\fbidi \fswiss\fcharset161\fprq2 Tahoma Greek;}
-{\f974\fbidi \fswiss\fcharset162\fprq2 Tahoma Tur;}{\f975\fbidi \fswiss\fcharset177\fprq2 Tahoma (Hebrew);}{\f976\fbidi \fswiss\fcharset178\fprq2 Tahoma (Arabic);}{\f977\fbidi \fswiss\fcharset186\fprq2 Tahoma Baltic;}
-{\f978\fbidi \fswiss\fcharset163\fprq2 Tahoma (Vietnamese);}{\f979\fbidi \fswiss\fcharset222\fprq2 Tahoma (Thai);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}
-{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}
-{\fhimajor\f31533\fbidi \fswiss\fcharset177\fprq2 Calibri Light (Hebrew);}{\fhimajor\f31534\fbidi \fswiss\fcharset178\fprq2 Calibri Light (Arabic);}{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}
-{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Calibri Light (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}
-{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}
-{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
-{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;
-\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;
-\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\chyperlink\ctint255\cshade255\red5\green99\blue193;\red96\green94\blue92;\red225\green223\blue221;\red165\green165\blue165;\red51\green51\blue51;\red204\green204\blue204;
-\red166\green166\blue166;\red5\green99\blue193;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
-\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\snext0 \sqformat \spriority0 Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
+{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f549\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\f550\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f552\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f553\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f554\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\f555\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f556\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f557\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f559\fbidi \fswiss\fcharset238\fprq2 Arial CE;}
+{\f560\fbidi \fswiss\fcharset204\fprq2 Arial Cyr;}{\f562\fbidi \fswiss\fcharset161\fprq2 Arial Greek;}{\f563\fbidi \fswiss\fcharset162\fprq2 Arial Tur;}{\f564\fbidi \fswiss\fcharset177\fprq2 Arial (Hebrew);}
+{\f565\fbidi \fswiss\fcharset178\fprq2 Arial (Arabic);}{\f566\fbidi \fswiss\fcharset186\fprq2 Arial Baltic;}{\f567\fbidi \fswiss\fcharset163\fprq2 Arial (Vietnamese);}{\f589\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}
+{\f590\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}{\f592\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f593\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f594\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}
+{\f595\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}{\f596\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f597\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f889\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
+{\f890\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f892\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f893\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f896\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
+{\f897\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f1009\fbidi \fswiss\fcharset238\fprq2 Tahoma CE;}{\f1010\fbidi \fswiss\fcharset204\fprq2 Tahoma Cyr;}{\f1012\fbidi \fswiss\fcharset161\fprq2 Tahoma Greek;}
+{\f1013\fbidi \fswiss\fcharset162\fprq2 Tahoma Tur;}{\f1014\fbidi \fswiss\fcharset177\fprq2 Tahoma (Hebrew);}{\f1015\fbidi \fswiss\fcharset178\fprq2 Tahoma (Arabic);}{\f1016\fbidi \fswiss\fcharset186\fprq2 Tahoma Baltic;}
+{\f1017\fbidi \fswiss\fcharset163\fprq2 Tahoma (Vietnamese);}{\f1018\fbidi \fswiss\fcharset222\fprq2 Tahoma (Thai);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}
+{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}
+{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
+{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;
+\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;
+\chyperlink\ctint255\cshade255\red5\green99\blue193;\red96\green94\blue92;\red225\green223\blue221;\cfollowedhyperlink\ctint255\cshade255\red149\green79\blue114;\red165\green165\blue165;\red51\green51\blue51;\red204\green204\blue204;
+\red166\green166\blue166;\cbackgroundone\ctint255\cshade166\red166\green166\blue166;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa160\sl259\slmult1
+\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
+\fs22\lang2057\langfe2057\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \snext0 \sqformat \spriority0 Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
 \ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl259\slmult1
-\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \snext11 \ssemihidden \sunhideused 
+\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid4260455 Hyperlink;}{\*\cs16 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 
-\sbasedon10 \ssemihidden \sunhideused \styrsid4260455 Unresolved Mention;}}{\*\rsidtbl \rsid3294270\rsid4260455\rsid6779184\rsid7823083\rsid8931681\rsid11013703\rsid15956851}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0
-\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim0}{\info{\operator Sylvester Knudsen}{\creatim\yr2020\mo7\dy16\hr15\min9}{\revtim\yr2020\mo10\dy6\hr12\min53}{\version6}{\edmins5}{\nofpages4}{\nofwords1130}{\nofchars6442}{\nofcharsws7557}{\vern7}}
-{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\sbasedon10 \ssemihidden \sunhideused \styrsid4260455 Unresolved Mention;}{\*\cs17 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf22 \sbasedon10 \ssemihidden \sunhideused \styrsid752623 FollowedHyperlink;}}{\*\rsidtbl \rsid752623\rsid2718254\rsid2951944
+\rsid3294270\rsid4260455\rsid4870749\rsid5973028\rsid6779184\rsid7823083\rsid8931681\rsid11013703\rsid12671756\rsid13784132\rsid15029151\rsid15170072\rsid15803843\rsid15956851\rsid16273942\rsid16712281}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim0}{\info{\operator Michael Kirschner}{\creatim\yr2020\mo7\dy16\hr15\min9}{\revtim\yr2021\mo1\dy14\hr15\min53}{\version17}{\edmins29}{\nofpages4}{\nofwords1380}
+{\nofchars7867}{\nofcharsws9229}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11013703 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
 \pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
 \pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
-\fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Dynamo License}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
-\b\f44\cf23\insrsid3294270 
-\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf22\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 Those portions created by Ian are provided with the following copyright:
-
+\fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Dynamo License}{
+\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+Those portions created by Ian are provided with the following copyright:
 \par \hich\af4\dbch\af31505\loch\f4 Copyright 2017 Ian Keough
 \par \hich\af4\dbch\af31505\loch\f4 Those portions created by Autodesk employees are provided with the following copyright:
-\par \hich\af4\dbch\af31505\loch\f4 Copyright 2020 Autodesk, Inc.
+\par \hich\af4\dbch\af31505\loch\f4 Copyright 202}{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid12671756\charrsid752623 \hich\af4\dbch\af31505\loch\f4 1}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4  Autodesk, Inc.
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may o\hich\af4\dbch\af31505\loch\f4 btain a copy of the License at}{\rtlch\fcs1 \af45 
-\ltrch\fcs0 \f45\cf24\insrsid3294270 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+\ltrch\fcs0 \f45\cf25\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf22\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 Unless requi\hich\af4\dbch\af31505\loch\f4 
-red by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissi
-\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4 ns and limitations under the License.
-\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 LIBG, ProtoGeometry, Analytics.NET, ADP, GRegRevitAuth, AGET }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf22\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 are closed source files licensed by Autodesk under the license that can be found here 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/A
-\hich\af4\dbch\af31505\loch\f4 utodesk.rtf }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 Unless requ\hich\af4\dbch\af31505\loch\f4 
+ired by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permiss
+\hich\af4\dbch\af31505\loch\f4 i\hich\af4\dbch\af31505\loch\f4 ons and limitations under the License.
+\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
+LIBG, ProtoGeometry, Analytics.NET, ADP, GRegRevitAuth, AGET }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+are closed source files licensed by Autodesk under the license that can be found here 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/\hich\af4\dbch\af31505\loch\f4 Autodesk.rtf }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba8000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
-610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000ab}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }\pard \ltrpar\ql \li0\ri0\sb240\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Third Party Licenses
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf25\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Aval\hich\af43\dbch\af31505\loch\f43 on Edit
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://avalonedit.net/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000003}}}{\fldrslt {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://avalonedit.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://opensource.org/licenses/lgpl-2.1.php }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006c00670070006c002d0032002e0031002e00
-7000680070000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000e5}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/lgpl-2.1.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 CEFSharp
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/cefsharp/CefSharp/blob/master/LICENSE/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000ab0000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sb240\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Third Party Licenses}{\rtlch\fcs1 
+\ab\af43 \ltrch\fcs0 \b\f43\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+\par 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
+AngleSharp
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE\hich\af4\dbch\af31505\loch\f4 "
+\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid16273942\charrsid752623 
+\par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Avalon Edit
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://avalonedit.net/"\hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://avalonedit.net
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK 
+\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/lgpl-2.1.php\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/lgpl-2.1.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 CEFSharp
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/cefsharp/CefSharp/blob/master/LICENSE/"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00630065006600730068006100720070002f00430065006600530068006100720070002f0062006c006f006200
-2f006d00610073007400650072002f004c004900430045004e00530045002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003db0000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/cefsharp/CefSharp/blob/master/LICENSE/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 CSharpAnalytics}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/AttackPattern/CSharpAnalytics }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+2f006d00610073007400650072002f004c004900430045004e00530045002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/cefsharp/CefSharp/blob/master/LICENSE/}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 CSharpAnalytics}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/AttackPattern/CSharpAnalytics"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00410074007400610063006b005000610074007400650072006e002f0043005300680061007200700041006e00
-61006c00790074006900630073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003310000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/AttackPattern/CSharpAnalytics}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af46 \ltrch\fcs0 \f46\cf23\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERL\hich\af4\dbch\af31505\loch\f4 
-INK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003530034}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
+61006c00790074006900630073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/AttackPattern/CSharpAnalytics}{\rtlch\fcs1 \af46 \ltrch\fcs0 \cs15\f46\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
+"\hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 
+\f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Cyotek.Drawing.BitmapFont}{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf22\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/cyotek/Cyotek.Drawing.BitmapFont }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Cyotek.Drawing.BitmapFont}{\rtlch\fcs1 \af45 \ltrch\fcs0 
+\f45\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/c\hich\af4\dbch\af31505\loch\f4 
+yotek/Cyotek.Drawing.BitmapFont"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b80000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00630079006f00740065006b002f00430079006f00740065006b002e00440072006100770069006e0067002e00
-4200690074006d006100700046006f006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300002c}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+4200690074006d006100700046006f006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/cyotek/Cyotek.Drawing.BitmapFont}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00630079006f00740065006b002f00430079006f00740065006b002e00440072006100770069006e0067002e00
-4200690074006d006100700046006f006e0074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003001000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf25\lang1033\langfe2057\kerning1\langnp1033\insrsid8931681 \hich\af43\dbch\af31505\loch\f43 DiffPlex
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid4260455\charrsid15956851 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/mmanela/diffplex" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid15956851\charrsid15956851 
-{\*\datafield 
+4200690074006d006100700046006f006e0074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyo\hich\af4\dbch\af31505\loch\f4 tek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}{\rtlch\fcs1 \af45 \ltrch\fcs0 
+\cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\kerning1\langnp1033\insrsid8931681\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
+DiffPlex
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/mmanela/diffplex"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b60000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d006d0061006e0065006c0061002f00640069006600660070006c00650078000000795881f43b1d7f48af2c
-825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid4260455\charrsid15956851 \hich\af4\dbch\af31505\loch\f4 https://github.com/mmanela/diffplex}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\ul\insrsid8931681\charrsid15956851 
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid15956851\charrsid15956851 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/mmanela/diffplex/blob/master/License.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\ul\insrsid15956851\charrsid15956851 {\*\datafield 
+825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid4260455\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mmanela/diffpl\hich\af4\dbch\af31505\loch\f4 ex}{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid8931681\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/mmanela/diffplex/blob/master/License.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d006d0061006e0065006c0061002f00640069006600660070006c00650078002f0062006c006f0062002f00
-6d00610073007400650072002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid4260455\charrsid15956851 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/mmanela/diffplex/blob/master/License.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid4260455\charrsid15956851 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid8931681 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 DirectX
-\par }{\field{\*\fldinst {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/DirectX%20SDK%20EULA.txt"}{\rtlch\fcs1 
-\ab\af4 \ltrch\fcs0 \b\f4\insrsid11013703 {\*\datafield 
+6d00610073007400650072002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid4260455\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/mmanela/diffplex/blob/master/License.txt
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 }}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
+\fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid8931681\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 DirectX
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/DirectX%20SDK%20EULA.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfe000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f0044006900720065006300740058002000530044004b
-002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extr\hich\af4\dbch\af31505\loch\f4 
-a/DirectX/License%20Agreements/directx%20redist.txt"}{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\insrsid11013703 {\*\datafield 
+002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \cs15\b\f43\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/directx%20redist.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfa000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f00640069007200650063007400780020007200650064
-006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ff00}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/D\hich\af4\dbch\af31505\loch\f4 
-ynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Fontawesome
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.nuget.org/packages/FontAwesome.WPF/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.co
+\hich\af4\dbch\af31505\loch\f4 m/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Fontawesome
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.nuget.org/packages/FontAwesome.WPF/"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b78000000680074007400700073003a002f002f007700770077002e006e0075006700650074002e006f00720067002f007000610063006b0061006700650073002f0046006f006e00740041007700650073006f006d00
-65002e005700500046002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000064}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://www.nuget.org/packages/FontAwesome.WPF/}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+65002e005700500046002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://www.nuget.org/packages/FontAwesome.WPF/}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006300680061007200720069002f0046006f006e0074002d0041007700650073006f006d0065002d0057005000
-46002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000061}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 GNU gettext (libintl)}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.gnu.org/software/gettext/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+46002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 GNU gettext (libintl)}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.gnu.org/software/gettext/"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b64000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f000000795881f43b1d
-7f48af2c825dc485276300000000a5ab000300004e}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 
-\f45\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f006d0061006e007500
-61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c00000000002d}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Helix Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/\hich\af4\dbch\af31505\loch\f4 helix-toolkit/helix-toolkit }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}{\rtlch\fcs1 \af45 
+\ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html" \\l "GNU-LGPL"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+08d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f006d0061006e007500
+61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Helix Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/helix-toolkit/helix-toolkit"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00680065006c00690078002d0074006f006f006c006b00690074002f00680065006c00690078002d0074006f00
-6f006c006b00690074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300e665}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/helix-toolkit/helix-toolkit/blo\hich\af4\dbch\af31505\loch\f4 b/develop/LICENSE }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\insrsid11013703 {\*\datafield 
+6f006c006b00690074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/helix-toolkit/helix-toolkit}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00680065006c00690078002d0074006f006f006c006b00690074002f00680065006c00690078002d0074006f00
-6f006c006b00690074002f0062006c006f0062002f0064006500760065006c006f0070002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003350000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Immutable
-\par }{\field{\*\fldinst {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid11013703 
-{\*\datafield 
+6f006c006b00690074002f0062006c006f0062002f0064006500760065006c006f0070002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENS\hich\af4\dbch\af31505\loch\f4 E
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
+HTML Sanitizer}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "https://github.com/mganss/HtmlSanitizer"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b68000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d00670061006e00730073002f00480074006d006c00530061006e006900740069007a006500720000007958
+81f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d00670061006e00730073002f00480074006d006c00530061006e006900740069007a00650072002f006200
+6c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs26 \ltrch\fcs0 \f4\fs26\cf24\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Immutable
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003150001}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/dotnet/corefx/blob/master/LICENSE.TXT/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Iron Python, Dynamic Language Runtime}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf22\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://ironpython.net/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f00690072006f006e0070007900740068006f006e002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003045300}}}{\fldrslt {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\cf23\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://opensource.org/licenses/apache2.0.php }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT/
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Iron Python, Dynamic Language Runtime}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://ironpython.net/"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f00690072006f006e0070007900740068006f006e002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://opensource.org/licenses/apache2.0.php"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7200000068007400740070003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f0061007000610063006800650032002e0030002e00
-7000680070000000795881f43b1d7f48af2c825dc485276300000000a5ab0003015000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 libiconv
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.gnu.org/software/libiconv/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+7000680070000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+http://opensource.org/licenses/apache2.0.php}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 \hich\af43\dbch\af31505\loch\f43 ILMerge}{
+\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/ILMerge"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0049004c004d0065007200670065000000795881f43b1d7f48af2c825dc485
+276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/ILMerge/blob/master/LICENSE"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0049004c004d0065007200670065002f0062006c006f0062002f006d006100
+73007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs28 \ltrch\fcs0 \f4\fs28\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 libiconv
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.gnu.org/software/libiconv/"\hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b66000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f006c0069006200690063006f006e0076002f000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab0003d45300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 
-\f45\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f006d0061006e007500
-61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c0000006c5300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid6779184 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6779184 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid6779184\charrsid6779184 \hich\af43\dbch\af31505\loch\f43 Markdig
-\par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid6779184\charrsid6779184 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid6779184\charrsid6779184 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK 
-\hich\af4\dbch\af31505\loch\f4 "}{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid6779184\charrsid6779184 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig/blob/master/license.txt}{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid6779184\charrsid6779184 
-\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid6779184\charrsid6779184 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig/blob/master/license.txt}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270\charrsid6779184 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid6779184\charrsid6779184 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 MiConvexHull
-\par }{\field{\*\fldinst {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 HYPERLINK "https://designengrlab.github.io/MIConvexHull/"}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid11013703 {\*\datafield 
+3b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}{\rtlch\fcs1 \af45 
+\ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html" \\l "GNU-LGPL"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+08d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f006d0061006e007500
+61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6779184 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Markdig
+
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/lunet-io/markdig"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
+\af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b60000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006c0075006e00650074002d0069006f002f006d00610072006b006400690067000000795881f43b1d7f48af2c
+825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/lunet-io/markdig/blob/master/license.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006c0075006e00650074002d0069006f002f006d00610072006b006400690067002f0062006c006f0062002f00
+6d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig/blob/master/license.txt}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 MiConvexHull
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://designengrlab.github.io/MIConvexHull/"\hich\af4\dbch\af31505\loch\f4  }
+{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b74000000680074007400700073003a002f002f00640065007300690067006e0065006e00670072006c00610062002e006700690074006800750062002e0069006f002f004d00490043006f006e007600650078004800
-75006c006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003618179}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\cf23\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 \hich\af45\dbch\af31505\loch\f45 HYPERLINK "https://github.com/DesignEngrLab/MIConvexHull/blob/master/LICENSE.txt"}{
-\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440065007300690067006e0045006e00670072004c00610062002f004d00490043006f006e00760065007800
-480075006c006c002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid3294270 
-\hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Microsoft 2013 C Runtime DLLs, msvcp120.dll, msvcr120.dll}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf22\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://msdn.microsoft.com/en-us/vstudio/dn501987 }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+75006c006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}{
+\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://miconvexhull.codeplex.com/license"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a00000068007400740070003a002f002f006d00690063006f006e00760065007800680075006c006c002e0063006f006400650070006c00650078002e0063006f006d002f006c006900630065006e00730065000000
+795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com
+\hich\af4\dbch\af31505\loch\f4 /license}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Microsoft 2013 C Runtime DLLs, msvcp120.dll, msvcr120.dll}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/vstudio/dn501987"\hich\af4\dbch\af31505\loch\f4  }
+{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a00000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f007600730074007500640069006f002f006400
-6e003500300031003900380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/vstudio/dn501987}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://docs.m\hich\af4\dbch\af31505\loch\f4 icrosoft.com/en-us/visualstudio/productinfo/2013-redistribution-vs }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\insrsid11013703 {\*\datafield 
+6e003500300031003900380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+http://msdn.microsoft.com/en-us/vstudio/dn501987}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://docs.microsoft.com/en-us/visualstudio/productinfo/2013-redistribution-vs"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba000000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00760069007300750061006c0073007400
-7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310033002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/vis\hich\af4\dbch\af31505\loch\f4 ualstudio/productinfo/2013-redistribution-vs}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\ul\cf26\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Microsoft 2015 C Runtime DLLs, msvcp140.dll, msvcr140.dll}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf22\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 
-{\*\datafield 
+7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310033002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/visualstudio/productinfo/2013-redistribution-vs
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Microsoft \hich\af43\dbch\af31505\loch\f43 2015 C Runtime DLLs, msvcp140.dll, msvcr140.dll}{\rtlch\fcs1 \ab\af44 
+\ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba000000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00760069007300750061006c0073007400
-7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310035002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002200}}}{\fldrslt {\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Moq
-\par }{\field{\*\fldinst {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 HYPERLINK "https://github.com/moq/moq4/blob/master/License.txt"}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid11013703 {\*\datafield 
+7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310035002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs}{\rtlch\fcs1 \af45 \ltrch\fcs0 
+\cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Moq
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/moq/moq4/blob/master/License.txt"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b80000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d006f0071002f006d006f00710034002f0062006c006f0062002f006d00610073007400650072002f004c00
-6900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003017200}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/moq/moq4/blob/master/License.txt/}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 NCalc
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://ncalc.codeplex.com/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f006e00630061006c0063002e0063006f006400650070006c00650078002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300776e}}
-}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\cf23\insrsid3294270 \line }{\field{\*\fldinst {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://ncalc.codeplex.com/license }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid11013703 {\*\datafield 
+6900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/moq/moq4/blob/master/License.txt/
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 NCalc
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "http://ncalc.codeplex.com/"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f006e00630061006c0063002e0063006f006400650070006c00650078002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}
+}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/}{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://ncalc.codeplex.com/license"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c00000068007400740070003a002f002f006e00630061006c0063002e0063006f006400650070006c00650078002e0063006f006d002f006c006900630065006e00730065000000795881f43b1d7f48af2c825dc485
-276300000000a5ab000300656f}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf25\lang1053\langfe2057\langnp1053\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 NDesk Options}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf25\lang1053\langfe2057\langnp1053\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://ndesk.org/Options#License }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1053\langfe2057\langnp1053\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90b4a00000068007400740070003a002f002f006e006400650073006b002e006f00720067002f004f007000740069006f006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003080000004c006900
-630065006e0073006500000000006e}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://ndesk.org/Options#License}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Newtonsoft JSON
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/JamesNK/Newtonsoft.Json }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/license}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 NDesk Options}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf26\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://ndesk.org/Options" \\l "License"\hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+08d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90b4a00000068007400740070003a002f002f006e006400650073006b002e006f00720067002f004f007000740069006f006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003080000004c006900
+630065006e00730065000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ndesk.org/Options#License
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Newtonsoft JSON
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/JamesNK/Newtonsoft.Json"\hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a0061006d00650073004e004b002f004e006500770074006f006e0073006f00660074002e004a0073006f00
-6e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300006f}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+6e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}{
+\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a0061006d00650073004e004b002f004e006500770074006f006e0073006f00660074002e004a0073006f00
-6e002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 NUnit
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.nunit.org/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703 
-{\*\datafield 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4400000068007400740070003a002f002f007700770077002e006e0075006e00690074002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300005f}}
-}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af1 \ltrch\fcs0 
-\f1\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.nunit.org/index.php?p=license&r=2.6.2 }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+6e002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 NUnit
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.nunit.org/"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4400000068007400740070003a002f002f007700770077002e006e0075006e00690074002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
+"http://www.nunit.org/index.php?p=license&r=2.6.2"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a00000068007400740070003a002f002f007700770077002e006e0075006e00690074002e006f00720067002f0069006e006400650078002e007000680070003f0070003d006c006900630065006e00730065002600
-72003d0032002e0036002e0032000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004e32}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-http://www.nunit.org/index.php?p=license&r=2.6.2}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\langnp1033\insrsid3294270 
+72003d0032002e0036002e0032000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+http://www.nunit.org/index.php?p=license&r=2.6.2}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par \hich\af43\dbch\af31505\loch\f43 OpenSans font from Google
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.google.com/fonts/specimen/Open+Sans }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.google.com/fonts/specimen/Open+Sans"\hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7600000068007400740070003a002f002f007700770077002e0067006f006f0067006c0065002e0063006f006d002f0066006f006e00740073002f00730070006500630069006d0065006e002f004f00700065006e00
-2b00530061006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006f00}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://www.google.com/fonts/specimen/Open+Sans}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 
-\hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0.html }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+2b00530061006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+http://www.google.com/fonts/specimen/Open+Sans}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0.html"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7800000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003007000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Prism
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 YPERLINK http://msdn.microsoft.com/en-us/library/gg406140.aspx }{\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+30002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+http://www.apache.org/licenses/LICENSE-2.0.html}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Prism
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/library/gg406140.aspx"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8400000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f006c006900620072006100720079002f006700
-67003400300036003100340030002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-http://msdn.microsoft.com/en-us/library/gg406140.aspx}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af1 \ltrch\fcs0 \f1\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \line }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg405489(PandP.40).aspx }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+67003400300036003100340030002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg406140.aspx}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid752623\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
+"http://msdn.microsoft.com/en-us/library/gg405489(PandP.40).aspx"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9800000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f006c006900620072006100720079002f006700
-67003400300035003400380039002800500061006e00640050002e003400300029002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg405489(PandP.40\hich\af4\dbch\af31505\loch\f4 ).aspx}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Python Standard Library
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://docs.python.org/2.7/library/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+67003400300035003400380039002800500061006e00640050002e003400300029002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg405489(PandP\hich\af4\dbch\af31505\loch\f4 .40).aspx}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Python Standard Library
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/library/"\hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b62000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900620072006100720079002f000000795881f43b1d7f48
-af2c825dc485276300000000a5ab0003006300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYP\hich\af4\dbch\af31505\loch\f4 ERLINK https://docs.python.org/2.7/license.html }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/license.html"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900630065006e00730065002e00680074006d006c000000
-795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Python.NET
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/pythonnet/p\hich\af4\dbch\af31505\loch\f4 ythonnet/blob/master/LICENSE }{\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703 {\*\datafield 
+795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html}{\rtlch\fcs1 
+\af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Python.NET
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/pythonnet/pythonnet/blob/master/LICENSE"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0070007900740068006f006e006e00650074002f0070007900740068006f006e006e00650074002f0062006c00
-6f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/pythonnet/pythonnet/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 RestSharp
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.ap\hich\af4\dbch\af31505\loch\f4 ache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+6f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/pythonnet/pythonnet/blob/master/LICE\hich\af4\dbch\af31505\loch\f4 NSE}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 RestSharp
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.apache.or\hich\af4\dbch\af31505\loch\f4 
+g/licenses/LICENSE-2.0"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003001000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 SharpDX
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https\hich\af4\dbch\af31505\loch\f4 ://github.com/sharpdx/SharpDX/blob/master/LICENSE }{\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+http://www.apache.org/licenses/LICENSE-2.0
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 SharpDX
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
+"https://github.com/sharpdx/SharpDX/blob/master/LICENSE"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b86000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0073006800610072007000640078002f0053006800610072007000440058002f0062006c006f0062002f006d00
-610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/sharpdx/SharpDX/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf25\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 SimplexNoise
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLIN\hich\af4\dbch\af31505\loch\f4 K https://unlicense.org/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b46000000680074007400700073003a002f002f0075006e006c006900630065006e00730065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004165}}}{\fldrslt {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://unlicense.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf25\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 StarMath
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://g\hich\af4\dbch\af31505\loch\f4 ithub.com/sharpdx/SharpDX/blob/master/LICENSE}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 SimplexNoise
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://unlicense.org/"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
+\af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b46000000680074007400700073003a002f002f0075006e006c006900630065006e00730065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://unlicense.org/
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 StarMath
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b94000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440065007300690067006e0045006e00670072004c00610062002f0053007400610072004d00610074006800
-2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/DesignEngrLab/StarMath/blob/mast\hich\af4\dbch\af31505\loch\f4 er/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af43\dbch\af31505\loch\f43 Xceed Extended WPF Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
-\b\f44\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af44\dbch\af31505\loch\f44 HYPERLINK "https://opensource.org/licenses/ms-pl.html"}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
-\b\f44\cf22\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid15803843\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+System.Buffers
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid2718254\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Memory
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Numerics.Vectors
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Runtime.CompilerServices.Unsafe
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.c\hich\af4\dbch\af31505\loch\f4 om/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Text.Encoding.CodePages
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid752623 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/b\hich\af4\dbch\af31505\loch\f4 lob/master/LICENSE.TXT"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid3294270\charrsid752623 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid752623 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
+Xceed Extended WPF Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://opensource.org/licenses/ms-pl.html"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006d0073002d0070006c002e00680074006d00
-6c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid11013703 {\*\datafield 
+6c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License}{\rtlch\fcs1 
+\af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 }}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 \rtlch\fcs1 \af0\afs22\alang1025 
+\ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007800630065006500640073006f006600740077006100720065002f0077007000660074006f006f006c006b00
-690074002f0062006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002100}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270 \hich\af4\dbch\af31505\loch\f4 https://gith\hich\af4\dbch\af31505\loch\f4 ub.com/xceedsoftware/wpftoolkit/blob/master/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid8931681 
+690074002f0062006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -495,17 +671,33 @@ faadb081f196af190c6a98242f8467912ab0a651ad6a5a548d8cc3c1aafb6121653923699635d3ca
 \lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
 \lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
 \lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;}}{\*\datastore 01050000
-02000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
-d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+02000000180000004d73786d6c322e534158584d4c5265616465722e362e30000000000000000000000e0000
+d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff0900060000000000000000000000010000000100000000000000001000000200000001000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e06c
-094fd79bd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
-000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
-0000000000000000000000000000000000000000000000000105000000000000}}
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000805f
+805cb7ead60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000805f805cb7ead601
+805f805cb7ead6010000000000000000000000003100d600410030004a00dd00430047003100450043004800c1004500c200470032005a00c700cd00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000805f805cb7ea
+d601805f805cb7ead6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+00000000000000000000000000000000210100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3c3f786d6c2076657273696f6e3d22312e3022207374616e64616c6f6e653d226e6f223f3e3c623a536f757263657320786d6c6e733a623d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666
+696365446f63756d656e742f323030362f6269626c696f6772617068792220786d6c6e733d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222053656c65637465645374796c653d225c41504153
+6978746845646974696f6e4f66666963654f6e6c696e652e78736c22205374796c654e616d653d22415041222056657273696f6e3d2236223e3c2f623a536f75726365733e000000000000000000000000000000000000000000000000000000000000003c3f786d6c2076657273696f6e3d22312e302220656e636f6469
+6e673d225554462d3822207374616e64616c6f6e653d226e6f223f3e0d0a3c64733a6461746173746f72654974656d2064733a6974656d49443d227b32373141363036462d383644302d343036432d383738342d3438383637313939454438307d2220786d6c6e733a64733d22687474703a2f2f736368656d61732e6f70
+656e786d6c666f726d6174732e6f72672f6f6666696365446f63756d656e742f323030362f637573500072006f007000650072007400690065007300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000200ffffffffffffffffffffffff000000000000
+0000000000000000000000000000000000000000000000000000000000000500000055010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000
+000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff
+000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000746f6d586d6c223e3c64733a736368656d61526566733e3c64733a736368656d615265662064733a7572693d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f7267
+2f6f6666696365446f63756d656e742f323030362f6269626c696f677261706879222f3e3c2f64733a736368656d61526566733e3c2f64733a6461746173746f72654974656d3e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000105000000000000}}

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -1,28 +1,29 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang2057\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f1\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Arial;}
 {\f4\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Helvetica;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
 {\f43\fbidi \fswiss\fcharset0\fprq0{\*\panose 00000000000000000000}Helvetica-Bold{\*\falt Helvetica};}{\f44\fbidi \froman\fcharset0\fprq0{\*\panose 00000000000000000000}TimesNewRomanPS-BoldMT{\*\falt Times New Roman};}
-{\f45\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}TimesNewRomanPSMT{\*\falt Times New Roman};}{\f46\fbidi \fswiss\fcharset0\fprq2{\*\panose 00000000000000000000}Tahoma;}
+{\f45\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}TimesNewRomanPSMT{\*\falt Times New Roman};}{\f46\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604030504040204}Tahoma;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f549\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\f550\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f552\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f553\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f554\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\f555\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f556\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f557\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f559\fbidi \fswiss\fcharset238\fprq2 Arial CE;}
-{\f560\fbidi \fswiss\fcharset204\fprq2 Arial Cyr;}{\f562\fbidi \fswiss\fcharset161\fprq2 Arial Greek;}{\f563\fbidi \fswiss\fcharset162\fprq2 Arial Tur;}{\f564\fbidi \fswiss\fcharset177\fprq2 Arial (Hebrew);}
-{\f565\fbidi \fswiss\fcharset178\fprq2 Arial (Arabic);}{\f566\fbidi \fswiss\fcharset186\fprq2 Arial Baltic;}{\f567\fbidi \fswiss\fcharset163\fprq2 Arial (Vietnamese);}{\f589\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}
-{\f590\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}{\f592\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f593\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f594\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}
-{\f595\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}{\f596\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f597\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f889\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
-{\f890\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f892\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f893\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f896\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
-{\f897\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f1009\fbidi \fswiss\fcharset238\fprq2 Tahoma CE;}{\f1010\fbidi \fswiss\fcharset204\fprq2 Tahoma Cyr;}{\f1012\fbidi \fswiss\fcharset161\fprq2 Tahoma Greek;}
-{\f1013\fbidi \fswiss\fcharset162\fprq2 Tahoma Tur;}{\f1014\fbidi \fswiss\fcharset177\fprq2 Tahoma (Hebrew);}{\f1015\fbidi \fswiss\fcharset178\fprq2 Tahoma (Arabic);}{\f1016\fbidi \fswiss\fcharset186\fprq2 Tahoma Baltic;}
-{\f1017\fbidi \fswiss\fcharset163\fprq2 Tahoma (Vietnamese);}{\f1018\fbidi \fswiss\fcharset222\fprq2 Tahoma (Thai);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f547\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\f548\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f550\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f551\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f552\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\f553\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f554\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f555\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f557\fbidi \fswiss\fcharset238\fprq2 Arial CE;}
+{\f558\fbidi \fswiss\fcharset204\fprq2 Arial Cyr;}{\f560\fbidi \fswiss\fcharset161\fprq2 Arial Greek;}{\f561\fbidi \fswiss\fcharset162\fprq2 Arial Tur;}{\f562\fbidi \fswiss\fcharset177\fprq2 Arial (Hebrew);}
+{\f563\fbidi \fswiss\fcharset178\fprq2 Arial (Arabic);}{\f564\fbidi \fswiss\fcharset186\fprq2 Arial Baltic;}{\f565\fbidi \fswiss\fcharset163\fprq2 Arial (Vietnamese);}{\f587\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}
+{\f588\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}{\f590\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f591\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f592\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}
+{\f593\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}{\f594\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f595\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f887\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
+{\f888\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f890\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f891\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f894\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
+{\f895\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f1007\fbidi \fswiss\fcharset238\fprq2 Tahoma CE;}{\f1008\fbidi \fswiss\fcharset204\fprq2 Tahoma Cyr;}{\f1010\fbidi \fswiss\fcharset161\fprq2 Tahoma Greek;}
+{\f1011\fbidi \fswiss\fcharset162\fprq2 Tahoma Tur;}{\f1012\fbidi \fswiss\fcharset177\fprq2 Tahoma (Hebrew);}{\f1013\fbidi \fswiss\fcharset178\fprq2 Tahoma (Arabic);}{\f1014\fbidi \fswiss\fcharset186\fprq2 Tahoma Baltic;}
+{\f1015\fbidi \fswiss\fcharset163\fprq2 Tahoma (Vietnamese);}{\f1016\fbidi \fswiss\fcharset222\fprq2 Tahoma (Thai);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
 {\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
 {\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
 {\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}
-{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}{\fhimajor\f31533\fbidi \fswiss\fcharset177\fprq2 Calibri Light (Hebrew);}{\fhimajor\f31534\fbidi \fswiss\fcharset178\fprq2 Calibri Light (Arabic);}
+{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Calibri Light (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -32,22 +33,23 @@
 {\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
 {\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}
 {\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;
-\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;
-\chyperlink\ctint255\cshade255\red5\green99\blue193;\red96\green94\blue92;\red225\green223\blue221;\cfollowedhyperlink\ctint255\cshade255\red149\green79\blue114;\red165\green165\blue165;\red51\green51\blue51;\red204\green204\blue204;
-\red166\green166\blue166;\cbackgroundone\ctint255\cshade166\red166\green166\blue166;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa160\sl259\slmult1
-\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
-\fs22\lang2057\langfe2057\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \snext0 \sqformat \spriority0 Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
+{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
+{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
+{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
+\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\chyperlink\ctint255\cshade255\red5\green99\blue193;\red96\green94\blue92;\red225\green223\blue221;
+\cfollowedhyperlink\ctint255\cshade255\red149\green79\blue114;\red165\green165\blue165;\red51\green51\blue51;\red204\green204\blue204;\red166\green166\blue166;\cbackgroundone\ctint255\cshade166\red166\green166\blue166;}{\*\defchp 
+\fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\sa160\sl259\slmult1
+\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \snext0 \sqformat \spriority0 Normal;}{\*
+\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
 \ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl259\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid4260455 Hyperlink;}{\*\cs16 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 
 \sbasedon10 \ssemihidden \sunhideused \styrsid4260455 Unresolved Mention;}{\*\cs17 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf22 \sbasedon10 \ssemihidden \sunhideused \styrsid752623 FollowedHyperlink;}}{\*\rsidtbl \rsid752623\rsid2718254\rsid2951944
-\rsid3294270\rsid4260455\rsid4870749\rsid5973028\rsid6779184\rsid7823083\rsid8931681\rsid11013703\rsid12671756\rsid13784132\rsid15029151\rsid15170072\rsid15803843\rsid15956851\rsid16273942\rsid16712281}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
-\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim0}{\info{\operator Michael Kirschner}{\creatim\yr2020\mo7\dy16\hr15\min9}{\revtim\yr2021\mo1\dy14\hr15\min53}{\version17}{\edmins29}{\nofpages4}{\nofwords1380}
-{\nofchars7867}{\nofcharsws9229}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3294270\rsid4148832\rsid4260455\rsid4870749\rsid5973028\rsid6779184\rsid7823083\rsid8931681\rsid11013703\rsid12671756\rsid13003194\rsid13784132\rsid15029151\rsid15074591\rsid15170072\rsid15803843\rsid15956851\rsid16273942\rsid16712281}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim0}{\info{\operator Michael Kirschner}{\creatim\yr2020\mo7\dy16\hr15\min9}{\revtim\yr2021\mo1\dy14\hr16\min30}{\version20}{\edmins31}
+{\nofpages4}{\nofwords1368}{\nofchars7800}{\nofcharsws9150}{\vern17}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11013703 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
 \pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
@@ -63,479 +65,478 @@ Those portions created by Ian are provided with the following copyright:
 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4  Autodesk, Inc.
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may o\hich\af4\dbch\af31505\loch\f4 btain a copy of the License at}{\rtlch\fcs1 \af45 
 \ltrch\fcs0 \f45\cf25\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703\charrsid752623 {\*\datafield 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15074591 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK 
+\hich\af4\dbch\af31505\loch\f4 "http://www.apache.org/licenses/LICENSE-2.0"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15074591 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 Unless requ\hich\af4\dbch\af31505\loch\f4 
-ired by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permiss
-\hich\af4\dbch\af31505\loch\f4 i\hich\af4\dbch\af31505\loch\f4 ons and limitations under the License.
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}{
+\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid15074591 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 Unless req\hich\af4\dbch\af31505\loch\f4 
+uired by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permis
+\hich\af4\dbch\af31505\loch\f4 s\hich\af4\dbch\af31505\loch\f4 ions and limitations under the License.
 \par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
 LIBG, ProtoGeometry, Analytics.NET, ADP, GRegRevitAuth, AGET }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 are closed source files licensed by Autodesk under the license that can be found here 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/\hich\af4\dbch\af31505\loch\f4 Autodesk.rtf }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid11013703\charrsid752623 {\*\datafield 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15074591 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15074591 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba8000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
-610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000ab0000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf
+\par }\pard \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 }}\pard\plain \ltrpar\ql \li0\ri0\sb225\sl383\slmult0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
+\fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sb240\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Third Party Licenses}{\rtlch\fcs1 
 \ab\af43 \ltrch\fcs0 \b\f43\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
 AngleSharp
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
-\af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/AngleSharp/AngleSharp" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15074591\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0041006e0067006c006500530068006100720070002f0041006e0067006c006500530068006100720070000000
+795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE\hich\af4\dbch\af31505\loch\f4 "
-\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid16273942\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15074591\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b92000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0041006e0067006c006500530068006100720070002f0041006e0067006c006500530068006100720070002f00
+62006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/AngleSharp/AngleSharp/blob/maste\hich\af4\dbch\af31505\loch\f4 r/LICENSE}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid16273942\charrsid752623 
 \par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Avalon Edit
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://avalonedit.net/"\hich\af4\dbch\af31505\loch\f4  }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://avalonedit.net/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {
 \rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://avalonedit.net
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK 
-\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/lgpl-2.1.php\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/lgpl-2.1.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://opensource.org/licenses/lgpl-2.1.php" }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15074591\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006c00670070006c002d0032002e0031002e00
+7000680070000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+https://opensource.org/licenses/lgpl-2.1.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 CEFSharp
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/cefsharp/CefSharp/blob/master/LICENSE/"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/cefsharp/CefSharp/blob/master/LICENSE/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00630065006600730068006100720070002f00430065006600530068006100720070002f0062006c006f006200
-2f006d00610073007400650072002f004c004900430045004e00530045002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+2f006d00610073007400650072002f004c004900430045004e00530045002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/cefsharp/CefSharp/blob/master/LICENSE/}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid15170072\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 CSharpAnalytics}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
 \b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/AttackPattern/CSharpAnalytics"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/AttackPattern/CSharpAnalytics" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00410074007400610063006b005000610074007400650072006e002f0043005300680061007200700041006e00
-61006c00790074006900630073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+61006c00790074006900630073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/AttackPattern/CSharpAnalytics}{\rtlch\fcs1 \af46 \ltrch\fcs0 \cs15\f46\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
-"\hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 
-\f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  HY\hich\af4\dbch\af31505\loch\f4 
+PERLINK "http://www.apache.org/licenses/LICENSE-2.0" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15074591\charrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Cyotek.Drawing.BitmapFont}{\rtlch\fcs1 \af45 \ltrch\fcs0 
 \f45\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/c\hich\af4\dbch\af31505\loch\f4 
-yotek/Cyotek.Drawing.BitmapFont"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/cyotek/Cyotek.Drawing.BitmapFont" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b80000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00630079006f00740065006b002f00430079006f00740065006b002e00440072006100770069006e0067002e00
-4200690074006d006100700046006f006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+4200690074006d006100700046006f006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+ HYPERLINK "https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LIC\hich\af4\dbch\af31505\loch\f4 ENSE.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00630079006f00740065006b002f00430079006f00740065006b002e00440072006100770069006e0067002e00
-4200690074006d006100700046006f006e0074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyo\hich\af4\dbch\af31505\loch\f4 tek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}{\rtlch\fcs1 \af45 \ltrch\fcs0 
+4200690074006d006100700046006f006e0074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}{\rtlch\fcs1 \af45 \ltrch\fcs0 
 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\kerning1\langnp1033\insrsid8931681\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
 DiffPlex
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/mmanela/diffplex"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/mmanela/diffplex" }{\rtlch\fcs1 
+\af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b60000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d006d0061006e0065006c0061002f00640069006600660070006c00650078000000795881f43b1d7f48af2c
-825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid4260455\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mmanela/diffpl\hich\af4\dbch\af31505\loch\f4 ex}{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid8931681\charrsid752623 
+825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid4260455\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mmanela/diffplex}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid8931681\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/mmanela/diffplex/blob/master/License.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+ HYPERLINK "https://github.com/mmanela/diffplex/blob/master/Lic\hich\af4\dbch\af31505\loch\f4 ense.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d006d0061006e0065006c0061002f00640069006600660070006c00650078002f0062006c006f0062002f00
-6d00610073007400650072002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid4260455\charrsid752623 
+6d00610073007400650072002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid4260455\charrsid752623 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/mmanela/diffplex/blob/master/License.txt
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 }}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid8931681\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 DirectX
 \par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/DirectX%20SDK%20EULA.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/DirectX%20SDK%20EULA.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfe000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f0044006900720065006300740058002000530044004b
-002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \cs15\b\f43\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/directx%20redist.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+ HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Ex\hich\af4\dbch\af31505\loch\f4 tra/DirectX/License%20Agreements/directx%20redist.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfa000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f00640069007200650063007400780020007200650064
-006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.co
+006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.co
 \hich\af4\dbch\af31505\loch\f4 m/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Fontawesome
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.nuget.org/packages/FontAwesome.WPF/"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://www.nuget.org/packages/FontAwesome.WPF/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b78000000680074007400700073003a002f002f007700770077002e006e0075006700650074002e006f00720067002f007000610063006b0061006700650073002f0046006f006e00740041007700650073006f006d00
-65002e005700500046002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+65002e005700500046002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 https://www.nuget.org/packages/FontAwesome.WPF/}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE\hich\af4\dbch\af31505\loch\f4 "\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+ HYPERLINK "https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006300680061007200720069002f0046006f006e0074002d0041007700650073006f006d0065002d0057005000
-46002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+46002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 GNU gettext (libintl)}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
 \b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.gnu.org/software/gettext/"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.gnu.org/software/gettext/" }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b64000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f000000795881f43b1d
-7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}{\rtlch\fcs1 \af45 
+7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}{\rtlch\fcs1 \af45 
 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html" \\l "GNU-LGPL"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+HYPERLINK "https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html" \\l "GNU-LGPL" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 08d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f006d0061006e007500
-61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL
+61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c00000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.g\hich\af4\dbch\af31505\loch\f4 nu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Helix Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
-\b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/helix-toolkit/helix-toolkit"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 Helix Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\b\f44\cf24\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/helix-toolkit/helix-toolkit" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00680065006c00690078002d0074006f006f006c006b00690074002f00680065006c00690078002d0074006f00
-6f006c006b00690074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/helix-toolkit/helix-toolkit}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+6f006c006b00690074000000795881f43b1d7f48af2c825dc485276300000000a5ab00031a}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/helix-toolkit/helix-toolkit}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
+ HYPERLINK "https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00680065006c00690078002d0074006f006f006c006b00690074002f00680065006c00690078002d0074006f00
-6f006c006b00690074002f0062006c006f0062002f0064006500760065006c006f0070002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENS\hich\af4\dbch\af31505\loch\f4 E
+6f006c006b00690074002f0062006c006f0062002f0064006500760065006c006f0070002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid16273942\charrsid15074591 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16273942 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
 HTML Sanitizer}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf24\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "https://github.com/mganss/HtmlSanitizer"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 {\*\datafield 
+\hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/mganss/HtmlSanitizer" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b68000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d00670061006e00730073002f00480074006d006c00530061006e006900740069007a006500720000007958
-81f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}
+81f43b1d7f48af2c825dc485276300000000a5ab00035f}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 {\*\datafield 
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d00670061006e00730073002f00480074006d006c00530061006e006900740069007a00650072002f006200
-6c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
-\af4\afs26 \ltrch\fcs0 \f4\fs26\cf24\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
+6c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer/blob/ma\hich\af4\dbch\af31505\loch\f4 ster/LICENSE.md}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs26 \ltrch\fcs0 \f4\fs26\cf24\lang1033\langfe2057\langnp1033\insrsid16273942\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Immutable
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00035f}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Iron Python, Dynamic Language Runtime}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://ironpython.net/"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f00690072006f006e0070007900740068006f006e002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://ironpython.net/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 
+{\*\datafield 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4600000068007400740070003a002f002f00690072006f006e0070007900740068006f006e002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000302}}
+}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}{\rtlch\fcs1 \af1 \ltrch\fcs0 
 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://opensource.org/licenses/apache2.0.php"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://opensource.org/licenses/apache2.0.php" }{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7200000068007400740070003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f0061007000610063006800650032002e0030002e00
-7000680070000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+7000680070000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 http://opensource.org/licenses/apache2.0.php}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 \hich\af43\dbch\af31505\loch\f43 ILMerge}{
 \rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  
-\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/ILMerge"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/ILMerge" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0049004c004d0065007200670065000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge}}}\sectd \ltrsect
+276300000000a5ab000302}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15029151 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  
-\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/ILMerge/blob/master/LICENSE"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/ILMerge/blob/master/LICENSE" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0049004c004d0065007200670065002f0062006c006f0062002f006d006100
-73007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
+73007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d0}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15029151\charrsid752623 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs28 \ltrch\fcs0 \f4\fs28\lang1033\langfe2057\langnp1033\insrsid15029151\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 libiconv
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.gnu.org/software/libiconv/"\hich\af4\dbch\af31505\loch\f4  }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://www.gnu.org/software/libiconv/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b66000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f006c0069006200690063006f006e0076002f000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}{\rtlch\fcs1 \af45 
+3b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}{\rtlch\fcs1 \af45 
 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html" \\l "GNU-LGPL"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+HYPERLINK "https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html" \\l "GNU-LGPL" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 08d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f007700770077002e0067006e0075002e006f00720067002f0073006f006600740077006100720065002f0067006500740074006500780074002f006d0061006e007500
-61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL
+61006c002f00680074006d006c005f006e006f00640065002f0047004e0055002d004c00470050004c002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030900000047004e0055002d004c00470050004c00000002}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://www.g\hich\af4\dbch\af31505\loch\f4 nu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6779184 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Markdig
 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/lunet-io/markdig"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
-\af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/lunet-io/markdig" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b60000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006c0075006e00650074002d0069006f002f006d00610072006b006400690067000000795881f43b1d7f48af2c
-825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/lunet-io/markdig/blob/master/license.txt"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet\hich\af4\dbch\af31505\loch\f4 -io/markdig}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4 
+ HYPERLINK "https://github.com/lunet-io/markdig/blob/master/license.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006c0075006e00650074002d0069006f002f006d00610072006b006400690067002f0062006c006f0062002f00
-6d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig/blob/master/license.txt}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+6d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig/bl\hich\af4\dbch\af31505\loch\f4 ob/master/license.txt}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid6779184\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 MiConvexHull
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://designengrlab.github.io/MIConvexHull/"\hich\af4\dbch\af31505\loch\f4  }
-{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://designengrlab.github.io/MIConvexHull/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b74000000680074007400700073003a002f002f00640065007300690067006e0065006e00670072006c00610062002e006700690074006800750062002e0069006f002f004d00490043006f006e007600650078004800
-75006c006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}{
-\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+75006c006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/
+}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://miconvexhull.codeplex.com/license"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://miconvexhull.codeplex.com/license" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a00000068007400740070003a002f002f006d00690063006f006e00760065007800680075006c006c002e0063006f006400650070006c00650078002e0063006f006d002f006c006900630065006e00730065000000
-795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com
-\hich\af4\dbch\af31505\loch\f4 /license}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/license}{\rtlch\fcs1 
+\af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Microsoft 2013 C Runtime DLLs, msvcp120.dll, msvcr120.dll}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Microsoft 2015 C Runtime DLLs, msvcp140.dll, msvcr140.dll}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/vstudio/dn501987"\hich\af4\dbch\af31505\loch\f4  }
-{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a00000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f007600730074007500640069006f002f006400
-6e003500300031003900380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-http://msdn.microsoft.com/en-us/vstudio/dn501987}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://docs.microsoft.com/en-us/visualstudio/productinfo/2013-redistribution-vs"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba000000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00760069007300750061006c0073007400
-7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310033002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/visualstudio/productinfo/2013-redistribution-vs
-\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Microsoft \hich\af43\dbch\af31505\loch\f43 2015 C Runtime DLLs, msvcp140.dll, msvcr140.dll}{\rtlch\fcs1 \ab\af44 
-\ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba000000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00760069007300750061006c0073007400
-7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310035002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310035002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs}{\rtlch\fcs1 \af45 \ltrch\fcs0 
 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Moq
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/moq/moq4/blob/master/License.txt"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4148832 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid4148832\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
+Microsoft 201}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid4148832 \hich\af43\dbch\af31505\loch\f43 9}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid4148832\charrsid752623 
+\hich\af43\dbch\af31505\loch\f43  C Runtime DLLs, msvcp140.dll, msvcr140.dll}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\langnp1033\insrsid4148832\charrsid752623 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid4148832 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://visualstudio.microsoft.com/license-terms/mlt031619/"
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid4148832 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f00760069007300750061006c00730074007500640069006f002e006d006900630072006f0073006f00660074002e0063006f006d002f006c006900630065006e007300
+65002d007400650072006d0073002f006d006c0074003000330031003600310039002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid4148832\charrsid4148832 \hich\af4\dbch\af31505\loch\f4 https://visualstudio.microsoft.com/license-terms/mlt031619/}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid4148832\charrsid4148832 
+\par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4148832 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid4148832\charrsid752623 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Moq
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/moq/moq4/blob/master/License.txt" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\ul\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b80000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006d006f0071002f006d006f00710034002f0062006c006f0062002f006d00610073007400650072002f004c00
-6900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+6900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/moq/moq4/blob/master/License.txt/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 NCalc
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "http://ncalc.codeplex.com/"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f006e00630061006c0063002e0063006f006400650070006c00650078002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://ncalc.codeplex.com/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 
+{\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f006e00630061006c0063002e0063006f006400650070006c00650078002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000361}}
 }{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/}{\rtlch\fcs1 \af1 \ltrch\fcs0 
 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://ncalc.codeplex.com/license"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://ncalc.codeplex.com/license" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c00000068007400740070003a002f002f006e00630061006c0063002e0063006f006400650070006c00650078002e0063006f006d002f006c006900630065006e00730065000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/license}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+276300000000a5ab00035f}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/license}{\rtlch\fcs1 \af4 \ltrch\fcs0 
 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
 \par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 NDesk Options}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 
 \b\f44\cf26\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://ndesk.org/Options" \\l "License"\hich\af4\dbch\af31505\loch\f4  }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://ndesk.org/Options" \\l "License" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 08d0c9ea79f9bace118c8200aa004ba90b020000000b000000e0c9ea79f9bace118c8200aa004ba90b4a00000068007400740070003a002f002f006e006400650073006b002e006f00720067002f004f007000740069006f006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003080000004c006900
-630065006e00730065000000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://ndesk.org/Options#License
+630065006e0073006500000002}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 http://ndesk.org/Options#License
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Newtonsoft JSON
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/JamesNK/Newtonsoft.Json"\hich\af4\dbch\af31505\loch\f4  }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 Newtonsoft JSON
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/JamesNK/Newtonsoft.Json" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a0061006d00650073004e004b002f004e006500770074006f006e0073006f00660074002e004a0073006f00
-6e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}{
-\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+6e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}
+{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a0061006d00650073004e004b002f004e006500770074006f006e0073006f00660074002e004a0073006f00
-6e002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+6e002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json\hich\af4\dbch\af31505\loch\f4 /blob/master/LICENSE.md}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 NUnit
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.nunit.org/"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4400000068007400740070003a002f002f007700770077002e006e0075006e00690074002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
-\af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
-
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 NUnit
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://www.nunit.org/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4400000068007400740070003a002f002f007700770077002e006e0075006e00690074002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
+\af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}{\rtlch\fcs1 \af1 \ltrch\fcs0 
+\cs15\f1\ul\cf19\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
-"http://www.nunit.org/index.php?p=license&r=2.6.2"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://www.nunit.org/index.php?p=license&r=2.6.2" }{\rtlch\fcs1 
+\af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a00000068007400740070003a002f002f007700770077002e006e0075006e00690074002e006f00720067002f0069006e006400650078002e007000680070003f0070003d006c006900630065006e00730065002600
-72003d0032002e0036002e0032000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-http://www.nunit.org/index.php?p=license&r=2.6.2}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+72003d0032002e0036002e0032000000795881f43b1d7f48af2c825dc485276300000000a5ab000322}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
+http://www.nunit.org/index.php?p=license&r=2.6.2}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
 \par \hich\af43\dbch\af31505\loch\f43 OpenSans font from Google
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.google.com/fonts/specimen/Open+Sans"\hich\af4\dbch\af31505\loch\f4  }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.google.com/fonts/specimen/Open+Sans" }{\rtlch\fcs1 
+\af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7600000068007400740070003a002f002f007700770077002e0067006f006f0067006c0065002e0063006f006d002f0066006f006e00740073002f00730070006500630069006d0065006e002f004f00700065006e00
-2b00530061006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-http://www.google.com/fonts/specimen/Open+Sans}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 
+2b00530061006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
+http://www.google.com/fonts/specimen/Open+Sans}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0.html"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://www.apache\hich\af4\dbch\af31505\loch\f4 
+.org/licenses/LICENSE-2.0.html" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7800000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
-http://www.apache.org/licenses/LICENSE-2.0.html}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
+30002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab000302}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
+http://www.apache.org/licenses/LICENSE-2.0.html}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Prism
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/library/gg406140.aspx"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 Prism
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/library/gg406140.aspx" }
+{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8400000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f006c006900620072006100720079002f006700
-67003400300036003100340030002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg406140.aspx}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid752623\charrsid752623 
+67003400300036003100340030002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab000302}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg406140.aspx}{\rtlch\fcs1 \af1 \ltrch\fcs0 \cs15\f1\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
-"http://msdn.microsoft.com/en-us/library/gg405489(PandP.40).aspx"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLIN\hich\af4\dbch\af31505\loch\f4 
+K "http://msdn.microsoft.com/en-us/library/gg405489(PandP.40).aspx" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9800000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f006c006900620072006100720079002f006700
-67003400300035003400380039002800500061006e00640050002e003400300029002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid752623\charrsid752623 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg405489(PandP\hich\af4\dbch\af31505\loch\f4 .40).aspx}{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+67003400300035003400380039002800500061006e00640050002e003400300029002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg405489(PandP\hich\af4\dbch\af31505\loch\f4 .40).aspx}{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Python Standard Library
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/library/"\hich\af4\dbch\af31505\loch\f4  }{
-\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 Python Standard Library
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://docs.python.org/2.7/library/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b62000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900620072006100720079002f000000795881f43b1d7f48
-af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
+af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/license.html"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://docs.python.org/2.7/license.html" }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900630065006e00730065002e00680074006d006c000000
-795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html}{\rtlch\fcs1 
-\af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html}{
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 Python.NET
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/pythonnet/pythonnet/blob/master/LICENSE"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\cf24\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 Python\hich\af43\dbch\af31505\loch\f43 .NET
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/pythonnet/pythonnet/blob/master/LICENSE" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0070007900740068006f006e006e00650074002f0070007900740068006f006e006e00650074002f0062006c00
-6f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\langnp1033\insrsid3294270\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/pythonnet/pythonnet/blob/master/LICE\hich\af4\dbch\af31505\loch\f4 NSE}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+6f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\langnp1053\insrsid3294270\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/pythonnet/pythonnet/blob/maste\hich\af4\dbch\af31505\loch\f4 r/LICENSE}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 RestSharp
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.apache.or\hich\af4\dbch\af31505\loch\f4 
-g/licenses/LICENSE-2.0"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 RestSharp
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00036e}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
 http://www.apache.org/licenses/LICENSE-2.0
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 SharpDX
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
-"https://github.com/sharpdx/SharpDX/blob/master/LICENSE"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 SharpDX
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/sharpdx/SharpDX/blob/master/LICENSE" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b86000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0073006800610072007000640078002f0053006800610072007000440058002f0062006c006f0062002f006d00
-610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://g\hich\af4\dbch\af31505\loch\f4 ithub.com/sharpdx/SharpDX/blob/master/LICENSE}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000302}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/sharpdx/SharpDX/blob/master/LICENSE}{\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 SimplexNoise
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://unlicense.org/"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
-\af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b46000000680074007400700073003a002f002f0075006e006c006900630065006e00730065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {
-\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://unlicense.org/
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af45 \ltrch\fcs0 \f45\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 SimplexNoise
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://unlicense.org/" }{\rtlch\fcs1 \af4 \ltrch\fcs0 
+\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b46000000680074007400700073003a002f002f0075006e006c006900630065006e00730065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {
+\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://unlicense.org/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 StarMath
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf26\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af43\dbch\af31505\loch\f43 StarMath
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE" }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b94000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440065007300690067006e0045006e00670072004c00610062002f0053007400610072004d00610074006800
-2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE
+2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
+\cs15\f4\ul\cf19\lang1053\langfe2057\kerning1\langnp1053\insrsid3294270\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid15803843\charrsid752623 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1053\langfe2057\kerning1\langnp1053\insrsid15803843\charrsid15074591 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 
 System.Buffers
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/dotnet/coref\hich\af4\dbch\af31505\loch\f4 
+x/blob/master/LICENSE.TXT" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid2718254\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid2718254\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Memory
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 System.Memory
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Numerics.Vectors
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 System.Numerics.Vectors
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT" }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Runtime.CompilerServices.Unsafe
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 System.Runtime.CompilerServices.Unsafe
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.co\hich\af4\dbch\af31505\loch\f4 
+m/dotnet/corefx/blob/master/LICENSE.TXT" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://github.c\hich\af4\dbch\af31505\loch\f4 om/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 https://github.c\hich\af4\dbch\af31505\loch\f4 om/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4870749 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1033\langfe1033\langnp1033\langfenp1033\insrsid15803843\charrsid752623 \hich\af4\dbch\af31505\loch\f4 System.Text.Encoding.CodePages
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid752623 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  
-\hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/dotnet/corefx/b\hich\af4\dbch\af31505\loch\f4 lob/master/LICENSE.TXT"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\f4\cf27\lang1053\langfe1033\langnp1053\langfenp1033\insrsid15803843\charrsid15074591 \hich\af4\dbch\af31505\loch\f4 System.Text.Encoding.CodePages
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid752623 {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT" }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f0063006f0072006500660078002f0062006c006f0062002f006d0061007300
-7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid3294270\charrsid752623 
+7400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/corefx/blob/master/LICENSE.TXT}{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1053\langfe1033\langnp1053\langfenp1033\insrsid3294270\charrsid15074591 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid752623 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid752623\charrsid752623 
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1053\langfe1033\langnp1053\langfenp1033\insrsid752623\charrsid15074591 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af43\dbch\af31505\loch\f43 
 Xceed Extended WPF Toolkit}{\rtlch\fcs1 \ab\af44 \ltrch\fcs0 \b\f44\cf23\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://opensource.org/licenses/ms-pl.html"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://opensource.org/licenses/ms-pl.html" }{\rtlch\fcs1 \af4 
+\ltrch\fcs0 \f4\ul\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006d0073002d0070006c002e00680074006d00
-6c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License}{\rtlch\fcs1 
-\af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+6c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License}{
+\rtlch\fcs1 \af45 \ltrch\fcs0 \cs15\f45\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 }}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8931681 \rtlch\fcs1 \af0\afs22\alang1025 
 \ltrch\fcs0 \fs22\lang2057\langfe2057\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp2057\langfenp2057 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md"
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid752623 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007800630065006500640073006f006600740077006100720065002f0077007000660074006f006f006c006b00
-690074002f0062006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 
-\cs15\f4\ul\cf19\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 \hich\af4\dbch\af31505\loch\f4 https://github.com/xceedsoftware/wpftoolkit/blob/master/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 
-\ltrch\fcs0 \f4\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid752623 
+\f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid13003194 \hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 
+"https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md"\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4 \ltrch\fcs0 \f4\cf1\lang1033\langfe1033\langnp1033\langfenp1033\insrsid13003194 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be2000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007800630065006500640073006f006600740077006100720065002f0077007000660074006f006f006c006b00
+690074002f0062006c006f0062002f0030006500640034006500640038003400310035003200640036006100330065003200610036003200370066003200650066003000350066003800320036003200370066006400610066003300660063002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f
+48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \cs15\f4\ul\cf19\lang1033\langfe1033\langnp1033\langfenp1033\insrsid13003194\charrsid13003194 \hich\af4\dbch\af31505\loch\f4 
+https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs24 \ltrch\fcs0 
+\f4\fs24\lang1033\langfe2057\kerning1\langnp1033\insrsid3294270\charrsid13003194 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -680,10 +681,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000805f
-805cb7ead60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000805f805cb7ead601
-805f805cb7ead6010000000000000000000000003100d600410030004a00dd00430047003100450043004800c1004500c200470032005a00c700cd00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000805f805cb7ea
-d601805f805cb7ead6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000d00c
+6a7abcead60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000c0e5697abcead601
+d00c6a7abcead6010000000000000000000000003100d600410030004a00dd00430047003100450043004800c1004500c200470032005a00c700cd00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000c0e5697abcea
+d601d00c6a7abcead6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000210100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.11.0.3796")]
+[assembly: AssemblyVersion("2.11.0.3355")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.11.0.3796")]
+[assembly: AssemblyFileVersion("2.11.0.3355")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.11.0.3355")]
+[assembly: AssemblyVersion("2.11.0.3796")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.11.0.3355")]
+[assembly: AssemblyFileVersion("2.11.0.3796")]


### PR DESCRIPTION


### Purpose

PR does the following:
* adds references that were missed for pythonmigration extension
* adds references used in markdown2html.exe project
* removes old reference to msvc redistributable for 2013
* updates license pointer for xceed wpf to version that we reference were the license was still MS-PL - NOTE! we will not be able to update this dependency without investigating the new license. beware. ⚠️ 
* updates the link styling in the rtf doc so all the links now appear blue, highlight subtly, and open a browser.


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
