### PR TITLE
Adding a new "IF" node that would simply return the truevalue or falsevalue based on the test condition. 

### DIFF
--- a/src/Libraries/CoreNodeModels/Logic/If.cs
+++ b/src/Libraries/CoreNodeModels/Logic/If.cs
@@ -35,58 +35,11 @@ namespace CoreNodeModels.Logic
             var lhs = GetAstIdentifierForOutputIndex(0);
             AssociativeNode rhs;
 
-            if (IsPartiallyApplied)
-            {
-                // Build partial function for If node if it were a single function call:
-                // Get.ValueAtIndex([t, f], cond ? 0 : 1);
-                var connectedInputs = new List<AssociativeNode>();
-                var inputs = new List<AssociativeNode>();
-
-                if (InPorts[1].IsConnected && InPorts[2].IsConnected)
-                {
-                    connectedInputs.Add(new IntNode(0));
-                    inputs.Add(AstFactory.BuildExprList(new List<AssociativeNode>
-                        {inputAstNodes[1], inputAstNodes[2]}));
-                }
-                if (InPorts[0].IsConnected)
-                {
-                    connectedInputs.Add(new IntNode(1));
-                    inputs.Add(AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1)));
-                }
-
-                var functionNode = new IdentifierListNode
-                {
-                    LeftNode = new IdentifierNode(ProtoCore.AST.Node.BuiltinGetValueAtIndexTypeName),
-                    RightNode = new IdentifierNode(ProtoCore.AST.Node.BuiltinValueAtIndexMethodName)
-                };
-                var paramNumNode = new IntNode(2);
-                var positionNode = AstFactory.BuildExprList(connectedInputs);
-
-                var args = new List<AssociativeNode>();
-                args.Add(AstFactory.BuildExprList(new List<AssociativeNode>
-                    {inputAstNodes[1], inputAstNodes[2]}));
-                args.Add(AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1)));
-                
-                var arguments = AstFactory.BuildExprList(args);
-                var inputParams = new List<AssociativeNode>
-                {
-                    functionNode,
-                    paramNumNode,
-                    positionNode,
-                    arguments,
-                    AstFactory.BuildBooleanNode(true)
-                };
-
-                rhs = AstFactory.BuildFunctionCall("__CreateFunctionObject", inputParams);
-            }
-            else
-            {
-                var conditional = AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1));
-                var trueStmt = inputAstNodes[1];
-                var falseStmt = inputAstNodes[2];
-                var list = AstFactory.BuildExprList(new List<AssociativeNode> {trueStmt, falseStmt});
-                rhs = AstFactory.BuildIndexExpression(list, conditional);
-            }
+            var conditional = AstFactory.BuildConditionalNode(inputAstNodes[0], new IntNode(0), new IntNode(1));
+            var trueStmt = inputAstNodes[1];
+            var falseStmt = inputAstNodes[2];
+            var list = AstFactory.BuildExprList(new List<AssociativeNode> {trueStmt, falseStmt});
+            rhs = AstFactory.BuildIndexExpression(list, conditional);
 
             return new[]
             {

--- a/src/Libraries/CoreNodeModels/Logic/If.cs
+++ b/src/Libraries/CoreNodeModels/Logic/If.cs
@@ -36,7 +36,7 @@ namespace CoreNodeModels.Logic
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            Warning("This node will be removed in a future version of Dynamo. Please use the new 'If' node instead.", true);
+            Warning(Resources.IFNodeWarningMessage, true);
 
             var lhs = GetAstIdentifierForOutputIndex(0);
             AssociativeNode rhs;

--- a/src/Libraries/CoreNodeModels/Logic/If.cs
+++ b/src/Libraries/CoreNodeModels/Logic/If.cs
@@ -101,6 +101,14 @@ namespace CoreNodeModels.Logic
             RegisterAllPorts();
         }
 
