### PR TITLE
DYN-3529: Migrate clr.AddReferenceToFileAndPath() to clr.AddReference() in python migration tool

### DIFF
--- a/src/PythonMigrationViewExtension/MigrationAssistant/migrate_2to3.py
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/migrate_2to3.py
@@ -13,7 +13,7 @@ def transform(source):
     fixers = get_all_fixers_from_zipfolder(python_zip_folder)
 
     sys.path.append(os.path.join(path_name, '.\\python_migration_fixers'))
-    fixers.extend(['fix_none'])
+    fixers.extend(['fix_none', 'fix_add_reference_to_file_and_path'])
 
     refactoring_tool = RefactoringTool(fixers)
 

--- a/src/PythonMigrationViewExtension/MigrationAssistant/python_migration_fixers/fix_add_reference_to_file_and_path.py
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/python_migration_fixers/fix_add_reference_to_file_and_path.py
@@ -1,0 +1,16 @@
+# Local imports
+
+from lib2to3.fixer_base import BaseFix
+from lib2to3.fixer_util import Name
+
+#
+# Rename AddReferenceToFileAndPath -> AddReference
+#
+
+class FixAddReferenceToFileAndPath(BaseFix):
+
+    PATTERN = "fixnode='AddReferenceToFileAndPath'"
+
+    def transform(self, node, results):
+        fixnode = results['fixnode']
+        fixnode.replace(Name('AddReference', prefix=fixnode.prefix))

--- a/src/PythonMigrationViewExtension/MigrationAssistant/python_migration_fixers/fix_add_reference_to_file_and_path.py
+++ b/src/PythonMigrationViewExtension/MigrationAssistant/python_migration_fixers/fix_add_reference_to_file_and_path.py
@@ -9,7 +9,9 @@ from lib2to3.fixer_util import Name
 
 class FixAddReferenceToFileAndPath(BaseFix):
 
-    PATTERN = "fixnode='AddReferenceToFileAndPath'"
+    PATTERN = """
+              power< any+ trailer< '.' fixnode='AddReferenceToFileAndPath'> any* >
+              """
 
     def transform(self, node, results):
         fixnode = results['fixnode']

--- a/test/DynamoCoreTests/PythonMigrationAssistantTests.cs
+++ b/test/DynamoCoreTests/PythonMigrationAssistantTests.cs
@@ -94,5 +94,23 @@ OUT = groupBox1
             var actual = ScriptMigrator.MigrateCode(original);
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        public void CanMigrateFixAddReferenceToFileAndPathToPython3AddReference()
+        {
+            var original = @"
+import sys
+import clr
+clr.AddReferenceToFileAndPath('System.Windows.Forms')
+";
+            var expected = @"
+import sys
+import clr
+clr.AddReference('System.Windows.Forms')
+";
+            var actual = ScriptMigrator.MigrateCode(original);
+            Assert.AreEqual(expected, actual);
+        }
+
     }
 }


### PR DESCRIPTION
### Purpose

DYN-3529: Migrate clr.AddReferenceToFileAndPath() to clr.AddReference() in python migration tool

![image](https://user-images.githubusercontent.com/7033002/119397349-ffaab200-bca3-11eb-8fa6-034845ed5d01.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

