### PR TITLE
Address the case where the thumb element on the watch node was not visible

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -331,12 +331,15 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            
+            <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
             <!-- Shows counts of all items in List -->
             
-            <TextBlock Name="ListItems" Grid.Column="2" Margin="0,3,0,7" Foreground="Gray" FontStyle="Italic"
+            <TextBlock Name="ListItems" Grid.Row="0" Grid.Column="2" Margin="0,3,0,7" Foreground="Gray" FontStyle="Italic"
                        Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
             {<Run Foreground="DarkRed" Text="{Binding NumberOfItems}" />}
                 </TextBlock>
@@ -344,6 +347,7 @@
             <!-- Shows list@level labels in List -->
             
             <ListView Name="listLevelsView"
+                      Grid.Row="0"
                       Grid.Column ="0" Margin="6,3,0,7" 
                       Background="Transparent"
                       Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
@@ -384,10 +388,10 @@
                 </ListView.ItemTemplate>
             </ListView>
 
-            <Thumb Name ="resizeThumb" Grid.Column ="3"
+            <Thumb Name ="resizeThumb" Grid.Row="1" Grid.Column ="2"
                Width="10" Height="10" 
                HorizontalAlignment="Right"
-               Margin="5"
+               Margin="2,2,10,2"
                DragDelta="ThumbResizeThumbOnDragDeltaHandler"
                Visibility="Hidden"/>
           </Grid>


### PR DESCRIPTION

### Purpose

This PR is to address the edge case found by @QilongTang for this task:https://jira.autodesk.com/browse/DYN-2457

I have moved the thumb element to the next row of WatchTree user-control. This will handle the case when the width of watch node is too small.

![edge case](https://user-images.githubusercontent.com/43763136/105814433-67afec80-5f7f-11eb-9293-6d6c6d0acc49.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

