### PR TITLE
add new package manager prefs section

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2613,6 +2613,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installed Packages.
+        /// </summary>
+        public static string InstalledPackagesExpanderName {
+            get {
+                return ResourceManager.GetString("InstalledPackagesExpanderName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Additional Files.
         /// </summary>
         public static string InstalledPackageViewAdditionalFileLabel {
@@ -3891,6 +3900,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package Paths.
+        /// </summary>
+        public static string PackagePathsExpanderName {
+            get {
+                return ResourceManager.GetString("PackagePathsExpanderName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Accept Changes.
         /// </summary>
         public static string PackagePathViewAccept {
@@ -4373,6 +4391,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PortViewContextMenuUserDefaultValue {
             get {
                 return ResourceManager.GetString("PortViewContextMenuUserDefaultValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package Manager.
+        /// </summary>
+        public static string PreferencesPackageManagerSettingsTab {
+            get {
+                return ResourceManager.GetString("PreferencesPackageManagerSettingsTab", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2613,15 +2613,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Installed Packages.
-        /// </summary>
-        public static string InstalledPackagesExpanderName {
-            get {
-                return ResourceManager.GetString("InstalledPackagesExpanderName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Additional Files.
         /// </summary>
         public static string InstalledPackageViewAdditionalFileLabel {
@@ -3900,7 +3891,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package Paths.
+        ///   Looks up a localized string similar to Node and Package Paths.
         /// </summary>
         public static string PackagePathsExpanderName {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2399,4 +2399,13 @@ Uninstall the following packages: {0}?</value>
   <data name="ResetCPythonButtonToolTip" xml:space="preserve">
     <value>Resets CPython environment by reloading modules.</value>
   </data>
+  <data name="InstalledPackagesExpanderName" xml:space="preserve">
+    <value>Installed Packages</value>
+  </data>
+  <data name="PackagePathsExpanderName" xml:space="preserve">
+    <value>Package Paths</value>
+  </data>
+  <data name="PreferencesPackageManagerSettingsTab" xml:space="preserve">
+    <value>Package Manager</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2399,11 +2399,8 @@ Uninstall the following packages: {0}?</value>
   <data name="ResetCPythonButtonToolTip" xml:space="preserve">
     <value>Resets CPython environment by reloading modules.</value>
   </data>
-  <data name="InstalledPackagesExpanderName" xml:space="preserve">
-    <value>Installed Packages</value>
-  </data>
   <data name="PackagePathsExpanderName" xml:space="preserve">
-    <value>Package Paths</value>
+    <value>Node and Package Paths</value>
   </data>
   <data name="PreferencesPackageManagerSettingsTab" xml:space="preserve">
     <value>Package Manager</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2399,4 +2399,13 @@ Uninstall the following packages: {0}?</value>
   <data name="ResetCPythonButtonToolTip" xml:space="preserve">
     <value>Resets CPython environment by reloading modules.</value>
   </data>
+  <data name="InstalledPackagesExpanderName" xml:space="preserve">
+    <value>Installed Packages</value>
+  </data>
+  <data name="PackagePathsExpanderName" xml:space="preserve">
+    <value>Package Paths</value>
+  </data>
+  <data name="PreferencesPackageManagerSettingsTab" xml:space="preserve">
+    <value>Package Manager</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2399,11 +2399,8 @@ Uninstall the following packages: {0}?</value>
   <data name="ResetCPythonButtonToolTip" xml:space="preserve">
     <value>Resets CPython environment by reloading modules.</value>
   </data>
-  <data name="InstalledPackagesExpanderName" xml:space="preserve">
-    <value>Installed Packages</value>
-  </data>
   <data name="PackagePathsExpanderName" xml:space="preserve">
-    <value>Package Paths</value>
+    <value>Node and Package Paths</value>
   </data>
   <data name="PreferencesPackageManagerSettingsTab" xml:space="preserve">
     <value>Package Manager</value>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2501,7 +2501,7 @@
                                             HorizontalAlignment="Stretch" 
                                             VerticalAlignment="Stretch">
                             <Grid Name="TabPanel" 
-                                          Width="100"
+                                          Width="150"
                                           Height="30">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="5" />

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -18,7 +18,7 @@
         ResizeMode="NoResize"
         mc:Ignorable="d" 
         Height="474" 
-        Width="530" >
+        Width="580" >
 
     <!--Using the Styles from the SharedResourcesDictionary located in DynamoCoreWpf/UI/Themes/DynamoModern.xaml-->
     <Window.Resources>
@@ -75,7 +75,7 @@
                                     Margin="0,0,8,0"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"
-                                    Click="removeStyle_Click"
+                                    Click="RemoveStyle_Click"
                                     Style="{StaticResource RemoveStyleButtonStyle}"
                                     Width="20"
                                     Height="30">
@@ -574,7 +574,7 @@
                                                         <Button x:Name="buttonColorPicker"
                                                                 Style="{StaticResource ButtonColorPickerStyle}"
                                                                 Background="{Binding AddStyleControl.HexColorString}" 
-                                                                Click="buttonColorPicker_Click"
+                                                                Click="ButtonColorPicker_Click"
                                                                 Width="25" 
                                                                 Height="15"/>
                                                         <Label x:Name="colorHexVal" 
@@ -695,6 +695,42 @@
                                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                     </StackPanel>
                                 </Grid>
+                            </Expander>
+                        </Grid>
+                    </TabItem>
+
+                    <!--Package Manager Settings Tab-->
+                    <TabItem Header="{x:Static p:Resources.PreferencesPackageManagerSettingsTab}"
+                             Style="{StaticResource LeftTab}">
+                        <!--This Grid contains the package mangager settings tab-->
+                        <Grid x:Name="PackageManagerTab" 
+                              Margin="1"
+                              HorizontalAlignment="Stretch">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <!--This Grid row contains the Package Paths section-->
+                            <Expander x:Name="PackagePathsExpander"
+                                        Grid.Row="0"
+                                        Style="{StaticResource MenuExpanderStyle}" 
+                                        IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=PackagePathsExpander}"
+                                        Header="{x:Static p:Resources.PackagePathsExpanderName}">
+                                <StackPanel Orientation="Vertical" Margin="0,6,0,0">
+                                    <Label>SOME CONTENT</Label>
+                                </StackPanel>
+                            </Expander>
+
+                            <!--This Grid row contains the Installed Packages section-->
+                            <Expander x:Name="InstalledPackagesExpander" 
+                                          Style="{StaticResource MenuExpanderStyle}" 
+                                       IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=InstalledPackagesExpander}"
+                                          Grid.Row="1"
+                                          Header="{x:Static p:Resources.InstalledPackagesExpanderName}">
+                                <StackPanel Orientation="Vertical" Margin="0,6,0,0">
+                                    <Label>SOME CONTENT</Label>
+                                </StackPanel>
                             </Expander>
                         </Grid>
                     </TabItem>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -18,7 +18,7 @@
         ResizeMode="NoResize"
         mc:Ignorable="d" 
         Height="474" 
-        Width="580" >
+        Width="530" >
 
     <!--Using the Styles from the SharedResourcesDictionary located in DynamoCoreWpf/UI/Themes/DynamoModern.xaml-->
     <Window.Resources>
@@ -727,7 +727,7 @@
                                           Style="{StaticResource MenuExpanderStyle}" 
                                        IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=InstalledPackagesExpander}"
                                           Grid.Row="1"
-                                          Header="{x:Static p:Resources.InstalledPackagesExpanderName}">
+                                          Header="{x:Static p:Resources.InstalledPackageViewTitle}">
                                 <StackPanel Orientation="Vertical" Margin="0,6,0,0">
                                     <Label>SOME CONTENT</Label>
                                 </StackPanel>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -61,9 +61,9 @@ namespace Dynamo.Wpf.Views
             RadioMediumDesc.Inlines.Add(new Run(Res.ChangeScaleFactorPromptDescriptionDefaultSetting) { FontWeight = FontWeights.Bold });
             RadioMediumDesc.Inlines.Add(" " + viewModel.OptionsGeometryScale.DescriptionScaleRange[1]);
 
-            RadioLargeDesc.Inlines.Add(viewModel.OptionsGeometryScale.DescriptionScaleRange[1]);
+            RadioLargeDesc.Inlines.Add(viewModel.OptionsGeometryScale.DescriptionScaleRange[2]);
 
-            RadioExtraLargeDesc.Inlines.Add(viewModel.OptionsGeometryScale.DescriptionScaleRange[2]);
+            RadioExtraLargeDesc.Inlines.Add(viewModel.OptionsGeometryScale.DescriptionScaleRange[3]);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -18,7 +18,6 @@ namespace Dynamo.Wpf.Views
     /// </summary>
     public partial class PreferencesView : Window
     {
-        private List<Expander> allExpandersList;
         private readonly PreferencesViewModel viewModel;
         private readonly DynamoViewModel dynViewModel;
 
@@ -142,7 +141,7 @@ namespace Dynamo.Wpf.Views
             viewModel.ResetAddStyleControl();
         }
 
-        private void removeStyle_Click(object sender, RoutedEventArgs e)
+        private void RemoveStyle_Click(object sender, RoutedEventArgs e)
         {
            var removeButton = sender as Button;
 
@@ -156,7 +155,7 @@ namespace Dynamo.Wpf.Views
             viewModel.RemoveStyleEntry(groupNameLabel.Content.ToString());
         }
 
-        private void buttonColorPicker_Click(object sender, RoutedEventArgs e)
+        private void ButtonColorPicker_Click(object sender, RoutedEventArgs e)
         {
             System.Windows.Forms.ColorDialog colorDialog = new System.Windows.Forms.ColorDialog();
 


### PR DESCRIPTION
### Purpose

- adds a new tab for package manager client settings.
- adds expanders with empty labels to be filled in.
- increases width of tabs by 50 pixels.
- ~~increases width of window by 50pixels.~~
- renames some methods to follow c# naming standards.
- fixes a bug with the labels for geometry scaling-  both medium and large had the same description.

- [x] ~~I would like to make the window resizable horizontally to deal with localized text being longer - but need to check with Morpheus team if that is okay.~~ We're going to wait on this.

![Screen Shot 2021-06-04 at 6 35 16 PM](https://user-images.githubusercontent.com/508936/120869244-023ebe80-c564-11eb-9bd5-9913b0e28dd0.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

