### PR TITLE
add tolist to cache returned products inside queries

### DIFF
--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -65,7 +65,13 @@ namespace DynamoInstallDetective
             return string.Empty;
         }
 
-        // Returns all the products registered under "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\" that have a valid DisplayName and an InstallLocation.
+        
+        /// <summary>
+        /// Returns all the products registered under "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\" that have a valid DisplayName and an InstallLocation.
+        /// NOTE! Because this static method returns a static field that might be cleaned up by the owning RegistryCacher don't use this method in deffered queries
+        /// unless you force a copy to be made using ToList(), ToArray() or some other immediate query.
+        /// </summary>
+        /// <returns></returns>
         public static Dictionary<string, (string DisplayName, string InstallLocation)> GetInstalledProducts()
         {
             lock (mutex)
@@ -281,7 +287,7 @@ namespace DynamoInstallDetective
 
         public virtual IEnumerable<string> GetProductNameList()
         {
-            return RegUtils.GetInstalledProducts().Select(s => s.Value.DisplayName).Where(s => {
+            return RegUtils.GetInstalledProducts().ToList().Select(s => s.Value.DisplayName).Where(s => {
                 return s?.Contains(ProductLookUpName) ?? false;
             });
         }
@@ -289,7 +295,7 @@ namespace DynamoInstallDetective
         //Returns product names and code tuples for products which have valid display name.
         internal virtual IEnumerable<(string DisplayName, string ProductKey)> GetProductNameAndCodeList()
         {
-            return RegUtils.GetInstalledProducts().Select(s => (s.Value.DisplayName,s.Key)).Where(s => {
+            return RegUtils.GetInstalledProducts().ToList().Select(s => (s.Value.DisplayName,s.Key)).Where(s => {
                 return s.DisplayName?.Contains(ProductLookUpName) ?? false;
             });
         }


### PR DESCRIPTION
### Purpose

better solution to deferred query over registry cacher - Tibi suggested copying just the values returned from the registry cacher instead of the entire query, so this lets our version check still breakout early.
It seems about as fast if not faster than previous code.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

