### PR TITLE
remove debug modes for python

### DIFF
--- a/src/DynamoCore/Configuration/DebugModes.cs
+++ b/src/DynamoCore/Configuration/DebugModes.cs
@@ -47,8 +47,6 @@ namespace Dynamo.Configuration
         private static void RegisterDebugModes()
         {
             // Register app wide new debug modes here.
-            AddDebugMode("PythonEngineSelectionUIDebugMode", "Enable/disable PythonEngineSelectionUI.", true);
-            AddDebugMode("Python2ObsoleteMode", "Enable/disable warnings regarding Python 2 obsoletion.");
         }
 
         internal static void LoadDebugModesStatusFromConfig(string configPath)

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -38,35 +38,32 @@ namespace PythonNodeModelsWpf
 
             nodeView.MainContextMenu.Items.Add(editWindowItem);
             editWindowItem.Click += EditScriptContent;
-            // If it is a Debug build, display a python engine switcher
-            if (Dynamo.Configuration.DebugModes.IsEnabled("PythonEngineSelectionUIDebugMode"))
+
+            var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
+            nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
+            pythonEngine2Item.Click += UpdateToPython2Engine;
+            // Bind menu item check state to the Engine property in the ViewModel.
+            // By doing this, we make sure the check status is in sync with the ViewModel,
+            // no matter if we update it through the context menu or other means.
+            // Setting the IsChecked property, on the other hand, is error prone and redundant
+            // once data binding has been set up.
+            pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
             {
-                var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
-                nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
-                pythonEngine2Item.Click += UpdateToPython2Engine;
-                // Bind menu item check state to the Engine property in the ViewModel.
-                // By doing this, we make sure the check status is in sync with the ViewModel,
-                // no matter if we update it through the context menu or other means.
-                // Setting the IsChecked property, on the other hand, is error prone and redundant
-                // once data binding has been set up.
-                pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
-                {
-                    Source = pythonNodeModel,
-                    Converter = new EnumToBooleanConverter(),
-                    ConverterParameter = PythonEngineVersion.IronPython2.ToString()
-                });
-                pythonEngine3Item.Click += UpdateToPython3Engine;
-                pythonEngine3Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
-                {
-                    Source = pythonNodeModel,
-                    Converter = new EnumToBooleanConverter(),
-                    ConverterParameter = PythonEngineVersion.CPython3.ToString()
-                });
-                learnMoreItem.Click += OpenPythonLearningMaterial;
-                pythonEngineVersionMenu.Items.Add(pythonEngine2Item);
-                pythonEngineVersionMenu.Items.Add(pythonEngine3Item);
-                nodeView.MainContextMenu.Items.Add(learnMoreItem);
-            }
+                Source = pythonNodeModel,
+                Converter = new EnumToBooleanConverter(),
+                ConverterParameter = PythonEngineVersion.IronPython2.ToString()
+            });
+            pythonEngine3Item.Click += UpdateToPython3Engine;
+            pythonEngine3Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonNodeModel.Engine))
+            {
+                Source = pythonNodeModel,
+                Converter = new EnumToBooleanConverter(),
+                ConverterParameter = PythonEngineVersion.CPython3.ToString()
+            });
+            learnMoreItem.Click += OpenPythonLearningMaterial;
+            pythonEngineVersionMenu.Items.Add(pythonEngine2Item);
+            pythonEngineVersionMenu.Items.Add(pythonEngine3Item);
+            nodeView.MainContextMenu.Items.Add(learnMoreItem);
 
             nodeView.UpdateLayout();
 

--- a/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
@@ -28,30 +28,26 @@ namespace PythonNodeModelsWpf
             pythonStringNodeView = nodeView;
             dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
 
