### PR TITLE
DYN-3834-GeoScaling-GraphRun

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Dynamo.Configuration;
+using Dynamo.Events;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.Models;
@@ -747,8 +748,7 @@ namespace Dynamo.ViewModels
             //This piece of code will populate all the description text for the RadioButtons in the Geometry Scaling section.
             optionsGeometryScale = new GeometryScalingOptions();
 
-            //This will set the default option for the Geometry Scaling Radio Buttons, the value is comming from the DynamoViewModel
-            optionsGeometryScale.EnumProperty = (GeometryScaleSize)GeometryScalingOptions.ConvertScaleFactorToUI(dynamoViewModel.ScaleFactorLog);
+            UpdateGeoScaleRadioButtonSelected(dynamoViewModel.ScaleFactorLog);
 
             optionsGeometryScale.DescriptionScaleRange = new ObservableCollection<string>();
             optionsGeometryScale.DescriptionScaleRange.Add(string.Format(Res.ChangeScaleFactorPromptDescriptionContent, scaleRanges[GeometryScaleSize.Small].Item2,
@@ -781,7 +781,28 @@ namespace Dynamo.ViewModels
 
             PackagePathsViewModel.RootLocations.CollectionChanged += PackagePathsViewModel_RootLocations_CollectionChanged;
 
+            WorkspaceEvents.WorkspaceSettingsChanged += PreferencesViewModel_WorkspaceSettingsChanged;
+
             PropertyChanged += Model_PropertyChanged;
+        }
+
+        /// <summary>
+        /// This method will be executed everytime the WorkspaceModel.ScaleFactor value is updated.
+        /// </summary>
+        /// <param name="args"></param>
+        private void PreferencesViewModel_WorkspaceSettingsChanged(WorkspacesSettingsChangedEventArgs args)
+        {
+            //The WorkspaceSettingsChanged event is refering to the double ScaleFactor, then we need to make the conversion to Logarithm scale factor ScaleFactorLog       
+            UpdateGeoScaleRadioButtonSelected(Convert.ToInt32(Math.Log10(args.ScaleFactor)));
+        }
+
+        /// <summary>
+        /// This method will update the currently selected Radio Button in the Geometry Scaling section.
+        /// </summary>
+        /// <param name="scaleFactor"></param>
+        public void UpdateGeoScaleRadioButtonSelected(int scaleFactor)
+        {
+            optionsGeometryScale.EnumProperty = (GeometryScaleSize)GeometryScalingOptions.ConvertScaleFactorToUI(scaleFactor);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -798,7 +798,7 @@ namespace Dynamo.ViewModels
         /// This method will update the currently selected Radio Button in the Geometry Scaling section.
         /// </summary>
         /// <param name="scaleFactor"></param>
-        public void UpdateGeoScaleRadioButtonSelected(int scaleFactor)
+        private void UpdateGeoScaleRadioButtonSelected(int scaleFactor)
         {
             optionsGeometryScale.EnumProperty = (GeometryScaleSize)GeometryScalingOptions.ConvertScaleFactorToUI(scaleFactor);
         }

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -812,6 +812,7 @@ namespace Dynamo.ViewModels
         {
             PropertyChanged -= Model_PropertyChanged;
             PackagePathsViewModel.RootLocations.CollectionChanged -= PackagePathsViewModel_RootLocations_CollectionChanged;
+            WorkspaceEvents.WorkspaceSettingsChanged -= PreferencesViewModel_WorkspaceSettingsChanged;
         }
 
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -130,7 +130,8 @@ namespace Dynamo.Wpf.Views
                         Res.PreferencesViewVisualSettingsGeoScaling);
                 }
 
-                dynViewModel.ExecuteCommand(new DynamoModel.ForceRunCancelCommand(false, false));
+                var allNodes = dynViewModel.HomeSpace.Nodes;
+                dynViewModel.HomeSpace.MarkNodesAsModifiedAndRequestRun(allNodes, forceExecute: true);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using Dynamo.Controls;
 using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.ViewModels;
 using Res = Dynamo.Wpf.Properties.Resources;
 
@@ -21,6 +22,7 @@ namespace Dynamo.Wpf.Views
     {
         private readonly PreferencesViewModel viewModel;
         private readonly DynamoViewModel dynViewModel;
+        private int scaleValue = 0;
 
         // Used for tracking the manage package command event
         // This is not a command any more but we keep it
@@ -50,6 +52,9 @@ namespace Dynamo.Wpf.Views
             }
 
             InitRadioButtonsDescription();
+
+            //We need to store the ScaleFactor value in a temporary variable always when the Preferences dialog is created.
+            scaleValue = dynViewModel.ScaleFactorLog;
         }
 
         /// <summary>
