### PR TITLE
Package Manager: Margin and font size adjustment

### DIFF
--- a/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
@@ -138,10 +138,11 @@
 
                                         <StackPanel Margin="25,5,5,10">
 
-                                            <StackPanel Visibility="{Binding Path=HasCustomNodes, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                            <StackPanel Visibility="{Binding Path=HasCustomNodes, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                                                        Margin="0,0,0,5">
 
                                                 <Label Content="{x:Static p:Resources.InstalledPackageViewCustomNodesLabel}"
-                                                           FontSize="10"
+                                                           FontSize="11"
                                                        Padding="0,5,5,5"
                                                            Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                                 <ItemsControl Name="LoadedCustomNodes"
@@ -161,11 +162,12 @@
 
                                             </StackPanel>
 
-                                            <StackPanel Visibility="{Binding Path=HasNodeLibraries, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                            <StackPanel Visibility="{Binding Path=HasNodeLibraries, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                                                        Margin="0,0,0,5">
 
                                                 <Label Padding="0,5,5,5" Content="{x:Static p:Resources.InstalledPackageViewNodeLibrariesLabel}"
                                                            Foreground="{StaticResource PreferencesWindowFontColor}"
-                                                           FontSize="10"></Label>
+                                                           FontSize="11"></Label>
                                                 <ItemsControl Name="NodeLibraries"
                                                                       ItemsSource="{Binding Path=Model.LoadedAssemblies}"
                                                                       Background="Transparent">
@@ -192,10 +194,11 @@
                                                 </ItemsControl>
                                             </StackPanel>
 
-                                            <StackPanel Visibility="{Binding Path=HasAdditionalAssemblies, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                            <StackPanel Visibility="{Binding Path=HasAdditionalAssemblies, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                                                        Margin="0,0,0,5">
 
                                                 <Label Content="{x:Static p:Resources.InstalledPackageViewAdditionalLabel}"
-                                                           FontSize="10"
+                                                           FontSize="11"
                                                            Padding="0,5,5,5"
                                                            Foreground="{StaticResource PreferencesWindowFontColor}"></Label>
                                                 <ItemsControl Name="AddAssemblies"
@@ -225,10 +228,11 @@
 
                                             </StackPanel>
 
-                                            <StackPanel Visibility="{Binding Path=HasAdditionalFiles, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                            <StackPanel Visibility="{Binding Path=HasAdditionalFiles, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                                                        Margin="0,0,0,5">
 
                                                 <Label Content="{x:Static p:Resources.InstalledPackageViewAdditionalFileLabel}"
-                                                           FontSize="10"
+                                                           FontSize="11"
                                                        Padding="0,5,5,5"
                                                            Foreground="{StaticResource PreferencesWindowFontColor}"></Label>
                                                 <ItemsControl Name="AdditionalFiles"


### PR DESCRIPTION
### Purpose

This pull request does:
* add 5 units to the bottom of each package manager category
* increase the package manager category label font size from 10 to 11.

![image](https://user-images.githubusercontent.com/7033002/124625448-ce4d0680-de4b-11eb-8a58-f9102b25ffc6.png)
![image](https://user-images.githubusercontent.com/7033002/124625476-d60cab00-de4b-11eb-873d-cb68b79b99e1.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
