### PR TITLE
Add tests for the new IF node.

### DIFF
--- a/test/DynamoCoreTests/Nodes/IfTest.cs
+++ b/test/DynamoCoreTests/Nodes/IfTest.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using CoreNodeModels.Input;
+using Dynamo.Graph.Nodes;
 using NUnit.Framework;
 using ProtoCore.AST.ImperativeAST;
 
@@ -81,7 +83,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("SmokeTest")]
-        public void TestNewIfForPreview()
+        public void TestIfNodeForPreview()
         {
             string testFilePath = Path.Combine(testFolder, "testNewIf.dyn");
             OpenModel(testFilePath);
@@ -89,13 +91,91 @@ namespace Dynamo.Tests
 
             boolSelectorNode.Value = true;
             AssertPreviewValue("886a464b-9b2b-4e66-a033-c18d0753c2cf", true);
-            AssertPreviewValue("904dcd03-94a3-4560-9cdf-8825e2ce63e6", new object[] { "a1", "b1", "c1" });
-            AssertPreviewValue("ceefb203-19b9-4eb3-b0e4-c355dcb84365", new object[] { 1, new object[] { 2 } });
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { "a1", "b1", "c1" });
+            // The output preview for partially connected "IF" node should return the function itself irrespective of test value.
+            AssertPreviewValue("e1630959-8338-4b1a-9832-248246aef8a0", "Function");
 
             boolSelectorNode.Value = false;
             AssertPreviewValue("886a464b-9b2b-4e66-a033-c18d0753c2cf", false);
-            AssertPreviewValue("904dcd03-94a3-4560-9cdf-8825e2ce63e6", new object[] { new object[] { "a2" }, "b2" });
-            AssertPreviewValue("ceefb203-19b9-4eb3-b0e4-c355dcb84365", new object[] { });
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { new object[] { "a2" }, "b2" });
+            // The output preview for partially connected "IF" node should return the function itself irrespective of test value.
+            AssertPreviewValue("e1630959-8338-4b1a-9832-248246aef8a0", "Function");
+        }
+
+        [Test]
+        [Category("SmokeTest")]
+        public void TestIfNodeLacingOptions()
+        {
+            string testFilePath = Path.Combine(testFolder, "testNewIf.dyn");
+            OpenModel(testFilePath);
+
+            /* IF node inputs:
+            *   true value: ["a1","b1","c1"];
+            *   false value: [["a2"],"b2"];
+            */
+
+            BoolSelector boolSelectorNode = (BoolSelector)this.CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("886a464b-9b2b-4e66-a033-c18d0753c2cf");
+
+            /* ArgumentLacing: Auto
+             * 
+             * expected output: if test value is true, output will be ["a1","b1","c1"]
+             *                  if test value is false, output will be  [["a2"],"b2"]
+             */
+
+            NodeModel ifNode = this.CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("f945529e-62e3-4c7a-b07a-0b18d7449f9b");
+            Assert.AreEqual(LacingStrategy.Auto, ifNode.ArgumentLacing);
+            boolSelectorNode.Value = true;
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { "a1", "b1", "c1" });
+            boolSelectorNode.Value = false;
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { new object[] { "a2" }, "b2" });
+
+            /* ArgumentLacing: Longest
+             * 
+             * expected output: if test value is true, output will be ["a1","b1","c1"]
+             *                  if test value is false, output will be  [["a2"],"b2","b2"]
+             */
+            CurrentDynamoModel.CurrentWorkspace.UpdateModelValue(new List<Guid> { ifNode.GUID }, "ArgumentLacing", "Longest");
+            Assert.AreEqual(LacingStrategy.Longest, ifNode.ArgumentLacing);
+            boolSelectorNode.Value = true;
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { "a1", "b1", "c1" });
+            boolSelectorNode.Value = false;
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { new object[] { "a2" }, "b2", "b2"});
+
+
+            /* ArgumentLacing: Shortest
+             * 
+             * expected output: if test value is true, output will be ["a1"]
+             *                  if test value is false, output will be  [["a2"]]
+             */
+            CurrentDynamoModel.CurrentWorkspace.UpdateModelValue(new List<Guid> { ifNode.GUID }, "ArgumentLacing", "Shortest");
+            Assert.AreEqual(LacingStrategy.Shortest, ifNode.ArgumentLacing);
+            boolSelectorNode.Value = true;
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { "a1" });
+            boolSelectorNode.Value = false;
+            AssertPreviewValue("f945529e-62e3-4c7a-b07a-0b18d7449f9b", new object[] { new object[] { "a2" }});
+        }
+
+        [Test]
+        [Category("SmokeTest")]
+        public void TestIfNodeListAtLevel()
+        {
+            string testFilePath = Path.Combine(testFolder, "testNewIf.dyn");
+            OpenModel(testFilePath);
+            BoolSelector boolSelectorNode = (BoolSelector)this.CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("886a464b-9b2b-4e66-a033-c18d0753c2cf");
+
+            /* IF node inputs:
+             *   true value: [1,[2],3]; List level set at L3
+             *   false value: [4,5];    List level set at L3
+             * 
+             * expected output: if test value is true, output will be [[ 1, [2], 3]]
+             *                  if test value is false, output will be [[[ 4 , 5 ]]]
+             */
+
+            boolSelectorNode.Value = true;
+            AssertPreviewValue("699f9236-9fb0-4b91-a6a3-fb5dd23ed70b", new object[] { new object[] { 1, new object[] { 2 }, 3 } });
+
+            boolSelectorNode.Value = false;
+            AssertPreviewValue("699f9236-9fb0-4b91-a6a3-fb5dd23ed70b", new object[] { new object[] { new object[] { 4, 5 } } });
         }
     }
 }

