### PR TITLE
Fix node overlap issue by skipping the original node from AutoLayout repositioning

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -20,7 +20,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         /// <param name="workspace">Workspace on which graph layout will be performed.</param>
         /// <param name="reuseUndoRedoGroup">If true, skip initializing new undo action group.</param>
-        internal static List<GraphLayout.Graph> DoGraphAutoLayout(this WorkspaceModel workspace, bool reuseUndoRedoGroup = false)
+        internal static List<GraphLayout.Graph> DoGraphAutoLayout(this WorkspaceModel workspace, bool reuseUndoRedoGroup = false, bool isNodeAutoComplete = false, Guid? originalNodeGUID = null)
         {
             if (workspace.Nodes.Count() < 2) return null;
 
@@ -50,7 +50,13 @@ namespace Dynamo.Graph.Workspaces
             // Run layout algorithm for each subgraph
             layoutSubgraphs.Skip(1).ToList().ForEach(g => RunLayoutSubgraph(g, isGroupLayout));
             AvoidSubgraphOverlap(layoutSubgraphs);
-            SaveLayoutGraph(workspace, layoutSubgraphs);
+            if (isNodeAutoComplete)
+            {
+                SaveLayoutGraphForNodeAutoComplete(workspace, layoutSubgraphs, originalNodeGUID);
+            }
+            else {
+                SaveLayoutGraph(workspace, layoutSubgraphs);
+            }
 
             // Restore the workspace model selection information
             selection.ToList().ForEach(x => x.Select());
@@ -423,6 +429,52 @@ namespace Dynamo.Graph.Workspaces
 
                     node.X = n.X;
                     node.Y = n.Y + n.NotesHeight + offsetY;
+                    node.ReportPosition();
+                    workspace.HasUnsavedChanges = true;
+
+                    double noteOffset = -n.NotesHeight;
+                    foreach (NoteModel note in n.LinkedNotes)
+                    {
+                        if (note.IsSelected || DynamoSelection.Instance.Selection.Count == 0)
+                        {
+                            note.X = node.X;
+                            note.Y = node.Y + noteOffset;
+                            noteOffset += note.Height + GraphLayout.Graph.VerticalNoteDistance;
+                            note.ReportPosition();
+                        }
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// This method pushes changes from the GraphLayout.Graph objects
+        /// back to the workspace models.
+        /// </summary>
+        private static void SaveLayoutGraphForNodeAutoComplete(this WorkspaceModel workspace, List<GraphLayout.Graph> layoutSubgraphs, Guid? originalNodeGUID)
+        {
+            var originalNode = workspace.Nodes.FirstOrDefault(n => n.GUID == originalNodeGUID);
+            GraphLayout.Graph originalNodegraph = layoutSubgraphs
+                    .FirstOrDefault(g => g.FindNode(originalNode.GUID) != null);
+            GraphLayout.Node ogn = originalNodegraph.FindNode(originalNode.GUID);
+            double marginX = originalNode.X - ogn.X;
+            double marginY = originalNode.Y - ogn.Y;
+
+            // Assign coordinates to nodes outside groups
+            foreach (var node in workspace.Nodes)
+            {
+                GraphLayout.Graph graph = layoutSubgraphs
+                    .FirstOrDefault(g => g.FindNode(node.GUID) != null);
+
+                if (graph != null)
+                {
+                    GraphLayout.Node n = graph.FindNode(node.GUID);
+                    double offsetY = graph.OffsetY;
+                    if (node.GUID != originalNodeGUID )
+                    {
+                            node.X = n.X;
+                            node.Y = n.Y + n.NotesHeight + offsetY;
+                        
+                    }
                     node.ReportPosition();
                     workspace.HasUnsavedChanges = true;
 

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -50,6 +50,7 @@ namespace Dynamo.Graph.Workspaces
             // Run layout algorithm for each subgraph
             layoutSubgraphs.Skip(1).ToList().ForEach(g => RunLayoutSubgraph(g, isGroupLayout));
             AvoidSubgraphOverlap(layoutSubgraphs);
+
             if (isNodeAutoComplete)
             {
                 SaveLayoutGraphForNodeAutoComplete(workspace, layoutSubgraphs, originalNodeGUID);
@@ -448,17 +449,10 @@ namespace Dynamo.Graph.Workspaces
         }
         /// <summary>
         /// This method pushes changes from the GraphLayout.Graph objects
-        /// back to the workspace models.
+        /// back to the workspace models, but only for nodes placed by NodeAutocomplete.
         /// </summary>
         private static void SaveLayoutGraphForNodeAutoComplete(this WorkspaceModel workspace, List<GraphLayout.Graph> layoutSubgraphs, Guid? originalNodeGUID)
         {
-            var originalNode = workspace.Nodes.FirstOrDefault(n => n.GUID == originalNodeGUID);
-            GraphLayout.Graph originalNodegraph = layoutSubgraphs
-                    .FirstOrDefault(g => g.FindNode(originalNode.GUID) != null);
-            GraphLayout.Node ogn = originalNodegraph.FindNode(originalNode.GUID);
-            double marginX = originalNode.X - ogn.X;
-            double marginY = originalNode.Y - ogn.Y;
-
             // Assign coordinates to nodes outside groups
             foreach (var node in workspace.Nodes)
             {
@@ -469,6 +463,7 @@ namespace Dynamo.Graph.Workspaces
                 {
                     GraphLayout.Node n = graph.FindNode(node.GUID);
                     double offsetY = graph.OffsetY;
+                    //skipping the original node to avoid jumping of node
                     if (node.GUID != originalNodeGUID )
                     {
                             node.X = n.X;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -286,11 +286,12 @@ namespace Dynamo.Wpf.ViewModels
             dynamoViewModel.ExecuteCommand(new DynamoModel.CreateAndConnectNodeCommand(id, initialNode.GUID,
                 Model.CreationName, 0, portModel.Index, adjustedX, 0, createAsDownStreamNode, false, true));
 
-            // Clear current selections and select all input nodes as we need to perform Auto layout on only the input nodes.
-            DynamoSelection.Instance.ClearSelection();
             var inputNodes = initialNode.InputNodes.Values.Where(x => x != null).Select(y => y.Item2);
 
+            // Clear current selections and select all input nodes as we need to perform Auto layout on only the input nodes.
+            DynamoSelection.Instance.ClearSelection();
             DynamoSelection.Instance.Selection.AddRange(inputNodes);
+            DynamoSelection.Instance.Selection.Add(initialNode);
         }
 
         protected virtual bool CanCreateAndConnectToPort(object parameter)
@@ -305,8 +306,9 @@ namespace Dynamo.Wpf.ViewModels
         {
             var nodeView = (NodeView) sender;
             var dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
+            var originalNodeId = nodeView.ViewModel.NodeModel.OutputNodes.Values.SelectMany(s => s.Select(t => t.Item2)).Distinct().FirstOrDefault().GUID;
 
-            dynamoViewModel.CurrentSpace.DoGraphAutoLayout(true);
+            dynamoViewModel.CurrentSpace.DoGraphAutoLayout(true, true, originalNodeId);
 
             DynamoSelection.Instance.ClearSelection();
 


### PR DESCRIPTION
### Purpose

Wider nodes tend to overlap the parent node, the fix is to include the parent node in the auto layout group, and then restrict original node's repositioning to prevent jumping effect.

Problem:
![node_placement_bug](https://user-images.githubusercontent.com/32665108/105197813-05ac4d00-5b63-11eb-81fb-8d75d61448f0.gif)
 
Fix:
![ovrlp2](https://user-images.githubusercontent.com/32665108/105198013-3e4c2680-5b63-11eb-87b3-c9083644394d.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@DynamoDS/dynamo 
