### PR TITLE
DYN3806 & DYN3810: Fix GLOB bugs.

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2683,7 +2683,7 @@
                                             HorizontalAlignment="Stretch" 
                                             VerticalAlignment="Stretch">
                             <Grid Name="TabPanel" 
-                                          Width="150"
+                                          Width="165"
                                           Height="30">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="5" />

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -18,7 +18,7 @@
         WindowStyle="None"
         mc:Ignorable="d" 
         Height="474" 
-        Width="650"
+        Width="665"
         ResizeMode="NoResize">
 
     <!--Using the Styles from the SharedResourcesDictionary located in DynamoCoreWpf/UI/Themes/DynamoModern.xaml-->
@@ -434,8 +434,8 @@
                                     <Button x:Name="ReloadCPython"
                                                 Style="{StaticResource FlatButtonStyle}" 
                                                 HorizontalAlignment="Left"                                             
-                                                Width="100"
                                                 Height="25"
+                                                MinWidth="100"
                                                 Grid.Row="0"
                                                 Margin="0,10,0,10"
                                                 Click="ReloadCPython_Click"


### PR DESCRIPTION
### Purpose

This pull request does:
* Fix [DYN-3806](https://jira.autodesk.com/browse/DYN-3806) by making the preference dialog and the left column in preference dialog 15 units wider.

![image](https://user-images.githubusercontent.com/7033002/124309214-64291e80-db38-11eb-97e3-90a223a1db1b.png)
![image](https://user-images.githubusercontent.com/7033002/124309243-7014e080-db38-11eb-834a-476951587893.png)

* Fix [DYN-3810](https://jira.autodesk.com/browse/DYN-3810) by allowing the "Reset CPython" button to resize itself if it needs to be wider than 100 units.

![image](https://user-images.githubusercontent.com/7033002/124309305-8622a100-db38-11eb-8d31-45fec57cc513.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
