### PR TITLE
Fix Expander Expanding Functionality

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3068,9 +3068,11 @@ namespace Dynamo.Controls
         /// <returns>bool indicating if the Expander should be expanded or not</returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is string)
+            var expanderValue = value as string;
+
+            if (expanderValue != null &&
+                !string.IsNullOrEmpty(expanderValue))
             {
-                var expanderValue = value as string;
                 var expanderName = parameter as string;
                 return expanderName.Equals(expanderValue);
             }

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -903,7 +903,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    expanderActive = "";
+                    expanderActive = string.Empty;
                 }
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -900,7 +900,11 @@ namespace Dynamo.ViewModels
                 {
                     expanderActive = value;
                     OnPropertyChanged(nameof(ExpanderActive));
-                }          
+                }
+                else
+                {
+                    expanderActive = "";
+                }
             }
         }
     }

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -307,7 +307,6 @@
                                         Grid.Row="0"
                                         Style="{StaticResource MenuExpanderStyle}" 
                                         IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=PythonExpander}"
-                                        Expanded="Expander_Expanded"
                                         Header="{x:Static p:Resources.PreferencesViewPython}">
                                 <StackPanel Orientation="Vertical" Margin="0,6,0,0">
                                     <Label  Content="{x:Static p:Resources.PreferencesViewDefaultPythonEngine}" 
@@ -362,7 +361,6 @@
                                           Style="{StaticResource MenuExpanderStyle}" 
                                        IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=ExperimentalExpander}"
                                           Grid.Row="1"
-                                          Expanded="Expander_Expanded"
                                           Header="{x:Static p:Resources.PreferencesViewExperimentalLabel}">
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -432,7 +430,6 @@
                             <!--Group Styles Expander-->
                             <Expander x:Name="Styles"
                                       Grid.Row="0"
-                                      Expanded="Expander_Expanded"
                                       IsExpanded="{Binding PreferencesTabs[VisualSettings].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=Styles}"
                                       Header="{x:Static p:Resources.PreferencesViewVisualSettingsGroupStyles}"
                                       Style="{StaticResource MenuExpanderStyle}">
@@ -538,8 +535,7 @@
                             <!--Geometry Scaling Expander-->
                             <Expander x:Name="Scale"
                                       Grid.Row="1"                   
-                                      Style="{StaticResource MenuExpanderStyle}" 
-                                      Expanded="Expander_Expanded"
+                                      Style="{StaticResource MenuExpanderStyle}"
                                       IsExpanded="{Binding PreferencesTabs[VisualSettings].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=Scale}"
                                       Header="{x:Static p:Resources.PreferencesViewVisualSettingsGeoScaling}">
                                 <StackPanel x:Name="GeometryScalingRadiosPanel"
@@ -602,7 +598,6 @@
                             <Expander x:Name="Precision"
                                       Grid.Row="2"
                                       Style="{StaticResource MenuExpanderStyle}" 
-                                      Expanded="Expander_Expanded"
                                       IsExpanded="{Binding PreferencesTabs[VisualSettings].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=Precision}"
                                       Header="{x:Static p:Resources.PreferencesViewVisualSettingsRenderPrecision}">
                                 <StackPanel Orientation="Horizontal" 
@@ -622,7 +617,6 @@
                             <Expander x:Name="Display"
                                       Grid.Row="3"
                                       Style="{StaticResource MenuExpanderStyle}" 
-                                      Expanded="Expander_Expanded"
                                       IsExpanded="{Binding PreferencesTabs[VisualSettings].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=Display}"
                                       Header="{x:Static p:Resources.PreferencesViewVisualSettingsDisplaySettings}">
                                 <Grid>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -168,18 +168,6 @@ namespace Dynamo.Wpf.Views
             }
         }
 
-        private void Expander_Expanded(object sender, RoutedEventArgs e)
-        {
-            Expander currentExpander = sender as Expander;
-            Grid parentGrid = currentExpander.Parent as Grid;
-            foreach (Expander expander in parentGrid.Children)
-            {
-                if (expander != currentExpander && expander.IsExpanded)
-                    expander.IsExpanded = false;
-
-            }
-        }
-
         /// <summary>
         /// This event is generated every time the user clicks a Radio Button in the Geometry Scaling section
         /// This are the values used for the scales:


### PR DESCRIPTION
### Purpose

Fixing the issue reported during texting  "clicking on header of an expanded Expander doesn't collapse it. Hence, there is no way to collapse all the expanders once one of them is expanded."

I removed the Expanded event since it was producing saving wrong expanded status per each expander.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Astul-Betizagasti 