### PR TITLE
DYN-3606-Preferences Panel -> Expanders Functionality

### DIFF
--- a/src/DynamoCore/Configuration/ExpanderSettings.cs
+++ b/src/DynamoCore/Configuration/ExpanderSettings.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dynamo.Configuration
+{
+    /// <summary>
+    /// This class is used for storing the expanders status of the Preferences window
+    /// </summary>
+    public class ExpanderSettings : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private bool isExpanded;
+        public ExpanderSettings(string name, bool isExpanded)
+        {
+            Name = name;
+            IsExpanded = isExpanded;
+        }
+        public string Name { get; set; }
+        public string Tab { get; set; }
+        public bool IsExpanded 
+        {
+            get
+            {
+                return isExpanded;
+            }
+            set
+            {
+                isExpanded = value;
+                OnPropertyChanged(nameof(IsExpanded));
+            }
+        }
+    }
+}

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -102,6 +102,7 @@ limitations under the License.
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="Configuration\ExecutionSession.cs" />
+    <Compile Include="Configuration\ExpanderSettings.cs" />
     <Compile Include="Configuration\ViewExtensionSettings.cs" />
     <Compile Include="Core\CrashPromptArgs.cs" />
     <Compile Include="Configuration\DebugSettings.cs" />

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -380,6 +380,11 @@ namespace Dynamo.Models
         public readonly PreferenceSettings PreferenceSettings;
 
         /// <summary>
+        /// This list contains the settings (current status) of the expanders located in the Preferences panel
+        /// </summary>
+        public List<ExpanderSettings> ExpandersSettings;
+
+        /// <summary>
         ///     Node Factory, used for creating and intantiating loaded Dynamo nodes.
         /// </summary>
         public readonly NodeFactory NodeFactory;
@@ -652,6 +657,10 @@ namespace Dynamo.Models
                 PreferenceSettings = settings;
                 PreferenceSettings.PropertyChanged += PreferenceSettings_PropertyChanged;
             }
