### PR TITLE
Update link to code documentation in FuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Looking to learn or download Dynamo?  Check out [dynamobim.org](http://dynamobim
 If you're interested in developing a Node library for Dynamo, the easiest place to start is by browsing the [DynamoSamples](https://github.com/DynamoDS/DynamoSamples).  
 These samples use the [Dynamo NuGet packages](https://www.nuget.org/packages?q=DynamoVisualProgramming) which can be installed using the NuGet package manager in Visual Studio.
 
-[Documentation of the Dynamo API via Fuget.org]( https://www.fuget.org/packages/DynamoVisualProgramming.Core/2.5.0.7432) with a searchable index of public API calls for core functionality in the dynamo nuget packages. *WIP*. 
-#### note: link may change in the near future.
+[Documentation of the Dynamo API via Fuget.org](https://www.fuget.org/packages/DynamoVisualProgramming.Core/) with a searchable index of public API calls for core functionality in the dynamo nuget packages. *WIP*.
 
 The [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document explains changes made to the Dynamo API with every version.
 


### PR DESCRIPTION
### Purpose

Make the link point to latest "not beta" release rather than old version

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
