### PR TITLE
DYN-3628: Refactor package paths to account for standard library

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -163,7 +163,14 @@ namespace Dynamo.Core
 
         public string DefaultUserDefinitions
         {
-            get { return TransformPath(RootDirectories.First(), DefinitionsDirectoryName); }
+            get 
+            {
+                if (Preferences is PreferenceSettings preferences)
+                {
+                    return TransformPath(preferences.SelectedPackagePathForInstall, DefinitionsDirectoryName);
+                }
+                return TransformPath(RootDirectories.First(), DefinitionsDirectoryName); 
+            }
         }
 
         public IEnumerable<string> DefinitionDirectories

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -95,7 +95,39 @@ namespace Dynamo.Core
 
         private IEnumerable<string> RootDirectories
         {
-            get { return Preferences != null ? Preferences.CustomPackageFolders.Where(path => path != DynamoModel.StandardLibraryToken) : rootDirectories; }
+            get 
+            { 
+                return Preferences != null ? 
+                    Preferences.CustomPackageFolders.Select(path => path == DynamoModel.StandardLibraryToken ? StandardLibraryDirectory : path) 
+                    : rootDirectories;
+            }
+        }
+
+        private const string stdLibName = @"Standard Library";
+        private string stdLibDirectory = null;
+
+        //Todo in Dynamo 3.0, Add this to the IPathManager interface
+        /// <summary>
+        /// The standard library directory is located in the same directory as the DynamoCore.dll
+        /// Property should only be set during testing.
+        /// </summary>
+        internal string StandardLibraryDirectory
+        {
+            get
+            {
+                if (stdLibDirectory == null)
+                {
+                    stdLibDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(GetType()).Location), stdLibName, @"Packages");
+                }
+                return stdLibDirectory;
+            }
+            set
+            {
+                if (stdLibDirectory != value)
+                {
+                    stdLibDirectory = value;
+                }
+            }
         }
 
         //Todo in Dynamo 3.0, Add this to the IPathManager interface

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -372,7 +372,8 @@ namespace Dynamo.Configuration
         /// will be installed. The default package path for install is the user data directory
         /// currently used by the Dynamo environment.
         /// </summary>