+
+            //Due that the Expanders settings are stored by session (when dynamo is closed, settings are lost) then we read the settings from a json string
+            string jsonExpandersSettings = Resources.PreferencesExpandersSettings;
+            ExpandersSettings = JsonConvert.DeserializeObject<List<ExpanderSettings>>(jsonExpandersSettings);
 
             UpdateManager = config.UpdateManager ?? new DefaultUpdateManager(null);
 

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1263,6 +1263,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [{&quot;name&quot;:&quot;PythonExpander&quot;,&quot;tab&quot;:&quot;Features&quot;,&quot;isexpanded&quot;:false},{&quot;name&quot;:&quot;ExperimentalExpander&quot;,&quot;tab&quot;:&quot;Features&quot;,&quot;isexpanded&quot;:false},{&quot;name&quot;:&quot;Styles&quot;,&quot;tab&quot;:&quot;Visual Settings&quot;,&quot;isexpanded&quot;:false},{&quot;name&quot;:&quot;Scale&quot;,&quot;tab&quot;:&quot;Visual Settings&quot;,&quot;isexpanded&quot;:false},{&quot;name&quot;:&quot;Precision&quot;,&quot;tab&quot;:&quot;Visual Settings&quot;,&quot;isexpanded&quot;:false},{&quot;name&quot;:&quot;Display&quot;,&quot;tab&quot;:&quot;Visual Settings&quot;,&quot;isexpanded&quot;:false}].
+        /// </summary>
+        public static string PreferencesExpandersSettings {
+            get {
+                return ResourceManager.GetString("PreferencesExpandersSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 3D preview has been deactivated.
         /// </summary>
         public static string Preview3DOutageTitle {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -747,4 +747,8 @@ Parameter name: {0}</value>
   <data name="DuplicatedNewerPackage" xml:space="preserve">
     <value>A newer version of the package called {0} version {2} was found at {1} with version {3}. The newer version has been ignored.</value>
   </data>
+  <data name="PreferencesExpandersSettings" xml:space="preserve">
+    <value>[{"name":"PythonExpander","tab":"Features","isexpanded":false},{"name":"ExperimentalExpander","tab":"Features","isexpanded":false},{"name":"Styles","tab":"Visual Settings","isexpanded":false},{"name":"Scale","tab":"Visual Settings","isexpanded":false},{"name":"Precision","tab":"Visual Settings","isexpanded":false},{"name":"Display","tab":"Visual Settings","isexpanded":false}]</value>
+    <comment>Json that contains the setting for the expanders in the Preferences window</comment>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -747,4 +747,8 @@ Parameter name: {0}</value>
   <data name="Autocomplete" xml:space="preserve">
     <value>Autocomplete</value>
   </data>
+  <data name="PreferencesExpandersSettings" xml:space="preserve">
+    <value>[{"name":"PythonExpander","tab":"Features","isexpanded":false},{"name":"ExperimentalExpander","tab":"Features","isexpanded":false},{"name":"Styles","tab":"Visual Settings","isexpanded":false},{"name":"Scale","tab":"Visual Settings","isexpanded":false},{"name":"Precision","tab":"Visual Settings","isexpanded":false},{"name":"Display","tab":"Visual Settings","isexpanded":false}]</value>
+    <comment>Json that contains the setting for the expanders in the Preferences window</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -95,6 +95,22 @@ namespace Dynamo.ViewModels
             get { return Model.PreferenceSettings; }
         }
 
+        /// <summary>
+        /// This property will be used by the Preferences screen to store and retrieve all the seetings from the expanders
+        /// </summary>
+        public List<ExpanderSettings> ExpandersSettings
+        {
+            get 
+            { 
+                return Model.ExpandersSettings; 
+            }
+            set
+            {
+                Model.ExpandersSettings = value;
+                RaisePropertyChanged(nameof(ExpandersSettings));
+            }
+        }
+
         public Point TransformOrigin
         {
             get { return transformOrigin; }

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -303,65 +303,24 @@
                             </Grid.RowDefinitions>
 
                             <!--This Grid row contains the Python section-->
-                            <Grid Grid.Row="0">
-                                <Expander x:Name="PythonExpander" 
-                                          IsExpanded="True"
-                                          Style="{StaticResource MenuExpanderStyle}" 
-                                          Header="{x:Static p:Resources.PreferencesViewPython}">
-                                    <StackPanel Orientation="Vertical" Margin="0,6,0,0">
-                                        <Label  Content="{x:Static p:Resources.PreferencesViewDefaultPythonEngine}" 
-                                                Padding="0,5,5,5"
-                                                FontSize="13"
-                                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                        <ComboBox Name="PythonEngineSelector" 
-                                                  Width="213"
-                                                  HorizontalAlignment="Left"
-                                                  ItemsSource="{Binding Path=PythonEnginesList}"
-                                                  SelectedItem="{Binding Path=SelectedPythonEngine}"
-                                                  Style="{StaticResource NoBordersComboBoxStyle}">
-                                        </ComboBox>
-                                        
-                                        <Grid>
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>
-                                            </Grid.RowDefinitions>
+                            <Expander x:Name="PythonExpander"
+                                        Grid.Row="0"
+                                        Style="{StaticResource MenuExpanderStyle}" 
+                                        Expanded="Expander_Expanded"
+                                        Header="{x:Static p:Resources.PreferencesViewPython}">
+                                <StackPanel Orientation="Vertical" Margin="0,6,0,0">
+                                    <Label  Content="{x:Static p:Resources.PreferencesViewDefaultPythonEngine}" 
+                                            Padding="0,5,5,5"
+                                            FontSize="13"
+                                            Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                    <ComboBox Name="PythonEngineSelector" 
+                                                Width="213"
+                                                HorizontalAlignment="Left"
+                                                ItemsSource="{Binding Path=PythonEnginesList}"
+                                                SelectedItem="{Binding Path=SelectedPythonEngine}"
+                                                Style="{StaticResource NoBordersComboBoxStyle}">
+                                    </ComboBox>
 
-                                            <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="0">
-                                                <ToggleButton Name="IronPythonAlertsToggle"
-                                                              Width="{StaticResource ToggleButtonWidth}"
-                                                              Height="{StaticResource ToggleButtonHeight}"
-                                                              VerticalAlignment="Center"
-                                                              IsChecked="{Binding Path=HideIronPythonAlertsIsChecked}"
-                                                              Style="{StaticResource EllipseToggleButton1}"/>
-                                                <Label Content="Hide IronPython alerts" 
-                                                       Margin="10,0,0,0"
-                                                       VerticalAlignment="Center"
-                                                       Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                            </StackPanel>
-
-                                            <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="1">
-                                                <ToggleButton Name="ShowWhitespaceToggle"
-                                                              Width="{StaticResource ToggleButtonWidth}"
-                                                              Height="{StaticResource ToggleButtonHeight}"
-                                                              VerticalAlignment="Center"
-                                                              IsChecked="{Binding Path=ShowWhitespaceIsChecked}"
-                                                              Style="{StaticResource EllipseToggleButton1}"/>
-                                                <Label Content="{x:Static p:Resources.PreferencesViewShowWhitespaceInPythonEditor}" 
-                                                       VerticalAlignment="Center"
-                                                       Margin="10,0,0,0"
-                                                       Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                            </StackPanel>
-                                        </Grid>
-                                    </StackPanel>
-                                </Expander>
-                            </Grid>
-
-                            <!--This Grid row contains the Experimental section-->
-                            <Grid Grid.Row="1">
-                                <Expander x:Name="ExperimentalExpander" 
-                                          Style="{StaticResource MenuExpanderStyle}" 
-                                          Header="{x:Static p:Resources.PreferencesViewExperimentalLabel}">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
@@ -369,40 +328,80 @@
                                         </Grid.RowDefinitions>
 
                                         <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="0">
-                                            <ToggleButton Name="NodeAutocompleteToggle"
+                                            <ToggleButton Name="IronPythonAlertsToggle"
+                                                            Width="{StaticResource ToggleButtonWidth}"
+                                                            Height="{StaticResource ToggleButtonHeight}"
+                                                            VerticalAlignment="Center"
+                                                            IsChecked="{Binding Path=HideIronPythonAlertsIsChecked}"
+                                                            Style="{StaticResource EllipseToggleButton1}"/>
+                                            <Label Content="Hide IronPython alerts" 
+                                                    Margin="10,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="1">
+                                            <ToggleButton Name="ShowWhitespaceToggle"
+                                                            Width="{StaticResource ToggleButtonWidth}"
+                                                            Height="{StaticResource ToggleButtonHeight}"
+                                                            VerticalAlignment="Center"
+                                                            IsChecked="{Binding Path=ShowWhitespaceIsChecked}"
+                                                            Style="{StaticResource EllipseToggleButton1}"/>
+                                            <Label Content="{x:Static p:Resources.PreferencesViewShowWhitespaceInPythonEditor}" 
+                                                    VerticalAlignment="Center"
+                                                    Margin="10,0,0,0"
+                                                    Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </StackPanel>
+                            </Expander>
+
+                                <!--This Grid row contains the Experimental section-->
+                            <Expander x:Name="ExperimentalExpander" 
+                                          Style="{StaticResource MenuExpanderStyle}" 
+                                          Grid.Row="1"
+                                          Expanded="Expander_Expanded"
+                                          Header="{x:Static p:Resources.PreferencesViewExperimentalLabel}">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+
+                                    <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="0">
+                                        <ToggleButton Name="NodeAutocompleteToggle"
                                                       Width="{StaticResource ToggleButtonWidth}"
                                                       Height="{StaticResource ToggleButtonHeight}"
                                                       VerticalAlignment="Center"
                                                       IsChecked="{Binding Path=NodeAutocompleteIsChecked}"
                                                       Style="{StaticResource EllipseToggleButton1}"/>
-                                            <Label Content="{x:Static p:Resources.PreferencesViewEnableNodeAutoComplete}" 
+                                        <Label Content="{x:Static p:Resources.PreferencesViewEnableNodeAutoComplete}" 
                                                    Margin="10,0,0,0"
                                                    VerticalAlignment="Center"
                                                    Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="1">
-                                            <ToggleButton Name="EnableTSplineToggle"
+                                    <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="1">
+                                        <ToggleButton Name="EnableTSplineToggle"
                                                           Width="{StaticResource ToggleButtonWidth}"
                                                           Height="{StaticResource ToggleButtonHeight}"
                                                           VerticalAlignment="Center"
                                                           IsChecked="{Binding Path=EnableTSplineIsChecked}"
                                                           Style="{StaticResource EllipseToggleButton1}"/>
-                                            <StackPanel VerticalAlignment="Center">
-                                                <Label Content="{x:Static p:Resources.PreferencesViewEnableTSplineNodes}"
+                                        <StackPanel VerticalAlignment="Center">
+                                            <Label Content="{x:Static p:Resources.PreferencesViewEnableTSplineNodes}"
                                                        Padding="5,5,5,0"
                                                        Margin="10,0,0,0"
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                                <Label Content="{x:Static p:Resources.PreferencesViewRequiresRelaunchOfDynamo}" 
+                                            <Label Content="{x:Static p:Resources.PreferencesViewRequiresRelaunchOfDynamo}" 
                                                        FontSize="10"
                                                        Margin="10,0,0,0"
                                                        Padding="5,0,5,5"
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                            </StackPanel>
                                         </StackPanel>
-                                    </Grid>
-                                </Expander>
-                            </Grid>
+                                    </StackPanel>
+                                </Grid>
+                            </Expander>
                         </Grid>
                     </TabItem>
                     
@@ -421,7 +420,6 @@
                             <!--Group Styles Expander-->
                             <Expander x:Name="Styles"
                                       Grid.Row="0"
-                                      IsExpanded="True"
                                       Expanded="Expander_Expanded"
                                       Header="{x:Static p:Resources.PreferencesViewVisualSettingsGroupStyles}"
                                       Style="{StaticResource MenuExpanderStyle}">

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -10,6 +10,7 @@ using Dynamo.ViewModels;
 using Res = Dynamo.Wpf.Properties.Resources;
 using System.Linq;
 using Dynamo.Logging;
+using System.Windows.Data;
 
 namespace Dynamo.Wpf.Views
 {
@@ -37,8 +38,58 @@ namespace Dynamo.Wpf.Views
                 viewModel = viewModelTemp;
             }
 
+            SetAllExpanderBindings();
+
             InitRadioButtonsDescription();
         }
+
+        /// <summary>
+        /// Due that all the settings for the expanders is stored in DynamoModel in a List property, we need to create expanders bindings dynamically
+        /// </summary>
+        private void SetAllExpanderBindings()
+        {
+            AssignExpanderBinding(PythonExpander);
+            AssignExpanderBinding(ExperimentalExpander);
+            AssignExpanderBinding(Styles);
+            AssignExpanderBinding(Scale);
+            AssignExpanderBinding(Precision);
+            AssignExpanderBinding(Display);
+        }
+
+        //For each expander passed as a parameter, it binds the right IsExpanded property.
+        private void AssignExpanderBinding(Expander expanderTarget)
+        {
+            var expanderStoredSetting = (from setting
+                                        in dynViewModel.ExpandersSettings
+                                         where setting.Name.Equals(expanderTarget.Name)
+                                         select setting).FirstOrDefault();
+
+            if (expanderStoredSetting != null)
+            {
+                Binding expanderBinding = new Binding("IsExpanded");
+                expanderBinding.Source = expanderStoredSetting;
+                expanderTarget.SetBinding(Expander.IsExpandedProperty, expanderBinding);
+            }
+        }
+
+        /// <summary>
+        /// When closing the Preferences window all the expander bindings are cleared
+        /// </summary>
+        private void ClearAllExpanderBindings()
+        {
+            ClearExpanderBinding(PythonExpander);
+            ClearExpanderBinding(ExperimentalExpander);
+            ClearExpanderBinding(Styles);
+            ClearExpanderBinding(Scale);
+            ClearExpanderBinding(Precision);
+            ClearExpanderBinding(Display);
+        }
+
+        private void ClearExpanderBinding(Expander expanderTarget)
+        {
+            BindingOperations.ClearBinding(expanderTarget, Expander.IsExpandedProperty);
+        }
+
 
         private void InitRadioButtonsDescription()
         {
@@ -54,6 +105,7 @@ namespace Dynamo.Wpf.Views
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
+            ClearAllExpanderBindings();
             this.Close();
         }
 


### PR DESCRIPTION
### Purpose

I added the functionality in the Features tab of having just one Expander expander at one time (this functionality already exits in the Visual Settings expander).

Also I added the functionality of recording the current state of the Expander in a way that every time that the Preference window is closed and re-opened then the Expanders will remember the previous state. Due that this functionality was implemented by session then when the Dynamo app is closed  the previous Expander settings will be lost.
### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Astul-Betizagasti 