### PR TITLE
Use checkboxes to select node libraries

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4543,6 +4543,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select Node Libraries.
+        /// </summary>
+        public static string PublishPackageSelectNodeLibraries {
+            get {
+                return ResourceManager.GetString("PublishPackageSelectNodeLibraries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add file....
         /// </summary>
         public static string PublishPackageViewAddFileButton {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2281,4 +2281,7 @@ Uninstall the following packages: {0}?</value>
     <value>An error occurred when loading the application icon: {0}</value>
     <comment>{0} = detailed error message</comment>
   </data>
+  <data name="PublishPackageSelectNodeLibraries" xml:space="preserve">
+    <value>Select Node Libraries</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2283,4 +2283,7 @@ Uninstall the following packages: {0}?</value>
     <value>An error occurred when loading the application icon: {0}</value>
     <comment>{0} = detailed error message</comment>
   </data>
+  <data name="PublishPackageSelectNodeLibraries" xml:space="preserve">
+    <value>Select Node Libraries</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -237,6 +237,7 @@
 
                 <Grid.RowDefinitions>
                     <RowDefinition Height="40"></RowDefinition>
+                    <RowDefinition Height="20"></RowDefinition>
                     <RowDefinition Height="*" ></RowDefinition>
                 </Grid.RowDefinitions>
 
@@ -251,7 +252,11 @@
                             Content="{x:Static p:Resources.PublishPackageViewAddFileButton}"/>
                 </DockPanel>
 
-                <ScrollViewer Grid.Row="1" Margin="0" VerticalScrollBarVisibility="Visible" Name="BrowserScrollView" Background="#222" BorderThickness="0">
+                <DockPanel Background="#222" Grid.Row="1">
+                    <TextBlock Text="{x:Static p:Resources.PublishPackageSelectNodeLibraries}" FontSize="10" Margin="15,0,0,0" Foreground="DarkGray" HorizontalAlignment="Left"  VerticalAlignment="Top"/>
+                </DockPanel>
+
+                <ScrollViewer Grid.Row="2" Margin="0" VerticalScrollBarVisibility="Visible" Name="BrowserScrollView" Background="#222" BorderThickness="0">
 
                     <ScrollViewer.Resources>
 
@@ -379,82 +384,71 @@
 
                     </ScrollViewer.Resources>
 
-                    <TreeView ItemsSource="{Binding Path=PackageContents}" Style="{StaticResource SearchTreeView}" BorderThickness="0">
+                    <StackPanel Orientation="Vertical">
 
-                        <TreeView.Resources>
+                        <TreeView ItemsSource="{Binding Path=PackageContents}" Style="{StaticResource SearchTreeView}" BorderThickness="0">
 
-                            <DataTemplate x:Key="sharedTemplate">
-                                <StackPanel Orientation="Horizontal">
-                                    <Image Name="Icon" Width="32" Height="32" />
-                                    <TextBlock Name="DepName" Padding="7" FontSize="13" Foreground="WhiteSmoke" Text="{Binding Path=Name}"/>
+                            <TreeView.Resources>
 
-                                    <StackPanel.ContextMenu>
+                                <DataTemplate x:Key="sharedTemplate">
+                                    <StackPanel Orientation="Horizontal">
+                                        <CheckBox Name="IsNodeLibrary" IsEnabled="False" Visibility="Hidden" IsChecked="{Binding IsNodeLibrary, Mode=TwoWay}"/>
+                                        <Image Name="Icon" Width="32" Height="32" />
+                                        <TextBlock Name="DepName" Padding="7" FontSize="13" Foreground="WhiteSmoke" Text="{Binding Path=Name}"/>
+                                    </StackPanel>
 
-                                        <ContextMenu Name="DepContextMenu">
-                                            <MenuItem Name="IsNodeLibraryButton" Header="{x:Static p:Resources.PublishPackageViewContextMenuIsNodeLibrary}" IsCheckable="True" IsChecked="{Binding IsNodeLibrary}"></MenuItem>
-                                        </ContextMenu>
+                                    <DataTemplate.Triggers>
+                                        <DataTrigger Binding="{Binding DependencyType}">
+                                            <DataTrigger.Value>
+                                                <packagemanager:DependencyType>File</packagemanager:DependencyType>
+                                            </DataTrigger.Value>
+                                            <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/files.png"/>
+                                        </DataTrigger>
 
-                                    </StackPanel.ContextMenu>
+                                        <DataTrigger Binding="{Binding DependencyType}">
+                                            <DataTrigger.Value>
+                                                <packagemanager:DependencyType>Assembly</packagemanager:DependencyType>
+                                            </DataTrigger.Value>
+                                            <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/assemblies.png"/>
+                                            <Setter TargetName="IsNodeLibrary" Property="IsEnabled" Value="True"/>
+                                            <Setter TargetName="IsNodeLibrary" Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
 
-                                </StackPanel>
+                                        <DataTrigger Binding="{Binding DependencyType}">
+                                            <DataTrigger.Value>
+                                                <packagemanager:DependencyType>CustomNode</packagemanager:DependencyType>
+                                            </DataTrigger.Value>
+                                            <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/nodes.png"/>
+                                        </DataTrigger>
 
-                                <DataTemplate.Triggers>
-                                    <DataTrigger Binding="{Binding DependencyType}">
-                                        <DataTrigger.Value>
-                                            <packagemanager:DependencyType>File</packagemanager:DependencyType>
-                                        </DataTrigger.Value>
-                                        <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/files.png"/>
-                                    </DataTrigger>
+                                        <DataTrigger Binding="{Binding IsNodeLibrary}" Value="true">
+                                            <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
+                                        </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding DependencyType}">
-                                        <DataTrigger.Value>
-                                            <packagemanager:DependencyType>Assembly</packagemanager:DependencyType>
-                                        </DataTrigger.Value>
-                                        <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/assemblies.png"/>
-                                    </DataTrigger>
-
-                                    <DataTrigger Binding="{Binding DependencyType}">
-                                        <DataTrigger.Value>
-                                            <packagemanager:DependencyType>CustomNode</packagemanager:DependencyType>
-                                        </DataTrigger.Value>
-                                        <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/nodes.png"/>
-                                    </DataTrigger>
-
-                                    <DataTrigger Binding="{Binding DependencyType}">
-                                        <DataTrigger.Value>
-                                            <packagemanager:DependencyType>Assembly</packagemanager:DependencyType>
-                                        </DataTrigger.Value>
-                                        <Setter Property="Visibility" TargetName="IsNodeLibraryButton" Value="Visible"/>
-                                    </DataTrigger>
-
-                                    <DataTrigger Binding="{Binding IsNodeLibrary}" Value="true">
-                                        <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
-                                    </DataTrigger>
-
-                                    <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TreeViewItem}}}"
+                                        <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TreeViewItem}}}"
                                                  Value="true">