@@ -96,7 +101,37 @@ namespace Dynamo.Wpf.Views
             viewModel.PackagePathsViewModel.SaveSettingCommand.Execute(null);
             viewModel.CommitPackagePathsForInstall();
             PackagePathView.Dispose();
+
+            RunGraphWhenScaleFactorUpdated();
+
             Close();
+        }
+
+        /// <summary>
+        /// This method will run the graph only if the Geometry Scaling was updated otherwise will not be executed
+        /// </summary>
+        private void RunGraphWhenScaleFactorUpdated()
+        {
+            //If the new radio button selected (ScaleValue) is different than the current one in Dynamo, we update the current one
+            if (dynViewModel.ScaleFactorLog != scaleValue)
+            {
+                dynViewModel.ScaleFactorLog = scaleValue;
+                dynViewModel.CurrentSpace.HasUnsavedChanges = true;
+
+                //Due that binding are done before the contructor of this class we need to execute the Log only if the viewModel was assigned previously
+                if (viewModel != null)
+                {
+                    Log(String.Format("Geometry working range changed to {0} ({1}, {2})",
+                    viewModel.ScaleRange.Item1, viewModel.ScaleRange.Item2, viewModel.ScaleRange.Item3));
+                    viewModel.UpdateSavedChangesLabel();
+                    Dynamo.Logging.Analytics.TrackEvent(
+                        Actions.Switch,
+                        Categories.Preferences,
+                        Res.PreferencesViewVisualSettingsGeoScaling);
+                }
+
+                dynViewModel.ExecuteCommand(new DynamoModel.ForceRunCancelCommand(false, false));
+            }
         }
 
         /// <summary>
@@ -189,6 +224,7 @@ namespace Dynamo.Wpf.Views
 
         /// <summary>
         /// This event is generated every time the user clicks a Radio Button in the Geometry Scaling section
+        /// The method just get the Radio Button clicked and saves the ScaleValue selected
         /// This are the values used for the scales:
         /// - 2 - Small
         ///   0 - Medium (Default)
@@ -202,8 +238,7 @@ namespace Dynamo.Wpf.Views
             RadioButton selectedScaling = sender as RadioButton;
             var radioButtons = GeometryScalingRadiosPanel.Children.OfType<RadioButton>();
 
-            int index = 0;
-            int scaleValue = 0;
+            int index = 0;      
 
             //We need to loop all the radiobuttons in the GeometryScaling section in order to find the index of the selected one
             foreach (var radio in radioButtons)
@@ -214,28 +249,6 @@ namespace Dynamo.Wpf.Views
                     break;
                 }
                 index++;
-            }
-
-            //If the new radio button selected (ScaleValue) is different than the current one in Dynamo, we update the current one
-            if (dynViewModel.ScaleFactorLog != scaleValue)
-            {
-                dynViewModel.ScaleFactorLog = scaleValue;
-                dynViewModel.CurrentSpace.HasUnsavedChanges = true;
-
-                //Due that binding are done before the contructor of this class we need to execute the Log only if the viewModel was assigned previously
-                if (viewModel != null)
-                {
-                    Log(String.Format("Geometry working range changed to {0} ({1}, {2})",
-                    viewModel.ScaleRange.Item1, viewModel.ScaleRange.Item2, viewModel.ScaleRange.Item3));
-                    viewModel.UpdateSavedChangesLabel();
-                    Dynamo.Logging.Analytics.TrackEvent(
-                        Actions.Switch,
-                        Categories.Preferences,
-                        Res.PreferencesViewVisualSettingsGeoScaling);
-                }                 
-
-                var allNodes = dynViewModel.HomeSpace.Nodes;
-                dynViewModel.HomeSpace.MarkNodesAsModifiedAndRequestRun(allNodes, forceExecute: true);
             }
         }
 


### PR DESCRIPTION
### Purpose

There was an issue that when the Geometry Scaling was updated in a very large graph the Preferences panel was blocked not allowing the user to close it. I think this behavior was because when the Preference panel was opened immediately a graph run was executed (without changing anything in the Preferences panel).
I was NOT able to reproduce the Preferences panel freezing behavior but we noticed that the graph execution was always happening when the Preferences panel was opened (when nothing was changed), then I did a fix in a way that the selected radio button (in geometry scaling section) is updated every time a new workspace is created or a dyn file is loaded (as is happening with the WorkspaceModel.ScaleFactor), so the graph run will be executed just when the ScaleFactor is changed.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
@mjkkirschner 

### FYIs

@aparajit-pratap 
