### PR TITLE
DYN-3738: enhance readyparams api

### DIFF
--- a/src/DynamoCore/Extensions/ReadyParams.cs
+++ b/src/DynamoCore/Extensions/ReadyParams.cs
@@ -23,7 +23,10 @@ namespace Dynamo.Extensions
         {
             dynamoModel = dynamoM;
             dynamoModel.PropertyChanged += OnDynamoModelPropertyChanged;
+            dynamoModel.WorkspaceOpened += OnCurrentWorkspaceModelOpened;
+            dynamoModel.WorkspaceClearing += OnCurrentWorkspaceModelClearing;
             dynamoModel.WorkspaceCleared += OnCurrentWorkspaceModelCleared;
+            dynamoModel.WorkspaceRemoveStarted += OnCurrentWorkspaceRemoveStarted;
             dynamoM.Logger.NotificationLogged += OnNotificationRecieved;
             startupParams = new StartupParams(dynamoModel.AuthenticationManager.AuthProvider,
                 dynamoModel.PathManager, new ExtensionLibraryLoader(dynamoModel), dynamoModel.CustomNodeManager,
@@ -104,6 +107,36 @@ namespace Dynamo.Extensions
                 CurrentWorkspaceCleared(ws);
         }
 
+        /// <summary>
+        /// Occurs when current workspace is clearing
+        /// </summary>
+        public event Action<IWorkspaceModel> CurrentWorkspaceClearing;
+        private void OnCurrentWorkspaceModelClearing(IWorkspaceModel ws)
+        {
+            if (CurrentWorkspaceClearing != null)
+                CurrentWorkspaceClearing(ws);
+        }
+
+        /// <summary>
+        /// Occurs when current workspace has finished opening
+        /// </summary>
+        public event Action<IWorkspaceModel> CurrentWorkspaceOpened;
+        private void OnCurrentWorkspaceModelOpened(IWorkspaceModel ws)
+        {
+            if (CurrentWorkspaceOpened != null)
+                CurrentWorkspaceOpened(ws);
+        }
+
+        /// <summary>
+        /// Occurs when a worspace is about to be removed
+        /// </summary>
+        public event Action<IWorkspaceModel> CurrentWorkspaceRemoveStarted;
+        private void OnCurrentWorkspaceRemoveStarted(IWorkspaceModel ws)
+        {
+            if (CurrentWorkspaceRemoveStarted != null)
+                CurrentWorkspaceRemoveStarted(ws);
+        }
+
         private void OnDynamoModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "CurrentWorkspace")
@@ -117,7 +150,10 @@ namespace Dynamo.Extensions
         public void Dispose()
         {
             dynamoModel.PropertyChanged -= OnDynamoModelPropertyChanged;
+            dynamoModel.WorkspaceOpened -= OnCurrentWorkspaceModelOpened;
+            dynamoModel.WorkspaceClearing -= OnCurrentWorkspaceModelClearing;
             dynamoModel.WorkspaceCleared -= OnCurrentWorkspaceModelCleared;
+            dynamoModel.WorkspaceRemoveStarted -= OnCurrentWorkspaceRemoveStarted;
             dynamoModel.Logger.NotificationLogged -= OnNotificationRecieved;
         }
     }

--- a/src/DynamoCore/Extensions/ReadyParams.cs
+++ b/src/DynamoCore/Extensions/ReadyParams.cs
@@ -24,7 +24,7 @@ namespace Dynamo.Extensions
             dynamoModel = dynamoM;
             dynamoModel.PropertyChanged += OnDynamoModelPropertyChanged;
             dynamoModel.WorkspaceOpened += OnCurrentWorkspaceModelOpened;
-            dynamoModel.WorkspaceClearing += OnCurrentWorkspaceModelClearing;
+            dynamoModel.WorkspaceClearingStarted += OnCurrentWorkspaceModelClearingStarted;
             dynamoModel.WorkspaceCleared += OnCurrentWorkspaceModelCleared;
             dynamoModel.WorkspaceRemoveStarted += OnCurrentWorkspaceRemoveStarted;
             dynamoM.Logger.NotificationLogged += OnNotificationRecieved;
@@ -110,11 +110,11 @@ namespace Dynamo.Extensions
         /// <summary>
         /// Occurs when current workspace is clearing
         /// </summary>
