### PR TITLE
modify python logging test to check each line, not whole string

### DIFF
--- a/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
+++ b/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
@@ -131,8 +131,10 @@ Python Script: considering importlib.util";
           
             RunCurrentModel();
             CurrentDynamoModel.OnRequestPythonReset(nameof(PythonEngineVersion.CPython3));
-
-            StringAssert.Contains(expectedOutput, CurrentDynamoModel.Logger.LogText);
+            foreach(var line in expectedOutput.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                StringAssert.Contains(line, CurrentDynamoModel.Logger.LogText);
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose

make test tolerant of changes in module loading order.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
