### PR TITLE
DYN-3738 : separate graph opening and closing contexts for linter extension

### DIFF
--- a/src/DynamoCore/Extensions/LinterExtensionBase.cs
+++ b/src/DynamoCore/Extensions/LinterExtensionBase.cs
@@ -90,7 +90,9 @@ namespace Dynamo.Extensions
                 LinkToWorkspace(ReadyParamsRef.CurrentWorkspaceModel as HomeWorkspaceModel);
             }            
 
-            SetupComplete = true;                       
+            SetupComplete = true;
+
+            OnActivated();
         }
 
         /// <summary>
@@ -112,6 +114,8 @@ namespace Dynamo.Extensions
             UnlinkFromCurrentWorkspace();
 
             SetupComplete = false;
+
+            OnDeactivated();
         }
 
         #endregion
@@ -231,6 +235,8 @@ namespace Dynamo.Extensions
                 SubscribeNodeEvents();
                 SubscribeGraphEvents();
                 InitializeRules();
+
+                OnLink();
             }
         }
 
@@ -241,6 +247,8 @@ namespace Dynamo.Extensions
                 UnsubscribeGraphEvents(currentWorkspace);
                 linterManager.RuleEvaluationResults.Clear();
                 currentWorkspace = null;
+
+                OnUnlink();
             }
         }
 
@@ -350,6 +358,35 @@ namespace Dynamo.Extensions
             }
 
         }
+
+        internal event Action OnLinterExtensionActivated;
+
+        private void OnActivated()
+        {
+            OnLinterExtensionActivated?.Invoke();
+        }
+
+        internal event Action OnLinterExtensionDeactivated;
+
+        private void OnDeactivated()
+        {
+            OnLinterExtensionDeactivated?.Invoke();
+        }
+
+        internal event Action OnLinterUnlinkFromWorkspace;
+
+        private void OnUnlink()
+        {
+            OnLinterUnlinkFromWorkspace?.Invoke();
+        }
+
+        internal event Action OnLinterLinkToWorkspace;
+
+        private void OnLink()
+        {
+            OnLinterLinkToWorkspace?.Invoke();
+        }
+
         #endregion
     }
 }

--- a/src/DynamoCore/Extensions/LinterExtensionBase.cs
+++ b/src/DynamoCore/Extensions/LinterExtensionBase.cs
@@ -71,7 +71,7 @@ namespace Dynamo.Extensions
         /// <summary>
         /// Activate this linter by subscribing the workspace and initializing its rules
         /// </summary>
-        internal void Activate()
+        internal void Activate(bool linkToWorkspace = true)
         {
             //Nothing left to do if initial setup is complete and we are already linked to application events
             if (SetupComplete)
@@ -85,8 +85,12 @@ namespace Dynamo.Extensions
             ReadyParamsRef.CurrentWorkspaceClearingStarted += OnCurrentWorkspaceClosing;
             ReadyParamsRef.CurrentWorkspaceRemoveStarted += OnCurrentWorkspaceClosing;
 
-            LinkToWorkspace(ReadyParamsRef.CurrentWorkspaceModel as HomeWorkspaceModel);
-            SetupComplete = true;
+            if (linkToWorkspace)
+            {
+                LinkToWorkspace(ReadyParamsRef.CurrentWorkspaceModel as HomeWorkspaceModel);
+            }            
+
+            SetupComplete = true;                       
         }
 
         /// <summary>
@@ -182,12 +186,6 @@ namespace Dynamo.Extensions
         public virtual void Ready(ReadyParams sp)
         {
             currentWorkspace = null;
-            HomeWorkspaceModel newWorkspace = sp.CurrentWorkspaceModel as HomeWorkspaceModel;
-            if (newWorkspace != null && !String.IsNullOrEmpty(newWorkspace.FileName))
-            {
-                currentWorkspace = newWorkspace;
-            }
-
             ReadyParamsRef = sp;
         }
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -705,7 +705,7 @@ namespace Dynamo.Graph.Workspaces
             if (linterDescriptor is null)
                 return;
 
