### PR TITLE
DYN-3777: disable linter choice in forbidden workspaces

### DIFF
--- a/src/LintingViewExtension/LinterView.xaml
+++ b/src/LintingViewExtension/LinterView.xaml
@@ -149,6 +149,7 @@
                 </Grid.ColumnDefinitions>
                 <ComboBox Grid.Column="0"
                           Name="LinterSelector"
+                          IsEnabled="{Binding CanChangeLinter, Mode=OneWay}"
                           DisplayMemberPath="Name"
                           SelectedItem="{Binding ActiveLinter, Mode=TwoWay}"
                           Style="{StaticResource SComboBox}"

--- a/src/LintingViewExtension/LinterViewModel.cs
+++ b/src/LintingViewExtension/LinterViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows.Threading;
 using Dynamo.Core;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Linting;
 using Dynamo.Linting.Rules;
 using Dynamo.LintingViewExtension.Controls;
@@ -88,6 +89,7 @@ namespace Dynamo.LintingViewExtension
             GraphIssues = new ObservableCollection<IRuleIssue>();
             this.linterManager.RuleEvaluationResults.CollectionChanged += RuleEvaluationResultsCollectionChanged;
             this.linterManager.PropertyChanged += OnLinterManagerPropertyChange;
+            viewLoadedParams.CurrentWorkspaceChanged += OnCurrentWorkspaceChanged;
         }
 
         #region Private methods
@@ -257,7 +259,12 @@ namespace Dynamo.LintingViewExtension
             }
         }
 
-        private void OnLinterManagerPropertyChange(object sender, System.ComponentModel.PropertyChangedEventArgs e )
+        private void OnCurrentWorkspaceChanged(IWorkspaceModel obj)
+        {
+            RaisePropertyChanged(nameof(CanChangeLinter));
+        }
+
+        private void OnLinterManagerPropertyChange(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(linterManager.ActiveLinter))
             {
@@ -284,6 +291,11 @@ namespace Dynamo.LintingViewExtension
         {
             this.linterManager.RuleEvaluationResults.CollectionChanged -= RuleEvaluationResultsCollectionChanged;
             this.linterManager.PropertyChanged -= OnLinterManagerPropertyChange;
+            viewLoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
+        }
+
+        public bool CanChangeLinter { 
+            get => viewLoadedParams.CurrentWorkspaceModel is HomeWorkspaceModel ? true : false; 
         }
         #endregion
     }

--- a/src/LintingViewExtension/LinterViewModel.cs
+++ b/src/LintingViewExtension/LinterViewModel.cs
@@ -294,6 +294,9 @@ namespace Dynamo.LintingViewExtension
             viewLoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
         }
 
+        /// <summary>
+        /// Check to see if we can set an active linter for the current workspace
+        /// </summary>
         public bool CanChangeLinter { 
             get => viewLoadedParams.CurrentWorkspaceModel is HomeWorkspaceModel ? true : false; 
         }


### PR DESCRIPTION
### Purpose
For now, we will only allow users to change Linter in HomeWorkspaceModels. This is temporary and we will remove this limitation in the near future.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