-        public string SelectedPackagePathForInstall {
+        public string SelectedPackagePathForInstall 
+        {
             get
             {
                 if (string.IsNullOrEmpty(selectedPackagePathForInstall))

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -319,9 +319,6 @@ namespace Dynamo.ViewModels
                 if (preferenceSettings.SelectedPackagePathForInstall != value)
                 {
                     preferenceSettings.SelectedPackagePathForInstall = value;
-                    //TODO remove along with PackageLoader.DefaultPackagesDirectory and PackageLoader.DefaultPackagesDirectoryIndex
-                    dynamoViewModel.PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.SetPackagesDownloadDirectory(
-                        value, dynamoViewModel.Model.PathManager.UserDataDirectory);
                     RaisePropertyChanged(nameof(SelectedPackagePathForInstall));
                 }
             }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -536,7 +536,8 @@ namespace Dynamo.ViewModels
                 {
                     if (localPkg == null) continue;
 
-                    if (localPkg.RootDirectory.Contains(pmExt.PackageLoader.StandardLibraryDirectory))
+                    if (DynamoViewModel.Model.PathManager is PathManager pathManager && 
+                        localPkg.RootDirectory.Contains(pathManager.StandardLibraryDirectory))
                     {
                         stdLibPackages.Add(localPkg);
                         continue;

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -125,29 +125,32 @@ namespace Dynamo.PackageManager
 
         private readonly List<string> packagesDirectoriesToVerifyCertificates = new List<string>();
 
-        private string stdLibDirectory = null;
+        private readonly IPathManager pathManager;
+
+        //private string stdLibDirectory = null;
 
         /// <summary>
         /// The standard library directory is located in the same directory as the DynamoPackages.dll
         /// Property should only be set during testing.
         /// </summary>
-        internal string StandardLibraryDirectory
-        {
-            get
-            {
-                return stdLibDirectory == null ?
-                    Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(GetType()).Location),stdLibName, @"Packages")
-                    : stdLibDirectory;
-            }
-            set
-            {
-                if (stdLibDirectory != value)
-                {
-                    stdLibDirectory = value;
-                }
-            }
-        }
+        //internal string StandardLibraryDirectory
+        //{
+        //    get
+        //    {
+        //        return stdLibDirectory == null ?
+        //            Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(GetType()).Location),stdLibName, @"Packages")
+        //            : stdLibDirectory;
+        //    }
+        //    set
+        //    {
+        //        if (stdLibDirectory != value)
+        //        {
+        //            stdLibDirectory = value;
+        //        }
+        //    }
+        //}
 
+        [Obsolete]
         public PackageLoader(string overridePackageDirectory)
             : this(new[] { overridePackageDirectory })
         {
@@ -161,16 +164,25 @@ namespace Dynamo.PackageManager
         internal PackageLoader(IEnumerable<string> packagesDirectories, string stdLibDirectory)
         {
             InitPackageLoader(packagesDirectories, stdLibDirectory);
-
-            //override the property.
-            this.StandardLibraryDirectory = stdLibDirectory;
         }
-
+        [Obsolete]
         public PackageLoader(IEnumerable<string> packagesDirectories)
         {
-            InitPackageLoader(packagesDirectories, StandardLibraryDirectory);
+            InitPackageLoader(packagesDirectories, null);
         }
 
+        internal PackageLoader(IPathManager pathManager)
+        {
+            this.pathManager = pathManager;
+            InitPackageLoader(pathManager.PackagesDirectories, (pathManager as PathManager)?.StandardLibraryDirectory);
+
+            if (!string.IsNullOrEmpty(pathManager.CommonDataDirectory))
+            {
+                packagesDirectoriesToVerifyCertificates.Add(pathManager.CommonDataDirectory);
+            }
+        }
+
+        [Obsolete]
         /// <summary>
         /// Initialize a new instance of PackageLoader class
         /// </summary>
@@ -446,7 +458,7 @@ namespace Dynamo.PackageManager
                     &&
                     //if this directory is the standard library location
                     //and loading from there is disabled, don't scan the directory.
-                    ((disablePrefs.DisableStandardLibrary && packagesDirectory == StandardLibraryDirectory)
+                    ((disablePrefs.DisableStandardLibrary && packagesDirectory == (pathManager as PathManager)?.StandardLibraryDirectory)
                     //or if custom package directories are disabled, and this is a custom package directory, don't scan.
                     || (disablePrefs.DisableCustomPackageLocations && preferences.CustomPackageFolders.Contains(packagesDirectory))))
                 {
@@ -490,14 +502,14 @@ namespace Dynamo.PackageManager
                     // verify if the package directory requires certificate verifications
                     // This is done by default for the package directory defined in PathManager common directory location.
                     var checkCertificates = false;
-                    foreach (var pathToVerifyCert in packagesDirectoriesToVerifyCertificates)
-                    {
-                        if (root.Contains(pathToVerifyCert))
-                        {
-                            checkCertificates = true;
-                            break;
-                        }
-                    }
+                    //foreach (var pathToVerifyCert in packagesDirectoriesToVerifyCertificates)
+                    //{
+                    //    if (root.Contains(pathToVerifyCert))
+                    //    {
+                    //        checkCertificates = true;
+                    //        break;
+                    //    }
+                    //}
 
                     var pkg = ScanPackageDirectory(dir, checkCertificates);
                     if (pkg != null && preferences.PackageDirectoriesToUninstall.Contains(dir))

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -182,7 +182,7 @@ namespace Dynamo.PackageManager
             this.packagesDirectories.AddRange(packagesDirectories);
 
             // Setup standard library
-            var standardLibraryIndex = this.packagesDirectories.IndexOf(DynamoModel.StandardLibraryToken);
+            var standardLibraryIndex = this.packagesDirectories.IndexOf(stdLibDirectory);
             if (standardLibraryIndex == -1)
             {
                 // No standard library in list

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -73,9 +73,6 @@ namespace Dynamo.PackageManager
 
         private readonly List<string> packagesDirectories = new List<string>();
 
-        //TODO remove.
-        private int defaultPackagesDirectoryIndex = -1;
-        //TODO this should get DefaultPackagesDirectoryFrom PathManager directly.
         /// <summary>
         /// Returns the default package directory where new packages will be installed
         /// This is the first non standard library directory
@@ -85,7 +82,7 @@ namespace Dynamo.PackageManager
         [Obsolete("This property is redundant, please use the PathManager.DefaultPackagesDirectory property instead.")]
         public string DefaultPackagesDirectory
         {
-            get { return defaultPackagesDirectoryIndex != -1 ? packagesDirectories[defaultPackagesDirectoryIndex] : null; }
+            get { return pathManager.DefaultPackagesDirectory; }
         }
 
         /// <summary>
@@ -114,13 +111,6 @@ namespace Dynamo.PackageManager
             catch (UnauthorizedAccessException) { }
 
             return root;
-        }
-
-        //TODO remove when removing DefaultPackagesDirectory and DefaultPackagesDirectoryIndex
-        internal void SetPackagesDownloadDirectory(string downloadDirectory, string userDataFolder)
-        {
-            defaultPackagesDirectoryIndex = packagesDirectories.IndexOf(
-                TransformPath(downloadDirectory, userDataFolder, PathManager.PackagesDirectoryName));
         }
 
         private readonly List<string> packagesDirectoriesToVerifyCertificates = new List<string>();
@@ -207,18 +197,6 @@ namespace Dynamo.PackageManager
                 // Replace token with runtime library location
                 this.packagesDirectories[standardLibraryIndex] = stdLibDirectory;
             }
-
-            // Setup Default Package Directory
-            if (standardLibraryIndex == -1)
-            {
-                defaultPackagesDirectoryIndex = this.packagesDirectories.Count > 1 ? 1 : -1;
-            }
-            else
-            {
-                var safeIndex = this.packagesDirectories.Count > 1 ? 1 : -1;
-                defaultPackagesDirectoryIndex = standardLibraryIndex == 1 ? 0 : safeIndex;
-            }
-
             packagesDirectoriesToVerifyCertificates.Add(stdLibDirectory);
         }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -181,6 +181,8 @@ namespace Dynamo.PackageManager
 
             this.packagesDirectories.AddRange(packagesDirectories);
 
+            if (stdLibDirectory == null) return;
+
             // Setup standard library
             var standardLibraryIndex = this.packagesDirectories.IndexOf(stdLibDirectory);
             if (standardLibraryIndex == -1)

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -127,29 +127,6 @@ namespace Dynamo.PackageManager
 
         private readonly IPathManager pathManager;
 
-        //private string stdLibDirectory = null;
-
-        /// <summary>
-        /// The standard library directory is located in the same directory as the DynamoPackages.dll
-        /// Property should only be set during testing.
-        /// </summary>
-        //internal string StandardLibraryDirectory
-        //{
-        //    get
-        //    {
-        //        return stdLibDirectory == null ?
-        //            Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(GetType()).Location),stdLibName, @"Packages")
-        //            : stdLibDirectory;
-        //    }
-        //    set
-        //    {
-        //        if (stdLibDirectory != value)
-        //        {
-        //            stdLibDirectory = value;
-        //        }
-        //    }
-        //}
-
         [Obsolete]
         public PackageLoader(string overridePackageDirectory)
             : this(new[] { overridePackageDirectory })
@@ -502,14 +479,14 @@ namespace Dynamo.PackageManager
                     // verify if the package directory requires certificate verifications
                     // This is done by default for the package directory defined in PathManager common directory location.
                     var checkCertificates = false;
-                    //foreach (var pathToVerifyCert in packagesDirectoriesToVerifyCertificates)
-                    //{
-                    //    if (root.Contains(pathToVerifyCert))
-                    //    {
-                    //        checkCertificates = true;
-                    //        break;
-                    //    }
-                    //}
+                    foreach (var pathToVerifyCert in packagesDirectoriesToVerifyCertificates)
+                    {
+                        if (root.Contains(pathToVerifyCert))
+                        {
+                            checkCertificates = true;
+                            break;
+                        }
+                    }
 
                     var pkg = ScanPackageDirectory(dir, checkCertificates);
                     if (pkg != null && preferences.PackageDirectoriesToUninstall.Contains(dir))

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -127,7 +127,11 @@ namespace Dynamo.PackageManager
 
         private readonly IPathManager pathManager;
 
-        [Obsolete]
+        [Obsolete("This constructor will be removed in Dynamo 3.0 and should not be used any longer. If used, it should be passed parameters from PathManager properties.")]
+        /// <summary>
+        /// This constructor is currently being used for testing and these tests should be updated to use 
+        /// another constructor when this is obsoleted.
+        /// </summary>
         public PackageLoader(string overridePackageDirectory)
             : this(new[] { overridePackageDirectory })
         {
@@ -142,7 +146,12 @@ namespace Dynamo.PackageManager
         {
             InitPackageLoader(packagesDirectories, stdLibDirectory);
         }
-        [Obsolete]
+
+        [Obsolete("This constructor will be removed in Dynamo 3.0 and should not be used any longer. If used, it should be passed parameters from PathManager properties.")]
+        /// <summary>
+        /// This constructor is currently being used by other constructors that have also been deprecated and by tests,
+        /// which should be updated to use another constructor when this is obsoleted.
+        /// </summary>
         public PackageLoader(IEnumerable<string> packagesDirectories)
         {
             InitPackageLoader(packagesDirectories, null);
@@ -159,9 +168,11 @@ namespace Dynamo.PackageManager
             }
         }
 
-        [Obsolete]
+        [Obsolete("This constructor will be removed in Dynamo 3.0 and should not be used any longer. If used, it should be passed parameters from PathManager properties.")]
         /// <summary>
-        /// Initialize a new instance of PackageLoader class
+        /// Initialize a new instance of PackageLoader class.
+        /// This constructor is currently being used for testing and these tests should be updated to use 
+        /// another constructor when this is obsoleted.
         /// </summary>
         /// <param name="packagesDirectories">Default package directories</param>
         /// <param name="packageDirectoriesToVerify">Default package directories where node library files require certificate verification before loading</param>

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -131,8 +131,8 @@ namespace Dynamo.PackageManager
                 throw new ArgumentException("Incorrectly formatted URL provided for Package Manager address.", "url");
             }
 
-            //Initialize the PackageLoader with the CommonDataDirectory so that packages found here are checked first for dll's with signed certificates
-            //PackageLoader = new PackageLoader(startupParams.PathManager.PackagesDirectories, new [] {startupParams.PathManager.CommonDataDirectory});
+            // Initialize the PackageLoader with the PathManager so that packages found in its common data directory
+            // are checked first for dll's with signed certificates.
             PackageLoader = new PackageLoader(startupParams.PathManager);
             PackageLoader.MessageLogged += OnMessageLogged;
             PackageLoader.PackgeLoaded += OnPackageLoaded;

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -131,8 +131,6 @@ namespace Dynamo.PackageManager
                 throw new ArgumentException("Incorrectly formatted URL provided for Package Manager address.", "url");
             }
 
