### PR TITLE
Make Python console test more robust

### DIFF
--- a/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
+++ b/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
@@ -29,16 +29,17 @@ namespace DynamoPythonTests
         [Test]
         public void DynamoPrintLogsToConsole()
         {
-            var expectedOutput = "Greeting CPython node: Hello from Python3!!!" + Environment.NewLine
-                + "Greeting IronPython node: Hello from Python2!!!" + Environment.NewLine
-                + "Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
-                + "Greeting IronPython String node: Hello from Python2!!!" + Environment.NewLine
-                + "Multiple print parameter node: Hello Dynamo Print !!!" + Environment.NewLine
-                + "Print separator parameter node: Hello_Dynamo_Print_!!!" + Environment.NewLine
-                + @"`!""£$%^&*()_+-[{]}#~'@;:|\,<.>/? Special character node: Lot's of special characters!!!" + Environment.NewLine;
+            var expectedOutput = ".*Greeting CPython node: Hello from Python3!!!" + Environment.NewLine
+                + ".*Greeting IronPython node: Hello from Python2!!!" + Environment.NewLine
+                + ".*Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
+                + ".*Greeting IronPython String node: Hello from Python2!!!" + Environment.NewLine
+                + ".*Multiple print parameter node: Hello Dynamo Print !!!" + Environment.NewLine
+                + ".*Print separator parameter node: Hello_Dynamo_Print_!!!" + Environment.NewLine
+                + ".*`!\"£\\$%\\^&\\*\\(\\)_\\+-\\[\\{\\]\\}#~'@;:\\|\\\\,<\\.>/\\? Special character node: Lot's of special characters!!!" + Environment.NewLine
+                + ".*";
 
             CurrentDynamoModel.OpenFileFromPath(Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn"));
-            StringAssert.EndsWith(expectedOutput, CurrentDynamoModel.Logger.LogText);
+            StringAssert.IsMatch(expectedOutput, CurrentDynamoModel.Logger.LogText);
         }
     }
 }


### PR DESCRIPTION
### Purpose

The test assertions the test makes can fail. Sometimes the text 'Dynamo
is up to date.' can appear logged in the middle of the expected output.
The test is made more robust by relaxing the check using a regular
expression instead. This will allow random lines of text logged before,
after, and between the output of each node.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
