### PR TITLE
Update LibG with fix for regression in 2.11

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -83,8 +83,8 @@ limitations under the License.
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -83,8 +83,8 @@ limitations under the License.
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>

--- a/src/DynamoCore/packages.config
+++ b/src/DynamoCore/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_225_0_0" version="2.11.0.4230" targetFramework="net48" developmentDependency="true" />
-  <package id="DynamoVisualProgramming.LibG_226_0_0" version="2.11.0.4230" targetFramework="net48" developmentDependency="true" />
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_225_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_226_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="Greg" version="2.0.7507.22529" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />

--- a/src/DynamoCore/packages.config
+++ b/src/DynamoCore/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_225_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
-  <package id="DynamoVisualProgramming.LibG_226_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_225_0_0" version="2.11.1.4617" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_226_0_0" version="2.11.1.4617" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="Greg" version="2.0.7507.22529" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -75,10 +75,10 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
-        <Private>False</Private>
     </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -73,8 +73,8 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -73,12 +73,12 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -36,8 +36,8 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -36,9 +36,9 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/DynamoManipulation/packages.config
+++ b/src/DynamoManipulation/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/DynamoManipulation/packages.config
+++ b/src/DynamoManipulation/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -38,8 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -38,9 +38,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Libraries/Analysis/packages.config
+++ b/src/Libraries/Analysis/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/Analysis/packages.config
+++ b/src/Libraries/Analysis/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -53,8 +53,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -53,9 +53,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Libraries/CoreNodes/packages.config
+++ b/src/Libraries/CoreNodes/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="ncalc" version="1.3.8" targetFramework="net48" />
 </packages>

--- a/src/Libraries/CoreNodes/packages.config
+++ b/src/Libraries/CoreNodes/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="ncalc" version="1.3.8" targetFramework="net48" />
 </packages>

--- a/src/Libraries/GeometryColor/GeometryColor.csproj
+++ b/src/Libraries/GeometryColor/GeometryColor.csproj
@@ -38,8 +38,8 @@
     <DocumentationFile>..\..\..\bin\AnyCPU\Release\en-US\GeometryColor.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Libraries/GeometryColor/GeometryColor.csproj
+++ b/src/Libraries/GeometryColor/GeometryColor.csproj
@@ -38,9 +38,9 @@
     <DocumentationFile>..\..\..\bin\AnyCPU\Release\en-US\GeometryColor.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Libraries/GeometryColor/packages.config
+++ b/src/Libraries/GeometryColor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/GeometryColor/packages.config
+++ b/src/Libraries/GeometryColor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/GeometryUI/GeometryUI.csproj
+++ b/src/Libraries/GeometryUI/GeometryUI.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Libraries/GeometryUI/GeometryUI.csproj
+++ b/src/Libraries/GeometryUI/GeometryUI.csproj
@@ -39,9 +39,9 @@
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Libraries/GeometryUI/packages.config
+++ b/src/Libraries/GeometryUI/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/GeometryUI/packages.config
+++ b/src/Libraries/GeometryUI/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
 </packages>

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -39,9 +39,9 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Libraries/GeometryUIWpf/packages.config
+++ b/src/Libraries/GeometryUIWpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/GeometryUIWpf/packages.config
+++ b/src/Libraries/GeometryUIWpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -41,9 +41,9 @@
       <HintPath>..\..\packages\MIConvexHull.1.1.17.0411\lib\netstandard1.0\MIConvexHull.NET Standard.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="StarMath, Version=2.0.14.1114, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\StarMath.2.0.14.1114\lib\portable-net45+sl5+wp8+win8\StarMath.dll</HintPath>

--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -41,8 +41,8 @@
       <HintPath>..\..\packages\MIConvexHull.1.1.17.0411\lib\netstandard1.0\MIConvexHull.NET Standard.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="StarMath, Version=2.0.14.1114, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Libraries/Tesellation/packages.config
+++ b/src/Libraries/Tesellation/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="MIConvexHull" version="1.1.17.0411" targetFramework="net48" />
   <package id="StarMath" version="2.0.14.1114" targetFramework="net48" />
 </packages>

--- a/src/Libraries/Tesellation/packages.config
+++ b/src/Libraries/Tesellation/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="MIConvexHull" version="1.1.17.0411" targetFramework="net48" />
   <package id="StarMath" version="2.0.14.1114" targetFramework="net48" />
 </packages>

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -39,9 +39,9 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -39,8 +39,8 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Libraries/AnalysisTests/packages.config
+++ b/test/Libraries/AnalysisTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/AnalysisTests/packages.config
+++ b/test/Libraries/AnalysisTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
+++ b/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
@@ -47,9 +47,9 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
+++ b/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
@@ -47,8 +47,8 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Libraries/CoreNodesTests/packages.config
+++ b/test/Libraries/CoreNodesTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/CoreNodesTests/packages.config
+++ b/test/Libraries/CoreNodesTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -71,9 +71,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.5.1.7, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="System" />

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -71,8 +71,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="Python.Runtime, Version=2.5.1.7, Culture=neutral, PublicKeyToken=null" />

--- a/test/Libraries/DynamoPythonTests/packages.config
+++ b/test/Libraries/DynamoPythonTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AvalonEdit" version="4.3.1.9430" targetFramework="net48" />
   <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net48" />
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="IronPython" version="2.7.9" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />

--- a/test/Libraries/DynamoPythonTests/packages.config
+++ b/test/Libraries/DynamoPythonTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AvalonEdit" version="4.3.1.9430" targetFramework="net48" />
   <package id="DynamicLanguageRuntime" version="1.2.2" targetFramework="net48" />
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="IronPython" version="2.7.9" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />

--- a/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
+++ b/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
@@ -39,9 +39,9 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
+++ b/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
@@ -39,8 +39,8 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Libraries/GeometryColorTests/packages.config
+++ b/test/Libraries/GeometryColorTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/GeometryColorTests/packages.config
+++ b/test/Libraries/GeometryColorTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/TestServices/TestServices.csproj
+++ b/test/Libraries/TestServices/TestServices.csproj
@@ -40,9 +40,9 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/test/Libraries/TestServices/TestServices.csproj
+++ b/test/Libraries/TestServices/TestServices.csproj
@@ -40,8 +40,8 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Libraries/TestServices/packages.config
+++ b/test/Libraries/TestServices/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/TestServices/packages.config
+++ b/test/Libraries/TestServices/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -38,8 +38,8 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4616, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4616\lib\net48\ProtoGeometry.dll</HintPath>
         <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -38,9 +38,9 @@
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ProtoGeometry, Version=2.11.0.4226, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.0.4226\lib\net48\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="ProtoGeometry, Version=2.11.1.4606, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\..\src\packages\DynamoVisualProgramming.LibG_227_0_0.2.11.1.4606\lib\net48\ProtoGeometry.dll</HintPath>
+        <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/Libraries/WorkflowTests/packages.config
+++ b/test/Libraries/WorkflowTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.0.4226" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>

--- a/test/Libraries/WorkflowTests/packages.config
+++ b/test/Libraries/WorkflowTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4606" targetFramework="net48" developmentDependency="true" />
+  <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.11.1.4616" targetFramework="net48" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
### Purpose
Update LibG with fix for regression in 2.11

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs
@QilongTang 