+        /// <summary>
+        /// This node will translate the following DS code into an AST output for the If NodeModel node. 
+        ///   result  = [trueValue, falseValue][boolCondition ? 0 : 1]
+        /// This node will just return the trueValue or the falseValue based on the input condition
+        /// and would be different to the conditional "If" node that was present before.
+        /// </summary>
+        /// <param name="inputAstNodes"> List of input AST nodes. </param>
+        /// <returns></returns>
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var lhs = GetAstIdentifierForOutputIndex(0);

--- a/src/Libraries/CoreNodeModels/Logic/If.cs
+++ b/src/Libraries/CoreNodeModels/Logic/If.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autodesk.DesignScript.Runtime;
 using CoreNodeModels.Properties;
 using Dynamo.Graph.Nodes;
 using Newtonsoft.Json;
@@ -15,6 +16,7 @@ namespace CoreNodeModels.Logic
     [OutPortTypes("Function")]
     [IsDesignScriptCompatible]
     [AlsoKnownAs("DSCoreNodesUI.Logic.If")]
+    [IsVisibleInDynamoLibrary(false)]
     [Obsolete("This node will be removed in a future version of Dynamo. Please use the new if node instead.")]
     public class If : NodeModel
     {
@@ -75,18 +77,18 @@ namespace CoreNodeModels.Logic
         }
     }
 
-    [NodeName("NewIf")]
+    [NodeName("If")]
     [NodeCategory(BuiltinNodeCategories.LOGIC)]
     [NodeDescription("ScopeIfDescription", typeof(Resources))]
     [OutPortTypes("Function")]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.Logic.NewIf")]
-    public class NewIf : NodeModel
+    [AlsoKnownAs("DSCoreNodesUI.Logic.If")]
+    public class RefactoredIf : NodeModel
     {
         [JsonConstructor]
-        private NewIf(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+        private RefactoredIf(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
 
-        public NewIf()
+        public RefactoredIf()
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("test", Resources.PortDataTestBlockToolTip)));
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("true", Resources.PortDataTrueBlockToolTip)));

--- a/src/Libraries/CoreNodeModels/Logic/If.cs
+++ b/src/Libraries/CoreNodeModels/Logic/If.cs
@@ -17,7 +17,7 @@ namespace CoreNodeModels.Logic
     [IsDesignScriptCompatible]
     [AlsoKnownAs("DSCoreNodesUI.Logic.If")]
     [IsVisibleInDynamoLibrary(false)]
