### PR TITLE
Show Run Preview preference setting should persist across Dynamo sessions

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -387,6 +387,11 @@ namespace Dynamo.Configuration
         /// Defines the default run type when opening a workspace
         /// </summary>
         public RunType DefaultRunType { get; set; }
+
+        /// <summary>
+        /// Show Run Preview flag.
+        /// </summary>
+        public bool ShowRunPreview { get; set; }
         #endregion
 
         /// <summary>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4539,6 +4539,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Editable only when the current workspace is in Manual run mode..
+        /// </summary>
+        public static string PreferencesViewShowRunPreviewTooltip {
+            get {
+                return ResourceManager.GetString("PreferencesViewShowRunPreviewTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show Whitespace in Python Editor.
         /// </summary>
         public static string PreferencesViewShowWhitespaceInPythonEditor {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4539,7 +4539,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Editable only when the current workspace is in Manual run mode..
+        ///   Looks up a localized string similar to Switchable only when the current workspace is in Manual run mode..
         /// </summary>
         public static string PreferencesViewShowRunPreviewTooltip {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2405,4 +2405,7 @@ Uninstall the following packages: {0}?</value>
   <data name="PreferencesPackageManagerSettingsTab" xml:space="preserve">
     <value>Package Manager</value>
   </data>
+  <data name="PreferencesViewShowRunPreviewTooltip" xml:space="preserve">
+    <value>Editable only when the current workspace is in Manual run mode.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2406,6 +2406,6 @@ Uninstall the following packages: {0}?</value>
     <value>Package Manager</value>
   </data>
   <data name="PreferencesViewShowRunPreviewTooltip" xml:space="preserve">
-    <value>Editable only when the current workspace is in Manual run mode.</value>
+    <value>Switchable only when the current workspace is in Manual run mode.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2405,4 +2405,7 @@ Uninstall the following packages: {0}?</value>
   <data name="PreferencesPackageManagerSettingsTab" xml:space="preserve">
     <value>Package Manager</value>
   </data>
+  <data name="PreferencesViewShowRunPreviewTooltip" xml:space="preserve">
+    <value>Editable only when the current workspace is in Manual run mode.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2406,6 +2406,6 @@ Uninstall the following packages: {0}?</value>
     <value>Package Manager</value>
   </data>
   <data name="PreferencesViewShowRunPreviewTooltip" xml:space="preserve">
-    <value>Editable only when the current workspace is in Manual run mode.</value>
+    <value>Switchable only when the current workspace is in Manual run mode.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -211,10 +211,11 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return dynamoViewModel.ShowRunPreview;
+                return preferenceSettings.ShowRunPreview;
             }
             set
             {
+                preferenceSettings.ShowRunPreview = value;
                 dynamoViewModel.ShowRunPreview = value;
                 RaisePropertyChanged(nameof(RunPreviewIsChecked));
             }
@@ -651,6 +652,7 @@ namespace Dynamo.ViewModels
             SelectedNumberFormat = preferenceSettings.NumberFormat;
 
             runSettingsIsChecked = preferenceSettings.DefaultRunType;
+            RunPreviewIsChecked = preferenceSettings.ShowRunPreview;
 
             //By Default the warning state of the Visual Settings tab (Group Styles section) will be disabled
             isWarningEnabled = false;

--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -297,7 +297,6 @@ namespace Dynamo.Wpf.ViewModels
                 case RunType.Manual:                    
                     return;
                 case RunType.Automatic:
-                    dynamoViewModel.ShowRunPreview = false;
                     RunExpressionCommand.Execute(true);
                     return;
                 case RunType.Periodic:

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -229,7 +229,7 @@
                                 <!--This Grid contains controls for selecting Run Preview options-->
                                 <Grid Grid.Row="2"
                                   Margin="4,0,0,20">
-                                    <Grid>
+                                    <Grid ToolTip="{x:Static p:Resources.PreferencesViewShowRunPreviewTooltip}">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="*"/>
@@ -243,7 +243,7 @@
                                                   IsChecked="{Binding Path=RunPreviewIsChecked}"
                                                   Style="{StaticResource EllipseToggleButton1}"/>
                                         <Label Grid.Column="1"
-                                           Content="{x:Static p:Resources.DynamoViewSettingShowRunPreview}" 
+                                           Content="{x:Static p:Resources.DynamoViewSettingShowRunPreview}"
                                            Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                     </Grid>
                                 </Grid>


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-3749

Currently the Show Run Preview control(in preferences tab) is not serialized in the DynamoSettings.xml, so it would reset back to false whenever Dynamo is restarted. We want to serialize this setting so that the user can save their preference across Dynamo sessions. This preference setting is now saved in DynamoSettings.xml.
Note that this control will only be editable when the current workspace is in Manual run mode. Added the same as a tooltip for that control.

![Show Run Preview control](https://user-images.githubusercontent.com/43763136/122386175-9bde7680-cf3b-11eb-9be5-44af5a7a9d4c.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

