### PR TITLE
DYN-3770 : handle modified flag for graph properties change

### DIFF
--- a/src/GraphMetadataViewExtension/Controls/CustomPropertyControl.xaml.cs
+++ b/src/GraphMetadataViewExtension/Controls/CustomPropertyControl.xaml.cs
@@ -25,6 +25,11 @@ namespace Dynamo.GraphMetadata.Controls
         /// </summary>
         public event EventHandler RequestDelete;
 
+        /// <summary>
+        /// This event fires when the Name or Value of the CustomProperty has changed. It signals to the ViewModel so that the owner graph is marked with unsaved changes.
+        /// </summary>
+        public event EventHandler PropertyChanged;
+
         private void OnRequestDelete(EventArgs e)
         {
             RequestDelete?.Invoke(this, e);
@@ -67,6 +72,17 @@ namespace Dynamo.GraphMetadata.Controls
         }
 
         #region DependencyProperties
+
+        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+
+            if ((e.Property.Name == nameof(PropertyName) || e.Property.Name == nameof(PropertyValue)) 
+                && e.OldValue != e.NewValue)
+            {
+                PropertyChanged?.Invoke(this, null);
+            }
+        }
 
         public string PropertyName
         {

--- a/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
@@ -69,7 +69,7 @@ namespace Dynamo.GraphMetadata
 
                 var valueModified = kv.Value == null ? string.Empty : kv.Value;
 
-                this.viewModel.AddCustomProperty(kv.Key, valueModified);
+                this.viewModel.AddCustomProperty(kv.Key, valueModified, false);
             }
         }
 

--- a/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
@@ -198,7 +198,7 @@ namespace Dynamo.GraphMetadata
             AddCustomProperty(propName, string.Empty);
         }
 
-        internal void AddCustomProperty(string propertyName, string propertyValue)
+        internal void AddCustomProperty(string propertyName, string propertyValue, bool markChange = true)
         {
             var control = new CustomPropertyControl
             {
@@ -207,8 +207,17 @@ namespace Dynamo.GraphMetadata
             };
 
             control.RequestDelete += HandleDeleteRequest;
+            control.PropertyChanged += HandlePropertyChanged;
             CustomProperties.Add(control);
 
+            if (markChange && this.currentWorkspace != null)
+            {
+                this.currentWorkspace.HasUnsavedChanges = true;
+            }
+        }
+
+        private void HandlePropertyChanged(object sender, EventArgs e)
+        {
             if (this.currentWorkspace != null)
             {
                 this.currentWorkspace.HasUnsavedChanges = true;
@@ -220,6 +229,7 @@ namespace Dynamo.GraphMetadata
             if (sender is CustomPropertyControl customProperty)
             {
                 customProperty.RequestDelete -= HandleDeleteRequest;
+                customProperty.PropertyChanged -= HandlePropertyChanged;
                 CustomProperties.Remove(customProperty);
                 if (this.currentWorkspace != null)
                 {
@@ -235,6 +245,7 @@ namespace Dynamo.GraphMetadata
             foreach (var cp in CustomProperties)
             {
                 cp.RequestDelete -= HandleDeleteRequest;
+                cp.PropertyChanged -= HandlePropertyChanged;
             }
        }
     }


### PR DESCRIPTION
### Purpose
Mark graph with unsaved changes when a custom property name or value is modified.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