-            linterManager.ActiveLinter = linterDescriptor;
+            linterManager.SetActiveLinter(linterDescriptor, false);
         }
 
         private static List<ExtensionData> GetExtensionData(JsonSerializer serializer, JObject obj)

--- a/src/DynamoCore/Linting/LinterManager.cs
+++ b/src/DynamoCore/Linting/LinterManager.cs
@@ -52,12 +52,14 @@ namespace Dynamo.Linting
                     linterExtension.Deactivate();
                 }
 
+                activeLinter = value;
+
                 if (TryGetLinterExtension(value, out linterExtension))
                 {
                     linterExtension.Activate();
                 }
 
-                activeLinter = value;
+                RaisePropertyChanged(nameof(ActiveLinter));
             }
         }
 

--- a/src/DynamoCore/Linting/LinterManager.cs
+++ b/src/DynamoCore/Linting/LinterManager.cs
@@ -37,30 +37,31 @@ namespace Dynamo.Linting
         internal ObservableCollection<IRuleEvaluationResult> RuleEvaluationResults { get; set; }
 
         /// <summary>
-        /// The LinterDescripter that is currently set as active
+        /// The LinterDescriptor that is currently set as active
         /// </summary>
-        public LinterExtensionDescriptor ActiveLinter
+        public LinterExtensionDescriptor ActiveLinter { get => activeLinter; }
+
+        /// <summary>
+        /// The LinterDescriptor setter that can be fully or partially activated
+        /// </summary>
+        public void SetActiveLinter(LinterExtensionDescriptor value, bool fullActivation = true)
         {
-            get => activeLinter;
-            set
+            if (activeLinter == value) return;
+
+            if (activeLinter != null &&
+                TryGetLinterExtension(activeLinter, out LinterExtensionBase linterExtension))
             {
-                if (activeLinter == value) return;
-
-                if (activeLinter != null &&
-                    TryGetLinterExtension(activeLinter, out LinterExtensionBase linterExtension))
-                {
-                    linterExtension.Deactivate();
-                }
-
-                activeLinter = value;
-
-                if (TryGetLinterExtension(value, out linterExtension))
-                {
-                    linterExtension.Activate();
-                }
-
-                RaisePropertyChanged(nameof(ActiveLinter));
+                linterExtension.Deactivate();
             }
+
+            activeLinter = value;
+
+            if (TryGetLinterExtension(value, out linterExtension))
+            {
+                linterExtension.Activate(fullActivation);
+            }
+
+            RaisePropertyChanged(nameof(ActiveLinter));
         }
 
         #endregion

--- a/src/DynamoCore/Linting/Rules/LinterRule.cs
+++ b/src/DynamoCore/Linting/Rules/LinterRule.cs
@@ -47,6 +47,14 @@ namespace Dynamo.Linting.Rules
         private protected abstract List<IRuleEvaluationResult> InitializeRule(WorkspaceModel workspaceModel);
 
         /// <summary>
+        /// Uses the cleanup function to allow a rule to get rid of any transient data 
+        /// it might have stored before the workspace model is disposed
+        /// </summary>
+        /// <param name="muribundWorkspaceModel"></param>
+        /// <returns></returns>
+        internal protected void CleanupRule(WorkspaceModel muribundWorkspaceModel) { }
+
+        /// <summary>
         /// Initializes this rule using the <see cref="InitFunction(WorkspaceModel)"/>
         /// </summary>
         /// <param name="workspaceModel"></param>

--- a/src/LintingViewExtension/LinterViewModel.cs
+++ b/src/LintingViewExtension/LinterViewModel.cs
@@ -61,7 +61,7 @@ namespace Dynamo.LintingViewExtension
                     return;
 
                 activeLinter = value;
