### PR TITLE
fix crash when entire line of python code is removed during migration

### DIFF
--- a/src/PythonMigrationViewExtension/Differ/RichTextBoxHandler.cs
+++ b/src/PythonMigrationViewExtension/Differ/RichTextBoxHandler.cs
@@ -57,6 +57,8 @@ namespace Dynamo.PythonMigration.Differ
                     case ChangeType.Deleted:
                         paragraphs.Add(ShowSubPieceDiffs(line, true));
                         break;
+                    case ChangeType.Imaginary:
+                        break;
                     case ChangeType.Modified:
                         paragraphs.Add(ShowSubPieceDiffs(line, isBeforePanel));
                         break;


### PR DESCRIPTION

### Purpose

fix crash reported in:
https://github.com/DynamoDS/Dynamo/issues/11712

![Screen Shot 2021-06-25 at 5 08 33 PM](https://user-images.githubusercontent.com/508936/123485547-51fb2d80-d5d8-11eb-88a4-6d9e6f7e9d78.png)

see last line of migrator is completely removed generating an `imaginary line change`

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