-    [Obsolete("This node will be removed in a future version of Dynamo. Please use the new if node instead.")]
+    [Obsolete("This node will be removed in a future version of Dynamo. Please use the new 'If' node instead.")]
     public class If : NodeModel
     {
         [JsonConstructor]
@@ -36,6 +36,8 @@ namespace CoreNodeModels.Logic
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
+            Warning("This node will be removed in a future version of Dynamo. Please use the new 'If' node instead.", true);
+
             var lhs = GetAstIdentifierForOutputIndex(0);
             AssociativeNode rhs;
 

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -638,6 +638,15 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This node has been updated and will be removed in a future version of Dynamo. Existing behavior is retained, but a new version now supports Empty Lists, Null values and inputs of varying length. Please replace this node if you wish to use this improved behavior..
+        /// </summary>
+        public static string IFNodeWarningMessage {
+            get {
+                return ResourceManager.GetString("IFNodeWarningMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A slider that produces integer values..
         /// </summary>
         public static string IntegerSliderDescription {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -614,4 +614,7 @@ Default value: {0}</value>
   <data name="FilePathOutputDescription" xml:space="preserve">
     <value>File Path</value>
   </data>
+  <data name="IFNodeWarningMessage" xml:space="preserve">
+    <value>This node has been updated and will be removed in a future version of Dynamo. Existing behavior is retained, but a new version now supports Empty Lists, Null values and inputs of varying length. Please replace this node if you wish to use this improved behavior.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -614,4 +614,7 @@ Default value: {0}</value>
   <data name="FilePathOutputDescription" xml:space="preserve">
     <value>File Path</value>
   </data>
+  <data name="IFNodeWarningMessage" xml:space="preserve">
+    <value>This node has been updated and will be removed in a future version of Dynamo. Existing behavior is retained, but a new version now supports Empty Lists, Null values and inputs of varying length. Please replace this node if you wish to use this improved behavior.</value>
+  </data>
 </root>

--- a/test/DynamoCoreTests/Nodes/IfTest.cs
+++ b/test/DynamoCoreTests/Nodes/IfTest.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using CoreNodeModels.Input;
 using NUnit.Framework;
+using ProtoCore.AST.ImperativeAST;
 
 namespace Dynamo.Tests
 {
@@ -75,6 +77,26 @@ namespace Dynamo.Tests
             RunModel(testFilePath);
             AssertPreviewValue("9fe8e82f-760d-43a6-90b2-5f9c252139d7", 42);
             AssertPreviewValue("23a03082-5807-4e44-9a3d-2d1eec4a914c", 42);
+        }
+
+
+        [Test]
+        [Category("SmokeTest")]
+        public void TestNewIfForPreview()
+        {
+            string testFilePath = Path.Combine(testFolder, "testNewIf.dyn");
+            OpenModel(testFilePath);
+            BoolSelector boolSelectorNode = (BoolSelector) this.CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("886a464b-9b2b-4e66-a033-c18d0753c2cf");
+
+            boolSelectorNode.Value = true;
+            AssertPreviewValue("886a464b-9b2b-4e66-a033-c18d0753c2cf", true);
+            AssertPreviewValue("8ec964ca-a03c-4fd3-b11d-bcf399642d3e", new object[] { "a1", "b1", "c1" });
+            AssertPreviewValue("61f0a2f7-d923-4dda-8a57-ff12ff130fc0", new object[] { 1, new object[] { 2 } });
+
+            boolSelectorNode.Value = false;
+            AssertPreviewValue("886a464b-9b2b-4e66-a033-c18d0753c2cf", false);
+            AssertPreviewValue("8ec964ca-a03c-4fd3-b11d-bcf399642d3e", new object[] { new object[] { "a2" }, "b2" });
+            AssertPreviewValue("61f0a2f7-d923-4dda-8a57-ff12ff130fc0", new object[] { });
         }
     }
 }

--- a/test/DynamoCoreTests/Nodes/IfTest.cs
+++ b/test/DynamoCoreTests/Nodes/IfTest.cs
@@ -89,13 +89,13 @@ namespace Dynamo.Tests
 
             boolSelectorNode.Value = true;
             AssertPreviewValue("886a464b-9b2b-4e66-a033-c18d0753c2cf", true);
-            AssertPreviewValue("8ec964ca-a03c-4fd3-b11d-bcf399642d3e", new object[] { "a1", "b1", "c1" });
-            AssertPreviewValue("61f0a2f7-d923-4dda-8a57-ff12ff130fc0", new object[] { 1, new object[] { 2 } });
+            AssertPreviewValue("904dcd03-94a3-4560-9cdf-8825e2ce63e6", new object[] { "a1", "b1", "c1" });
+            AssertPreviewValue("ceefb203-19b9-4eb3-b0e4-c355dcb84365", new object[] { 1, new object[] { 2 } });
 
             boolSelectorNode.Value = false;
             AssertPreviewValue("886a464b-9b2b-4e66-a033-c18d0753c2cf", false);
-            AssertPreviewValue("8ec964ca-a03c-4fd3-b11d-bcf399642d3e", new object[] { new object[] { "a2" }, "b2" });
-            AssertPreviewValue("61f0a2f7-d923-4dda-8a57-ff12ff130fc0", new object[] { });
+            AssertPreviewValue("904dcd03-94a3-4560-9cdf-8825e2ce63e6", new object[] { new object[] { "a2" }, "b2" });
+            AssertPreviewValue("ceefb203-19b9-4eb3-b0e4-c355dcb84365", new object[] { });
         }
     }
 }

--- a/test/DynamoCoreTests/Nodes/IfTest.cs
+++ b/test/DynamoCoreTests/Nodes/IfTest.cs
@@ -79,7 +79,6 @@ namespace Dynamo.Tests
             AssertPreviewValue("23a03082-5807-4e44-9a3d-2d1eec4a914c", 42);
         }
 
