### PR TITLE
DYN-3526 : call shutdown on extensions (#11816)

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -365,6 +365,18 @@ namespace Dynamo.Models
 
             OnShutdownStarted(); // Notify possible event handlers.
 
+            foreach (var ext in ExtensionManager.Extensions)
+            {
+                try
+                {
+                    ext.Shutdown();
+                }
+                catch (Exception exc)
+                {
+                    Logger.Log($"{ext.Name} :  {exc.Message} during shutdown");
+                }
+            }
+
             PreShutdownCore(shutdownHost);
             ShutDownCore(shutdownHost);
             PostShutdownCore(shutdownHost);

--- a/src/DynamoManipulation/DynamoManipulationExtension.cs
+++ b/src/DynamoManipulation/DynamoManipulationExtension.cs
@@ -238,7 +238,7 @@ namespace Dynamo.Manipulation
 
         public void Shutdown()
         {
-            Dispose();   
+            //Dispose();   
         }
 
         #endregion

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -197,7 +197,7 @@ namespace Dynamo.PackageManager
 
         public void Shutdown()
         {
-            this.Dispose();
+            //this.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

Call shutdown for extensions and avoid calling Dispose for existing Shutdown implementations.
Until now Shutdown was not called we assume Dispose was called from somewhere else already.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang @mjkkirschner 
