### PR TITLE
Option for users to exclude specified list of packages from loading

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -9,6 +9,13 @@ using Dynamo.Interfaces;
 
 namespace Dynamo.Configuration
 {
+    public class Package
+    {
+        public string Name { get; set; }
+
+        public string Version { get; set; }
+    }
+
     /// <summary>
     /// PreferenceSettings is a class for GUI to persist certain settings.
     /// Upon running of the GUI, those settings that are persistent will be loaded
@@ -233,6 +240,12 @@ namespace Dynamo.Configuration
 
         #region Dynamo application settings
 
+        // TODO: Add to IPreferences in Dynamo 3.0
+        /// <summary>
+        /// List of packages referenced by (name, version) pair to exclude from loading.
+        /// </summary>
+        public List<Package> PackagesToExcludeLoading { get; set; }
+
         /// <summary>
         /// The decimal precision used to display numbers.
         /// </summary>
@@ -421,6 +434,7 @@ namespace Dynamo.Configuration
             EnableNodeAutoComplete = false;
             DefaultPythonEngine = string.Empty;
             ViewExtensionSettings = new List<ViewExtensionSettings>();
+            PackagesToExcludeLoading = new List<Package>();
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
@@ -187,7 +187,7 @@ namespace DynamoCoreWpfTests
                 viewLoaded = true;
                 var loader = Model.GetPackageManagerExtension().PackageLoader;
                 var pkg = loader.ScanPackageDirectory(pkgDir);
-                loader.LoadPackages(new List<Package> {pkg});
+                loader.LoadPackages(new List<Dynamo.PackageManager.Package> {pkg});
                 Assert.AreEqual(0, loader.RequestedExtensions.Count());
                 Assert.AreEqual(2, this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
                 Assert.IsTrue(viewExtensionLoadStart);


### PR DESCRIPTION
### Purpose

DYN-3325
This explores adding an option to exclude loading certain packages selected by the user. A use case could be where a user doesn't want specific packages to load by default from the standard library. Proposed here is a solution where a package exclusion list is added to the global preference settings file. This is the format it will look like in the Dynamo preference settings XML:
```
<PackagesToExcludeLoading>
	<Package>
		<Name>MeshToolkit</Name>
		<Version>2.0.1</Version>
	</Package>
</PackagesToExcludeLoading>
```

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