-            // Initialize the PackageLoader with the PathManager so that packages found in its common data directory
-            // are checked first for dll's with signed certificates.
             PackageLoader = new PackageLoader(startupParams.PathManager);
             PackageLoader.MessageLogged += OnMessageLogged;
             PackageLoader.PackgeLoaded += OnPackageLoaded;

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -132,7 +132,8 @@ namespace Dynamo.PackageManager
             }
 
             //Initialize the PackageLoader with the CommonDataDirectory so that packages found here are checked first for dll's with signed certificates
-            PackageLoader = new PackageLoader(startupParams.PathManager.PackagesDirectories, new [] {startupParams.PathManager.CommonDataDirectory});
+            //PackageLoader = new PackageLoader(startupParams.PathManager.PackagesDirectories, new [] {startupParams.PathManager.CommonDataDirectory});
+            PackageLoader = new PackageLoader(startupParams.PathManager);
             PackageLoader.MessageLogged += OnMessageLogged;
             PackageLoader.PackgeLoaded += OnPackageLoaded;
             PackageLoader.PackageRemoved += OnPackageRemoved;

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -158,8 +158,10 @@ namespace DynamoCoreWpfTests
         [Description("User tries to download pacakges that might conflict with existing packages in std lib")]
         public void PackageManagerConflictsWithStdLib()
         {
+            var pathMgr = ViewModel.Model.PathManager;
             var pkgLoader = GetPackageLoader();
-            pkgLoader.StandardLibraryDirectory = StandardLibraryTestDirectory;
+            if(pathMgr is Dynamo.Core.PathManager pm)
+                pm.StandardLibraryDirectory = StandardLibraryTestDirectory;
 
             // Load a std lib package
             var stdPackageLocation = Path.Combine(StandardLibraryTestDirectory, "SignedPackage2");

--- a/test/DynamoCoreWpfTests/PackagePathTests.cs
+++ b/test/DynamoCoreWpfTests/PackagePathTests.cs
@@ -267,14 +267,15 @@ namespace DynamoCoreWpfTests
             var setting = Model.PreferenceSettings;
             var loader = Model.GetPackageManagerExtension().PackageLoader;
 
-            var appDataFolder = Path.Combine(GetAppDataFolder());
-            Assert.AreEqual(3, ViewModel.Model.PathManager.PackagesDirectories.Count());
+            var appDataFolder = GetAppDataFolder();
+            Assert.AreEqual(4, ViewModel.Model.PathManager.PackagesDirectories.Count());
             Assert.AreEqual(4, setting.CustomPackageFolders.Count);
-            Assert.AreEqual(Path.Combine(appDataFolder, PathManager.PackagesDirectoryName), ViewModel.Model.PathManager.DefaultPackagesDirectory);
+            var appDataPackagesDir = Path.Combine(appDataFolder, PathManager.PackagesDirectoryName);
+            Assert.AreEqual(appDataPackagesDir, ViewModel.Model.PathManager.DefaultPackagesDirectory);
             Assert.AreEqual(appDataFolder, setting.SelectedPackagePathForInstall);
             //TODO this is incorrect, but this property has been obsoleted and will be made correct after refactoring pathmanager and packageloader.
             //this should be changed to Assert.AreEqual after refactor.
-            Assert.AreNotEqual(Path.Combine(appDataFolder, PathManager.PackagesDirectoryName), loader.DefaultPackagesDirectory);
+            Assert.AreNotEqual(appDataPackagesDir, loader.DefaultPackagesDirectory);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/PackagePathTests.cs
+++ b/test/DynamoCoreWpfTests/PackagePathTests.cs
@@ -273,9 +273,6 @@ namespace DynamoCoreWpfTests
             var appDataPackagesDir = Path.Combine(appDataFolder, PathManager.PackagesDirectoryName);
             Assert.AreEqual(appDataPackagesDir, ViewModel.Model.PathManager.DefaultPackagesDirectory);
             Assert.AreEqual(appDataFolder, setting.SelectedPackagePathForInstall);
-            //TODO this is incorrect, but this property has been obsoleted and will be made correct after refactoring pathmanager and packageloader.
-            //this should be changed to Assert.AreEqual after refactor.
-            Assert.AreNotEqual(appDataPackagesDir, loader.DefaultPackagesDirectory);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
@@ -20,8 +20,8 @@ namespace DynamoCoreWpfTests
             // This setter also affects the default package directory of the PackageLoader.
             preferencesVM.SelectedPackagePathForInstall = Path.GetTempPath();
 
-            var packageLoader = ViewModel.PackageManagerClientViewModel.PackageManagerExtension.PackageLoader;
-            Assert.Null(packageLoader.DefaultPackagesDirectory);
+            var pathManager = ViewModel.Model.PathManager;
+            Assert.AreEqual(Path.GetTempPath(), pathManager.DefaultPackagesDirectory);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -980,7 +980,7 @@ namespace DynamoCoreWpfTests
             new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode2.InPorts.FirstOrDefault(), Guid.NewGuid());
 
 
