### PR TITLE
DYN-3818-GuidedTours-MenuEntries

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2487,6 +2487,123 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Get Started.
+        /// </summary>
+        public static string GetStartedGuide {
+            get {
+                return ResourceManager.GetString("GetStartedGuide", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Library contains all default Dynamo nodes, and any other nodes you have loaded, such as #custom=https://primer.dynamobim.org/10_Custom-Nodes/10-1_Introduction.html nodes or #packages=https://primer.dynamobim.org/11_Packages/11-1_Introduction.html \n\nYou can browse through the node Categories, or search the library to find a node..
+        /// </summary>
+        public static string GetStartedGuideLibraryText {
+            get {
+                return ResourceManager.GetString("GetStartedGuideLibraryText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Library.
+        /// </summary>
+        public static string GetStartedGuideLibraryTitle {
+            get {
+                return ResourceManager.GetString("GetStartedGuideLibraryTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In the Preferences palette, you can customize your Dynamo experience, from language and time zone settings, to experimental features and visual styles of your workspace..
+        /// </summary>
+        public static string GetStartedGuidePreferencesText {
+            get {
+                return ResourceManager.GetString("GetStartedGuidePreferencesText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preferences.
+        /// </summary>
+        public static string GetStartedGuidePreferencesTitle {
+            get {
+                return ResourceManager.GetString("GetStartedGuidePreferencesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use the Help menu to access tools and resources to help you get started.\n\nYou can choose sample scripts, browse the Dynamo Dictionary, replay this and other tutorials, and more!.
+        /// </summary>
+        public static string GetStartedGuideResourcesText {
+            get {
+                return ResourceManager.GetString("GetStartedGuideResourcesText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resources.
+        /// </summary>
+        public static string GetStartedGuideResourcesTitle {
+            get {
+                return ResourceManager.GetString("GetStartedGuideResourcesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use the Run Status Bar to run your Dynamo graphs and choose between automatic and manual run types. \n\nSelecting Automatic means your graph will run each time you make a change, and selecting manual means your graph will only run when you select the Run button..
+        /// </summary>
+        public static string GetStartedGuideRunStatusBarText {
+            get {
+                return ResourceManager.GetString("GetStartedGuideRunStatusBarText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run Status Bar.
+        /// </summary>
+        public static string GetStartedGuideRunStatusBarTitle {
+            get {
+                return ResourceManager.GetString("GetStartedGuideRunStatusBarTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From the Toolbar, you can: -Open a new workspace- -Open a saved Dynamo file- -Save your current Dynamo file- -Undo or redo changes-.
+        /// </summary>
+        public static string GetStartedGuideToolbarText {
+            get {
+                return ResourceManager.GetString("GetStartedGuideToolbarText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toolbar.
+        /// </summary>
+        public static string GetStartedGuideToolbarTitle {
+            get {
+                return ResourceManager.GetString("GetStartedGuideToolbarTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Take a short tour to learn some basics about the Dynamo interface and features to help you get started on your visual programming journey..
+        /// </summary>
+        public static string GetStartedGuideWelcomeText {
+            get {
+                return ResourceManager.GetString("GetStartedGuideWelcomeText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Welcome To Dynamo.
+        /// </summary>
+        public static string GetStartedGuideWelcomeTitle {
+            get {
+                return ResourceManager.GetString("GetStartedGuideWelcomeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cancel and Show Issues.
         /// </summary>
         public static string GraphIssuesOnSave_CancelBtn {
@@ -2897,6 +3014,15 @@ namespace Dynamo.Wpf.Properties {
         public static string InstallMessageCaption {
             get {
                 return ResourceManager.GetString("InstallMessageCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interactive Guides.
+        /// </summary>
+        public static string InteractiveGuides {
+            get {
+                return ResourceManager.GetString("InteractiveGuides", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2448,4 +2448,48 @@ Uninstall the following packages: {0}?</value>
   <data name="PackagePathUpdatePathTooltip" xml:space="preserve">
     <value>Edit Path</value>
   </data>
+  <data name="GetStartedGuide" xml:space="preserve">
+    <value>Get Started</value>
+    <comment>Get Started Dynamo Tour</comment>
+  </data>
+  <data name="InteractiveGuides" xml:space="preserve">
+    <value>Interactive Guides</value>
+    <comment>Dynamo Guided Tours</comment>
+  </data>
+  <data name="GetStartedGuideLibraryText" xml:space="preserve">
+    <value>The Library contains all default Dynamo nodes, and any other nodes you have loaded, such as #custom=https://primer.dynamobim.org/10_Custom-Nodes/10-1_Introduction.html nodes or #packages=https://primer.dynamobim.org/11_Packages/11-1_Introduction.html \n\nYou can browse through the node Categories, or search the library to find a node.</value>
+  </data>
+  <data name="GetStartedGuideLibraryTitle" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="GetStartedGuidePreferencesText" xml:space="preserve">
+    <value>In the Preferences palette, you can customize your Dynamo experience, from language and time zone settings, to experimental features and visual styles of your workspace.</value>
+  </data>
+  <data name="GetStartedGuidePreferencesTitle" xml:space="preserve">
+    <value>Preferences</value>
+  </data>
+  <data name="GetStartedGuideResourcesText" xml:space="preserve">
+    <value>Use the Help menu to access tools and resources to help you get started.\n\nYou can choose sample scripts, browse the Dynamo Dictionary, replay this and other tutorials, and more!</value>
+  </data>
+  <data name="GetStartedGuideResourcesTitle" xml:space="preserve">
+    <value>Resources</value>
+  </data>
+  <data name="GetStartedGuideRunStatusBarText" xml:space="preserve">
+    <value>Use the Run Status Bar to run your Dynamo graphs and choose between automatic and manual run types. \n\nSelecting Automatic means your graph will run each time you make a change, and selecting manual means your graph will only run when you select the Run button.</value>
+  </data>
+  <data name="GetStartedGuideRunStatusBarTitle" xml:space="preserve">
+    <value>Run Status Bar</value>
+  </data>
+  <data name="GetStartedGuideToolbarText" xml:space="preserve">
+    <value>From the Toolbar, you can: -Open a new workspace- -Open a saved Dynamo file- -Save your current Dynamo file- -Undo or redo changes-</value>
+  </data>
+  <data name="GetStartedGuideToolbarTitle" xml:space="preserve">
+    <value>Toolbar</value>
+  </data>
+  <data name="GetStartedGuideWelcomeText" xml:space="preserve">
+    <value>Take a short tour to learn some basics about the Dynamo interface and features to help you get started on your visual programming journey.</value>
+  </data>
+  <data name="GetStartedGuideWelcomeTitle" xml:space="preserve">
+    <value>Welcome To Dynamo</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2448,4 +2448,48 @@ Uninstall the following packages: {0}?</value>
   <data name="PackagePathUpdatePathTooltip" xml:space="preserve">
     <value>Edit Path</value>
   </data>
+  <data name="GetStartedGuide" xml:space="preserve">
+    <value>Get Started</value>
+    <comment>Get Started Dynamo Tour</comment>
+  </data>
+  <data name="InteractiveGuides" xml:space="preserve">
+    <value>Interactive Guides</value>
+    <comment>Dynamo Guided Tours</comment>
+  </data>
+  <data name="GetStartedGuideLibraryText" xml:space="preserve">
+    <value>The Library contains all default Dynamo nodes, and any other nodes you have loaded, such as #custom=https://primer.dynamobim.org/10_Custom-Nodes/10-1_Introduction.html nodes or #packages=https://primer.dynamobim.org/11_Packages/11-1_Introduction.html \n\nYou can browse through the node Categories, or search the library to find a node.</value>
+  </data>
+  <data name="GetStartedGuideLibraryTitle" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="GetStartedGuidePreferencesText" xml:space="preserve">
+    <value>In the Preferences palette, you can customize your Dynamo experience, from language and time zone settings, to experimental features and visual styles of your workspace.</value>
+  </data>
+  <data name="GetStartedGuidePreferencesTitle" xml:space="preserve">
+    <value>Preferences</value>
+  </data>
+  <data name="GetStartedGuideResourcesText" xml:space="preserve">
+    <value>Use the Help menu to access tools and resources to help you get started.\n\nYou can choose sample scripts, browse the Dynamo Dictionary, replay this and other tutorials, and more!</value>
+  </data>
+  <data name="GetStartedGuideResourcesTitle" xml:space="preserve">
+    <value>Resources</value>
+  </data>
+  <data name="GetStartedGuideRunStatusBarText" xml:space="preserve">
+    <value>Use the Run Status Bar to run your Dynamo graphs and choose between automatic and manual run types. \n\nSelecting Automatic means your graph will run each time you make a change, and selecting manual means your graph will only run when you select the Run button.</value>
+  </data>
+  <data name="GetStartedGuideRunStatusBarTitle" xml:space="preserve">
+    <value>Run Status Bar</value>
+  </data>
+  <data name="GetStartedGuideToolbarText" xml:space="preserve">
+    <value>From the Toolbar, you can: -Open a new workspace- -Open a saved Dynamo file- -Save your current Dynamo file- -Undo or redo changes-</value>
+  </data>
+  <data name="GetStartedGuideToolbarTitle" xml:space="preserve">
+    <value>Toolbar</value>
+  </data>
+  <data name="GetStartedGuideWelcomeText" xml:space="preserve">
+    <value>Take a short tour to learn some basics about the Dynamo interface and features to help you get started on your visual programming journey.</value>
+  </data>
+  <data name="GetStartedGuideWelcomeTitle" xml:space="preserve">
+    <value>Welcome To Dynamo</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -112,6 +112,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
     public class Content
     {
+        #region Private Fields
+        private string formattedText;
+        #endregion
+
+        #region Public Properties
         /// <summary>
         /// Title of the Popup shown at the top-center
         /// </summary>
@@ -120,6 +125,18 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// The content of the Popup using a specific format for showing text, hyperlinks,images, bullet points in a RichTextBox
         /// </summary>
-        public string FormattedText { get; set; }
+        public string FormattedText 
+        { 
+            get
+            {
+                return formattedText;
+            }
+            set
+            {
+                //Because we are reading the value from a Resource, the \n is converted to char escaped and we need to replace it by the special char
+                formattedText = value.Replace("\\n", Environment.NewLine);
+            }
+        }
+        #endregion
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -623,6 +623,15 @@
                                   Header="{x:Static p:Resources.StartPageWhatsNew}"
                                   Command="{Binding ShowGalleryCommand}">
                         </MenuItem>
+                        <MenuItem x:Name="InteractiveGuidesMenuItem"
+                                  Focusable="False"
+                                  Header="{x:Static p:Resources.InteractiveGuides}">
+                            <MenuItem x:Name="GetStartedMenuItem"
+                                      Focusable="False"
+                                      Header="{x:Static p:Resources.GetStartedGuide}"
+                                      Click="GetStartedMenuItem_Click">
+                            </MenuItem>
+                        </MenuItem>
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewHepMenuSamples}"
                                   Name="SamplesMenu"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -38,6 +38,7 @@ using Dynamo.Wpf;
 using Dynamo.Wpf.Authentication;
 using Dynamo.Wpf.Controls;
 using Dynamo.Wpf.Extensions;
+using Dynamo.Wpf.UI.GuidedTour;
 using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels.Core;
 using Dynamo.Wpf.Views;
@@ -47,6 +48,7 @@ using Dynamo.Wpf.Views.PackageManager;
 using Dynamo.Wpf.Windows;
 using HelixToolkit.Wpf.SharpDX;
 using ResourceNames = Dynamo.Wpf.Interfaces.ResourceNames;
+using Res = Dynamo.Wpf.Properties.Resources;
 using String = System.String;
 
 namespace Dynamo.Controls
@@ -2320,6 +2322,143 @@ namespace Dynamo.Controls
             {
                 HidePopupWhenWindowDeactivated();
             }
+        }
+
+        private void GetStartedMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            ShowGetStartedGuidedTour();
+        }
+
+        /// <summary>
+        /// This method probably will be modified or deleted in the future when the GuideManager and Guide class are created
+        /// For now will be used just for testing/demo purposes since the popups will be created probably in the Guide class.
+        /// </summary>
+        private void ShowGetStartedGuidedTour()
+        {
+
+            Step.TotalSteps = 6;
+
+            //Welcome Popup
+            var hostPopupInfo = new HostControlInfo()
+            {
+                HostClass = string.Empty,
+                PopupPlacement = PlacementMode.Center,
+                HostUIElement = WorkspaceTabs,
+                VerticalPopupOffSet = 0,
+                HorizontalPopupOffSet = 0
+            };
+
+            var customWelcome = new Welcome(hostPopupInfo, 480, 180)
+            {
+                Sequence = 0,
+                StepContent = new Content()
+                {
+                    Title = Res.GetStartedGuideWelcomeTitle,
+                    FormattedText = Res.GetStartedGuideWelcomeText
+                }
+            };
+            customWelcome.Show();
+
+            //Library Popup
+            var libraryPopupInfo = new HostControlInfo()
+            {
+                HostClass = string.Empty,
+                PopupPlacement = PlacementMode.Right,
+                HostUIElement = sidebarGrid,
+                VerticalPopupOffSet = 250,
+                HorizontalPopupOffSet = 0
+            };
+
+            var customTooltip = new Tooltip(libraryPopupInfo, 480, 250, Step.PointerDirection.BOTTOM_LEFT)
+            {
+                Sequence = 1,
+                StepContent = new Content()
+                {
+                    Title = Res.GetStartedGuideLibraryTitle,        
+                    FormattedText = Res.GetStartedGuideLibraryText
+                }
+            };
+            customTooltip.Show();
+
+            //Run Status Bar Popup
+            var runStatusPopupInfo = new HostControlInfo()
+            {
+                HostClass = string.Empty,
+                PopupPlacement = PlacementMode.Center,
+                HostUIElement = WorkspaceTabs,
+                VerticalPopupOffSet = 300,
+                HorizontalPopupOffSet = 100
+            };
+            var runStatusTooltip = new Tooltip(runStatusPopupInfo, 480, 250, Step.PointerDirection.BOTTOM_LEFT)
+            {
+                Sequence = 2,
+                StepContent = new Content()
+                {
+                    Title = Res.GetStartedGuideRunStatusBarTitle,
+                    FormattedText = Res.GetStartedGuideRunStatusBarText
+                }
+            };
+            runStatusTooltip.Show();
+
+            //Toolbar Popup
+            var toolbarPopupInfo = new HostControlInfo()
+            {
+                HostClass = string.Empty,
+                PopupPlacement = PlacementMode.Right,
+                HostUIElement = sidebarGrid,
+                VerticalPopupOffSet = 50,
+                HorizontalPopupOffSet = 500
+            };
+            var toolbarTooltip = new Tooltip(toolbarPopupInfo, 480, 250, Step.PointerDirection.TOP_LEFT)
+            {
+                Sequence = 3,
+                StepContent = new Content()
+                {
+                    Title = Res.GetStartedGuideToolbarTitle,
+                    FormattedText = Res.GetStartedGuideToolbarText
+                }
+            };
+            toolbarTooltip.Show();
+
+            //Preferences Popup
+            var preferencesPopupInfo = new HostControlInfo()
+            {
+                HostClass = string.Empty,
+                PopupPlacement = PlacementMode.Right,
+                HostUIElement = dynamoMenu,
+                VerticalPopupOffSet = 0,
+                HorizontalPopupOffSet = 0
+            };
+            var preferencesTooltip = new Tooltip(preferencesPopupInfo, 480, 190, Step.PointerDirection.TOP_LEFT)
+            {
+                Sequence = 4,
+                StepContent = new Content()
+                {
+                    Title = Res.GetStartedGuidePreferencesTitle,
+                    FormattedText = Res.GetStartedGuidePreferencesText
+                }
+            };
+            preferencesTooltip.Show();
+
+            //Resources Popup
+            var resourcesPopupInfo = new HostControlInfo()
+            {
+                HostClass = string.Empty,
+                PopupPlacement = PlacementMode.Right,
+                HostUIElement = ExtensionsMenu,
+                VerticalPopupOffSet = 150,
+                HorizontalPopupOffSet = 750
+            };
+            var resourcesTooltip = new Tooltip(resourcesPopupInfo, 480, 230, Step.PointerDirection.BOTTOM_RIGHT)
+            {
+                Sequence = 5,
+                StepContent = new Content()
+                {
+                    Title = Res.GetStartedGuideResourcesTitle,
+                    FormattedText = Res.GetStartedGuideResourcesText
+                }
+            };
+            resourcesTooltip.Show();
         }
 
         public void Dispose()


### PR DESCRIPTION
### Purpose

I added the "Get Started" submenu and the InteractiveGuide MenuItem, so we can show the Get Started popups.
Also in the DynamoView.xaml.cs I added the code needed for creating most of the popups for the GetStarted tour (the content of the popup is read from the Resources file, that's why I added several entries in the resources).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

