### PR TITLE
Catch exceptions from IExtensionStorageAccess

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -977,7 +977,16 @@ namespace Dynamo.Models
         {
             workspace.TryGetMatchingWorkspaceData(extension.UniqueId, out Dictionary<string, string> data);
             var extensionDataCopy = new Dictionary<string, string>(data);
-            extension.OnWorkspaceOpen(extensionDataCopy);
+
+            try
+            {
+                extension.OnWorkspaceOpen(extensionDataCopy);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
+                return;
+            }
         }
 
         internal static void RaiseIExtensionStorageAccessWorkspaceSaving(WorkspaceModel workspace, IExtensionStorageAccess extension, SaveContext saveContext)
@@ -986,7 +995,17 @@ namespace Dynamo.Models
             var version = $"{assemblyName.Version.Major}.{assemblyName.Version.Minor}";
 
             var hasMatchingExtensionData = workspace.TryGetMatchingWorkspaceData(extension.UniqueId, out Dictionary<string, string> data);
-            extension.OnWorkspaceSaving(data, saveContext);
+
+            try
+            {
+                extension.OnWorkspaceSaving(data, saveContext);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
+                return;
+            }
+            
             
             if (hasMatchingExtensionData)
             {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -961,7 +961,7 @@ namespace Dynamo.Models
         {
             foreach (var extension in extensionManager.StorageAccessExtensions)
             {
-                RaiseIExtensionStorageAccessWorkspaceOpened(workspace, extension);
+                RaiseIExtensionStorageAccessWorkspaceOpened(workspace, extension, this.Logger);
             }
         }
 
@@ -969,11 +969,11 @@ namespace Dynamo.Models
         {
             foreach (var extension in extensionManager.StorageAccessExtensions)
             {
-                RaiseIExtensionStorageAccessWorkspaceSaving(workspace, extension, saveContext);
+                RaiseIExtensionStorageAccessWorkspaceSaving(workspace, extension, saveContext, this.Logger);
             }
         }
 
-        internal static void RaiseIExtensionStorageAccessWorkspaceOpened(WorkspaceModel workspace, IExtensionStorageAccess extension)
+        internal static void RaiseIExtensionStorageAccessWorkspaceOpened(WorkspaceModel workspace, IExtensionStorageAccess extension, ILogger logger)
         {
             workspace.TryGetMatchingWorkspaceData(extension.UniqueId, out Dictionary<string, string> data);
             var extensionDataCopy = new Dictionary<string, string>(data);
@@ -984,12 +984,12 @@ namespace Dynamo.Models
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
+                logger.Log(ex.Message + " : " + ex.StackTrace);
                 return;
             }
         }
 
-        internal static void RaiseIExtensionStorageAccessWorkspaceSaving(WorkspaceModel workspace, IExtensionStorageAccess extension, SaveContext saveContext)
+        internal static void RaiseIExtensionStorageAccessWorkspaceSaving(WorkspaceModel workspace, IExtensionStorageAccess extension, SaveContext saveContext, ILogger logger)
         {
             var assemblyName = Assembly.GetAssembly(extension.GetType()).GetName();
             var version = $"{assemblyName.Version.Major}.{assemblyName.Version.Minor}";
@@ -1002,7 +1002,7 @@ namespace Dynamo.Models
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
+                logger.Log(ex.Message + " : " + ex.StackTrace);
                 return;
             }
             

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -217,7 +217,7 @@ namespace Dynamo.Controls
         {
             foreach (var extension in viewExtensionManager.StorageAccessViewExtensions)
             {
-                DynamoModel.RaiseIExtensionStorageAccessWorkspaceOpened(workspace, extension);
+                DynamoModel.RaiseIExtensionStorageAccessWorkspaceOpened(workspace, extension, dynamoViewModel.Model.Logger);
             }
         }
 
@@ -225,7 +225,7 @@ namespace Dynamo.Controls
         {
             foreach (var extension in viewExtensionManager.StorageAccessViewExtensions)
             {
-                DynamoModel.RaiseIExtensionStorageAccessWorkspaceSaving(workspace, extension, saveContext);
+                DynamoModel.RaiseIExtensionStorageAccessWorkspaceSaving(workspace, extension, saveContext, dynamoViewModel.Model.Logger);
             }
         }
 


### PR DESCRIPTION
### Purpose

While implementing the new `IExtensionStorageAccess` in GD i noticed a nasty little bug when calling `OnWorkspaceSaving`. Because i wasn't catching any exceptions thrown from the `IExtensionStorageAccess` implementer, any errors on the extension side would break the Dynamo save process, and make it impossible to save the current graph.

I wrapped `OnWorkspaceSaving` and `OnWorkspaceOpen` in a try/catch, so the Dynamo save and open process will continue even if the extension throws any exceptions.

For now im just logging the error to the debug console but would appreciate your inputs on if/how we should surface this to the user?

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 

### FYIs

@saintentropy 
