### PR TITLE
Change If node behaviour to avoid replication over true and false scopes

### DIFF
--- a/src/Libraries/CoreNodeModels/Logic/If.cs
+++ b/src/Libraries/CoreNodeModels/Logic/If.cs
@@ -35,58 +35,11 @@ namespace CoreNodeModels.Logic
             var lhs = GetAstIdentifierForOutputIndex(0);
             AssociativeNode rhs;
 
-            if (IsPartiallyApplied)
-            {
-                // Build partial function for If node if it were a single function call:
-                // Get.ValueAtIndex([t, f], cond ? 0 : 1);
-                var connectedInputs = new List<AssociativeNode>();
-                var inputs = new List<AssociativeNode>();
-
-                if (InPorts[1].IsConnected && InPorts[2].IsConnected)
-                {
-                    connectedInputs.Add(new IntNode(0));
-                    inputs.Add(AstFactory.BuildExprList(new List<AssociativeNode>
-                        {inputAstNodes[1], inputAstNodes[2]}));
-                }
-                if (InPorts[0].IsConnected)
-                {
-                    connectedInputs.Add(new IntNode(1));
-                    inputs.Add(AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1)));
-                }
-
-                var functionNode = new IdentifierListNode
-                {
-                    LeftNode = new IdentifierNode(ProtoCore.AST.Node.BuiltinGetValueAtIndexTypeName),
-                    RightNode = new IdentifierNode(ProtoCore.AST.Node.BuiltinValueAtIndexMethodName)
-                };
-                var paramNumNode = new IntNode(2);
-                var positionNode = AstFactory.BuildExprList(connectedInputs);
-
-                var args = new List<AssociativeNode>();
-                args.Add(AstFactory.BuildExprList(new List<AssociativeNode>
-                    {inputAstNodes[1], inputAstNodes[2]}));
-                args.Add(AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1)));
-                
-                var arguments = AstFactory.BuildExprList(args);
-                var inputParams = new List<AssociativeNode>
-                {
-                    functionNode,
-                    paramNumNode,
-                    positionNode,
-                    arguments,
-                    AstFactory.BuildBooleanNode(true)
-                };
-
-                rhs = AstFactory.BuildFunctionCall("__CreateFunctionObject", inputParams);
-            }
-            else
-            {
-                var conditional = AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1));
-                var trueStmt = inputAstNodes[1];
-                var falseStmt = inputAstNodes[2];
-                var list = AstFactory.BuildExprList(new List<AssociativeNode> {trueStmt, falseStmt});
-                rhs = AstFactory.BuildIndexExpression(list, conditional);
-            }
+            var conditional = AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1));
+            var trueStmt = inputAstNodes[1];
+            var falseStmt = inputAstNodes[2];
+            var list = AstFactory.BuildExprList(new List<AssociativeNode> {trueStmt, falseStmt});
+            rhs = AstFactory.BuildIndexExpression(list, conditional);
 
             return new[]
             {


### PR DESCRIPTION
### Purpose

DYN-1976
Proposed a solution where the following DS code is translated as AST output for the `If` NodeModel node:
```
[t, f][cond ? 0 : 1];
```
These changes cause the node to behave as per common user expectation as well as match the `ScopeIf+` clockwork package node behaviour.

This translates to building a conditional expression, an array, and an indexing expression in the AST for the NodeModel node.
Lacing and partial function support do not seem to make much sense for this new `If` node and have been omitted.

WIP for @reddyashish :
- Add this functionality to a new class
- Deprecate the old node while keeping it to maintain backward compatibility
- Add tests

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs

@reddyashish 
