### PR TITLE
Fix the crash when opening Preferences dialog.

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -207,6 +207,7 @@ namespace Dynamo.Wpf.Views
                 {
                     Log(String.Format("Geometry working range changed to {0} ({1}, {2})",
                     viewModel.ScaleRange.Item1, viewModel.ScaleRange.Item2, viewModel.ScaleRange.Item3));
+                    viewModel.UpdateSavedChangesLabel();
                     Dynamo.Logging.Analytics.TrackEvent(
                         Actions.Switch,
                         Categories.Preferences,
@@ -215,7 +216,6 @@ namespace Dynamo.Wpf.Views
 
                 var allNodes = dynViewModel.HomeSpace.Nodes;
                 dynViewModel.HomeSpace.MarkNodesAsModifiedAndRequestRun(allNodes, forceExecute: true);
-                viewModel.UpdateSavedChangesLabel();
             }
         }
 


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-3746

The crash was happening as the viewModel object was null. Moved the UpdateSavedChangesLabel() call into a "If" block that checks for the viewModel not being null. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit 