-            // If it is a Debug build, display a python engine switcher
-            if (Dynamo.Configuration.DebugModes.IsEnabled("PythonEngineSelectionUIDebugMode"))
+            var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
+            nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
+            pythonEngine2Item.Click += UpdateToPython2Engine;
+            pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonStringNodeModel.Engine))
             {
-                var pythonEngineVersionMenu = new MenuItem { Header = PythonNodeModels.Properties.Resources.PythonNodeContextMenuEngineSwitcher, IsCheckable = false };
-                nodeView.MainContextMenu.Items.Add(pythonEngineVersionMenu);
-                pythonEngine2Item.Click += UpdateToPython2Engine;
-                pythonEngine2Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonStringNodeModel.Engine))
-                {
-                    Source = pythonStringNodeModel,
-                    Converter = new EnumToBooleanConverter(),
-                    ConverterParameter = PythonEngineVersion.IronPython2.ToString()
-                });
-                pythonEngine3Item.Click += UpdateToPython3Engine;
-                pythonEngine3Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonStringNodeModel.Engine))
-                {
-                    Source = pythonStringNodeModel,
-                    Converter = new EnumToBooleanConverter(),
-                    ConverterParameter = PythonEngineVersion.CPython3.ToString()
-                });
-                learnMoreItem.Click += OpenPythonLearningMaterial;
-                pythonEngineVersionMenu.Items.Add(pythonEngine2Item);
-                pythonEngineVersionMenu.Items.Add(pythonEngine3Item);
-                nodeView.MainContextMenu.Items.Add(learnMoreItem);
-            }
+                Source = pythonStringNodeModel,
+                Converter = new EnumToBooleanConverter(),
+                ConverterParameter = PythonEngineVersion.IronPython2.ToString()
+            });
+            pythonEngine3Item.Click += UpdateToPython3Engine;
+            pythonEngine3Item.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(pythonStringNodeModel.Engine))
+            {
+                Source = pythonStringNodeModel,
+                Converter = new EnumToBooleanConverter(),
+                ConverterParameter = PythonEngineVersion.CPython3.ToString()
+            });
+            learnMoreItem.Click += OpenPythonLearningMaterial;
+            pythonEngineVersionMenu.Items.Add(pythonEngine2Item);
+            pythonEngineVersionMenu.Items.Add(pythonEngine3Item);
+            nodeView.MainContextMenu.Items.Add(learnMoreItem);
 
             nodeModel.Disposed += NodeModel_Disposed;
 

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -32,8 +32,8 @@ namespace PythonNodeModelsWpf
         public PythonEngineVersion CachedEngine { get; set; }
 
         public ScriptEditorWindow(
-            DynamoViewModel dynamoViewModel, 
-            PythonNode nodeModel, 
+            DynamoViewModel dynamoViewModel,
+            PythonNode nodeModel,
             NodeView nodeView,
             ref ModelessChildWindow.WindowRect windowRect
             ) : base(nodeView, ref windowRect)
@@ -42,17 +42,14 @@ namespace PythonNodeModelsWpf
             this.dynamoViewModel = dynamoViewModel;
             this.nodeModel = nodeModel;
 
-            completionProvider = new SharedCompletionProvider(nodeModel.Engine,dynamoViewModel.Model.PathManager.DynamoCoreDirectory);
+            completionProvider = new SharedCompletionProvider(nodeModel.Engine, dynamoViewModel.Model.PathManager.DynamoCoreDirectory);
             completionProvider.MessageLogged += dynamoViewModel.Model.Logger.Log;
             nodeModel.CodeMigrated += OnNodeModelCodeMigrated;
 
             InitializeComponent();
             this.DataContext = this;
 