-                                        <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
-                                    </DataTrigger>
-                                </DataTemplate.Triggers>
+                                            <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
+                                        </DataTrigger>
+                                    </DataTemplate.Triggers>
 
-                            </DataTemplate>
+                                </DataTemplate>
 
-                            <HierarchicalDataTemplate DataType = "{x:Type packagemanager:PackageItemRootViewModel}" ItemsSource="{Binding Path=Items}">
-                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
-                            </HierarchicalDataTemplate>
+                                <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemRootViewModel}" ItemsSource="{Binding Path=Items}">
+                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
+                                </HierarchicalDataTemplate>
 
-                            <HierarchicalDataTemplate DataType = "{x:Type packagemanager:PackageItemInternalViewModel}" ItemsSource="{Binding Path=Items}">
-                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
-                            </HierarchicalDataTemplate>
+                                <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemInternalViewModel}" ItemsSource="{Binding Path=Items}">
+                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
+                                </HierarchicalDataTemplate>
 
-                            <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemLeafViewModel}">
-                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
-                            </HierarchicalDataTemplate>
+                                <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemLeafViewModel}">
+                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
+                                </HierarchicalDataTemplate>
 
-                        </TreeView.Resources>
+                            </TreeView.Resources>
 
-                    </TreeView>
-
+                        </TreeView>
+                    </StackPanel>
                 </ScrollViewer>
             </Grid>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -384,71 +384,68 @@
 
                     </ScrollViewer.Resources>
 
-                    <StackPanel Orientation="Vertical">
+                    <TreeView ItemsSource="{Binding Path=PackageContents}" Style="{StaticResource SearchTreeView}" BorderThickness="0">
 
-                        <TreeView ItemsSource="{Binding Path=PackageContents}" Style="{StaticResource SearchTreeView}" BorderThickness="0">
+                        <TreeView.Resources>
 
-                            <TreeView.Resources>
+                            <DataTemplate x:Key="sharedTemplate">
+                                <StackPanel Orientation="Horizontal">
+                                    <CheckBox Name="IsNodeLibrary" IsEnabled="False" Visibility="Hidden" IsChecked="{Binding IsNodeLibrary, Mode=TwoWay}"/>
+                                    <Image Name="Icon" Width="32" Height="32" />
+                                    <TextBlock Name="DepName" Padding="7" FontSize="13" Foreground="WhiteSmoke" Text="{Binding Path=Name}"/>
+                                </StackPanel>
 
