### PR TITLE
fix logging during Cpython Reset

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -149,14 +149,16 @@ namespace DSCPython
         private const string NodeName = "__dynamonodename__";
         static PyScope globalScope;
         internal static readonly string globalScopeName = "global";
+        private static DynamoLogger dynamoLogger;
         internal static DynamoLogger DynamoLogger {
             get
             { // Session is null when running unit tests.
                 if (ExecutionEvents.ActiveSession != null)
                 {
-                    return ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger) as DynamoLogger;
+                    dynamoLogger = ExecutionEvents.ActiveSession.GetParameterValue(ParameterKeys.Logger) as DynamoLogger;
+                    return dynamoLogger;
                 }
-                return null;
+                return dynamoLogger;
             }
         }
 
@@ -361,7 +363,8 @@ clr.setPreload(True)
             // Session is null when running unit tests.
             if (ExecutionEvents.ActiveSession != null)
             {
-                Action<string> logFunction = msg => DynamoLogger?.Log($"{nodeName}: {msg}", LogLevel.ConsoleOnly);
+                var logger = DynamoLogger;
+                Action<string> logFunction = msg => logger.Log($"{nodeName}: {msg}", LogLevel.ConsoleOnly);
                 scope.Set(DynamoPrintFuncName, logFunction.ToPython());
                 scope.Exec(RedirectPrint());
             }

--- a/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
+++ b/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.IO;
 using Dynamo;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using NUnit.Framework;
+using PythonNodeModels;
 
 namespace DynamoPythonTests
 {
@@ -40,6 +42,97 @@ namespace DynamoPythonTests
 
             CurrentDynamoModel.OpenFileFromPath(Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn"));
             StringAssert.IsMatch(expectedOutput, CurrentDynamoModel.Logger.LogText);
+        }
+
+        [Test]
+        public void ResetCypythonLogsToConsoleAfterRun()
+        {
+            (CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunType = RunType.Manual;
+            var expectedOutput = @"attempting reload of cpython3 modules
+Python Script: considering sys
+Python Script: considering builtins
+Python Script: considering _frozen_importlib
+Python Script: considering _imp
+Python Script: considering _warnings
+Python Script: considering _frozen_importlib_external
+Python Script: considering _io
+Python Script: considering marshal
+Python Script: considering nt
+Python Script: considering _thread
+Python Script: considering _weakref
+Python Script: considering winreg
+Python Script: considering time
+Python Script: considering zipimport
+Python Script: considering zlib
+Python Script: considering _codecs
+Python Script: considering codecs
+Python Script: considering encodings.aliases
+Python Script: considering encodings
+Python Script: considering encodings.utf_8
+Python Script: considering encodings.cp1252
+Python Script: considering __main__
+Python Script: considering encodings.latin_1
+Python Script: considering _abc
+Python Script: considering abc
+Python Script: considering io
+Python Script: considering _collections_abc
+Python Script: considering _operator
+Python Script: considering operator
+Python Script: considering keyword
+Python Script: considering _heapq
+Python Script: considering heapq
+Python Script: considering itertools
+Python Script: considering reprlib
+Python Script: considering _collections
+Python Script: considering collections
+Python Script: considering _stat
+Python Script: considering stat
+Python Script: considering genericpath
+Python Script: considering ntpath
+Python Script: considering os.path
+Python Script: considering os
+Python Script: considering types
+Python Script: considering enum
+Python Script: considering _sre
+Python Script: considering sre_constants
+Python Script: considering sre_parse
+Python Script: considering sre_compile
+Python Script: considering _functools
+Python Script: considering functools
+Python Script: considering _locale
+Python Script: considering copyreg
+Python Script: considering re
+Python Script: considering platform
+Python Script: considering _socket
+Python Script: considering collections.abc
+Python Script: considering math
+Python Script: considering select
+Python Script: considering selectors
+Python Script: considering errno
+Python Script: considering socket
+Python Script: considering warnings
+Python Script: considering CLR
+Python Script: considering clr
+Python Script: considering atexit
+Python Script: considering clr._extras
+Python Script: considering Autodesk
+Python Script: considering Autodesk.DesignScript
+Python Script: considering Autodesk.DesignScript.Geometry
+Python Script: considering importlib._bootstrap
+Python Script: considering importlib._bootstrap_external
+Python Script: considering importlib
+Python Script: considering importlib.machinery
+Python Script: considering importlib.abc
+Python Script: considering contextlib
+Python Script: considering importlib.util";
+            var pythonNode = new PythonNode();
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(pythonNode);
+            pythonNode.Engine = PythonEngineVersion.CPython3;
+          
+            RunCurrentModel();
+            CurrentDynamoModel.OnRequestPythonReset(nameof(PythonEngineVersion.CPython3));
+
+            StringAssert.Contains(expectedOutput, CurrentDynamoModel.Logger.LogText);
         }
     }
 }


### PR DESCRIPTION
### Purpose

Logging was not working when the `ResetCPython` button was pressed as `ExecutionSession` is always null when a run is not active.

Now we cache the logger and update it on the next run - it should be valid as long as a single run of any CPython has occurred within process lifetime.

Also added a test for this functionality.

So far I have not been able to repro the crash that was reported with PreferencesView constructor - it may be unrelated to this feature.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
