### PR TITLE
Change DefaultWatch3DViewModel property - Active to virtual

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -699,7 +699,10 @@ namespace Dynamo.ViewModels
                     // A full regeneration is required to get the edge geometry.
                     foreach (var vm in Watch3DViewModels)
                     {
-                        vm.RegenerateAllPackages();
+                        if (vm is HelixWatch3DViewModel)
+                        {
+                            vm.RegenerateAllPackages();
+                        }
                     }
                     break;
                 case "MaxTessellationDivisions":

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -699,7 +699,7 @@ namespace Dynamo.ViewModels
                     // A full regeneration is required to get the edge geometry.
                     foreach (var vm in Watch3DViewModels)
                     {
-                        if (vm is HelixWatch3DViewModel)
+                        if (vm is HelixWatch3DViewModel) // just need a full regeneration when vm is HelixWatch3DViewModel
                         {
                             vm.RegenerateAllPackages();
                         }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -78,7 +78,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// geometry updates. When set to False, the Watch3DView corresponding
         /// to this view model is not displayed.
         /// </summary>
-        public bool Active
+        public virtual bool Active
         {
             get { return active; }
             set


### PR DESCRIPTION
### Purpose

[REVIT-166657](https://jira.autodesk.com/browse/REVIT-166657)

Some more info : 
 https://github.com/DynamoDS/Dynamo/issues/9934 
 https://github.com/DynamoDS/Dynamo/pull/9377

I have the same opinion with alfarok that when toggling "Revit Background Preview", it has no need to force a regeneration of the render packages for all nodes.
I think we can change "Active" to virtual, so it can be overridden in inherited classes.

I just have a change in DynamoRevit - https://github.com/DynamoDS/DynamoRevit/pull/2687  and override Active property.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang @aparajit-pratap 

### FYIs

