### PR TITLE
DYN-3517: Update perf test to hide excel

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/graphs/CurveParameterAtPointQA_2.7.0_1.dyn
+++ b/tools/Performance/DynamoPerformanceTests/graphs/CurveParameterAtPointQA_2.7.0_1.dyn
@@ -55,7 +55,7 @@
         {
           "Id": "56d4d099534b46c59d880eaa78a1b7cb",
           "Name": "file",
-          "Description": "File representing the Microsoft Excel spreadsheet.\n\nvar",
+          "Description": "File representing the Excel workbook\n\nvar",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -64,7 +64,7 @@
         {
           "Id": "c5d339789785455eb8f766bfc6bf5153",
           "Name": "sheetName",
-          "Description": "Name of the worksheet containing the data.\n\nstring",
+          "Description": "Name of the worksheet containing data\n\nstring",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -73,7 +73,7 @@
         {
           "Id": "dc8a26090cc542e582ace1701193c4d8",
           "Name": "readAsStrings",
-          "Description": "Toggle to switch between reading Excel file as strings.\n\nbool\nDefault value : false",
+          "Description": "Toggle to read cells as strings\n\nbool\nDefault value : false",
           "UsingDefaultValue": true,
           "Level": 2,
           "UseLevels": false,
@@ -82,7 +82,7 @@
         {
           "Id": "7ad54d689b92419ca5ab84461652392e",
           "Name": "showExcel",
-          "Description": "Toggle to switch between showing and hiding the main Excel window.\n\nbool\nDefault value : true",
+          "Description": "Toggle to show excel's main window\n\nbool\nDefault value : true",
           "UsingDefaultValue": true,
           "Level": 2,
           "UseLevels": false,
@@ -93,7 +93,7 @@
         {
           "Id": "3d9c928297244110b11b7a0e8463f1b0",
           "Name": "data",
-          "Description": "Rows of data from the Excel worksheet.",
+          "Description": "Rows of data from the Excel worksheet",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -543,7 +543,7 @@
         {
           "Id": "e44e9500a8be498fb474d5e496ded416",
           "Name": "double",
-          "Description": "The closest parameter along the curve",
+          "Description": "The parameter on the curve for PolyCurves or the closest parameter along the curve for other curve types.",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -551,7 +551,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Get the parameter at a particular point along the Curve\n\nCurve.ParameterAtPoint (point: Point): double"
+      "Description": "Get the parameter at a particular point along the Curve. If the input Curve is a PolyCurve this function will return a valid parameter only if the Point lies on the PolyCurve. For other Curve types this function will return the parameter along the Curve which lies at the closest Point to the input Point.\n\nCurve.ParameterAtPoint (point: Point): double"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -623,63 +623,6 @@
       "Description": "Produces a new CoordinateSystem representing this plane. It is based on the origin, and X and Y axis basis.\n\nPlane.ToCoordinateSystem ( ): CoordinateSystem"
     },
     {
-      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
-      "NodeType": "CodeBlockNode",
-      "Code": "//create polycurve by points\n//not closed\npl=PolyCurve.ByPoints(pts,false);\n\n//get parameter at point\npa=PolyCurve.ParameterAtPoint(pl,pts);\n\n//get the plane at the point\nplane=PolyCurve.PlaneAtParameter(pl,pa);\n\n//get cooridnate system of the plane\nco=Plane.ToCoordinateSystem(plane);",
-      "Id": "3262b6260a844a5d81ccc7360ce535dd",
-      "Inputs": [
-        {
-          "Id": "bac028dfce69498faf05acc5f020d99a",
-          "Name": "pts",
-          "Description": "pts",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "846c0f2670544cae8be46ed73cd00cea",
-          "Name": "",
-          "Description": "pl",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "8ea497bfb9214372a9c440035f5467be",
-          "Name": "",
-          "Description": "pa",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "6f01bc6707344e699467542bbb12483b",
-          "Name": "",
-          "Description": "plane",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "14e99a871788421a985b51d88882c7b0",
-          "Name": "",
-          "Description": "co",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "Allows for DesignScript code to be authored directly"
-    },
-    {
       "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
       "HintPath": "C:\\Users\\pratapa\\GitHub\\Dynamo\\tools\\Performance\\DynamoPerformanceTests\\graphs\\data\\test_data_CurveParameterAtPoint.xlsx",
       "InputValue": "data\\test_data_CurveParameterAtPoint.xlsx",
@@ -698,7 +641,27 @@
         }
       ],
       "Replication": "Disabled",
-      "Description": "Allows you to select a file on the system to get its filename"
+      "Description": "Allows you to select a file on the system to get its file path."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "false;",
+      "Id": "5d34f5bad0604bfea0ae36a58c617af9",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4b122fd8cb3f4951814152026941bb04",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
     }
   ],
   "Connectors": [
@@ -753,11 +716,6 @@
       "Id": "e32682d47d1448c7958ab75ea16abb7d"
     },
     {
-      "Start": "7849b7bde090435091d7319687cbaa4d",
-      "End": "bac028dfce69498faf05acc5f020d99a",
-      "Id": "3d0cdcfa5e314851bbd1ac019de70331"
-    },
-    {
       "Start": "a1e15edc6f2046e0a3575169991a71ac",
       "End": "bed264bc4f3f42bc86b88fcb6ba252b8",
       "Id": "1d18721006464739aff79afb3deee889"
@@ -801,17 +759,23 @@
       "Start": "41d81a78433542b6a1aa5457575167c2",
       "End": "af7df4a8560e4700a75ae8944564ddbc",
       "Id": "559098d0a5d74392aaab274eba3281cf"
+    },
+    {
+      "Start": "4b122fd8cb3f4951814152026941bb04",
+      "End": "7ad54d689b92419ca5ab84461652392e",
+      "Id": "f30e664e03ba498fabf3431f1c1784e7"
     }
   ],
   "Dependencies": [],
   "NodeLibraryDependencies": [],
+  "ExtensionWorkspaceData": [],
   "Bindings": [],
   "View": {
     "Dynamo": {
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.10.0.3005",
+      "Version": "2.12.0.4216",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },
@@ -960,16 +924,6 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "Code Block: PolyCurve.ParameterAtPoint",
-        "Id": "3262b6260a844a5d81ccc7360ce535dd",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": true,
-        "X": -261.87286254642936,
-        "Y": -904.11688855161947
-      },
-      {
-        "ShowGeometry": true,
         "Name": "File Path",
         "Id": "da5f2ac3d551404cb8e51eeeae8b35ba",
         "IsSetAsInput": false,
@@ -977,6 +931,16 @@
         "Excluded": false,
         "X": -2893.9725285348959,
         "Y": -1220.126877106984
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "5d34f5bad0604bfea0ae36a58c617af9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -2647.0,
+        "Y": -855.0
       }
     ],
     "Annotations": [
@@ -985,17 +949,16 @@
         "Title": "Geometry calculation",
         "Nodes": [
           "d4559a9a48904a63b1eba803745426f4",
-          "9039d05f6be241ac90b58e00539a010c",
-          "3262b6260a844a5d81ccc7360ce535dd"
+          "9039d05f6be241ac90b58e00539a010c"
         ],
         "Left": -819.8077856445957,
-        "Top": -1092.581854888683,
-        "Width": 980.93492309816634,
-        "Height": 466.46496633706352,
+        "Top": -1092.781854888683,
+        "Width": 489.4,
+        "Height": 198.20000000000005,
         "FontSize": 36.0,
         "InitialTop": -1039.581854888683,
         "InitialHeight": 280.46496633706352,
-        "TextblockHeight": 43.0,
+        "TextblockHeight": 43.2,
         "Background": "#FFC1D676"
       },
       {
@@ -1009,13 +972,13 @@
           "1c84975a1a6f4426a5cc72c351f6042b"
         ],
         "Left": -2423.8077856445957,
-        "Top": -1172.0218548886828,
-        "Width": 1505.5,
-        "Height": 299.8599999999999,
+        "Top": -1172.2218548886829,
+        "Width": 1505.0,
+        "Height": 300.3599999999999,
         "FontSize": 36.0,
         "InitialTop": -1119.0218548886828,
         "InitialHeight": 201.93333333333317,
-        "TextblockHeight": 43.0,
+        "TextblockHeight": 43.2,
         "Background": "#FFD4B6DB"
       },
       {
@@ -1029,18 +992,18 @@
           "97376b51f2714e878196f2a7570bfb9b"
         ],
         "Left": 324.01337957893361,
-        "Top": -1100.0615417921631,
-        "Width": 1446.4452657884142,
-        "Height": 315.87327556698585,
+        "Top": -1100.2615417921631,
+        "Width": 1445.9452657884142,
+        "Height": 316.0732755669859,
         "FontSize": 36.0,
         "InitialTop": -1047.0615417921631,
         "InitialHeight": 288.87327556698585,
-        "TextblockHeight": 43.0,
+        "TextblockHeight": 43.2,
         "Background": "#FFB9F9E1"
       }
     ],
-    "X": 2187.0281568041955,
-    "Y": 1058.3963437669397,
-    "Zoom": 0.83866312766216522
+    "X": 1919.9661511944355,
+    "Y": 906.77807817264238,
+    "Zoom": 0.65561279718965648
   }
 }


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3517
The perf CI has been consistently failing with one particular test that uses the DYN graph in this PR. When I logged in to the computer running these tests, I saw there were document recovery errors in excel with the excel file used in this graph. I hope that these errors do not reoccur if we allow excel to run headless.

The main change I made to the test graph here is to prevent Excel UI from showing by setting the `showExcel` input on the `ImportExcel` node to false.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

