### PR TITLE
small adjustment to package paths ui

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -723,7 +723,7 @@
                                         Header="{x:Static p:Resources.PackagePathsExpanderName}">
                                 <StackPanel Orientation="Vertical" Margin="0,6,0,0">
                                     <Label  Content="{x:Static p:Resources.PreferencesViewPackageDownloadDirectory}" 
-                                            Padding="0,5,5,5"
+                                            Padding="5,5,5,5"
                                             FontSize="13"
                                             Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                     <ComboBox Grid.Row="1" 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -728,13 +728,14 @@
                                             Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                     <ComboBox Grid.Row="1" 
                                               Width="Auto"
+                                              Margin="0,5,0,5"
                                               HorizontalAlignment="Left"
                                               ItemsSource="{Binding Path=PackagePathsForInstall}"
                                               SelectedItem="{Binding Path=SelectedPackagePathForInstall}"
                                               Style="{StaticResource NoBordersComboBoxStyle}"
                                               ToolTip="{Binding Path=SelectedPackagePathForInstall}">
                                     </ComboBox>
-                                    <ScrollViewer Height="250" VerticalScrollBarVisibility="Auto">
+                                    <ScrollViewer Height="200" VerticalScrollBarVisibility="Auto">
                                         <packagemanager:PackagePathView DataContext="{Binding PackagePathsViewModel}"/>
                                     </ScrollViewer>
                                 </StackPanel>


### PR DESCRIPTION
### Purpose

after both the package search paths and package download dropdown PRs were merged I noticed some small issues:

before:
![Screen Shot 2021-06-23 at 4 44 48 PM](https://user-images.githubusercontent.com/508936/123165828-b2586680-d442-11eb-91a6-16bf84ceee9d.png)

after:
![Screen Shot 2021-06-23 at 5 00 44 PM](https://user-images.githubusercontent.com/508936/123167540-acfc1b80-d444-11eb-84ed-8608cd0cc8f0.png)


* giving some margin to the combo box
* shrinking the srcrollviewer so it does not push the other expander off screen.
* align subtitles

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
