### PR TITLE
Upgrade Helix to 2.16.1

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -51,14 +51,14 @@
       <Private>True</Private>
       <HintPath>..\packages\Greg.2.0.7759.28389\lib\net48\Greg.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.2.16.1\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.2.16.1\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.16.1\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=4.3.1.9429, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\packages\AvalonEdit.4.3.1.9430\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -51,14 +51,14 @@
       <Private>True</Private>
       <HintPath>..\packages\Greg.2.0.7759.28389\lib\net48\Greg.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.2.15.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.2.15.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.15.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=4.3.1.9429, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\packages\AvalonEdit.4.3.1.9430\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeModelsWpf.csproj
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeModelsWpf.csproj
@@ -43,14 +43,14 @@
     <Reference Include="Cyotek.Drawing.BitmapFont, Version=1.0.0.0, Culture=neutral, PublicKeyToken=58daa28b0b2de221, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Cyotek.Drawing.BitmapFont.2.0.0\lib\net48\Cyotek.Drawing.BitmapFont.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HelixToolkit.2.16.1\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HelixToolkit.Wpf.2.16.1\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HelixToolkit.Wpf.SharpDX.2.16.1\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>

--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeModelsWpf.csproj
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeModelsWpf.csproj
@@ -43,14 +43,14 @@
     <Reference Include="Cyotek.Drawing.BitmapFont, Version=1.0.0.0, Culture=neutral, PublicKeyToken=58daa28b0b2de221, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Cyotek.Drawing.BitmapFont.2.0.0\lib\net48\Cyotek.Drawing.BitmapFont.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HelixToolkit.2.15.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HelixToolkit.Wpf.2.15.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HelixToolkit.Wpf.SharpDX.2.15.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>

--- a/src/Libraries/Watch3DNodeModelsWpf/packages.config
+++ b/src/Libraries/Watch3DNodeModelsWpf/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
-  <package id="HelixToolkit" version="2.15.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf" version="2.15.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.15.0" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.0" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net48" />

--- a/src/Libraries/Watch3DNodeModelsWpf/packages.config
+++ b/src/Libraries/Watch3DNodeModelsWpf/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
-  <package id="HelixToolkit" version="2.16.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf" version="2.16.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.16.1" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.16.1" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.1" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net48" />

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -925,7 +925,7 @@ namespace WpfVisualizationTests
             var totalExecutionTime = (endTime - startTime).TotalSeconds;
             Assert.LessOrEqual(totalExecutionTime, 20);
         }
-       
+/*       
         [Test]
         public void Display_BySurfaceColors_HasColoredMesh()
         {
@@ -944,7 +944,8 @@ namespace WpfVisualizationTests
             var width = new Bitmap(((PhongMaterial)dynGeometry.Material).DiffuseMap.CompressedStream).Width;
             Assert.AreEqual(52, width);
         }
-
+*/
+/*
         [Test]
         public void Display_MultipleTextureMaps_HasUniqueMeshsAndCorrectPerSurface()
         {
@@ -978,7 +979,7 @@ namespace WpfVisualizationTests
             
             Assert.IsTrue(((PhongMaterial)mesh3.Material).DiffuseMap == null);
         }
-
+*/
         [Test]
         public void Display_HasOneGeometryEntityInBackgroundPreviewPerNode()
         {

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -925,7 +925,7 @@ namespace WpfVisualizationTests
             var totalExecutionTime = (endTime - startTime).TotalSeconds;
             Assert.LessOrEqual(totalExecutionTime, 20);
         }
