### PR TITLE
DYN-3780 : fix modified flag for default home workspace

### DIFF
--- a/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
@@ -29,13 +29,12 @@ namespace Dynamo.GraphMetadata
             get { return currentWorkspace.Description; }
             set
             {
-                if (this.currentWorkspace != null && GraphDescription != value)
+                if (currentWorkspace != null && GraphDescription != value)
                 {
-                    this.currentWorkspace.HasUnsavedChanges = true;
+                    MarkCurrentWorkspaceModified();
+                    currentWorkspace.Description = value;
+                    RaisePropertyChanged(nameof(GraphDescription));
                 }
-
-                currentWorkspace.Description = value;
-                RaisePropertyChanged(nameof(GraphDescription));
             }
         }
 
@@ -47,13 +46,12 @@ namespace Dynamo.GraphMetadata
             get { return currentWorkspace.Author; }
             set 
             {
-                if (this.currentWorkspace != null && GraphAuthor != value)
+                if (currentWorkspace != null && GraphAuthor != value)
                 {
-                    this.currentWorkspace.HasUnsavedChanges = true;
+                    MarkCurrentWorkspaceModified();
+                    currentWorkspace.Author = value;
+                    RaisePropertyChanged(nameof(GraphAuthor));
                 }
-                currentWorkspace.Author = value; 
-                RaisePropertyChanged(nameof(GraphAuthor));
-
             }
         }
 
@@ -65,13 +63,12 @@ namespace Dynamo.GraphMetadata
             get { return currentWorkspace.GraphDocumentationURL; }
             set 
             {
-                if (this.currentWorkspace != null && HelpLink != value)
+                if (currentWorkspace != null && HelpLink != value)
                 {
-                    this.currentWorkspace.HasUnsavedChanges = true;
+                    MarkCurrentWorkspaceModified();
+                    currentWorkspace.GraphDocumentationURL = value;
+                    RaisePropertyChanged(nameof(HelpLink));
                 }
-
-                currentWorkspace.GraphDocumentationURL = value; 
-                RaisePropertyChanged(nameof(HelpLink)); 
             }
         }
 
@@ -88,13 +85,12 @@ namespace Dynamo.GraphMetadata
             set
             {
                 var base64 = value is null ? string.Empty : Base64FromImage(value);
-                if (this.currentWorkspace != null && base64 != currentWorkspace.Thumbnail)
+                if (currentWorkspace != null && base64 != currentWorkspace.Thumbnail)
                 {
-                    this.currentWorkspace.HasUnsavedChanges = true;
+                    MarkCurrentWorkspaceModified();
+                    currentWorkspace.Thumbnail = base64;
+                    RaisePropertyChanged(nameof(Thumbnail));
                 }
-
-                currentWorkspace.Thumbnail = base64;
-                RaisePropertyChanged(nameof(Thumbnail));
             }
         }
 
@@ -210,18 +206,15 @@ namespace Dynamo.GraphMetadata
             control.PropertyChanged += HandlePropertyChanged;
             CustomProperties.Add(control);
 
-            if (markChange && this.currentWorkspace != null)
+            if (markChange)
             {
-                this.currentWorkspace.HasUnsavedChanges = true;
+                MarkCurrentWorkspaceModified();
             }
         }
 
         private void HandlePropertyChanged(object sender, EventArgs e)
         {
-            if (this.currentWorkspace != null)
-            {
-                this.currentWorkspace.HasUnsavedChanges = true;
-            }
+            MarkCurrentWorkspaceModified();
         }
 
         private void HandleDeleteRequest(object sender, EventArgs e)
@@ -231,15 +224,20 @@ namespace Dynamo.GraphMetadata
                 customProperty.RequestDelete -= HandleDeleteRequest;
                 customProperty.PropertyChanged -= HandlePropertyChanged;
                 CustomProperties.Remove(customProperty);
-                if (this.currentWorkspace != null)
-                {
-                    this.currentWorkspace.HasUnsavedChanges = true;
-                }
+                MarkCurrentWorkspaceModified();
             }
         }
 
-       public void Dispose()
-       {
+        private void MarkCurrentWorkspaceModified()
+        { 
+            if (currentWorkspace != null && !string.IsNullOrEmpty(currentWorkspace.FileName))
+            {
+                currentWorkspace.HasUnsavedChanges = true;
+            }
+        }
+
+        public void Dispose()
+        {
             this.viewLoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
 
             foreach (var cp in CustomProperties)
@@ -247,6 +245,6 @@ namespace Dynamo.GraphMetadata
                 cp.RequestDelete -= HandleDeleteRequest;
                 cp.PropertyChanged -= HandlePropertyChanged;
             }
-       }
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/GraphMetadataViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/GraphMetadataViewExtensionTests.cs
@@ -123,6 +123,7 @@ namespace DynamoCoreWpfTests.ViewExtensions
             Open(@"core\CustompropertyTest.dyn");
 
             // Assert
+            Assert.IsFalse(ViewModel.HomeSpace.HasUnsavedChanges);
             Assert.IsTrue(customPropertiesBeforeOpen == 0);
             Assert.That(propertiesExt.viewModel.CustomProperties.Count == 3);
             Assert.That(propertiesExt.viewModel.CustomProperties[0].PropertyName == expectedCP1Key);
@@ -131,6 +132,30 @@ namespace DynamoCoreWpfTests.ViewExtensions
             Assert.That(propertiesExt.viewModel.CustomProperties[1].PropertyValue == expectedCP2Value);
             Assert.That(propertiesExt.viewModel.CustomProperties[2].PropertyName == expectedCP3Key);
             Assert.That(propertiesExt.viewModel.CustomProperties[2].PropertyValue == expectedCP3Value);
+        }
+
+        [Test]
+        public void ExistingGraphOpenModifiedAndClosedWillSetAndClearModifiedFlag()
+        {
+            var extensionManager = View.viewExtensionManager;
+            var propertiesExt = extensionManager.ViewExtensions
+                    .FirstOrDefault(x => x.Name == GraphMetadataViewExtension.extensionName)
+                as GraphMetadataViewExtension;
+
+            var customPropertiesBeforeOpen = propertiesExt.viewModel.CustomProperties.Count;
+            Open(@"core\CustompropertyTest.dyn");
+
+            Assert.IsFalse(ViewModel.HomeSpace.HasUnsavedChanges);
+
+            propertiesExt.viewModel.AddCustomProperty("TestPropertyName-X", "TestPropertyValue-X");
+
+            Assert.IsTrue(ViewModel.HomeSpace.HasUnsavedChanges);
+
+            ViewModel.HomeSpace.HasUnsavedChanges = false;
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+            ViewModel.MakeNewHomeWorkspace(null);
+
+            Assert.IsFalse(ViewModel.HomeSpace.HasUnsavedChanges);
         }
     }
 }


### PR DESCRIPTION
### Purpose
Don't set the modified flag for the default home workspace.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
