### PR TITLE
Adjust the node position when a Node-Autocompletion element is connected.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -286,7 +286,7 @@ namespace Dynamo.Wpf.ViewModels
                 // Placing the new node to the left of initial node
                 adjustedX -= initialNode.Width + 50;
 
-                // If the new node is a input slider node, adjust the position on X-axis to compensate for higher width of the slider node.
+                // If the new node is a slider input node, adjust the position on X-axis to compensate for higher width of the slider node.
                 if (Model.CreationName.Contains("Slider")) 
                 {
                     adjustedX -= 450;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -268,6 +268,7 @@ namespace Dynamo.Wpf.ViewModels
             var id = Guid.NewGuid();
 
             var adjustedX = initialNodeVm.X;
+            var adjustedY = initialNodeVm.Y;
 
             var createAsDownStreamNode = portModel.PortType == PortType.Output;
             // Placing the new node based on which port it is connecting to.
@@ -278,16 +279,22 @@ namespace Dynamo.Wpf.ViewModels
 
                 // Create a new node based on node creation name and connection ports
                 dynamoViewModel.ExecuteCommand(new DynamoModel.CreateAndConnectNodeCommand(id, initialNode.GUID,
-                    Model.CreationName, 0, Model.AutoCompletionNodeElementInfo.PortToConnect, adjustedX, 0, createAsDownStreamNode, false, true));
+                    Model.CreationName, 0, Model.AutoCompletionNodeElementInfo.PortToConnect, adjustedX, adjustedY, createAsDownStreamNode, false, true));
             }
             else
             {
                 // Placing the new node to the left of initial node
                 adjustedX -= initialNode.Width + 50;
 
+                // If the new node is a input slider node, adjust the position on X-axis to compensate for higher width of the slider node.
+                if (Model.CreationName.Contains("Slider")) 
+                {
+                    adjustedX -= 450;
+                }
+
                 // Create a new node based on node creation name and connection ports
                 dynamoViewModel.ExecuteCommand(new DynamoModel.CreateAndConnectNodeCommand(id, initialNode.GUID,
-                      Model.CreationName, 0, portModel.Index, adjustedX, 0, createAsDownStreamNode, false, true));
+                      Model.CreationName, 0, portModel.Index, adjustedX, adjustedY, createAsDownStreamNode, false, true));
             }
 
             var inputNodes = initialNode.InputNodes.Values.Where(x => x != null).Select(y => y.Item2);

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -25,6 +25,8 @@ namespace Dynamo.Wpf.ViewModels
         private bool isSelected;
         private SearchViewModel searchViewModel;
         private IDisposable undoRecorderGroup;
+        private int spacingBetweenNodes = 50;
+        private int spacingforHigherWidthNodes = 450;
 
         public event RequestBitmapSourceHandler RequestBitmapSource;
         public void OnRequestBitmapSource(IconRequestEventArgs e)
@@ -275,7 +277,7 @@ namespace Dynamo.Wpf.ViewModels
             if (createAsDownStreamNode)
             {
                 // Placing the new node to the right of initial node
-                adjustedX += initialNode.Width + 50;
+                adjustedX += initialNode.Width + spacingBetweenNodes;
 
                 // Create a new node based on node creation name and connection ports
                 dynamoViewModel.ExecuteCommand(new DynamoModel.CreateAndConnectNodeCommand(id, initialNode.GUID,
@@ -284,12 +286,12 @@ namespace Dynamo.Wpf.ViewModels
             else
             {
                 // Placing the new node to the left of initial node
-                adjustedX -= initialNode.Width + 50;
+                adjustedX -= initialNode.Width + spacingBetweenNodes;
 
                 // If the new node is a slider input node, adjust the position on X-axis to compensate for higher width of the slider node.
                 if (Model.CreationName.Contains("Slider")) 
                 {
-                    adjustedX -= 450;
+                    adjustedX -= spacingforHigherWidthNodes;
                 }
 
                 // Create a new node based on node creation name and connection ports


### PR DESCRIPTION
### Purpose

This PR is to adjust the position of the new nodes that are created from Node-Autocompletion functionality. 

In the current algorithm, the X-axis position of the new node is relative to position of the port and that looks fine. But the Y-axis position of the new node was not being set relative to parent node so that is set accordingly in these changes. If the input node is a slider, we want to adjust the X-axis position(move left) to compensate for the extra width of the slider node. For all other nodes, the current algorithm works fine. 

For the output port, we need a solution to handle placement of multiple nodes as it will be hard to compute how many nodes are already connected to that port and based on that we will need to set the location of the new node. @zeusongit are you covering this part in your task?

**Before:**

https://user-images.githubusercontent.com/43763136/122878553-e24e1f80-d305-11eb-94ee-eae927662abb.mov

**After:**
![NodeAutocompletion node alignment](https://user-images.githubusercontent.com/43763136/122878604-f09c3b80-d305-11eb-99aa-74beac9105a9.gif)

 
### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit @Amoursol 

