### PR TITLE
don't clean up registry cache until asm loading is completed

### DIFF
--- a/src/Tools/DynamoInstallDetective/Utilities.cs
+++ b/src/Tools/DynamoInstallDetective/Utilities.cs
@@ -88,22 +88,21 @@ namespace DynamoInstallDetective
         /// info.</returns>
         public static IEnumerable FindMultipleProductInstallations(List<string> productSearchPatterns, string fileSearchPattern)
         {
-            using (RegUtils.StartCache())
-            {
-                var installs = new InstalledProducts();
-                // Look up products with ASM installed on user's computer
-                foreach (var productSearchPattern in productSearchPatterns)
-                {
-                    installs.LookUpAndInitProducts(new InstalledProductLookUp(productSearchPattern, fileSearchPattern));
-                }
 
-                return
-                    installs.Products.Select(
-                        p =>
-                            new KeyValuePair<string, Tuple<int, int, int, int>>(
-                            p.InstallLocation,
-                            p.VersionInfo));
+            var installs = new InstalledProducts();
+            // Look up products with ASM installed on user's computer
+            foreach (var productSearchPattern in productSearchPatterns)
+            {
+                installs.LookUpAndInitProducts(new InstalledProductLookUp(productSearchPattern, fileSearchPattern));
             }
+
+            return
+                installs.Products.Select(
+                    p =>
+                        new KeyValuePair<string, Tuple<int, int, int, int>>(
+                        p.InstallLocation,
+                        p.VersionInfo));
+
         }
     }
 }


### PR DESCRIPTION
### Purpose

move using statement up to DynamoShapeManager and create cacher with reflection.

This works, it's not **too** ugly, but it probably needs some comments.

I'm also confused still very confused why the query doesn't work when the cacher is cleaned up, or why it used to work with a simpler query - since I'd assume it should just make uncached calls to the registry...

In any case, this does fix it - sending a simpler solution that will probably have some performance cost in another PR.
 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