-            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefinitionDirectories.FirstOrDefault(), "NewCustomNodeSaveAndLoad.dyf");
+            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefaultUserDefinitions, "NewCustomNodeSaveAndLoad.dyf");
             //save it to the definitions folder so it gets loaded at startup.
             ws.Save(savePath);
 
@@ -1006,7 +1006,7 @@ namespace DynamoCoreWpfTests
             Assert.NotNull(nodeingraph);
             Assert.IsTrue(nodeingraph.State == ElementState.Active);
             //remove custom node from definitions folder
-            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefinitionDirectories.FirstOrDefault(), "NewCustomNodeSaveAndLoad.dyf");
+            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefaultUserDefinitions, "NewCustomNodeSaveAndLoad.dyf");
             File.Delete(savePath);
 
         }

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -510,7 +510,8 @@ namespace Dynamo.Tests
                 count++;
                 Assert.AreEqual(count, (GetModel().CurrentWorkspace as HomeWorkspaceModel).EvaluationCount);
 
-                AssertPreviewCount(guid, 2);
+                // Python script returns list of paths contained in PathManager.PackageDirectories
+                AssertPreviewCount(guid, 3);
             }
         }
 

--- a/test/Libraries/PackageManagerTests/PackageLoaderCustomTest.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderCustomTest.cs
@@ -38,9 +38,6 @@ namespace Dynamo.PackageManager.Tests
         {
             var loader = GetPackageLoader();
             
-            Assert.AreEqual(loader.DefaultPackagesDirectory,
-                Path.Combine(TestDirectory, "pkgs", "multiple_locations", "folder1", "packages"));
-
             var expectedLoadedPackageNum = 0;
             foreach(var pkg in loader.LocalPackages)
             {

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -716,7 +716,8 @@ namespace Dynamo.PackageManager.Tests
         {
 
             //setup clean loader
-            var loader = new PackageLoader(new string[0], StandardLibraryTestDirectory);
+            (CurrentDynamoModel.PathManager as PathManager).StandardLibraryDirectory = StandardLibraryTestDirectory;
+            var loader = new PackageLoader(CurrentDynamoModel.PathManager);
             var settings = new PreferenceSettings();
             settings.DisableStandardLibrary = true;
 
@@ -889,8 +890,9 @@ namespace Dynamo.PackageManager.Tests
 
             // Assert
             Assert.AreNotEqual(@"%StandardLibrary%", defaultPackageDirectory);
-            Assert.AreEqual(2, packageDirectories.Count());
+            Assert.AreEqual(3, packageDirectories.Count());
             Assert.IsFalse(packageDirectories.Contains(@"%StandardLibrary%"));
+            Assert.IsTrue(packageDirectories.Contains((pathManager as PathManager).StandardLibraryDirectory));
             Assert.AreNotEqual(@"%StandardLibrary%", defaultUserDefinitions);
             Assert.AreEqual(2, userDefinitions.Count());
             Assert.IsFalse(userDefinitions.Contains(@"%StandardLibrary%"));

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -639,56 +639,20 @@ namespace Dynamo.PackageManager.Tests
         public void HasValidStandardLibraryAndDefaultPackagesPath()
         {
             // Arrange
-            var loader = new PackageLoader(new[] { PackagesDirectory }, new[] { PackagesDirectorySigned });
-            var directory = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(loader.GetType()).Location),
+            var pathManager = CurrentDynamoModel.PathManager as PathManager;
+            var directory = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(pathManager.GetType()).Location),
                 @"Standard Library", @"Packages");
 
             // Act
-            var pathManager = CurrentDynamoModel.PathManager as PathManager;
             var standardDirectory = pathManager.StandardLibraryDirectory;
-            var defaultDirectory = loader.DefaultPackagesDirectory;
+            var defaultDirectory = pathManager.DefaultPackagesDirectory;
 
             // Assert
             Assert.IsNotNullOrEmpty(standardDirectory);
             Assert.AreEqual(standardDirectory, directory);
             Assert.AreNotEqual(defaultDirectory, directory);
         }
