### PR TITLE
Display Python dep info to users on package manager window

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -77,6 +77,63 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
+    /// Converts the list of package dependencies to a string
+    /// </summary>
+    public class DependencyListToStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string depString = string.Empty;
+            bool flag = false;
+            if (value != null)
+            {
+                List<Greg.Responses.Dependency> depList = (List<Greg.Responses.Dependency>)value;
+                for (int i = 0; i < depList.Count(); i++)
+                {
+                    if (depList[i].name == "CPython" || depList[i].name == "IronPython")
+                    {
+                        depString += depList[i].name + " " + depList[i]._id + ", ";
+                        flag = true;
+                    }
+                }
+                return flag ? depString.Remove(depString.Length - 2) : null;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
+    public class EmptyDepStringToCollapsedConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter,
+          CultureInfo culture)
+        {
+            if (value != null)
+            {
+                List<Greg.Responses.Dependency> depList = (List<Greg.Responses.Dependency>)value;
+                for (int i = 0; i < depList.Count(); i++)
+                {
+                    if (depList[i].name == "CPython" || depList[i].name == "IronPython")
+                    {
+                        return Visibility.Visible;
+                    }
+                }
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter,
+          CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
     public class PackageSearchStateToStringConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter,

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Controls
     {
         private const int MaxChars = 100;
         private const double MinFontFactor = 7.0;
-        
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var tooltip = value as string;
@@ -82,6 +82,9 @@ namespace Dynamo.Controls
     /// </summary>
     public class DependencyListToStringConverter : IValueConverter
     {
+
+        private const string CPython = "CPython";
+        private const string IronPython = "IronPython";
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string depString = string.Empty;
@@ -89,11 +92,11 @@ namespace Dynamo.Controls
             if (value != null)
             {
                 List<Greg.Responses.Dependency> depList = (List<Greg.Responses.Dependency>)value;
-                for (int i = 0; i < depList.Count(); i++)
+                foreach (var dep in depList)
                 {
-                    if (depList[i].name == "CPython" || depList[i].name == "IronPython")
+                    if (dep.name == CPython || dep.name == IronPython)
                     {
-                        depString += depList[i].name + " " + depList[i]._id + ", ";
+                        depString += dep.name + " " + dep._id + ", ";
                         flag = true;
                     }
                 }
@@ -110,15 +113,17 @@ namespace Dynamo.Controls
 
     public class EmptyDepStringToCollapsedConverter : IValueConverter
     {
+        private const string CPython = "CPython";
+        private const string IronPython = "IronPython";
         public object Convert(object value, Type targetType, object parameter,
           CultureInfo culture)
         {
             if (value != null)
             {
                 List<Greg.Responses.Dependency> depList = (List<Greg.Responses.Dependency>)value;
-                for (int i = 0; i < depList.Count(); i++)
+                foreach (var dep in depList)
                 {
-                    if (depList[i].name == "CPython" || depList[i].name == "IronPython")
+                    if (dep.name == CPython || dep.name == IronPython)
                     {
                         return Visibility.Visible;
                     }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -573,6 +573,15 @@ namespace Dynamo.PackageManager
         private void AddToSearchResults(PackageManagerSearchElementViewModel element)
         {
             element.RequestDownload += this.PackageOnExecuted;
+
+            //added dummy values for representation, to be removed
+            if (element.Model.Name == "dronovBIM_v2")
+            {
+                element.Versions[0].Item1.full_dependency_ids.Add(new Dependency() { name = "CPython", _id = "3.0" });
+                element.Versions[1].Item1.full_dependency_ids.Add(new Dependency() { name = "IronPython", _id = "2.0" });
+                element.Versions[2].Item1.full_dependency_ids.Add(new Dependency() { name = "IronPython", _id = "2.0" });
+                element.Versions[2].Item1.full_dependency_ids.Add(new Dependency() { name = "CPython", _id = "3.0" });
+            }
             this.SearchResults.Add(element);
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -91,10 +91,22 @@
                 </Setter>
             </Style>
 
+            <Style x:Key="DependencyTooltip" TargetType="ToolTip">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ToolTip">
+                            <ContentPresenter />
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            
             <controls:EmptyStringToCollapsedConverter x:Key="EmptyStringToCollapsedConverter" />
             <controls:BoolToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
             <controls:PrettyDateConverter x:Key="PrettyDateConverter" />
-
+            <controls:DependencyListToStringConverter x:Key="DependencyListToStringConverter" />
+            <controls:EmptyDepStringToCollapsedConverter x:Key="EmptyDepStringToCollapsedConverter" />
+            
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}"/>
@@ -292,8 +304,18 @@
                                                 <StackPanel Orientation="Vertical" Width="340" IsHitTestVisible="True" >
                                                    <StackPanel Orientation="Horizontal">
                                                       <TextBlock Width ="Auto" MinWidth="235" FontSize="14"  Name="name" Text="{Binding Path=Model.Name}" Margin="5,0,0,0" HorizontalAlignment="Left" Foreground="WhiteSmoke" />
-                                                      <TextBlock Width ="90" FontSize="10"  Name="HostDependency" Text="{Binding Path=Model.HostsString}" Margin="5,0,0,0" HorizontalAlignment="Right" Foreground="LightBlue" 
-                                                                 VerticalAlignment="Center" ToolTip="{x:Static p:Resources.PackageHostDependencyTooltip}"/>
+                                                        <TextBlock Width ="90" FontSize="12"  Name="HostDependency" Margin="5,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Center"  Visibility="{Binding Path=Model.HostsString, Converter={StaticResource EmptyStringToCollapsedConverter}}">
+                                                            <TextBlock.ToolTip>
+                                                                <ToolTip Style="{StaticResource DependencyTooltip}">
+                                                                    <StackPanel Background="#535353" Height="Auto" Width="100" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" >
+                                                                        <TextBlock TextWrapping="Wrap" Padding="8" FontSize="12" Foreground="WhiteSmoke" Text="{Binding Path=Model.HostsString}"/>
+                                                                    </StackPanel>
+                                                                </ToolTip>
+                                                            </TextBlock.ToolTip>
+                                                            <Hyperlink Foreground="LightBlue">Dependencies</Hyperlink>
+                                                        </TextBlock>
+                                                        <!--<TextBlock Width ="90" FontSize="10"  Name="HostDependency" Text="{Binding Path=Model.HostsString}" Margin="5,0,0,0" HorizontalAlignment="Right" Foreground="LightBlue" 
+                                                                 VerticalAlignment="Center" ToolTip="{x:Static p:Resources.PackageHostDependencyTooltip}"/>-->
                                                    </StackPanel>
                                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,2">
 
@@ -361,7 +383,7 @@
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Path=Item1.version}" MinWidth="50" Margin="5"  Foreground="WhiteSmoke" />
-                                                        <TextBlock Text="{Binding Path=Item1.created, Converter={StaticResource PrettyDateConverter}}" MinWidth="100" Margin="24,5,5,5"  Foreground="DarkGray" />
+                                                        <TextBlock Text="{Binding Path=Item1.created, Converter={StaticResource PrettyDateConverter}}" MinWidth="100" Margin="24,5,5,5"  Foreground="DarkGray" /> 
 
                                                         <Border Background="#000000" Margin="3">
                                                             <StackPanel Orientation="Horizontal">
@@ -388,9 +410,8 @@
                                                                 </Button>
                                                             </StackPanel>
                                                         </Border>
-
-
-                                                    </StackPanel>
+                                                        <TextBlock FontSize="14" FontWeight="Bold" Text="ⓘ    " Foreground="WhiteSmoke" MinWidth="50" Margin="5 10 5 5" Visibility="{Binding Path=Item1.full_dependency_ids, Converter={StaticResource EmptyDepStringToCollapsedConverter}}" ToolTip="{Binding Path=Item1.full_dependency_ids, Converter={StaticResource DependencyListToStringConverter}}" />
+                                                        </StackPanel>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -300,7 +300,6 @@
                                     <StackPanel Orientation="Vertical">
                                         <StackPanel Orientation="Horizontal">
                                             <Button Style="{StaticResource FlatButton}" Command="{Binding ToggleIsExpandedCommand }" Background="#333">
-
                                                 <StackPanel Orientation="Vertical" Width="340" IsHitTestVisible="True" >
                                                    <StackPanel Orientation="Horizontal">
                                                       <TextBlock Width ="Auto" MinWidth="235" FontSize="14"  Name="name" Text="{Binding Path=Model.Name}" Margin="5,0,0,0" HorizontalAlignment="Left" Foreground="WhiteSmoke" />
@@ -314,9 +313,7 @@
                                                             </TextBlock.ToolTip>
                                                             <Hyperlink Foreground="LightBlue">Dependencies</Hyperlink>
                                                         </TextBlock>
-                                                        <!--<TextBlock Width ="90" FontSize="10"  Name="HostDependency" Text="{Binding Path=Model.HostsString}" Margin="5,0,0,0" HorizontalAlignment="Right" Foreground="LightBlue" 
-                                                                 VerticalAlignment="Center" ToolTip="{x:Static p:Resources.PackageHostDependencyTooltip}"/>-->
-                                                   </StackPanel>
+                                                    </StackPanel>
                                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,2">
 
                                                         <StackPanel Orientation="Horizontal" Margin="5" Width="100">

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -64,6 +64,11 @@ namespace Dynamo.PackageManager
                         hostsString += host + "  ";
                     }
                 }
+                //added to this dummy package for representation, to be removed and replace space at the end with newline above
+                if (Name == "dronovBIM_v2")
+                {
+                    hostsString += "CPython3"+ Environment.NewLine + "IronPython2"+ Environment.NewLine + "Revit";
+                }
                 return hostsString;
             }
         }


### PR DESCRIPTION
### Purpose

This is a separate branch that will include all the visual changes until the backend is wired up, that includes a way to populate package dependency field with Python versions used in that package.

![pyspy3](https://user-images.githubusercontent.com/32665108/114738148-b581f880-9d15-11eb-9d40-8e7c0df4c5c7.gif)