-/*       
+       
         [Test]
         public void Display_BySurfaceColors_HasColoredMesh()
         {
@@ -941,11 +941,11 @@ namespace WpfVisualizationTests
             var numberOfColors = dynGeometry.Geometry.Colors.Count;
             Assert.AreEqual(6, numberOfColors);
             //decompress the texture to get the width
-            var width = new Bitmap(((PhongMaterial)dynGeometry.Material).DiffuseMap.CompressedStream).Width;
+            var width = new Bitmap(((PhongMaterial)dynGeometry.Material).DiffuseMap.Load().Texture).Width;
             Assert.AreEqual(52, width);
         }
-*/
-/*
+
+
         [Test]
         public void Display_MultipleTextureMaps_HasUniqueMeshsAndCorrectPerSurface()
         {
@@ -963,7 +963,7 @@ namespace WpfVisualizationTests
             // Expecting 6 color definitions for vertices in the DynamoGeometry
             Assert.AreEqual(6, mesh1.Geometry.Colors.Count);
             //decompress the texture to get the width
-            var width1 = new Bitmap(((PhongMaterial)mesh1.Material).DiffuseMap.CompressedStream).Width;
+            var width1 = new Bitmap(((PhongMaterial)mesh1.Material).DiffuseMap.Load().Texture).Width;
             Assert.AreEqual(5, width1);
 
             var mesh2 = meshes[1];
@@ -971,7 +971,7 @@ namespace WpfVisualizationTests
             // Expecting 6 color definitions for vertices in the DynamoGeometry
             Assert.AreEqual(6, mesh2.Geometry.Colors.Count);
             //decompress the texture to get the width
-            var width2 = new Bitmap(((PhongMaterial)mesh2.Material).DiffuseMap.CompressedStream).Width;
+            var width2 = new Bitmap(((PhongMaterial)mesh2.Material).DiffuseMap.Load().Texture).Width;
             Assert.AreEqual(9, width2);
 
             //Mesh 3 is has no texture map
@@ -979,7 +979,7 @@ namespace WpfVisualizationTests
             
             Assert.IsTrue(((PhongMaterial)mesh3.Material).DiffuseMap == null);
         }
-*/
+
         [Test]
         public void Display_HasOneGeometryEntityInBackgroundPreviewPerNode()
         {

--- a/src/VisualizationTests/WpfVisualizationTests.csproj
+++ b/src/VisualizationTests/WpfVisualizationTests.csproj
@@ -40,14 +40,14 @@
     <Reference Include="Cyotek.Drawing.BitmapFont, Version=1.0.0.0, Culture=neutral, PublicKeyToken=58daa28b0b2de221, processorArchitecture=MSIL">
       <HintPath>..\packages\Cyotek.Drawing.BitmapFont.2.0.0\lib\net48\Cyotek.Drawing.BitmapFont.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.2.16.1\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.2.16.1\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.16.1\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>

--- a/src/VisualizationTests/WpfVisualizationTests.csproj
+++ b/src/VisualizationTests/WpfVisualizationTests.csproj
@@ -40,14 +40,14 @@
     <Reference Include="Cyotek.Drawing.BitmapFont, Version=1.0.0.0, Culture=neutral, PublicKeyToken=58daa28b0b2de221, processorArchitecture=MSIL">
       <HintPath>..\packages\Cyotek.Drawing.BitmapFont.2.0.0\lib\net48\Cyotek.Drawing.BitmapFont.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.2.15.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.2.15.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.15.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>

--- a/src/VisualizationTests/packages.config
+++ b/src/VisualizationTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
-  <package id="HelixToolkit" version="2.16.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf" version="2.16.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.16.1" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.16.1" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.1" targetFramework="net48" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />

--- a/src/VisualizationTests/packages.config
+++ b/src/VisualizationTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
-  <package id="HelixToolkit" version="2.15.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf" version="2.15.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.15.0" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -51,14 +51,14 @@
       <HintPath>..\..\src\packages\Greg.2.0.7759.28389\lib\net48\Greg.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\HelixToolkit.2.15.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\HelixToolkit.Wpf.2.15.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.15.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\HelixToolkit.Wpf.SharpDX.2.15.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=4.3.1.9429, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\..\src\packages\AvalonEdit.4.3.1.9430\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -51,14 +51,14 @@
       <HintPath>..\..\src\packages\Greg.2.0.7759.28389\lib\net48\Greg.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="HelixToolkit, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\HelixToolkit.2.16.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>
+    <Reference Include="HelixToolkit, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\HelixToolkit.2.16.1\lib\netstandard1.1\HelixToolkit.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\HelixToolkit.Wpf.2.16.0\lib\net45\HelixToolkit.Wpf.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\HelixToolkit.Wpf.2.16.1\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\HelixToolkit.Wpf.SharpDX.2.16.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
+    <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.16.1.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\HelixToolkit.Wpf.SharpDX.2.16.1\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=4.3.1.9429, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\..\src\packages\AvalonEdit.4.3.1.9430\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/test/DynamoCoreWpfTests/packages.config
+++ b/test/DynamoCoreWpfTests/packages.config
@@ -3,9 +3,9 @@
   <package id="AvalonEdit" version="4.3.1.9430" targetFramework="net48" />
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
   <package id="Greg" version="2.0.7759.28389" targetFramework="net48" />
-  <package id="HelixToolkit" version="2.15.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf" version="2.15.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.15.0" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />

--- a/test/DynamoCoreWpfTests/packages.config
+++ b/test/DynamoCoreWpfTests/packages.config
@@ -3,9 +3,9 @@
   <package id="AvalonEdit" version="4.3.1.9430" targetFramework="net48" />
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
   <package id="Greg" version="2.0.7759.28389" targetFramework="net48" />
-  <package id="HelixToolkit" version="2.16.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf" version="2.16.0" targetFramework="net48" />
-  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.0" targetFramework="net48" />
+  <package id="HelixToolkit" version="2.16.1" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf" version="2.16.1" targetFramework="net48" />
+  <package id="HelixToolkit.Wpf.SharpDX" version="2.16.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />


### PR DESCRIPTION
### Purpose

[DYN-3769: Dynamo freeze/crash multiple screen or display resolution](https://jira.autodesk.com/browse/DYN-3729).

This pull request does:
* upgrade helix to version `2.16.1`.
* update two tests to use the new API in `2.16` for accessing textures from the texture cache (textures are not a member of the `TextureModel` anymore).

Helix `2.16` also have breaking API changes to low level hit methods but these are not directly used by Dynamo.  
  
### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
