### PR TITLE
Add Modified to the LinterExtensionBase notification infrastructure

### DIFF
--- a/src/DynamoCore/Extensions/LinterExtensionBase.cs
+++ b/src/DynamoCore/Extensions/LinterExtensionBase.cs
@@ -19,6 +19,7 @@ namespace Dynamo.Extensions
     {
         private const string NODE_ADDED_PROPERTY = "NodeAdded";
         private const string NODE_REMOVED_PROPERTY = "NodeRemoved";
+        private const string NODE_MODIFIED_PROPERTY = "Modified";
 
         #region Private/Internal properties
         private HashSet<LinterRule> linterRules = new HashSet<LinterRule>();
@@ -308,6 +309,7 @@ namespace Dynamo.Extensions
             foreach (var node in currentWorkspace.Nodes)
             {
                 node.PropertyChanged += OnNodePropertyChanged;
+                node.Modified += OnNodeModified;
             }
         }
 
@@ -323,6 +325,7 @@ namespace Dynamo.Extensions
         private void UnsubscribeNodeEvents(NodeModel node)
         {
             node.PropertyChanged -= OnNodePropertyChanged;
+            node.Modified -= OnNodeModified;
         }
 
         private void OnNodeAdded(NodeModel node)
@@ -330,13 +333,19 @@ namespace Dynamo.Extensions
             EvaluateGraphRules(node, NODE_ADDED_PROPERTY);
             EvaluateNodeRules(node, NODE_ADDED_PROPERTY);
             node.PropertyChanged += OnNodePropertyChanged;
+            node.Modified += OnNodeModified;
+        }
+
+        private void OnNodeModified(NodeModel node)
+        {
+            EvaluateGraphRules(node, NODE_MODIFIED_PROPERTY);
+            EvaluateNodeRules(node, NODE_MODIFIED_PROPERTY);
         }
 
         private void OnNodePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             EvaluateNodeRules(sender as NodeModel, e.PropertyName);
             EvaluateGraphRules(sender as NodeModel, e.PropertyName);
-
         }
 
         private void OnNodeRemoved(Graph.Nodes.NodeModel node)


### PR DESCRIPTION
### Purpose

This PR adds `Node.Modified` event to the `LinterExtensionBase` events so that rules can access the Modified event on Nodes.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@nate-peters @mjkkirschner 

### FYIs

@BogdanZavu @SHKnudsen 
