### PR TITLE
set IsFirstRun to false if hide report options is true

### DIFF
--- a/src/DynamoCoreWpf/Services/UsageReportingManager.cs
+++ b/src/DynamoCoreWpf/Services/UsageReportingManager.cs
@@ -146,14 +146,14 @@ namespace Dynamo.Services
         {
             resourceProvider = resource;
             // First run of Dynamo
-            if (dynamoViewModel.Model.PreferenceSettings.IsFirstRun)
+            if (dynamoViewModel.Model.PreferenceSettings.IsFirstRun
+                && !dynamoViewModel.HideReportOptions
+                && !DynamoModel.IsTestMode)
             {
-                FirstRun = false;
-
                 //Prompt user for detailed reporting
-                if (!DynamoModel.IsTestMode)
                     ShowUsageReportingPrompt(ownerWindow);
             }
+            FirstRun = false;
         }
 
         [Obsolete("Function will be removed in Dynamo 3.0, please set IsUsageReportingApproved.")]

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -503,7 +503,7 @@ namespace Dynamo.ViewModels
             get { return BackgroundPreviewViewModel.Active; }
         }
 
-        public bool HideReportOptions { get; }
+        public bool HideReportOptions { get; internal set; }
 
         /// <summary>
         /// Indicates if whether the Iron Python dialog box should be displayed before each new session.

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -909,16 +909,9 @@ namespace Dynamo.Controls
             //Backing up IsFirstRun to determine whether to show Gallery
             var isFirstRun = dynamoViewModel.Model.PreferenceSettings.IsFirstRun;
 
-            if (!dynamoViewModel.HideReportOptions)
-            {
-                // If first run, Collect Info Prompt will appear
-                UsageReportingManager.Instance.CheckIsFirstRun(this, dynamoViewModel.BrandingResourceProvider);
-            }
-            else
-            {
-            // If we've made it this far it's not the first run.
-            dynamoViewModel.Model.PreferenceSettings.IsFirstRun = false;
-            }
+            // If first run, Collect Info Prompt will appear
+            UsageReportingManager.Instance.CheckIsFirstRun(this, dynamoViewModel.BrandingResourceProvider);
+            
 
             WorkspaceTabs.SelectedIndex = 0;
             dynamoViewModel = (DataContext as DynamoViewModel);

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -914,6 +914,11 @@ namespace Dynamo.Controls
                 // If first run, Collect Info Prompt will appear
                 UsageReportingManager.Instance.CheckIsFirstRun(this, dynamoViewModel.BrandingResourceProvider);
             }
+            else
+            {
+            // If we've made it this far it's not the first run.
+            dynamoViewModel.Model.PreferenceSettings.IsFirstRun = false;
+            }
 
             WorkspaceTabs.SelectedIndex = 0;
             dynamoViewModel = (DataContext as DynamoViewModel);

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -666,6 +666,17 @@ namespace DynamoCoreWpfTests
             Assert.True(resultSetting.ShowEdges);
         }
 
+        [Test]
+        public void PreferenceSettings_IsFirstRun_And_HideReportOptions()
+        {
+            ViewModel.HideReportOptions = true;
+            ViewModel.Model.PreferenceSettings.IsFirstRun = true;
+            //force the dynamoview's loaded handler to be called again - 
+            View.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            Assert.IsFalse(ViewModel.PreferenceSettings.IsFirstRun);
+        }
+
         private void RestartTestSetup(bool startInTestMode)
         {
             // Shutdown Dynamo and restart it


### PR DESCRIPTION
### Purpose

when `hide report options` is enabled, the prompt to request user analytics is also hidden  - this function has the side effect that `IsFirstRun` is set to false so the gallery is not shown again.

If  `hide report options` is enabled we set `IsFirstRun` to false after this check, but before trying to raise a gallery window.

### TODO
- [x] tests

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