-        [Test]
-        public void HasValidStandardLibraryAndDefaultPackagesPathWhenStandardLibraryTokenIsAddedFirst()
-        {
-            // Arrange
-            var loader = new PackageLoader(new[] { DynamoModel.StandardLibraryToken, PackagesDirectory }, new[] { PackagesDirectorySigned });
-            var directory = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(loader.GetType()).Location),
-                @"Standard Library", @"Packages");
 
-            // Act
-            var pathManager = CurrentDynamoModel.PathManager as PathManager;
-            var standardDirectory = pathManager.StandardLibraryDirectory;
-            var defaultDirectory = loader.DefaultPackagesDirectory;
-
-            // Assert
-            Assert.IsNotNullOrEmpty(standardDirectory);
-            Assert.AreEqual(standardDirectory, directory);
-            Assert.AreNotEqual(defaultDirectory, directory);
-        }
-        [Test]
-        public void HasValidStandardLibraryAndDefaultPackagesPathWhenStandardLibraryTokenIsAddedLast()
-        {
-            // Arrange
-            var loader = new PackageLoader(new[] { PackagesDirectory, DynamoModel.StandardLibraryToken }, new[] { PackagesDirectorySigned });
-            var directory = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(loader.GetType()).Location),
-                @"Standard Library", @"Packages");
-
-            // Act
-            var pathManager = CurrentDynamoModel.PathManager as PathManager;
-            var standardDirectory = pathManager.StandardLibraryDirectory;
-            var defaultDirectory = loader.DefaultPackagesDirectory;
-
-            // Assert
-            Assert.IsNotNullOrEmpty(standardDirectory);
-            Assert.AreEqual(standardDirectory, directory);
-            Assert.AreNotEqual(defaultDirectory, directory);
-        }
         [Test]
         public void PackageInStandardLibLocationIsLoaded()
         {

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -644,7 +644,8 @@ namespace Dynamo.PackageManager.Tests
                 @"Standard Library", @"Packages");
 
             // Act
