### PR TITLE
WIP use product code to lookup product install when displayName returns null

### DIFF
--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -394,7 +394,7 @@ namespace DynamoInstallDetective
             var newProductTuples = lookUp.GetProductNameList().Select(x=>(DisplayName: x, ProductKey : string.Empty));
             if (lookUp is InstalledProductLookUp lookupAsInstalledProduct)
             {
-                newProductTuples = (lookUp as InstalledProductLookUp).GetProductNameAndCodeList();
+                newProductTuples = lookupAsInstalledProduct.GetProductNameAndCodeList();
             }
           
             var returnProducts = newProductTuples.Select(prod =>

--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -285,6 +285,14 @@ namespace DynamoInstallDetective
                 return s?.Contains(ProductLookUpName) ?? false;
             });
         }
+        //TODO consider adding new interface.
+        //Returns product names and code tuples for products which have valid display name.
+        internal IEnumerable<(string DisplayName, string ProductKey)> GetProductNameAndCodeList()
+        {
+            return RegUtils.GetInstalledProducts().Select(s => (s.Value.DisplayName,s.Key)).Where(s => {
+                return s.DisplayName?.Contains(ProductLookUpName) ?? false;
+            });
+        }
 
         public virtual bool ExistsAtPath(string basePath)
         {
@@ -383,9 +391,17 @@ namespace DynamoInstallDetective
 
         public virtual void LookUpAndInitProducts(IProductLookUp lookUp)
         {
-            var newProducts = lookUp.GetProductNameList()
-                    .Select(lookUp.GetProductFromProductName).Distinct()
-                    .Where(p => p != null).OrderBy(p => p);
+            //TODO fallback if this cast fails
+            var newProducts = (lookUp as InstalledProductLookUp).GetProductNameAndCodeList()
+             .Select(prod =>
+            {
+                var product = lookUp.GetProductFromProductName(prod.DisplayName);
+                if (product == null)
+                {
+                    product = lookUp.GetProductFromProductCode(prod.ProductKey);
+                }
+                return product;
+            }).Distinct().Where(p => p != null).OrderBy(p => p);
             Products = Products == null ? newProducts : Products.Concat(newProducts);
         }
     }

--- a/src/Tools/DynamoInstallDetective/Properties/AssemblyInfo.cs
+++ b/src/Tools/DynamoInstallDetective/Properties/AssemblyInfo.cs
@@ -1,7 +1,11 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("DynamoInstallDetective")]
 [assembly: AssemblyCulture("")]
+
+[assembly: InternalsVisibleTo("DynamoUtilitiesTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
### Purpose

I found that even though we started cacheing the product keys during asm product lookup - we were not actually using them to look in the registry to find the matching product - we were only using display name.

certain products no longer use their display name, and instead use their product code.

The following PR first tries to lookup the product in the cached registry data using the product name, then it uses the product key if the former returns null.

After this PR DynamoSandbox on my machine finds Revit 2022 and Revit 2021 as products with asm.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

