### PR TITLE
Fix node autocomplete suggetions on custom nodes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -429,9 +429,8 @@ namespace Dynamo.Graph.Nodes
                 }
                 return type;
             }
-
-            var cusNode = Owner as CustomNodes.Function;
-            if (cusNode != null)
+          
+            if (Owner is CustomNodes.Function cusNode)
             {
                 var cd = cusNode.Controller.Definition;
                 var param = cd.Parameters.ElementAt(Index);

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -430,6 +430,16 @@ namespace Dynamo.Graph.Nodes
                 return type;
             }
 
+            var cusNode = Owner as CustomNodes.Function;
+            if (cusNode != null)
+            {
+                var cd = cusNode.Controller.Definition;
+                var param = cd.Parameters.ElementAt(Index);
+                string type = param.Type.ToString();
+                
+                return type;
+            }
+
             var nmNode = Owner as NodeModel;
             if (nmNode != null)
             {

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -93,6 +93,29 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void NodeSuggestions_CanAutoCompleteOnCustomNodes()
+        {
+            Open(@"UI\builtin_inputport_suggestion.dyn");
+
+            // Pick the % node
+            NodeView nodeView = NodeViewWithGuid(Guid.Parse("05d82f5627314cc9bf802c5d6d3ed907").ToString());
+
+            var inPorts = nodeView.ViewModel.InPorts;
+            Assert.AreEqual(2, inPorts.Count());
+
+            var port = inPorts[1].PortModel;
+            var type = port.GetInputPortType();
+            Assert.AreEqual("Color", type);
+
+            var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
+            searchViewModel.PortViewModel = inPorts[1];
+
+            // The initial list will fill the FilteredResults with a few options - all basic input types
+            searchViewModel.PopulateAutoCompleteCandidates();
+            Assert.AreEqual(6, searchViewModel.FilteredResults.Count());
+        }
+
+        [Test]
         public void NodeSuggestions_InputPortZeroTouchNode_AreCorrect()
         {
             Open(@"UI\ffitarget_inputport_suggestion.dyn");

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -112,7 +112,7 @@ namespace DynamoCoreWpfTests
 
             // The initial list will fill the FilteredResults with a few options - all basic input types
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(6, searchViewModel.FilteredResults.Count());
+            Assert.AreEqual(8, searchViewModel.FilteredResults.Count());
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -105,7 +105,7 @@ namespace DynamoCoreWpfTests
 
             var port = inPorts[1].PortModel;
             var type = port.GetInputPortType();
-            Assert.AreEqual("Color", type);
+            Assert.AreEqual("DSCore.Color", type);
 
             var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
             searchViewModel.PortViewModel = inPorts[1];

--- a/test/UI/built_in_custom_geo_node.dyf
+++ b/test/UI/built_in_custom_geo_node.dyf
@@ -1,0 +1,325 @@
+{
+  "Uuid": "6b2be57e-3f4b-4e3a-af98-e12d2831b86f",
+  "IsCustomNode": true,
+  "Category": "testCat",
+  "Description": "",
+  "Name": "cusTest",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Autodesk.DesignScript.Geometry.Geometry": {
+        "Key": "Autodesk.DesignScript.Geometry.Geometry",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Geometry.Rotate": {
+        "Key": "Autodesk.DesignScript.Geometry.Geometry",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Geometry": {
+        "Key": "Autodesk.DesignScript.Geometry.Geometry",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Geometry.Geometry.Rotate": {
+        "Key": "Autodesk.DesignScript.Geometry.Geometry",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Autodesk.DesignScript.Curve": {
+        "Key": "Autodesk.DesignScript.Geometry.Curve",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Geometry.BoundingBox",
+      "Id": "7f60edd865ad49628281066a15c2b72f",
+      "Inputs": [
+        {
+          "Id": "a999a9367a6b48d083a3a1d2dc53a64a",
+          "Name": "geometry",
+          "Description": "Autodesk.DesignScript.Geometry.Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f0253e8cfdea4fc2b3c1ad16ff48553b",
+          "Name": "BoundingBox",
+          "Description": "BoundingBox",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the BoundingBox containing the given piece of Geometry\n\nGeometry.BoundingBox: BoundingBox"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "BoundingBox",
+      "Id": "7cf7b04f4b5846db8e0b0a3423f66700",
+      "Inputs": [
+        {
+          "Id": "cef5917f98d14967ba20b5d709a83ff1",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "geo",
+        "TypeName": "Autodesk.DesignScript.Geometry.Geometry",
+        "TypeRank": 0,
+        "DefaultValue": null,
+        "Description": ""
+      },
+      "Id": "fe3e5b6ac20540ff98b4515bbfc2f00f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "2c07384efdad4658bab700de4f078bea",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "Color",
+      "Id": "2bd17fe4a9234d60be2d299952f92fd3",
+      "Inputs": [
+        {
+          "Id": "d2fad19e4a3b42b9ad3e2b3e74b3e682",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "color",
+        "TypeName": "DSCore.Color",
+        "TypeRank": 0,
+        "DefaultValue": null,
+        "Description": ""
+      },
+      "Id": "e5c305d1ff484b3f8cd307b105463991",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "da5b6c538938482a90c2647abafe3ee6",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Color.Add@DSCore.Color,DSCore.Color",
+      "Id": "d91486340c474ddaa7f2982ff30aa06b",
+      "Inputs": [
+        {
+          "Id": "58876b058aab4bb7877d54d79b9f4966",
+          "Name": "color",
+          "Description": "A color to add\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8157d15fa40a4b28913fe6292c88e7fe",
+          "Name": "otherColor",
+          "Description": "Other color to add\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0e7227f8220d45f58051ded25ab9bef7",
+          "Name": "color",
+          "Description": "Color result from addition of two colors",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Construct a color by combining the ARGB values of two existing colors.\n\nColor.Add (color: Color, otherColor: Color): Color"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "f0253e8cfdea4fc2b3c1ad16ff48553b",
+      "End": "cef5917f98d14967ba20b5d709a83ff1",
+      "Id": "6d092f67dd6d4bf69f46469e4c1b0d9d"
+    },
+    {
+      "Start": "2c07384efdad4658bab700de4f078bea",
+      "End": "a999a9367a6b48d083a3a1d2dc53a64a",
+      "Id": "74b128cefa314c63ab20f9d3126e2289"
+    },
+    {
+      "Start": "da5b6c538938482a90c2647abafe3ee6",
+      "End": "58876b058aab4bb7877d54d79b9f4966",
+      "Id": "bc8fc756615846739ae41af16fddb547"
+    },
+    {
+      "Start": "da5b6c538938482a90c2647abafe3ee6",
+      "End": "8157d15fa40a4b28913fe6292c88e7fe",
+      "Id": "412276ca132b462c8540fd6de5d9f1a0"
+    },
+    {
+      "Start": "0e7227f8220d45f58051ded25ab9bef7",
+      "End": "d2fad19e4a3b42b9ad3e2b3e74b3e682",
+      "Id": "d80ea3b182be471b871decee693f569f"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Author": "None provided",
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.12.0.4836",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Geometry.BoundingBox",
+        "Id": "7f60edd865ad49628281066a15c2b72f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 238.0,
+        "Y": 175.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "7cf7b04f4b5846db8e0b0a3423f66700",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 438.5,
+        "Y": 272.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Input",
+        "Id": "fe3e5b6ac20540ff98b4515bbfc2f00f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 20.0,
+        "Y": 102.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "2bd17fe4a9234d60be2d299952f92fd3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 586.5,
+        "Y": 506.75
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Input",
+        "Id": "e5c305d1ff484b3f8cd307b105463991",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 55.5,
+        "Y": 342.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Color.Add",
+        "Id": "d91486340c474ddaa7f2982ff30aa06b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 308.0,
+        "Y": 380.75
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/UI/builtin_inputport_suggestion.dyn
+++ b/test/UI/builtin_inputport_suggestion.dyn
@@ -4,7 +4,16 @@
   "Description": null,
   "Name": "builtin_inputport_suggestion",
   "ElementResolver": {
-    "ResolutionMap": {}
+    "ResolutionMap": {
+      "Autodesk.DesignScript.Geometry.Geometry": {
+        "Key": "Autodesk.DesignScript.Geometry.Geometry",
+        "Value": "ProtoGeometry.dll"
+      },
+      "DSCore.Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
   },
   "Inputs": [],
   "Outputs": [],
@@ -18,7 +27,7 @@
         {
           "Id": "b090a79fa5914f049ad2fbc48d7fbf74",
           "Name": "list",
-          "Description": "list of values\n\nvar[]..[]",
+          "Description": "List to remove items from\n\nvar[]..[]",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -27,7 +36,7 @@
         {
           "Id": "9c013fa7a7f84505abbba72579e32545",
           "Name": "type",
-          "Description": "type of element\n\nstring",
+          "Description": "Type of element\n\nstring",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -37,8 +46,8 @@
       "Outputs": [
         {
           "Id": "1211bcfe948c46a39eacb248569c4cce",
-          "Name": "var[]..[]",
-          "Description": "var[]..[]",
+          "Name": "list",
+          "Description": "List with everything removed except a specified type",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -116,18 +125,73 @@
       ],
       "Replication": "Auto",
       "Description": "Finds the natural logarithm of a number in the range (0, ∞).\n\nMath.Log (number: double): double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "6b2be57e-3f4b-4e3a-af98-e12d2831b86f",
+      "FunctionType": "Graph",
+      "NodeType": "FunctionNode",
+      "Id": "05d82f5627314cc9bf802c5d6d3ed907",
+      "Inputs": [
+        {
+          "Id": "6bf39f98a859419cbf4509b8fa7139b7",
+          "Name": "geo",
+          "Description": "Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4edd71fa05ca43f09af4b439623e27cf",
+          "Name": "color",
+          "Description": "Color",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b16cfd6b33354f2f909e67662dffa972",
+          "Name": "BoundingBox",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4247f2858a3f4710a88df72fce92dba9",
+          "Name": "Color",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": ""
     }
   ],
   "Connectors": [],
-  "Dependencies": [],
+  "Dependencies": [
+    "6b2be57e-3f4b-4e3a-af98-e12d2831b86f"
+  ],
   "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [],
+  "Author": "None provided",
   "Bindings": [],
   "View": {
     "Dynamo": {
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.9.0.2607",
+      "Version": "2.12.0.4836",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -173,11 +237,21 @@
         "Excluded": false,
         "X": 504.0,
         "Y": 452.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "cusTest",
+        "Id": "05d82f5627314cc9bf802c5d6d3ed907",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 57.656928067267813,
+        "Y": 214.30198945020112
       }
     ],
     "Annotations": [],
-    "X": 0.0,
-    "Y": 0.0,
-    "Zoom": 1.0
+    "X": 69.626740644615722,
+    "Y": -1.6992606605420519,
+    "Zoom": 1.1511757837314402
   }
 }


### PR DESCRIPTION
### Purpose

The node-autocomplete feature was unable to identify the input type for custom nodes, thereby displaying default suggestions for all custom node inputs. That was fixed by casting node model to appropriate custom node class and extracting the type info of the input port to be used by the node-autocomplete search. 

![cusac2](https://user-images.githubusercontent.com/32665108/116471606-df253e80-a842-11eb-9e88-0cd237c71406.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@DynamoDS/dynamo 
