### PR TITLE
Update NodeAutocomplete search criteria to also include nodes keywords and description

### DIFF
--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -295,7 +295,7 @@ namespace Dynamo.Search
         /// </summary>
         /// <param name="subset">The subset that will be used to match elements in tagDictionary.</param>
         /// <returns></returns>
-        private static bool MatchWithSubset2(IGrouping<string, Tuple<V, double>> pair, IEnumerable<SearchElements.NodeSearchElement> subset)
+        private static bool MatchWithSubset(IGrouping<string, Tuple<V, double>> pair, IEnumerable<SearchElements.NodeSearchElement> subset)
         {
             foreach (var eleAndWeight in pair)
             {

--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -23,10 +23,16 @@ namespace Dynamo.Search
             this.logger = logger;
         }
 
+        /// <summary>
+        ///     Dictionary of searchElement:(tag, weight)
+        /// </summary>
         protected readonly Dictionary<V, Dictionary<string, double>> entryDictionary =
             new Dictionary<V, Dictionary<string, double>>();
 
-        private List<IGrouping<string, Tuple<V, double>>> tagDictionary;
+        /// <summary>
+        /// Dictionary of tag:(list(searchelement, weight)) which contains all nodes that share a tag 
+        /// </summary>
+        private List<IGrouping<string, Tuple<V, double>>> tagDictionary;        
 
         /// <summary>
         ///     All the current entries in search.
@@ -283,6 +289,29 @@ namespace Dynamo.Search
             return (double)numberOfMatchSymbols / numberOfAllSymbols > 0.8;
         }
 
+        /// <summary>
+        /// Check if any element in the given subset
+        /// matches any element in the tagDictionary.
+        /// </summary>
+        /// <param name="subset">The subset that will be used to match elements in tagDictionary.</param>
+        /// <returns></returns>
+        private static bool MatchWithSubset2(IGrouping<string, Tuple<V, double>> pair, IEnumerable<SearchElements.NodeSearchElement> subset)
+        {
+            foreach (var eleAndWeight in pair)
+            {
+                var currentElement = (eleAndWeight.Item1 as SearchElements.NodeSearchElement).FullName;
+                foreach (var ele in subset)
+                {
+                    //if any element in tagDictionary matches to any element in subset, return true
+                    if (currentElement.IndexOf(ele.FullName) != -1)
+                    {
+                        return true;
+                    }
+                }                
+            }
+            return false;
+        }
+
         private static string[] SplitOnWhiteSpace(string s)
         {
             return s.Split(null);
@@ -320,11 +349,26 @@ namespace Dynamo.Search
         }
 
         /// <summary>
-        /// Search for elements in the dictionary based on the query
+        /// Extract subset of nodes from tagDictionary to limit search scope
+        /// </summary>
+        /// <param name="subset"> The subset that will be extracted. </param>
+        private List<IGrouping<string, Tuple<V, double>>> BuildSubsetDictionary(IEnumerable<SearchElements.NodeSearchElement> subset)
+        {
+            var subsetDictionary = new List<IGrouping<string, Tuple<V, double>>>();
+            foreach (var pair in tagDictionary.Where(x => MatchWithSubset2(x, subset)))
+            {
+                subsetDictionary.Add(pair);
+            }
+            return subsetDictionary;
+        }
+
+        /// <summary>
+        /// Search for elements in the dictionary or subset based on the query
         /// </summary>
         /// <param name="query"> The query </param>
         /// <param name="minResultsForTolerantSearch">Minimum number of results in the original search strategy to justify doing more tolerant search</param>
-        internal IEnumerable<V> Search(string query, int minResultsForTolerantSearch = 0)
+        /// <param name="subset">Subset of nodes that should be used for the search instead of the complete set of nodes</param>
+        internal IEnumerable<V> Search(string query, int minResultsForTolerantSearch = 0, IEnumerable<SearchElements.NodeSearchElement> subset = null)
         {
 #if DEBUG
             Stopwatch stopwatch = null;
@@ -334,13 +378,13 @@ namespace Dynamo.Search
                 stopwatch.Start();
             }
 #endif
-
             var searchDict = new Dictionary<V, double>();
 
             if (tagDictionary == null)
             {
                 RebuildTagDictionary();
             }
+            var currentDictionary = tagDictionary;
 
             query = query.ToLower();
 
@@ -351,7 +395,13 @@ namespace Dynamo.Search
             subPatternsList.Insert(0, query);
             subPatterns = (subPatternsList).ToArray();
 
-            foreach (var pair in tagDictionary.Where(x => MatchWithQueryString(x.Key, subPatterns)))
+            //check if subset is provided, if yes then extract the subset from tagDictionary
+            if (subset != null)
+            {
+                currentDictionary = BuildSubsetDictionary(subset);
+            }
+
+            foreach (var pair in currentDictionary.Where(x => MatchWithQueryString(x.Key, subPatterns)))
             {
                 ComputeWeightAndAddToDictionary(query, pair, searchDict);
             }

