### PR TITLE
Update NodeModel Autocomplete Match Criteria

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -166,8 +166,6 @@ namespace Dynamo.ViewModels
             {
                 //for now, remove rank from descriptors
                 var returnTypeName = ztSearchElement.Descriptor.ReturnType.Name;
-
-                var descriptor = ztSearchElement.Descriptor;
                 if ((returnTypeName == inputPortType)
                     || DerivesFrom(inputPortType, returnTypeName, core))
                 {
@@ -175,10 +173,14 @@ namespace Dynamo.ViewModels
                 }
             }
 
-            // NodeModel nodes, match any output return type to inputport type name
+            // NodeModel nodes, match any output return type to InputPortType name
             foreach (var element in Model.SearchEntries.OfType<NodeModelSearchElement>())
             {
-                if (element.OutputParameters.Any(op => op == inputPortType))
+                // For NodeModel nodes, output types are defined by user which usually do not contain namespace
+                // e.g. For ColorRange, the OutPortType(OutputParameter) is Color instead of DSCore.Color
+                // While we can define output type with namespace there, in order to be consistent on simplified  
+                // PortType name display in library, we make it tolerant here
+                if (element.OutputParameters.Any(op => inputPortType.EndsWith(op)))
                 {
                     elements.Add(element);
                 }


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-3470. 

For NodeModel nodes, output types are defined by user which usually do not contain namespace

example
```
    [IsDesignScriptCompatible]
    [NodeName("Color Range")]
    [NodeCategory("Core.Color.Create")]
    [NodeDescription("ColorRangeDescription",typeof(Resources))]
    [NodeSearchTags("ColorRangeSearchTags", typeof(Resources))]

    [InPortNames("colors", "indices", "value")]
    [InPortTypes("DSCore.Color[]", "double[]", "double")]
    [InPortDescriptions(typeof(Resources),
        "ColorRangePortDataColorsToolTip",
        "ColorRangePortDataIndicesToolTip",
        "ColorRangePortDataValueToolTip")]
    [OutPortNames("color")]
    [OutPortTypes("Color")]
    [OutPortDescriptions(typeof(Resources),
        "ColorRangePortDataResultToolTip")]
    [AlsoKnownAs("DSCoreNodesUI.ColorRange")]
```
                
Since the OutPortType(OutputParameter) is Color instead of DSCore.Color, it was not a exact match for node autocompete. While we can define output type with namespace there, in order to be consistent on simplified PortType name display in library, we make it tolerant here.

Result:
NodeModel nodes like `Color.Range` and `Color.Pallette` now appear in NodeAutoComplete Suggestions
![image](https://user-images.githubusercontent.com/3942418/115023773-16274780-9e74-11eb-8b8b-ac219375bfff.png)



### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs


