### PR TITLE
Fix node overlap on node autocomplete

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -134,6 +134,11 @@ namespace Dynamo.ViewModels
             // before they get updated by the drag operation.
             // 
             RecordSelectionForUndo();
+            BeginDragSelectionWithUndoRecorder(mouseCursor);
+        }
+
+        internal void BeginDragSelectionWithUndoRecorder(Point2D mouseCursor)
+        {
             draggedNodes.Clear();
             foreach (ISelectable selectable in DynamoSelection.Instance.Selection)
             {

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -318,13 +318,10 @@ namespace Dynamo.Wpf.ViewModels
         private void OnRepositionNode(object sender, EventArgs a)
         {
             var n = sender as NodeView;
-            //n.ViewModel.X -= n.ActualWidth / 2.0;
             var dynamoViewModel = n.ViewModel.DynamoViewModel;
 
             DynamoSelection.Instance.Selection.Add(n.ViewModel.NodeModel);
 
-            //dynamoViewModel.ExecuteCommand(new DynamoModel.DragSelectionCommand(new Point2D(n.ViewModel.X, n.ViewModel.Y), 
-            //    DynamoModel.DragSelectionCommand.Operation.BeginDrag));
             n.ViewModel.WorkspaceViewModel.BeginDragSelectionWithUndoRecorder(new Point2D(n.ViewModel.X, n.ViewModel.Y));
 
             dynamoViewModel.ExecuteCommand(new DynamoModel.DragSelectionCommand(
@@ -338,7 +335,6 @@ namespace Dynamo.Wpf.ViewModels
             {
                 undoRecorderGroup.Dispose();
                 undoRecorderGroup = null;
-
             }
             dynamoViewModel.NodeViewReady -= AutoLayoutNodes;
             n.RepositionNodeHandler -= OnRepositionNode;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -154,6 +154,7 @@ namespace Dynamo.Controls
 
         #endregion
 
+        internal event EventHandler RepositionNodeHandler;
         /// <summary>
         /// Called when the size of the node changes. Communicates changes down to the view model 
         /// then to the model.
@@ -169,6 +170,8 @@ namespace Dynamo.Controls
             {
                 ViewModel.SetModelSizeCommand.Execute(size);
             }
+
+            RepositionNodeHandler?.Invoke(this, new EventArgs());
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

An alternative approach for https://github.com/DynamoDS/Dynamo/pull/11404.
![autocompleteOverlap](https://user-images.githubusercontent.com/5710686/104681398-3b16ed80-56c0-11eb-9590-b4c4879b991c.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### FYIs

@QilongTang 
