### PR TITLE
Fix the crash when Autocompletion is triggered on output port of watch node.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -157,8 +157,6 @@ namespace Dynamo.ViewModels
 
             var core = dynamoViewModel.Model.LibraryServices.LibraryManagementCore;
 
-            portType = StripUnwantedStringFromOutputType(portType);
-
             //if inputPortType is an array, use just the typename
             var parseResult = ParserUtils.ParseWithCore($"dummyName:{ portType};", core);
             var ast = parseResult.CodeBlockNode.Children().FirstOrDefault() as IdentifierNode;
@@ -262,16 +260,6 @@ namespace Dynamo.ViewModels
                 Debug.WriteLine($"failed to create class mirror for either {typea} or {typeb} during node autocomplete operation ");
                 return false;
             }
-        }
-
-        private String StripUnwantedStringFromOutputType(String portType)
-        {
-            String stringToRemove = "Node Output:";
-
-            int index = portType.IndexOf(stringToRemove);
-            portType = index < 0 ? portType : portType.Remove(index, stringToRemove.Length);
-
-            return portType;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -157,6 +157,8 @@ namespace Dynamo.ViewModels
 
             var core = dynamoViewModel.Model.LibraryServices.LibraryManagementCore;
 
+            portType = StripUnwantedStringFromOutputType(portType);
+
             //if inputPortType is an array, use just the typename
             var parseResult = ParserUtils.ParseWithCore($"dummyName:{ portType};", core);
             var ast = parseResult.CodeBlockNode.Children().FirstOrDefault() as IdentifierNode;
@@ -260,6 +262,16 @@ namespace Dynamo.ViewModels
                 Debug.WriteLine($"failed to create class mirror for either {typea} or {typeb} during node autocomplete operation ");
                 return false;
             }
+        }
+
+        private String StripUnwantedStringFromOutputType(String portType)
+        {
+            String stringToRemove = "Node Output:";
+
+            int index = portType.IndexOf(stringToRemove);
+            portType = index < 0 ? portType : portType.Remove(index, stringToRemove.Length);
+
+            return portType;
         }
 
         /// <summary>

--- a/src/Libraries/CoreNodeModels/Watch.cs
+++ b/src/Libraries/CoreNodeModels/Watch.cs
@@ -16,7 +16,7 @@ namespace CoreNodeModels
     [NodeDescription("WatchNodeDescription", typeof(Resources))]
     [NodeSearchTags("WatchNodeSearchTags", typeof(Resources))]
     [IsDesignScriptCompatible]
-    [OutPortTypes("Node Output: var")]
+    [OutPortTypes("var")]
     [AlsoKnownAs("Dynamo.Nodes.Watch", "DSCoreNodesUI.Watch")]
     public class Watch : NodeModel
     {


### PR DESCRIPTION
### Purpose

This PR is to fix the crash that was happening when Autocompletion was triggered on output port of watch node. The reason for the crash was the output port type returned for the Watch node is something like "Node Output:var". When this was passed into the parser, it would throw an exception. So we will just be stripping that unnecessary string from the port type. Aabishkar has found that this was happening only for this particular node. I tried looking any other similar nodes but couldn't find any. 

For now, we will be showing the default output suggestions for the Watch node.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit @mjkkirschner 