--- a/test/core/logic/conditional/testNewIf.dyn
+++ b/test/core/logic/conditional/testNewIf.dyn
@@ -12,12 +12,12 @@
     {
       "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
       "NodeType": "CodeBlockNode",
-      "Code": "[\"a1\",\"b1\",\"c1\"];\n[[\"a2\"],\"b2\"];\n[1,[2]];\n[];",
+      "Code": "[\"a1\",\"b1\",\"c1\"];\n[[\"a2\"],\"b2\"];\n[1,[2],3];\n[4,5];",
       "Id": "95224771f8f74d4b97ff0a84447c55fa",
       "Inputs": [],
       "Outputs": [
         {
-          "Id": "6e3a5447971b48d289766f5daa856d60",
+          "Id": "95a7995f2ecd4f208533dc5b150a648c",
           "Name": "",
           "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
@@ -26,7 +26,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "e261689194624bfe9969d0bb8b1d8a57",
+          "Id": "f73d32ffd2e94e8383063af06f67712e",
           "Name": "",
           "Description": "Value of expression at line 2",
           "UsingDefaultValue": false,
@@ -35,7 +35,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "bc74cb9869a44a838dc78eb273730263",
+          "Id": "38333ca1b5044f94a665ce92fa26006f",
           "Name": "",
           "Description": "Value of expression at line 3",
           "UsingDefaultValue": false,
@@ -44,7 +44,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "2a7abb946e5541de84576f400c8e726b",
+          "Id": "df20aa41822f4c9a854fb8124ddb4655",
           "Name": "",
           "Description": "Value of expression at line 4",
           "UsingDefaultValue": false,
@@ -79,10 +79,10 @@
     {
       "ConcreteType": "CoreNodeModels.Logic.RefactoredIf, CoreNodeModels",
       "NodeType": "ExtensionNode",
-      "Id": "904dcd0394a345609cdf8825e2ce63e6",
+      "Id": "f945529e62e34c7ab07a0b18d7449f9b",
       "Inputs": [
         {
-          "Id": "881567be242d4b328160f891a01f9ce3",
+          "Id": "c3f9c8e8bf7f45aa9828fa27839450ba",
           "Name": "test",
           "Description": "Boolean test",
           "UsingDefaultValue": false,
@@ -91,7 +91,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "81eee78dcf8e4c2ab744e579b4348e1d",
+          "Id": "d210b29dd01e43f78082970c9eed0de3",
           "Name": "true",
           "Description": "Returned if test is true",
           "UsingDefaultValue": false,
@@ -100,18 +100,18 @@
           "KeepListStructure": false
         },
         {
-          "Id": "e718c439a67e4a63b7a29edf8b4521fe",
+          "Id": "41ee33583a374165b80f91057f35b0d0",
           "Name": "false",
           "Description": "Returned if test is false",
           "UsingDefaultValue": false,
-          "Level": 2,
+          "Level": 3,
           "UseLevels": false,
           "KeepListStructure": false
         }
       ],
       "Outputs": [
         {
-          "Id": "6aeca93df5a44f609e175479f6a2748d",
+          "Id": "c079523312284208a050bad5d5f63916",
           "Name": "result",
           "Description": "Result block produced",
           "UsingDefaultValue": false,
@@ -120,16 +120,16 @@
           "KeepListStructure": false
         }
       ],
-      "Replication": "Disabled",
+      "Replication": "Auto",
       "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
     },
     {
       "ConcreteType": "CoreNodeModels.Logic.RefactoredIf, CoreNodeModels",
       "NodeType": "ExtensionNode",
-      "Id": "ceefb20319b94eb3b0e4c355dcb84365",
+      "Id": "699f92369fb04b91a6a3fb5dd23ed70b",
       "Inputs": [
         {
-          "Id": "7ccfe809ce154a20a345ed5b4c2601e5",
+          "Id": "9dd2ab67eb62411d86c0994b75f602d3",
           "Name": "test",
           "Description": "Boolean test",
           "UsingDefaultValue": false,
@@ -138,7 +138,54 @@
           "KeepListStructure": false
         },
         {
-          "Id": "d79e0899d98f4474a678aa0868068de1",
+          "Id": "9c598ef3a9104fa2ac626654f284f60c",
+          "Name": "true",
+          "Description": "Returned if test is true",
+          "UsingDefaultValue": false,
+          "Level": 3,
+          "UseLevels": true,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d10d3dd764c44054837264aae8438f30",
+          "Name": "false",
+          "Description": "Returned if test is false",
+          "UsingDefaultValue": false,
+          "Level": 3,
+          "UseLevels": true,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6c494e4e74c745e8a88a9c160c30965a",
+          "Name": "result",
+          "Description": "Result block produced",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Logic.RefactoredIf, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "e163095983384b1a9832248246aef8a0",
+      "Inputs": [
+        {
+          "Id": "5e6245f62649422383512c2431a25c7d",
+          "Name": "test",
+          "Description": "Boolean test",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dcd3ff62e1e84e05a8137be36b095305",
           "Name": "true",
           "Description": "Returned if test is true",
           "UsingDefaultValue": false,
@@ -147,7 +194,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "c16ded6761084fc59f157920ae14f6d4",
+          "Id": "620ef6832eab4ee59edca1bd19f978fd",
           "Name": "false",
           "Description": "Returned if test is false",
           "UsingDefaultValue": false,
@@ -158,7 +205,7 @@
       ],
       "Outputs": [
         {
-          "Id": "bdb0180b86f44c1a8dbdbb675d1bef8a",
+          "Id": "48125a118e0d4abfb1ca533166d6ac60",
           "Name": "result",
           "Description": "Result block produced",
           "UsingDefaultValue": false,
@@ -167,40 +214,50 @@
           "KeepListStructure": false
         }
       ],
-      "Replication": "Disabled",
+      "Replication": "Auto",
       "Description": "Returns the result of either the True or False input depending on what boolean value is toggled in the test input."
     }
   ],
   "Connectors": [
     {
-      "Start": "6e3a5447971b48d289766f5daa856d60",
-      "End": "81eee78dcf8e4c2ab744e579b4348e1d",
-      "Id": "1d9e83d8a7004c91bbe903d5d4008e02"
+      "Start": "95a7995f2ecd4f208533dc5b150a648c",
+      "End": "d210b29dd01e43f78082970c9eed0de3",
+      "Id": "e1757b20bc24444aa8ef71d1f806209a"
     },
     {
-      "Start": "e261689194624bfe9969d0bb8b1d8a57",
-      "End": "e718c439a67e4a63b7a29edf8b4521fe",
-      "Id": "3d6bc540015340efa3164787e413bba0"
+      "Start": "f73d32ffd2e94e8383063af06f67712e",
+      "End": "41ee33583a374165b80f91057f35b0d0",
+      "Id": "6dcd8689135e4b03a7bbb503dc2b548c"
     },
     {
-      "Start": "bc74cb9869a44a838dc78eb273730263",
-      "End": "d79e0899d98f4474a678aa0868068de1",
-      "Id": "ef2b605f523f45cea361eb7e69d5ac91"
+      "Start": "38333ca1b5044f94a665ce92fa26006f",
+      "End": "9c598ef3a9104fa2ac626654f284f60c",
+      "Id": "e07d1c06f58b4d7ead58b01599087864"
     },
     {
-      "Start": "2a7abb946e5541de84576f400c8e726b",
-      "End": "c16ded6761084fc59f157920ae14f6d4",
-      "Id": "a330d22125cc4f38b6c9bd9246d89317"
+      "Start": "df20aa41822f4c9a854fb8124ddb4655",
+      "End": "d10d3dd764c44054837264aae8438f30",
+      "Id": "cc861916309a4c658fcca3434e09c035"
+    },
+    {
+      "Start": "df20aa41822f4c9a854fb8124ddb4655",
+      "End": "620ef6832eab4ee59edca1bd19f978fd",
+      "Id": "85ee9536e6274864b3e6c312b8a87b8e"
     },
     {
       "Start": "3f90288806474ec2a7184fb87a41c006",
-      "End": "881567be242d4b328160f891a01f9ce3",
-      "Id": "6ca4ac90d6de48f4b938bff0333d8506"
+      "End": "c3f9c8e8bf7f45aa9828fa27839450ba",
+      "Id": "60c0f8ea833047df9fd76e85a1ad1655"
     },
     {
       "Start": "3f90288806474ec2a7184fb87a41c006",
-      "End": "7ccfe809ce154a20a345ed5b4c2601e5",
-      "Id": "8c56b3f1e2034f1dad8c3b34a453fd05"
+      "End": "9dd2ab67eb62411d86c0994b75f602d3",
+      "Id": "91ad2fe63dab4e8b986596dd1b3c2686"
+    },
+    {
+      "Start": "3f90288806474ec2a7184fb87a41c006",
+      "End": "5e6245f62649422383512c2431a25c7d",
+      "Id": "e9a81a2163b7489c85eb4677687d5fa9"
     }
   ],
   "Dependencies": [],
@@ -212,7 +269,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.11.0.4125",
+      "Version": "2.11.0.5135",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -236,8 +293,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 141.0,
-        "Y": 290.0
+        "X": 115.0,
+        "Y": 221.0
       },
       {
         "ShowGeometry": true,
@@ -246,28 +303,38 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 163.0,
-        "Y": 153.5
+        "X": 160.0,
+        "Y": 109.5
       },
       {
         "ShowGeometry": true,
         "Name": "If",
-        "Id": "904dcd0394a345609cdf8825e2ce63e6",
+        "Id": "f945529e62e34c7ab07a0b18d7449f9b",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 483.0,
-        "Y": 122.5
+        "X": 471.0,
+        "Y": 41.5
       },
       {
         "ShowGeometry": true,
         "Name": "If",
-        "Id": "ceefb20319b94eb3b0e4c355dcb84365",
+        "Id": "699f92369fb04b91a6a3fb5dd23ed70b",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 485.0,
-        "Y": 332.5
+        "X": 470.0,
+        "Y": 217.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "If",
+        "Id": "e163095983384b1a9832248246aef8a0",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 470.0,
+        "Y": 383.5
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

This PR is to add tests around Lacing, ListAtLevel and Partial function features for the new IF node

There are some tests in "IfTest" fixture that are testing the old "IF" node. Do we want to keep them around to support the old node or do we plan to replace the tests with the new node?

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@aparajit-pratap @QilongTang 