--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -355,7 +355,7 @@ namespace Dynamo.Search
         private List<IGrouping<string, Tuple<V, double>>> BuildSubsetDictionary(IEnumerable<SearchElements.NodeSearchElement> subset)
         {
             var subsetDictionary = new List<IGrouping<string, Tuple<V, double>>>();
-            foreach (var pair in tagDictionary.Where(x => MatchWithSubset2(x, subset)))
+            foreach (var pair in tagDictionary.Where(x => MatchWithSubset(x, subset)))
             {
                 subsetDictionary.Add(pair);
             }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -106,22 +106,10 @@ namespace Dynamo.ViewModels
         {
             if (PortViewModel == null) return;
 
-            var queriedSearchElements = searchElementsCache.Where(e => QuerySearchElements(e, input)).ToList();
+            //Providing the saved search results to limit the scope of the query search.
+            var foundNodes = Search(input, searchElementsCache);
+            FilteredResults = new List<NodeSearchElementViewModel>(foundNodes).OrderBy(x => x.Name).ThenBy(x => x.Description);
 
-            FilteredResults = GetViewModelForNodeSearchElements(queriedSearchElements);
-        }
-
-        /// <summary>
-        /// Returns true if the user input matches the full or partial name or any keyword or description of the filtered node element. 
-        /// </summary>
-        /// <returns>True or false</returns>
-        private bool QuerySearchElements(NodeSearchElement e, string input) 
-        {
-            StringComparison stringComparison = StringComparison.CurrentCultureIgnoreCase;
-
-            return e.Name.IndexOf(input, stringComparison) >= 0 || 
-                e.SearchKeywords.Any(x => x.IndexOf(input,stringComparison) >= 0) || 
-                e.Description.IndexOf(input, stringComparison) >= 0;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -119,7 +119,9 @@ namespace Dynamo.ViewModels
         {
             StringComparison stringComparison = StringComparison.CurrentCultureIgnoreCase;
 
-            return e.Name.IndexOf(input, stringComparison) >= 0;
+            return e.Name.IndexOf(input, stringComparison) >= 0 || 
+                e.SearchKeywords.Any(x => x.IndexOf(input,stringComparison) >= 0) || 
+                e.Description.IndexOf(input, stringComparison) >= 0;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -112,7 +112,7 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Returns true if the user input matches the name of the filtered node element. 
+        /// Returns true if the user input matches the full or partial name or any keyword or description of the filtered node element. 
         /// </summary>
         /// <returns>True or false</returns>
         private bool QuerySearchElements(NodeSearchElement e, string input) 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -866,13 +866,14 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        ///     Performs a search using the given string as query.
+        ///     Performs a search using the given string as query and subset, if provided.
         /// </summary>
         /// <returns> Returns a list with a maximum MaxNumSearchResults elements.</returns>
         /// <param name="search"> The search query </param>
-        internal IEnumerable<NodeSearchElementViewModel> Search(string search)
+        /// <param name="subset">Subset of nodes that should be used for the search instead of the complete set of nodes</param>
+        internal IEnumerable<NodeSearchElementViewModel> Search(string search, IEnumerable<NodeSearchElement> subset = null)
         {
-            var foundNodes = Model.Search(search);
+            var foundNodes = Model.Search(search, 0, subset);
             return foundNodes.Select(MakeNodeSearchElementVM);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -870,7 +870,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <returns> Returns a list with a maximum MaxNumSearchResults elements.</returns>
         /// <param name="search"> The search query </param>
-        /// <param name="subset">Subset of nodes that should be used for the search instead of the complete set of nodes</param>
+        /// <param name="subset">Subset of nodes that should be used for the search instead of the complete set of nodes. This is a list of NodeSearchElement types</param>
         internal IEnumerable<NodeSearchElementViewModel> Search(string search, IEnumerable<NodeSearchElement> subset = null)
         {
             var foundNodes = Model.Search(search, 0, subset);

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -349,7 +349,7 @@ namespace DynamoCoreWpfTests
 
             // Filter the node elements using the search field.
             searchViewModel.SearchAutoCompleteCandidates("ar");
-            Assert.AreEqual(2 , searchViewModel.FilteredResults.Count());
+            Assert.AreEqual(4 , searchViewModel.FilteredResults.Count());
         }
 
         [Test]


### PR DESCRIPTION
[DYN-3357](https://jira.autodesk.com/browse/DYN-3357)

The node-autocomplete search used only the node name to match the search key. It has been updated to include node's keywords and description as well.

In the example below `radius` is the search key that is present in `ByFillet` node's description and therefore did not use to appear in the search results before.

![Screen Shot 2021-04-15 at 10 28 04 AM](https://user-images.githubusercontent.com/32665108/114886701-c1cd8a80-9dd5-11eb-866d-84bcbefb8964.png)

Before:
![Screen Shot 2021-04-15 at 10 21 19 AM](https://user-images.githubusercontent.com/32665108/114886214-5aafd600-9dd5-11eb-9455-48a38ff9a4c7.png)

After:

![Screen Shot 2021-04-15 at 10 21 28 AM](https://user-images.githubusercontent.com/32665108/114886235-5f748a00-9dd5-11eb-8637-2dc69d44cbcc.png)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 
