### PR TITLE
Prevent node autocomplete from autohiding

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -117,11 +117,6 @@ namespace Dynamo.ViewModels
             stateMachine.CancelActiveState();
         }
 
-        internal DateTime GetLastStateTimestamp()
-        {
-            return stateMachine.Timestamp;
-        }
-
         internal void BeginDragSelection(Point2D mouseCursor)
         {
             // This represents the first mouse-move event after the mouse-down
@@ -444,11 +439,6 @@ namespace Dynamo.ViewModels
             #endregion
 
             #region Public Class Properties
-            /// <summary>
-            /// Optionally record the last time a particular state is updated.
-            /// Currently only used for Node AutoComplete feature.
-            /// </summary>
-            internal DateTime Timestamp { get; set; }
 
             internal bool IsInIdleState
             {
@@ -819,7 +809,6 @@ namespace Dynamo.ViewModels
                         this.currentState = State.Connection;
                         owningWorkspace.CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
                         owningWorkspace.IsCursorForced = false;
-                        Timestamp = DateTime.Now;
                         return true;
                     }
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -62,6 +62,7 @@ namespace Dynamo.Views
         private double currentNodeCascadeOffset;
         private Point inCanvasSearchPosition;
         private List<DependencyObject> hitResultsList = new List<DependencyObject>();
+        private bool isAutoCompleteLoading;
 
         public WorkspaceViewModel ViewModel
         {
@@ -164,6 +165,14 @@ namespace Dynamo.Views
 
         private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
         {
+            // Prevents hiding the dialog from releasing the left mouse button
+            if (flag == ShowHideFlags.Hide && isAutoCompleteLoading)
+            {
+                isAutoCompleteLoading = false;
+                return;
+            }
+
+            isAutoCompleteLoading = flag == ShowHideFlags.Show && !NodeAutoCompleteSearchBar.IsOpen;
             ShowHidePopup(flag, NodeAutoCompleteSearchBar);
         }
 
@@ -214,13 +223,8 @@ namespace Dynamo.Views
             }
             if (NodeAutoCompleteSearchBar.IsOpen)
             {
-                // Suppress the mouse action from last 0.2 second otherwise mouse button release 
-                // in Dynamo window will forcefully shutdown all the open SearchBars
-                if ((new TimeSpan(DateTime.Now.Ticks - ViewModel.GetLastStateTimestamp().Ticks)).TotalSeconds > 0.2)
-                {
-                    ShowHideNodeAutoCompleteControl(ShowHideFlags.Hide);
-                    ViewModel.CancelActiveState();
-                }
+                ShowHideNodeAutoCompleteControl(ShowHideFlags.Hide);
+                ViewModel.CancelActiveState();
             }
         }
 
@@ -390,7 +394,6 @@ namespace Dynamo.Views
                 ViewModel.RequestAddViewToOuterCanvas += vm_RequestAddViewToOuterCanvas;
                 ViewModel.WorkspacePropertyEditRequested += VmOnWorkspacePropertyEditRequested;
                 ViewModel.RequestSelectionBoxUpdate += VmOnRequestSelectionBoxUpdate;
-                ViewModel.RequestNodeAutoCompleteSearch += ShowHideNodeAutoCompleteControl;
 
                 ViewModel.Loaded();
             }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -109,7 +109,6 @@ namespace Dynamo.Views
             DynamoSelection.Instance.Selection.CollectionChanged += OnSelectionCollectionChanged;
 
             ViewModel.RequestShowInCanvasSearch += ShowHideInCanvasControl;
-            ViewModel.RequestNodeAutoCompleteSearch += ShowHideNodeAutoCompleteControl;
             ViewModel.DynamoViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
             infiniteGridView.AttachToZoomBorder(zoomBorder);
@@ -147,7 +146,6 @@ namespace Dynamo.Views
             ViewModel.Model.RequestNodeCentered -= vm_RequestNodeCentered;
             ViewModel.Model.RequestNodeCentered -= vm_RequestNodeCentered;
             ViewModel.Model.CurrentOffsetChanged -= vm_CurrentOffsetChanged;
-            ViewModel.RequestNodeAutoCompleteSearch -= ShowHideNodeAutoCompleteControl;
         }
 
         void OnWorkspaceViewUnloaded(object sender, RoutedEventArgs e)
@@ -378,6 +376,7 @@ namespace Dynamo.Views
                 oldViewModel.RequestAddViewToOuterCanvas -= vm_RequestAddViewToOuterCanvas;
                 oldViewModel.WorkspacePropertyEditRequested -= VmOnWorkspacePropertyEditRequested;
                 oldViewModel.RequestSelectionBoxUpdate -= VmOnRequestSelectionBoxUpdate;
+                oldViewModel.RequestNodeAutoCompleteSearch -= ShowHideNodeAutoCompleteControl;
                 removeViewModelsubscriptions(oldViewModel);
             }
 
@@ -394,6 +393,7 @@ namespace Dynamo.Views
                 ViewModel.RequestAddViewToOuterCanvas += vm_RequestAddViewToOuterCanvas;
                 ViewModel.WorkspacePropertyEditRequested += VmOnWorkspacePropertyEditRequested;
                 ViewModel.RequestSelectionBoxUpdate += VmOnRequestSelectionBoxUpdate;
+                ViewModel.RequestNodeAutoCompleteSearch += ShowHideNodeAutoCompleteControl;
 
                 ViewModel.Loaded();
             }

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -131,6 +131,9 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(currentWs.NodeAutoCompleteSearchBar.IsOpen);
 
             // Hide Node AutoCompleteSearchBar
+            // Note the event handler needs to be called twice. The first one is ignore because it is
+            // assumed to come from releasing the left mouse button when popping up AutoCompleteSearchBar
+            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Hide);
             ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Hide);
             Assert.IsFalse(currentWs.NodeAutoCompleteSearchBar.IsOpen);
         }


### PR DESCRIPTION
### Purpose

This happened when the amount of suggestions for an input surpassed a
certain number of suggestions. The cause was the following condition.

It turns out that popups, like autocomplete, close when the left mouse
button up event happens. The problem is that autocomplete itself is
launched by pressing the left mouse button. This would normally mean
that the popup would hide as soon as the button was released, but this
was actually prevented through a time condition, which ignored the
event if it was 'soon enough'.

Unfortunately, in cases where there were a lot of suggestions, the left
mouse button up event can come after the expected timespan. This
resulted in the workaround failing to prevent the popup from hiding
immediately.

The newly implemented solution replaces the previous time-based
workaround with a more robust solution, which is to ignore the next
event after the call to show the popup is made.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
