### PR TITLE
DYN-3776 : handle modified flag for linter type change

### DIFF
--- a/src/LintingViewExtension/LinterViewModel.cs
+++ b/src/LintingViewExtension/LinterViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows.Threading;
 using Dynamo.Core;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Linting;
 using Dynamo.Linting.Rules;
 using Dynamo.LintingViewExtension.Controls;
@@ -21,7 +22,6 @@ namespace Dynamo.LintingViewExtension
     {
         #region Private Fields
         private static Uri linterViewHelpLink = new Uri("LintingViewExtension;LinterViewHelpDoc.html", UriKind.Relative);
-        private LinterExtensionDescriptor activeLinter;
         private LinterManager linterManager;
         private ViewLoadedParams viewLoadedParams;
         private Dispatcher dispatcher;
@@ -53,15 +53,18 @@ namespace Dynamo.LintingViewExtension
         /// </summary>
         public LinterExtensionDescriptor ActiveLinter
         {
-            get { return activeLinter; }
+            get { return linterManager.ActiveLinter; }
             set
             {
-                if (activeLinter == value)
+                if (linterManager.ActiveLinter == value)
                     return;
+               
+                linterManager.SetActiveLinter(value);
 
-                activeLinter = value;
-                linterManager.SetActiveLinter(activeLinter);
-                RaisePropertyChanged(nameof(ActiveLinter));
+                if (viewLoadedParams.CurrentWorkspaceModel is HomeWorkspaceModel currentWorkspace)
+                {
+                    currentWorkspace.HasUnsavedChanges = true;
+                }
             }
         }
 
@@ -81,8 +84,6 @@ namespace Dynamo.LintingViewExtension
             this.viewLoadedParams = viewLoadedParams;
             dispatcher = viewLoadedParams.DynamoWindow.Dispatcher;
             InitializeCommands();
-
-            this.activeLinter = this.linterManager.ActiveLinter;
 
             NodeIssues = new ObservableCollection<IRuleIssue>();
             GraphIssues = new ObservableCollection<IRuleIssue>();
@@ -261,7 +262,7 @@ namespace Dynamo.LintingViewExtension
         {
             if (e.PropertyName == nameof(linterManager.ActiveLinter))
             {
-                ActiveLinter = (sender as LinterManager)?.ActiveLinter;
+                RaisePropertyChanged(nameof(ActiveLinter));
             }
         }
         


### PR DESCRIPTION
### Purpose
We want to mark the current graph with unsaved changes when we change the active linter.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