-        public event Action<IWorkspaceModel> CurrentWorkspaceClearing;
-        private void OnCurrentWorkspaceModelClearing(IWorkspaceModel ws)
+        public event Action<IWorkspaceModel> CurrentWorkspaceClearingStarted;
+        private void OnCurrentWorkspaceModelClearingStarted(IWorkspaceModel ws)
         {
-            if (CurrentWorkspaceClearing != null)
-                CurrentWorkspaceClearing(ws);
+            if (CurrentWorkspaceClearingStarted != null)
+                CurrentWorkspaceClearingStarted(ws);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Dynamo.Extensions
         {
             dynamoModel.PropertyChanged -= OnDynamoModelPropertyChanged;
             dynamoModel.WorkspaceOpened -= OnCurrentWorkspaceModelOpened;
-            dynamoModel.WorkspaceClearing -= OnCurrentWorkspaceModelClearing;
+            dynamoModel.WorkspaceClearingStarted -= OnCurrentWorkspaceModelClearingStarted;
             dynamoModel.WorkspaceCleared -= OnCurrentWorkspaceModelCleared;
             dynamoModel.WorkspaceRemoveStarted -= OnCurrentWorkspaceRemoveStarted;
             dynamoModel.Logger.NotificationLogged -= OnNotificationRecieved;

--- a/src/DynamoCore/Extensions/ReadyParams.cs
+++ b/src/DynamoCore/Extensions/ReadyParams.cs
@@ -83,8 +83,7 @@ namespace Dynamo.Extensions
         public event Action<Logging.NotificationMessage> NotificationRecieved;
         private void OnNotificationRecieved(Logging.NotificationMessage notification)
         {
-            if (NotificationRecieved != null)
-                NotificationRecieved(notification);
+            NotificationRecieved?.Invoke(notification);
         }
 
         /// <summary>
@@ -93,8 +92,7 @@ namespace Dynamo.Extensions
         public event Action<IWorkspaceModel> CurrentWorkspaceChanged;
         private void OnCurrentWorkspaceModelChanged(IWorkspaceModel ws)
         {
-            if (CurrentWorkspaceChanged != null)
-                CurrentWorkspaceChanged(ws);
+            CurrentWorkspaceChanged?.Invoke(ws);
         }
 
         /// <summary>
@@ -103,8 +101,7 @@ namespace Dynamo.Extensions
         public event Action<IWorkspaceModel> CurrentWorkspaceCleared;
         private void OnCurrentWorkspaceModelCleared(IWorkspaceModel ws)
         {
-            if (CurrentWorkspaceCleared != null)
-                CurrentWorkspaceCleared(ws);
+            CurrentWorkspaceCleared?.Invoke(ws);
         }
 
         /// <summary>
@@ -113,8 +110,7 @@ namespace Dynamo.Extensions
         public event Action<IWorkspaceModel> CurrentWorkspaceClearingStarted;
         private void OnCurrentWorkspaceModelClearingStarted(IWorkspaceModel ws)
         {
-            if (CurrentWorkspaceClearingStarted != null)
-                CurrentWorkspaceClearingStarted(ws);
+            CurrentWorkspaceClearingStarted?.Invoke(ws);
         }
 
         /// <summary>
@@ -123,8 +119,7 @@ namespace Dynamo.Extensions
         public event Action<IWorkspaceModel> CurrentWorkspaceOpened;
         private void OnCurrentWorkspaceModelOpened(IWorkspaceModel ws)
         {
-            if (CurrentWorkspaceOpened != null)
-                CurrentWorkspaceOpened(ws);
+            CurrentWorkspaceOpened?.Invoke(ws);
         }
 
         /// <summary>
@@ -133,13 +128,12 @@ namespace Dynamo.Extensions
         public event Action<IWorkspaceModel> CurrentWorkspaceRemoveStarted;
         private void OnCurrentWorkspaceRemoveStarted(IWorkspaceModel ws)
         {
-            if (CurrentWorkspaceRemoveStarted != null)
-                CurrentWorkspaceRemoveStarted(ws);
+            CurrentWorkspaceRemoveStarted?.Invoke(ws);
         }
 
         private void OnDynamoModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "CurrentWorkspace")
+            if (e.PropertyName == nameof(DynamoModel.CurrentWorkspace))
                 OnCurrentWorkspaceModelChanged((sender as DynamoModel).CurrentWorkspace);
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2607,7 +2607,8 @@ namespace Dynamo.Models
         /// </summary>
         public void ClearCurrentWorkspace()
         {
-            OnWorkspaceClearing(CurrentWorkspace);
+            OnWorkspaceClearingStarted(CurrentWorkspace);
+            OnWorkspaceClearing();
 
             CurrentWorkspace.Clear();
             if (CurrentWorkspace is HomeWorkspaceModel)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2607,7 +2607,7 @@ namespace Dynamo.Models
         /// </summary>
         public void ClearCurrentWorkspace()
         {
-            OnWorkspaceClearing();
+            OnWorkspaceClearing(CurrentWorkspace);
 
             CurrentWorkspace.Clear();
             if (CurrentWorkspace is HomeWorkspaceModel)

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -117,9 +117,7 @@ namespace Dynamo.Models
         /// <param name="workspace">Workspace about to be cleared</param>
         public virtual void OnWorkspaceClearingStarted(WorkspaceModel workspace)
         {
-            if (WorkspaceClearingStarted != null)
-                WorkspaceClearingStarted(workspace);
-
+            WorkspaceClearingStarted?.Invoke(workspace);
             WorkspaceEvents.OnWorkspaceClearing();
         }
 

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -90,15 +90,16 @@ namespace Dynamo.Models
         /// <summary>
         /// Occurs before current workspace is cleared
         /// </summary>
-        public event Action WorkspaceClearing;
+        public event Action<WorkspaceModel> WorkspaceClearing;
 
         /// <summary>
         /// Triggers WorkspaceClearing event
         /// </summary>
-        public virtual void OnWorkspaceClearing()
+        /// <param name="workspace">Workspace about to be cleared</param>
+        public virtual void OnWorkspaceClearing(WorkspaceModel workspace)
         {
             if (WorkspaceClearing != null)
-                WorkspaceClearing();
+                WorkspaceClearing(workspace);
 
             WorkspaceEvents.OnWorkspaceClearing();
         }

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -90,16 +90,35 @@ namespace Dynamo.Models
         /// <summary>
         /// Occurs before current workspace is cleared
         /// </summary>
-        public event Action<WorkspaceModel> WorkspaceClearing;
+        [Obsolete("Do not use! Use WorkspaceClearingStarted event instead")]
+        public event Action WorkspaceClearing;
+
+        /// <summary>
+        /// Triggers WorkspaceClearing event
+        /// </summary>
+
+        [Obsolete("Do not use! Use OnWorkspaceClearingStarted virtual instead")]
+        public virtual void OnWorkspaceClearing()
+        {
+            if (WorkspaceClearing != null)
+                WorkspaceClearing();
+
+            WorkspaceEvents.OnWorkspaceClearing();
+        }
+
+        /// <summary>
+        /// Occurs before current workspace is cleared
+        /// </summary>
+        public event Action<WorkspaceModel> WorkspaceClearingStarted;
 
         /// <summary>
         /// Triggers WorkspaceClearing event
         /// </summary>
         /// <param name="workspace">Workspace about to be cleared</param>
-        public virtual void OnWorkspaceClearing(WorkspaceModel workspace)
+        public virtual void OnWorkspaceClearingStarted(WorkspaceModel workspace)
         {
-            if (WorkspaceClearing != null)
-                WorkspaceClearing(workspace);
+            if (WorkspaceClearingStarted != null)
+                WorkspaceClearingStarted(workspace);
 
             WorkspaceEvents.OnWorkspaceClearing();
         }

--- a/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
+++ b/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
@@ -504,7 +504,7 @@ namespace Dynamo.Tests.ModelsTest
             workspaceRemoveStarted = true;
         }
 
-        private void CurrentDynamoModel_WorkspaceClearing()
+        private void CurrentDynamoModel_WorkspaceClearing(Graph.Workspaces.WorkspaceModel obj)
         {
             workspaceClearing = true;
         }

--- a/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
+++ b/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
@@ -23,6 +23,7 @@ namespace Dynamo.Tests.ModelsTest
         private bool migrationStatusDialog = false;
         private bool layoutUpdate = false;
         private bool workspaceClearing = false;
+        private bool workspaceClearingStarted = false;
         private bool workspaceRemoveStarted = false;
         private bool deletionStarted = false;
         private bool deletionComplete = false;
@@ -153,6 +154,27 @@ namespace Dynamo.Tests.ModelsTest
             CurrentDynamoModel.WorkspaceClearing -= CurrentDynamoModel_WorkspaceClearing;
             //This will validate that the local handler was executed and set the flag in true
             Assert.IsTrue(workspaceClearing);
+        }
+
+        /// <summary>
+        /// This test method will execute the event OnWorkspaceClearing
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestOnWorkspaceClearingStarted()
+        {
+            //Arrange
+            //This will subscribe our local method to the RequestLayoutUpdate event
+            CurrentDynamoModel.WorkspaceClearingStarted += CurrentDynamoModel_WorkspaceClearingStarted;
+
+            //Act
+            //Internally this will execute the OnWorkspaceClearing() method in DynamoModelEvents
+            CurrentDynamoModel.ClearCurrentWorkspace();
+
+            //Assert
+            CurrentDynamoModel.WorkspaceClearingStarted -= CurrentDynamoModel_WorkspaceClearingStarted;
+            //This will validate that the local handler was executed and set the flag in true
+            Assert.IsTrue(workspaceClearingStarted);
         }
 
         /// <summary>
@@ -504,9 +526,14 @@ namespace Dynamo.Tests.ModelsTest
             workspaceRemoveStarted = true;
         }
 
-        private void CurrentDynamoModel_WorkspaceClearing(Graph.Workspaces.WorkspaceModel obj)
+        private void CurrentDynamoModel_WorkspaceClearing()
         {
             workspaceClearing = true;
+        }
+
+        private void CurrentDynamoModel_WorkspaceClearingStarted(Graph.Workspaces.WorkspaceModel obj)
+        {
+            workspaceClearingStarted = true;
         }
 
         private void Model_RequestLayoutUpdate(object sender, EventArgs e)


### PR DESCRIPTION
### Purpose
Enhance existing ReadyParams API so that we can have better control over graph opening and closing operations as part of an extension. We will use this in LintingViewExtension where we want to do some cleanup when a graph is closed and allow an extension developer to perform cleanup operations on their listing rules.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