-            if (Dynamo.Configuration.DebugModes.IsEnabled("PythonEngineSelectionUIDebugMode"))
-            {
-                EngineSelectorComboBox.Visibility = Visibility.Visible;
-            }
+            EngineSelectorComboBox.Visibility = Visibility.Visible;
 
             Dynamo.Logging.Analytics.TrackScreenView("Python");
         }

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -148,8 +148,7 @@ namespace Dynamo.PythonMigration
 
         private void OnNodeAdded(Graph.Nodes.NodeModel obj)
         {
-            if (Configuration.DebugModes.IsEnabled("Python2ObsoleteMode")
-                && !NotificationTracker.ContainsKey(CurrentWorkspace.Guid)
+            if (!NotificationTracker.ContainsKey(CurrentWorkspace.Guid)
                 && GraphPythonDependencies.IsIronPythonNode(obj))
             {
                 LogIronPythonNotification();
@@ -196,8 +195,7 @@ namespace Dynamo.PythonMigration
                 NotificationTracker.Remove(CurrentWorkspace.Guid);
                 GraphPythonDependencies.CustomNodePythonDependencyMap.Clear();
 
-                if (Configuration.DebugModes.IsEnabled("Python2ObsoleteMode")
-                    && !Models.DynamoModel.IsTestMode
+                if (!Models.DynamoModel.IsTestMode
                     && PythonDependencies.CurrentWorkspaceHasIronPythonDependency())
                 {
                     LogIronPythonNotification();

--- a/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PythonMigrationViewExtensionTests.cs
@@ -35,7 +35,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillDisplayDialogWhenOpeningGraphWithIronPythonNodes()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
 
             // Act
@@ -59,7 +58,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillLogNotificationWhenAddingAnIronPythonNode()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             // Arrange
             string pythonNodeName = "Python Script";
             raisedEvents = new List<string>();
@@ -95,8 +93,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillOnlyLogNotificationWhenAddingAnIronPythonNodeOnce()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
-
             // Arrange
             string pythonNodeName = "Python Script";
             raisedEvents = new List<string>();
@@ -127,60 +123,12 @@ namespace DynamoCoreWpfTests
         }
 
         /// <summary>
-        /// Adding Python nodes that use IronPython should not generate notifications
-        /// when the Python2ObsoleteMode is disabled.
-        /// </summary>
-        [Test]
-        public void WillNotLogNotificationWhenAddingNodeWhenPython2ObsoleteFlagIsOff()
-        {
-            var debugMode = DebugModes.GetDebugMode("Python2ObsoleteMode");
-            bool shouldReenable = false;
-            if (debugMode != null && debugMode.IsEnabled)
-            {
-                debugMode.IsEnabled = false;
-                shouldReenable = true;
-            }
-
-            // Arrange
-            string pythonNodeName = "Python Script";
-            raisedEvents = new List<string>();
-
-            // Act
-            // open file
-            this.ViewModel.Model.Logger.NotificationLogged += Logger_NotificationLogged;
-
-
-            var nodesCountBeforeNodeAdded = this.ViewModel.CurrentSpace.Nodes.Count();
-
-            this.ViewModel.ExecuteCommand(new DynamoModel.
-                CreateNodeCommand(Guid.NewGuid().ToString(), pythonNodeName, 0, 0, false, false));
-
-            DispatcherUtil.DoEvents();
-
-            var nodesCountAfterNodeAdded = this.ViewModel.CurrentSpace.Nodes.Count();
-
-            // Assert
-            Assert.AreEqual(nodesCountBeforeNodeAdded + 1, nodesCountAfterNodeAdded);
-            Assert.AreEqual(raisedEvents.Count, 0);
-            raisedEvents.Clear();
-            this.ViewModel.Model.Logger.NotificationLogged -= Logger_NotificationLogged;
-            DispatcherUtil.DoEvents();
-
-            if (shouldReenable)
-            {
-                debugMode.IsEnabled = true;
-            }
-        }
-
-
-        /// <summary>
         /// This test verifies that the IronPython dialog wont show the second time a graph is opened
         /// even if it contains IronPython nodes
         /// </summary>
         [Test]
         public void WillNotDisplayDialogWhenOpeningGraphWithIronPythonNodesSecondTimeInSameSession()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
             // Arrange
             var examplePathIronPython = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "python.dyn");
@@ -221,7 +169,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillNotDisplayIronPythonDialogAgainWhenDoNotShowAgainSettingIsChecked()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
             // Arrange
             var examplePathIronPython = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "python.dyn");
@@ -269,7 +216,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void CanOpenDocumentationBrowserWhenMoreInformationIsClicked()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
 
             // Act
@@ -301,7 +247,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillDisplayDialogWhenCustomNodeInsideWorkspaceHasIronPythonNode()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
 
             // open file
@@ -344,7 +289,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void WillNotDisplayDialogWhenOpeningCustomNodeWithIronPythonNodesSecondTimeInSameSession()
         {
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
             // Arrange
             var examplePathIronPython = Path.Combine(UnitTestBase.TestDirectory, @"core\python", "PythonCustomNodeTest.dyf");

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -272,7 +272,6 @@ namespace DynamoCoreWpfTests
         public void VerifyDynamoLoadingOnOpeningWorkspaceWithMissingCustomNodes()
         {
             List<string> dependenciesList = new List<string>() { "MeshToolkit", "Clockwork for Dynamo 1.x", "Clockwork for Dynamo 2.x", "Dynamo Samples" };
-            DebugModes.LoadDebugModesStatusFromConfig(Path.Combine(GetTestDirectory(ExecutingDirectory), "DynamoCoreWpfTests", "python2ObsoleteMode.config"));
             DynamoModel.IsTestMode = false;
 
             var examplePath = Path.Combine(@"core\packageDependencyTests\PackageDependencyStates.dyn");

--- a/test/DynamoCoreWpfTests/python2ObsoleteMode.config
+++ b/test/DynamoCoreWpfTests/python2ObsoleteMode.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<DebugModes>
-    <DebugMode name="Python2ObsoleteMode" enabled="true"/>
-</DebugModes>


### PR DESCRIPTION
### Purpose

This PR removes the debug modes for `Ironpython obsolete` and `python engine selection ui`. So these features are now enabled by default.

Tests are updated to no longer set the debug mode and the test config is removed.

IronPython warnings will now be raised when opening dyn/dyfs unless the preference for suppressing them is selected or the session per graph "do not show again" checkbox is enabled.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

FYI @Amoursol 
