### PR TITLE
Address Unsaved Changes Edge Case

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1298,6 +1298,9 @@ namespace Dynamo.Graph.Workspaces
             }
 
             OnNodeRemoved(model);
+            // Force this change to address the edge case that user deleting the right edge
+            // node and do not see unsaved changes, e.g. the watch node at end of the graph
+            HasUnsavedChanges = true;
 
             if (dispose)
             {

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -699,6 +699,23 @@ namespace Dynamo.Tests
             Assert.IsFalse(sumNode.IsModified);
         }
 
+        /// <summary>
+        /// This test is added to test if the HasUnsavedChanges can be set 
+        /// correctly after node removal using an edge case
+        /// </summary>
+        [Test]
+        public void TestHasUnsavedChangesOnNodeRemovalEdgeCase()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\logic\comparison\testToleranceEquals_defaultTolerance.dyn");
+            OpenModel(openPath);
+            // Default state after graph open
+            Assert.AreEqual(false, CurrentDynamoModel.CurrentWorkspace.HasUnsavedChanges);
+            CurrentDynamoModel.CurrentWorkspace.RecordAndDeleteModels(
+                CurrentDynamoModel.CurrentWorkspace.Nodes.Where(x=>x.GUID.Equals(new Guid("c2f69bf434be47fa8f0a4a0ceca5910b"))).ToList<ModelBase>());
+            // Assert HasUnsavedChanges is true after a downstream node removal
+            Assert.AreEqual(true, CurrentDynamoModel.CurrentWorkspace.HasUnsavedChanges);
+        }
+
         [Test]
         public void TestFileDirtyOnLacingChange()
         {


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-1764, deleting a node with no connection or deleting a node which is the right end edge of the graph does not make the graph `HasUnsavedChanges = true`. This is due to the code in undoredo recorder to mute node modified to prevent flooding, see https://github.com/DynamoDS/Dynamo/blob/master/src/DynamoCore/Graph/Workspaces/UndoRedo.cs#L236 

After some consideration, I decided to append this step to node removing step to make sure it is always done. Let me know if you have better thoughts.

Before:
![HasUnsavedChanges_Before](https://user-images.githubusercontent.com/3942418/114399434-c5eb7500-9b55-11eb-9d3b-0e47e8681c9d.gif)


After:
![HasUnsavedChanges_After](https://user-images.githubusercontent.com/3942418/114396949-04336500-9b53-11eb-90ec-030cd904f126.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