-                                <DataTemplate x:Key="sharedTemplate">
-                                    <StackPanel Orientation="Horizontal">
-                                        <CheckBox Name="IsNodeLibrary" IsEnabled="False" Visibility="Hidden" IsChecked="{Binding IsNodeLibrary, Mode=TwoWay}"/>
-                                        <Image Name="Icon" Width="32" Height="32" />
-                                        <TextBlock Name="DepName" Padding="7" FontSize="13" Foreground="WhiteSmoke" Text="{Binding Path=Name}"/>
-                                    </StackPanel>
+                                <DataTemplate.Triggers>
+                                    <DataTrigger Binding="{Binding DependencyType}">
+                                        <DataTrigger.Value>
+                                            <packagemanager:DependencyType>File</packagemanager:DependencyType>
+                                        </DataTrigger.Value>
+                                        <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/files.png"/>
+                                    </DataTrigger>
 
-                                    <DataTemplate.Triggers>
-                                        <DataTrigger Binding="{Binding DependencyType}">
-                                            <DataTrigger.Value>
-                                                <packagemanager:DependencyType>File</packagemanager:DependencyType>
-                                            </DataTrigger.Value>
-                                            <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/files.png"/>
-                                        </DataTrigger>
+                                    <DataTrigger Binding="{Binding DependencyType}">
+                                        <DataTrigger.Value>
+                                            <packagemanager:DependencyType>Assembly</packagemanager:DependencyType>
+                                        </DataTrigger.Value>
+                                        <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/assemblies.png"/>
+                                        <Setter TargetName="IsNodeLibrary" Property="IsEnabled" Value="True"/>
+                                        <Setter TargetName="IsNodeLibrary" Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
 
-                                        <DataTrigger Binding="{Binding DependencyType}">
-                                            <DataTrigger.Value>
-                                                <packagemanager:DependencyType>Assembly</packagemanager:DependencyType>
-                                            </DataTrigger.Value>
-                                            <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/assemblies.png"/>
-                                            <Setter TargetName="IsNodeLibrary" Property="IsEnabled" Value="True"/>
-                                            <Setter TargetName="IsNodeLibrary" Property="Visibility" Value="Visible"/>
-                                        </DataTrigger>
+                                    <DataTrigger Binding="{Binding DependencyType}">
+                                        <DataTrigger.Value>
+                                            <packagemanager:DependencyType>CustomNode</packagemanager:DependencyType>
+                                        </DataTrigger.Value>
+                                        <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/nodes.png"/>
+                                    </DataTrigger>
 
-                                        <DataTrigger Binding="{Binding DependencyType}">
-                                            <DataTrigger.Value>
-                                                <packagemanager:DependencyType>CustomNode</packagemanager:DependencyType>
-                                            </DataTrigger.Value>
-                                            <Setter Property="Source" TargetName="Icon" Value="/DynamoCoreWpf;component/UI/Images/nodes.png"/>
-                                        </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsNodeLibrary}" Value="true">
+                                        <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
+                                    </DataTrigger>
 
-                                        <DataTrigger Binding="{Binding IsNodeLibrary}" Value="true">
-                                            <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
-                                        </DataTrigger>
-
-                                        <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TreeViewItem}}}"
+                                    <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TreeViewItem}}}"
                                                  Value="true">
-                                            <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
-                                        </DataTrigger>
-                                    </DataTemplate.Triggers>
+                                        <Setter Property="FontWeight" TargetName="DepName" Value="Bold"/>
+                                    </DataTrigger>
+                                </DataTemplate.Triggers>
 
-                                </DataTemplate>
+                            </DataTemplate>
 
-                                <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemRootViewModel}" ItemsSource="{Binding Path=Items}">
-                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
-                                </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemRootViewModel}" ItemsSource="{Binding Path=Items}">
+                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
+                            </HierarchicalDataTemplate>
 
-                                <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemInternalViewModel}" ItemsSource="{Binding Path=Items}">
-                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
-                                </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemInternalViewModel}" ItemsSource="{Binding Path=Items}">
+                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
+                            </HierarchicalDataTemplate>
 
-                                <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemLeafViewModel}">
-                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
-                                </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type packagemanager:PackageItemLeafViewModel}">
+                                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource sharedTemplate}" />
+                            </HierarchicalDataTemplate>
 
-                            </TreeView.Resources>
+                        </TreeView.Resources>
 
-                        </TreeView>
-                    </StackPanel>
+                    </TreeView>
                 </ScrollViewer>
             </Grid>
 


### PR DESCRIPTION
### Purpose

Changes the publish package dialog to use checkboxes rather than a
context menu to select which dlls are node libraries. Also adds an
instructive text on top to further guide users.

Snapshot:
<img width="339" alt="Screen Shot 2021-02-08 at 9 45 09 AM" src="https://user-images.githubusercontent.com/10048120/107236008-45908280-69f3-11eb-9039-c70ff8c1deff.png">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

