### PR TITLE
WIP: DYN-3625 Add shutdown handling for IExtensions

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -477,6 +477,18 @@ namespace Dynamo.Models
             ShutdownRequested = true;
 
             OnShutdownStarted(); // Notify possible event handlers.
+            
+            foreach (var ext in ExtensionManager.Extensions)
+            {
+                try
+                {
+                    ext.Shutdown();
+                }
+                catch (Exception exc)
+                {
+                    Logger.Log($"{ext.Name} :  {exc.Message} during shutdown");
+                }
+            }
 
             PreShutdownCore(shutdownHost);
             ShutDownCore(shutdownHost);


### PR DESCRIPTION
### Purpose

The purpose of this PR is to add invocation of the Shutdown() method defined in the IExtension interface.  Currently the Shutdown() method is called for IViewExtension when the DynamoWindowView is being closed -> https://github.com/DynamoDS/Dynamo/blob/master/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs#L1616 but the Extension Shutdown is never called.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

### FYIs

@QilongTang @mjkkirschner