-
         [Test]
         [Category("SmokeTest")]
         public void TestNewIfForPreview()

--- a/test/core/logic/conditional/testNewIf.dyn
+++ b/test/core/logic/conditional/testNewIf.dyn
@@ -1,0 +1,278 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "testNewIf",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\"a1\",\"b1\",\"c1\"];\n[[\"a2\"],\"b2\"];\n[1,[2]];\n[];",
+      "Id": "95224771f8f74d4b97ff0a84447c55fa",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "6e3a5447971b48d289766f5daa856d60",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e261689194624bfe9969d0bb8b1d8a57",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bc74cb9869a44a838dc78eb273730263",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2a7abb946e5541de84576f400c8e726b",
+          "Name": "",
+          "Description": "Value of expression at line 4",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Logic.NewIf, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "8ec964caa03c4fd3b11dbcf399642d3e",
+      "Inputs": [
+        {
+          "Id": "49cf2818d1e7445fa2515665dcd056ce",
+          "Name": "test",
+          "Description": "Boolean test",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "23c0cfd3fe8442ffbaf66e4cba78f308",
+          "Name": "true",
+          "Description": "Returned if test is true",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a7f2552ce978486bb3ff6f6c66114e35",
+          "Name": "false",
+          "Description": "Returned if test is false",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b8aaa4aabba84015b8204950ae5db8f0",
+          "Name": "result",
+          "Description": "Result block produced",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.BoolSelector, CoreNodeModels",
+      "NodeType": "BooleanInputNode",
+      "InputValue": true,
+      "Id": "886a464b9b2b4e66a033c18d0753c2cf",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "3f90288806474ec2a7184fb87a41c006",
+          "Name": "",
+          "Description": "Boolean",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Selection between a true and false."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Logic.NewIf, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "61f0a2f7d9234dda8a57ff12ff130fc0",
+      "Inputs": [
+        {
+          "Id": "c6121e78f6134d2fbfbe6c3d0d959755",
+          "Name": "test",
+          "Description": "Boolean test",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c8b9d93236bb46348cb1a113c84864e3",
+          "Name": "true",
+          "Description": "Returned if test is true",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "476ea13c11b5438da10917fa0317bbe2",
+          "Name": "false",
+          "Description": "Returned if test is false",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aa7222f4d9c84d0abe71e8e58155216c",
+          "Name": "result",
+          "Description": "Result block produced",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "6e3a5447971b48d289766f5daa856d60",
+      "End": "23c0cfd3fe8442ffbaf66e4cba78f308",
+      "Id": "30c0ad937c7f431ab3680939c0a0066f"
+    },
+    {
+      "Start": "e261689194624bfe9969d0bb8b1d8a57",
+      "End": "a7f2552ce978486bb3ff6f6c66114e35",
+      "Id": "d7dc066944bf407bb9cea3c1bab1b9c0"
+    },
+    {
+      "Start": "bc74cb9869a44a838dc78eb273730263",
+      "End": "c8b9d93236bb46348cb1a113c84864e3",
+      "Id": "20bd629b45e8487a8bdddb3e731ae8db"
+    },
+    {
+      "Start": "2a7abb946e5541de84576f400c8e726b",
+      "End": "476ea13c11b5438da10917fa0317bbe2",
+      "Id": "c7d3ff8264df4988b2b6d880fdd0fd64"
+    },
+    {
+      "Start": "3f90288806474ec2a7184fb87a41c006",
+      "End": "49cf2818d1e7445fa2515665dcd056ce",
+      "Id": "15148e8d8891447e9bdb62e49a12b0c2"
+    },
+    {
+      "Start": "3f90288806474ec2a7184fb87a41c006",
+      "End": "c6121e78f6134d2fbfbe6c3d0d959755",
+      "Id": "e9bac7270ade4f1fbdc53ed98c6eb648"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "ExtensionWorkspaceData": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.11.0.4052",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "95224771f8f74d4b97ff0a84447c55fa",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 141.0,
+        "Y": 290.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "NewIf",
+        "Id": "8ec964caa03c4fd3b11dbcf399642d3e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 437.0,
+        "Y": 177.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Boolean",
+        "Id": "886a464b9b2b4e66a033c18d0753c2cf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 163.0,
+        "Y": 153.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "NewIf",
+        "Id": "61f0a2f7d9234dda8a57ff12ff130fc0",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 437.0,
+        "Y": 349.5
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/logic/conditional/testNewIf.dyn
+++ b/test/core/logic/conditional/testNewIf.dyn
@@ -57,53 +57,6 @@
       "Description": "Allows for DesignScript code to be authored directly"
     },
     {
-      "ConcreteType": "CoreNodeModels.Logic.NewIf, CoreNodeModels",
-      "NodeType": "ExtensionNode",
-      "Id": "8ec964caa03c4fd3b11dbcf399642d3e",
-      "Inputs": [
-        {
-          "Id": "49cf2818d1e7445fa2515665dcd056ce",
-          "Name": "test",
-          "Description": "Boolean test",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "23c0cfd3fe8442ffbaf66e4cba78f308",
-          "Name": "true",
-          "Description": "Returned if test is true",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "a7f2552ce978486bb3ff6f6c66114e35",
-          "Name": "false",
-          "Description": "Returned if test is false",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "b8aaa4aabba84015b8204950ae5db8f0",
-          "Name": "result",
-          "Description": "Result block produced",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
-    },
-    {
       "ConcreteType": "CoreNodeModels.Input.BoolSelector, CoreNodeModels",
       "NodeType": "BooleanInputNode",
       "InputValue": true,
@@ -124,12 +77,12 @@
       "Description": "Selection between a true and false."
     },
     {
-      "ConcreteType": "CoreNodeModels.Logic.NewIf, CoreNodeModels",
+      "ConcreteType": "CoreNodeModels.Logic.RefactoredIf, CoreNodeModels",
       "NodeType": "ExtensionNode",
-      "Id": "61f0a2f7d9234dda8a57ff12ff130fc0",
+      "Id": "904dcd0394a345609cdf8825e2ce63e6",
       "Inputs": [
         {
-          "Id": "c6121e78f6134d2fbfbe6c3d0d959755",
+          "Id": "881567be242d4b328160f891a01f9ce3",
           "Name": "test",
           "Description": "Boolean test",
           "UsingDefaultValue": false,
@@ -138,7 +91,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "c8b9d93236bb46348cb1a113c84864e3",
+          "Id": "81eee78dcf8e4c2ab744e579b4348e1d",
           "Name": "true",
           "Description": "Returned if test is true",
           "UsingDefaultValue": false,
@@ -147,7 +100,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "476ea13c11b5438da10917fa0317bbe2",
+          "Id": "e718c439a67e4a63b7a29edf8b4521fe",
           "Name": "false",
           "Description": "Returned if test is false",
           "UsingDefaultValue": false,
@@ -158,7 +111,54 @@
       ],
       "Outputs": [
         {
-          "Id": "aa7222f4d9c84d0abe71e8e58155216c",
+          "Id": "6aeca93df5a44f609e175479f6a2748d",
+          "Name": "result",
+          "Description": "Result block produced",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Logic.RefactoredIf, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "ceefb20319b94eb3b0e4c355dcb84365",
+      "Inputs": [
+        {
+          "Id": "7ccfe809ce154a20a345ed5b4c2601e5",
+          "Name": "test",
+          "Description": "Boolean test",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d79e0899d98f4474a678aa0868068de1",
+          "Name": "true",
+          "Description": "Returned if test is true",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c16ded6761084fc59f157920ae14f6d4",
+          "Name": "false",
+          "Description": "Returned if test is false",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bdb0180b86f44c1a8dbdbb675d1bef8a",
           "Name": "result",
           "Description": "Result block produced",
           "UsingDefaultValue": false,
@@ -174,33 +174,33 @@
   "Connectors": [
     {
       "Start": "6e3a5447971b48d289766f5daa856d60",
-      "End": "23c0cfd3fe8442ffbaf66e4cba78f308",
-      "Id": "30c0ad937c7f431ab3680939c0a0066f"
+      "End": "81eee78dcf8e4c2ab744e579b4348e1d",
+      "Id": "1d9e83d8a7004c91bbe903d5d4008e02"
     },
     {
       "Start": "e261689194624bfe9969d0bb8b1d8a57",
-      "End": "a7f2552ce978486bb3ff6f6c66114e35",
-      "Id": "d7dc066944bf407bb9cea3c1bab1b9c0"
+      "End": "e718c439a67e4a63b7a29edf8b4521fe",
+      "Id": "3d6bc540015340efa3164787e413bba0"
     },
     {
       "Start": "bc74cb9869a44a838dc78eb273730263",
-      "End": "c8b9d93236bb46348cb1a113c84864e3",
-      "Id": "20bd629b45e8487a8bdddb3e731ae8db"
+      "End": "d79e0899d98f4474a678aa0868068de1",
+      "Id": "ef2b605f523f45cea361eb7e69d5ac91"
     },
     {
       "Start": "2a7abb946e5541de84576f400c8e726b",
-      "End": "476ea13c11b5438da10917fa0317bbe2",
-      "Id": "c7d3ff8264df4988b2b6d880fdd0fd64"
+      "End": "c16ded6761084fc59f157920ae14f6d4",
+      "Id": "a330d22125cc4f38b6c9bd9246d89317"
     },
     {
       "Start": "3f90288806474ec2a7184fb87a41c006",
-      "End": "49cf2818d1e7445fa2515665dcd056ce",
-      "Id": "15148e8d8891447e9bdb62e49a12b0c2"
+      "End": "881567be242d4b328160f891a01f9ce3",
+      "Id": "6ca4ac90d6de48f4b938bff0333d8506"
     },
     {
       "Start": "3f90288806474ec2a7184fb87a41c006",
-      "End": "c6121e78f6134d2fbfbe6c3d0d959755",
-      "Id": "e9bac7270ade4f1fbdc53ed98c6eb648"
+      "End": "7ccfe809ce154a20a345ed5b4c2601e5",
+      "Id": "8c56b3f1e2034f1dad8c3b34a453fd05"
     }
   ],
   "Dependencies": [],
@@ -212,7 +212,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.11.0.4052",
+      "Version": "2.11.0.4125",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -241,16 +241,6 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "NewIf",
-        "Id": "8ec964caa03c4fd3b11dbcf399642d3e",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 437.0,
-        "Y": 177.5
-      },
-      {
-        "ShowGeometry": true,
         "Name": "Boolean",
         "Id": "886a464b9b2b4e66a033c18d0753c2cf",
         "IsSetAsInput": false,
@@ -261,13 +251,23 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "NewIf",
-        "Id": "61f0a2f7d9234dda8a57ff12ff130fc0",
+        "Name": "If",
+        "Id": "904dcd0394a345609cdf8825e2ce63e6",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 437.0,
-        "Y": 349.5
+        "X": 483.0,
+        "Y": 122.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "If",
+        "Id": "ceefb20319b94eb3b0e4c355dcb84365",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 485.0,
+        "Y": 332.5
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-1976

This PR is made from the original one by @aparajit-pratap : https://github.com/DynamoDS/Dynamo/pull/11464.

Created a new if node that would create a AST output for the following DS code

`[t, f][cond ? 0 : 1];`

We will have to figure out a new name for this node so that it would be clear to the users and can be found easily.
Added a test to verify the functionality of this new node. 
The current if node can be removed in the next major version if we feel it would not be needed.

If the input condition has a list of boolean values then the output will be replicated based on the test input value.

![new if node](https://user-images.githubusercontent.com/43763136/107335488-fa737f80-6a85-11eb-89d2-b9f528fbf2fb.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@aparajit-pratap @QilongTang @mmisol @Amoursol @mjkkirschner 

