### PR TITLE
Do not set execution hint on undo move

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2234,7 +2234,7 @@ namespace Dynamo.Graph.Nodes
             argumentLacing = helper.ReadEnum("lacing", LacingStrategy.Disabled);
             IsSetAsInput = helper.ReadBoolean("isSelectedInput", false);
             IsSetAsOutput = helper.ReadBoolean("isSelectedOutput", false);
-            isFrozenExplicitly = helper.ReadBoolean("IsFrozen", false);
+            IsFrozen = helper.ReadBoolean("IsFrozen", false);
             PreviewPinned = helper.ReadBoolean("isPinned", false);
 
             var portInfoProcessed = new HashSet<int>();
@@ -2306,13 +2306,6 @@ namespace Dynamo.Graph.Nodes
                 RaisePropertyChanged(nameof(ArgumentLacing));
                 RaisePropertyChanged(nameof(IsVisible));
                 RaisePropertyChanged(nameof(DisplayLabels));
-                RaisePropertyChanged(nameof(IsSetAsInput));
-                RaisePropertyChanged(nameof(IsSetAsOutput));
-                //we need to modify the downstream nodes manually in case the
-                //undo is for toggling freeze. This is ONLY modifying the execution hint.
-                // this does not run the graph.
-                RaisePropertyChanged(nameof(IsFrozen));
-                MarkDownStreamNodesAsModified(this);
 
                 // Notify listeners that the position of the node has changed,
                 // then all connected connectors will also redraw themselves.

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -189,9 +189,12 @@ namespace Dynamo.Graph.Nodes
             get { return usingDefaultValue; }
             set
             {
-                usingDefaultValue = value;
-                RaisePropertyChanged("UsingDefaultValue");
-                RaisePropertyChanged("ToolTip");
+                if (usingDefaultValue != value)
+                {
+                    usingDefaultValue = value;
+                    RaisePropertyChanged("UsingDefaultValue");
+                    RaisePropertyChanged("ToolTip");
+                }
             }
         }
 

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -347,7 +347,14 @@ namespace PythonNodeModels
 
             if (engineNode != null)
             {
-                this.Engine = (PythonEngineVersion)Enum.Parse(typeof(PythonEngineVersion),engineNode.InnerText);
+                var oldEngine = Engine;
+                Engine = (PythonEngineVersion)Enum.Parse(typeof(PythonEngineVersion), engineNode.InnerText);
+                if (context == SaveContext.Undo && oldEngine != this.Engine)
+                {
+                    // For Python nodes, changing the Engine property does not set the node Modified flag.
+                    // This is done externally in all event handlers, so for Undo we do it here.
+                    OnNodeModified();
+                }
             }
         }
 

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -677,6 +677,29 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void UndoMoveDoesNotForceExecution()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\LacingTest.dyn");
+            OpenModel(openPath);
+            RunCurrentModel();
+
+            var sumNodeGuid = new Guid("088365b5-4543-4e73-9430-463475147e19");
+            var sumNode = CurrentDynamoModel.CurrentWorkspace.Nodes.First(node => node.GUID == sumNodeGuid);
+            Assert.IsFalse(sumNode.IsModified);
+
+            var oldX = sumNode.X;
+            var newX = sumNode.X + 100;
+            var newPosition = $"{newX};{sumNode.Y}";
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.UpdateModelValueCommand(Guid.Empty, sumNodeGuid, nameof(NodeModel.Position), newPosition));
+            Assert.AreEqual(newX, sumNode.X);
+
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.UndoRedoCommand(DynCmd.UndoRedoCommand.Operation.Undo));
+            Assert.AreEqual(oldX, sumNode.X);
+
+            Assert.IsFalse(sumNode.IsModified);
+        }
+
+        [Test]
         public void TestFileDirtyOnLacingChange()
         {
             string openPath = Path.Combine(TestDirectory, @"core\LacingTest.dyn");


### PR DESCRIPTION
### Purpose

There were a couple of issues that were causing a node to be set to be
executed on undoing an action that consisted of just a move:

1. The 'UsingDefaultValue' property was triggering a property changed
even if the deserialized value was the same as the current. This was
fixed by checking if the value is the same and not doing anything in
that case.

2. Even if the 'IsFrozen' property for the current node had not changed
an undo would mark the current and all downstream nodes as if they were
modified. This was fixed by relying on the 'IsFrozen' property
setter, which correctly handles the cases when the previous should be
done.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
