### PR TITLE
DYN-3814 & DYN-3822: Fix the event handler for the Root Locations Collection Change event.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -779,8 +779,6 @@ namespace Dynamo.ViewModels
             var packageLoader = dynamoViewModel.Model.GetPackageManagerExtension()?.PackageLoader;            
             PackagePathsViewModel = new PackagePathViewModel(packageLoader, loadPackagesParams, customNodeManager);
 
-            PackagePathsViewModel.RootLocations.CollectionChanged += PackagePathsViewModel_RootLocations_CollectionChanged;
-
             PropertyChanged += Model_PropertyChanged;
         }
 
@@ -790,7 +788,6 @@ namespace Dynamo.ViewModels
         internal virtual void UnsubscribeAllEvents()
         {
             PropertyChanged -= Model_PropertyChanged;
-            PackagePathsViewModel.RootLocations.CollectionChanged -= PackagePathsViewModel_RootLocations_CollectionChanged;
         }
 
 
@@ -844,6 +841,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void CommitPackagePathsForInstall()
         {
+            PackagePathsViewModel.RootLocations.CollectionChanged -= PackagePathsViewModel_RootLocations_CollectionChanged;
             preferenceSettings.SelectedPackagePathForInstall = SelectedPackagePathForInstall;
         }
 
@@ -854,6 +852,7 @@ namespace Dynamo.ViewModels
         {
             PackagePathsForInstall = null;
             SelectedPackagePathForInstall = preferenceSettings.SelectedPackagePathForInstall;
+            PackagePathsViewModel.RootLocations.CollectionChanged += PackagePathsViewModel_RootLocations_CollectionChanged;
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
@@ -58,7 +58,7 @@ namespace DynamoCoreWpfTests
             // Check that directory has been updated in the list of paths for install
             Assert.AreEqual(@"D:\", preferencesVM.PackagePathsForInstall.Last());
 
-            // Remove directory
+            // Remove path
             preferencesVM.SelectedPackagePathForInstall = @"D:\";
             preferencesVM.PackagePathsViewModel.RootLocations.Remove(@"D:\");
 
@@ -67,7 +67,7 @@ namespace DynamoCoreWpfTests
             Assert.AreNotEqual(@"D:\", selection);
             Assert.IsFalse(string.IsNullOrEmpty(selection));
 
-            // Check that the directory is not in the list
+            // Check that the path is not in the list
             Assert.IsFalse(preferencesVM.PackagePathsForInstall.Contains(@"D:\"));
 
             // Simulate exiting preference dialog

--- a/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Dynamo.Tests;
 using NUnit.Framework;
 
@@ -28,6 +29,49 @@ namespace DynamoCoreWpfTests
 
             var pathManager = ViewModel.Model.PathManager;
             Assert.AreEqual(Path.GetTempPath(), pathManager.DefaultPackagesDirectory);
+        }
+
+        [Test]
+        public void PackagePathForInstall_Add_Update_Remove_Paths()
+        {
+            var preferencesVM = ViewModel.PreferencesViewModel;
+            Assert.NotNull(preferencesVM);
+
+            // Simulate opening preference dialog
+            preferencesVM.PackagePathsViewModel.InitializeRootLocations();
+            preferencesVM.InitPackagePathsForInstall();
+
+            // The default selected package path for download is AppData.
+            var selectedPath = preferencesVM.SelectedPackagePathForInstall;
+            Assert.AreEqual(GetAppDataFolder(), selectedPath);
+
+            // Add a new path
+            preferencesVM.PackagePathsViewModel.RootLocations.Add(@"C:\");
+
+            // Check that the path is added to the list of paths for install
+            Assert.AreEqual(@"C:\", preferencesVM.PackagePathsForInstall.Last());
+
+            // Update path
+            preferencesVM.PackagePathsViewModel.RootLocations[
+                preferencesVM.PackagePathsViewModel.RootLocations.IndexOf(@"C:\")] = @"D:\";
+
+            // Check that directory has been updated in the list of paths for install
+            Assert.AreEqual(@"D:\", preferencesVM.PackagePathsForInstall.Last());
+
+            // Remove directory
+            preferencesVM.SelectedPackagePathForInstall = @"D:\";
+            preferencesVM.PackagePathsViewModel.RootLocations.Remove(@"D:\");
+
+            // Check that the selection has changed and is not empty
+            var selection = preferencesVM.SelectedPackagePathForInstall;
+            Assert.AreNotEqual(@"D:\", selection);
+            Assert.IsFalse(string.IsNullOrEmpty(selection));
+
+            // Check that the directory is not in the list
+            Assert.IsFalse(preferencesVM.PackagePathsForInstall.Contains(@"D:\"));
+
+            // Simulate exiting preference dialog
+            preferencesVM.CommitPackagePathsForInstall();
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
@@ -52,14 +52,17 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(@"C:\", preferencesVM.PackagePathsForInstall.Last());
 
             // Update path
+            preferencesVM.SelectedPackagePathForInstall = @"C:\";
             preferencesVM.PackagePathsViewModel.RootLocations[
                 preferencesVM.PackagePathsViewModel.RootLocations.IndexOf(@"C:\")] = @"D:\";
 
             // Check that directory has been updated in the list of paths for install
             Assert.AreEqual(@"D:\", preferencesVM.PackagePathsForInstall.Last());
 
+            // Check that the selection has updated
+            Assert.AreEqual(@"D:\", preferencesVM.SelectedPackagePathForInstall);
+
             // Remove path
-            preferencesVM.SelectedPackagePathForInstall = @"D:\";
             preferencesVM.PackagePathsViewModel.RootLocations.Remove(@"D:\");
 
             // Check that the selection has changed and is not empty


### PR DESCRIPTION
### Purpose

* Bug fix: Fix the event handler for the Root Locations Collection Change event.
* Added test that covers this functionality

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