-                linterManager.ActiveLinter = activeLinter;
+                linterManager.SetActiveLinter(activeLinter);
                 RaisePropertyChanged(nameof(ActiveLinter));
             }
         }

--- a/test/DynamoCoreTests/Linting/LinterManagerTests.cs
+++ b/test/DynamoCoreTests/Linting/LinterManagerTests.cs
@@ -60,9 +60,9 @@ namespace Dynamo.Tests.Linting
             Assert.That(!model.LinterManager.IsExtensionActive(MOCK_GUID));
 
             // Act
-            model.LinterManager.ActiveLinter = model.LinterManager.AvailableLinters
+            model.LinterManager.SetActiveLinter(model.LinterManager.AvailableLinters
                 .Where(x => x.Id == MOCK_GUID)
-                .FirstOrDefault();
+                .FirstOrDefault());
 
             // Assert
             Assert.That(model.LinterManager.ActiveLinter != activeLinterBefore);
@@ -87,9 +87,9 @@ namespace Dynamo.Tests.Linting
             // When setting a linter as the active linter, that linters Activate() gets called
             // which will initialize the rules using the init function. As we only have one mock rule
             // that checks if the node name is "NewNodeName" no failed evaluation results should be created here.
-            model.LinterManager.ActiveLinter = model.LinterManager.AvailableLinters
+            model.LinterManager.SetActiveLinter(model.LinterManager.AvailableLinters
                 .Where(x => x.Id == MOCK_GUID)
-                .FirstOrDefault();
+                .FirstOrDefault());
 
             // Update graph nodes name to trigger the node rule evaluation
             failureNode.Name = "NewNodeName";
@@ -141,13 +141,13 @@ namespace Dynamo.Tests.Linting
             // and subscribe everything. Then we change the active linter again but to the mock extension created in this test
             // this is to simulate a change in the active linter and to make sure we are only getting results from the active linter
             // even though two linters have been initialized.
-            model.LinterManager.ActiveLinter = model.LinterManager.AvailableLinters
+            model.LinterManager.SetActiveLinter(model.LinterManager.AvailableLinters
                 .Where(x => x.Id == MOCK_GUID)
-                .FirstOrDefault();
+                .FirstOrDefault());
 
-            model.LinterManager.ActiveLinter = model.LinterManager.AvailableLinters
+            model.LinterManager.SetActiveLinter(model.LinterManager.AvailableLinters
                 .Where(x => x.Id == secondLinterExtId)
-                .FirstOrDefault();
+                .FirstOrDefault());
 
             failureNode.Name = "NewNodeName";
 

--- a/test/DynamoCoreTests/Linting/LinterManagerTests.cs
+++ b/test/DynamoCoreTests/Linting/LinterManagerTests.cs
@@ -20,14 +20,16 @@ namespace Dynamo.Tests.Linting
         const string MOCK_GUID = "358321af-2633-4697-b475-81632582eba0";
         const string MOCK_RULE_ID = "1";
 
-        readonly Mock<LinterExtensionBase> mockExtension = new Mock<LinterExtensionBase>() { CallBase = true };
-        readonly Mock<NodeLinterRule> mockRule = new Mock<NodeLinterRule> { CallBase = true };
+        private Mock<LinterExtensionBase> mockExtension;
+        private Mock<NodeLinterRule> mockRule;
 
         private DynamoModel model;
 
         [SetUp]
         public void Init()
         {
+            mockExtension = new Mock<LinterExtensionBase>() { CallBase = true };
+            mockRule = new Mock<NodeLinterRule> { CallBase = true };
 
             // Setup mock rule
             mockRule.Setup(r => r.Id).Returns(MOCK_RULE_ID);


### PR DESCRIPTION
### Purpose
Separate graph opening and closing contexts handled by our linter extension.
This will allow us to perform cleanup operations for rules and base extension and also unhook from related events while the moribund workspace is still alive.

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

**Reviewers** : @SHKnudsen @mjkkirschner @saintentropy 