-            var standardDirectory = loader.StandardLibraryDirectory;
+            var pathManager = CurrentDynamoModel.PathManager as PathManager;
+            var standardDirectory = pathManager.StandardLibraryDirectory;
             var defaultDirectory = loader.DefaultPackagesDirectory;
 
             // Assert
@@ -661,7 +662,8 @@ namespace Dynamo.PackageManager.Tests
                 @"Standard Library", @"Packages");
 
             // Act
-            var standardDirectory = loader.StandardLibraryDirectory;
+            var pathManager = CurrentDynamoModel.PathManager as PathManager;
+            var standardDirectory = pathManager.StandardLibraryDirectory;
             var defaultDirectory = loader.DefaultPackagesDirectory;
 
             // Assert
@@ -678,7 +680,8 @@ namespace Dynamo.PackageManager.Tests
                 @"Standard Library", @"Packages");
 
             // Act
-            var standardDirectory = loader.StandardLibraryDirectory;
+            var pathManager = CurrentDynamoModel.PathManager as PathManager;
+            var standardDirectory = pathManager.StandardLibraryDirectory;
             var defaultDirectory = loader.DefaultPackagesDirectory;
 
             // Assert

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -894,8 +894,9 @@ namespace Dynamo.PackageManager.Tests
             Assert.IsFalse(packageDirectories.Contains(@"%StandardLibrary%"));
             Assert.IsTrue(packageDirectories.Contains((pathManager as PathManager).StandardLibraryDirectory));
             Assert.AreNotEqual(@"%StandardLibrary%", defaultUserDefinitions);
-            Assert.AreEqual(2, userDefinitions.Count());
+            Assert.AreEqual(3, userDefinitions.Count());
             Assert.IsFalse(userDefinitions.Contains(@"%StandardLibrary%"));
+            Assert.IsTrue(userDefinitions.Contains((pathManager as PathManager).StandardLibraryDirectory));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

- Moved `StandardLibararyDirectory` property from `PackageLoader` to `PathManager`
- Store PathManager as PackageLoader member by passing it to PackageLoader constructor

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

