### PR TITLE
Users should be able to type into the Auto completion search window.

### DIFF
--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -89,6 +89,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search Autocomplete Results.
+        /// </summary>
+        public static string AutocompleteSearchTextBlockText {
+            get {
+                return ResourceManager.GetString("AutocompleteSearchTextBlockText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Original file &apos;{0}&apos; gets backed up at &apos;{1}&apos;.
         /// </summary>
         public static string BackUpOriginalFileMessage {
@@ -1483,7 +1492,7 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search Autocomplete Results.
+        ///   Looks up a localized string similar to Search.
         /// </summary>
         public static string SearchTextBlockText {
             get {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -591,6 +591,9 @@ value : bool = false</value>
     <value>Nothing is selected. href=NothingIsSelectedWarning.html</value>
   </data>
   <data name="SearchTextBlockText" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="AutocompleteSearchTextBlockText" xml:space="preserve">
     <value>Search Autocomplete Results</value>
   </data>
   <data name="Autocomplete" xml:space="preserve">

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -591,6 +591,9 @@ value : bool = false</value>
     <value>Nothing is selected. href=NothingIsSelectedWarning.html</value>
   </data>
   <data name="SearchTextBlockText" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="AutocompleteSearchTextBlockText" xml:space="preserve">
     <value>Search Autocomplete Results</value>
   </data>
   <data name="WatermarkLabelText" xml:space="preserve">

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -81,8 +81,8 @@
                             </Image.Style>
                         </Image>
                         </Button>
-                        <Button Name="CloseButton" Margin="0,7,5,7" BorderThickness="0"  Background="{StaticResource autocompletionWindow}">
-                            <Image Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Center">
+                        <Button Name="CloseButton" Margin="0,7,5,7" Height="14" Width="14" BorderThickness="0" Click="CloseAutocompletionWindow" Background="{StaticResource autocompletionWindow}">
+                                <Image Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Center">
                                 <Image.Style>
                                     <Style TargetType="{x:Type Image}">
                                         <Style.Triggers>
@@ -188,7 +188,7 @@
                                    HorizontalAlignment="Center"
                                    Height="18"
                                    Margin="2,0,0,0"
-                                   Text="{x:Static resx:Resources.SearchTextBlockText}" />
+                                   Text="{x:Static resx:Resources.AutocompleteSearchTextBlockText}" />
 
                     </StackPanel>
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -197,6 +197,7 @@
                              Background="Transparent"
                              BorderThickness="0"
                              FontSize="12"
+                             Height="18"
                              IsEnabled="True"
                              VerticalAlignment="Center"
                              Text="{Binding Path=SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -275,5 +275,10 @@ namespace Dynamo.UI.Controls
         {
             ViewModel.dynamoViewModel.OpenDocumentationLinkCommand.Execute(new OpenDocumentationLinkEventArgs(new Uri(Dynamo.Wpf.Properties.Resources.NodeAutocompleteDocumentationUriString, UriKind.Relative)));
         }
+
+        internal void CloseAutocompletionWindow(object sender, RoutedEventArgs e)
+        {
+            OnRequestShowNodeAutoCompleteSearch(ShowHideFlags.Hide);
+        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -21,6 +21,7 @@ namespace Dynamo.ViewModels
 
         internal PortViewModel PortViewModel { get; set; }
         private List<NodeSearchElement> searchElementsCache;
+        private List<NodeSearchElement> defaultSearchElementsCache;
 
         /// <summary>
         /// Cache of default node suggestions, use it in case where
@@ -63,36 +64,43 @@ namespace Dynamo.ViewModels
             // These default suggestions will be populated based on the port type.
             if (!searchElementsCache.Any())
             {
-                if (PortViewModel.PortModel.PortType == PortType.Input) 
-                {
-                    switch (PortViewModel.PortModel.GetInputPortType())
-                    {
-                        case "int":
-                            FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
-                            break;
-                        case "double":
-                            FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
-                            break;
-                        case "string":
-                            FilteredResults = DefaultResults.Where(e => e.Name == "String").ToList();
-                            break;
-                        case "bool":
-                            FilteredResults = DefaultResults.Where(e => e.Name == "Boolean").ToList();
-                            break;
-                        default:
-                            FilteredResults = DefaultResults.Where(e => e.Name == "String" || e.Name == "Number Slider" || e.Name == "Integer Slider" || e.Name == "Number" || e.Name == "Boolean");
-                            break;
-                    }
-                }
-                else
-                {
-                    FilteredResults = DefaultResults.Where(e => e.Name == "Watch" || e.Name == "Watch 3D" || e.Name == "Python Script").ToList();
-                }
+                PopulateDefaultAutoCompleteCandidates();
             }
             else
             {
                 FilteredResults = GetViewModelForNodeSearchElements(searchElementsCache);
             }
+        }
+
+        internal void PopulateDefaultAutoCompleteCandidates()
+        {
+            if (PortViewModel.PortModel.PortType == PortType.Input)
+            {
+                switch (PortViewModel.PortModel.GetInputPortType())
+                {
+                    case "int":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
+                        break;
+                    case "double":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "Number Slider" || e.Name == "Integer Slider").ToList();
+                        break;
+                    case "string":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "String").ToList();
+                        break;
+                    case "bool":
+                        FilteredResults = DefaultResults.Where(e => e.Name == "Boolean").ToList();
+                        break;
+                    default:
+                        FilteredResults = DefaultResults.Where(e => e.Name == "String" || e.Name == "Number Slider" || e.Name == "Integer Slider" || e.Name == "Number" || e.Name == "Boolean");
+                        break;
+                }
+            }
+            else
+            {
+                FilteredResults = DefaultResults.Where(e => e.Name == "Watch" || e.Name == "Watch 3D" || e.Name == "Python Script").ToList();
+            }
+
+            defaultSearchElementsCache = FilteredResults.Select(x => x.Model).ToList();
         }
 
         /// <summary>
@@ -115,10 +123,31 @@ namespace Dynamo.ViewModels
         {
             if (PortViewModel == null) return;
 
-            //Providing the saved search results to limit the scope of the query search.
-            var foundNodes = Search(input, searchElementsCache);
-            FilteredResults = new List<NodeSearchElementViewModel>(foundNodes).OrderBy(x => x.Name).ThenBy(x => x.Description);
-
+            if (input.Equals(""))
+            {
+                if (searchElementsCache.Any())
+                {
+                    FilteredResults = GetViewModelForNodeSearchElements(searchElementsCache); 
+                }
+                else
+                {
+                    PopulateDefaultAutoCompleteCandidates();
+                }
+            }
+            else 
+            {
+                //Providing the saved search results to limit the scope of the query search.
+                if (searchElementsCache.Any()) 
+                {
+                    var foundNodes = Search(input, searchElementsCache);
+                    FilteredResults = new List<NodeSearchElementViewModel>(foundNodes).OrderBy(x => x.Name).ThenBy(x => x.Description);
+                }
+                else
+                {
+                    var foundNodes = Search(input, defaultSearchElementsCache);
+                    FilteredResults = new List<NodeSearchElementViewModel>(foundNodes).OrderBy(x => x.Name).ThenBy(x => x.Description);
+                }        
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -171,15 +171,7 @@ namespace Dynamo.Views
         }
 
         private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
-        {
-            // Prevents hiding the dialog from releasing the left mouse button
-            if (flag == ShowHideFlags.Hide && isAutoCompleteLoading)
-            {
-                isAutoCompleteLoading = false;
-                return;
-            }
-
-            isAutoCompleteLoading = flag == ShowHideFlags.Show && !NodeAutoCompleteSearchBar.IsOpen;
+        {            
             ShowHidePopup(flag, NodeAutoCompleteSearchBar);
         }
 
@@ -227,11 +219,6 @@ namespace Dynamo.Views
             {
                 ShowHideContextMenu(ShowHideFlags.Hide);
                 ShowHideInCanvasControl(ShowHideFlags.Hide);
-            }
-            if (NodeAutoCompleteSearchBar.IsOpen)
-            {
-                ShowHideNodeAutoCompleteControl(ShowHideFlags.Hide);
-                ViewModel.CancelActiveState();
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -62,7 +62,6 @@ namespace Dynamo.Views
         private double currentNodeCascadeOffset;
         private Point inCanvasSearchPosition;
         private List<DependencyObject> hitResultsList = new List<DependencyObject>();
-        private bool isAutoCompleteLoading;
 
         public WorkspaceViewModel ViewModel
         {

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -154,9 +154,6 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(currentWs.NodeAutoCompleteSearchBar.IsOpen);
 
             // Hide Node AutoCompleteSearchBar
-            // Note the event handler needs to be called twice. The first one is ignore because it is
-            // assumed to come from releasing the left mouse button when popping up AutoCompleteSearchBar
-            ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Hide);
             ViewModel.CurrentSpaceViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Hide);
             Assert.IsFalse(currentWs.NodeAutoCompleteSearchBar.IsOpen);
         }


### PR DESCRIPTION
### Purpose

Currently we have a regression on the master branch. The issue is that users are not able to type text into the Auto completion search window. After the new UI changes to the Autocompletion window, the window will not be closed/hidden when the user has clicked anywhere on the workspace as we now have a close button to close the window. We won't be needing the flag to monitor the behavior of the window.

![NodeAutocompletion search box](https://user-images.githubusercontent.com/43763136/119163671-9ddf1380-ba29-11eb-9950-805ccca8d42c.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


@QilongTang @zeusongit  @mmisol 
