### PR TITLE
[DYN-3828] Preference's Visual Settings tab expanders alignment (#11843)

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -139,7 +139,8 @@
                         Style="{DynamicResource CloseButtonStyle}" 
                         Click="CloseButton_Click" 
                         VerticalAlignment="Center"
-                        KeyboardNavigation.IsTabStop="False" />
+                        KeyboardNavigation.IsTabStop="False"
+                        Margin="0,0,4,0"/>
             </StackPanel>
         </Grid>
 
@@ -302,7 +303,7 @@
 
                                 <!--Geometry Scaling Expander-->
                                 <Grid Grid.Row="5"
-                                  Margin="-10,0,0,20">
+                                  Margin="-3,0,1,20">
                                     <Expander x:Name="Scale"
                                       Grid.Row="1" 
                                       Style="{StaticResource MenuExpanderStyle}"
@@ -510,7 +511,8 @@
                              Style="{StaticResource LeftTab}">
                         <Grid x:Name="VisualSettingsTab" 
                               Background="{StaticResource PreferencesWindowVisualSettingsBackground}"
-                              HorizontalAlignment="Left">
+                              HorizontalAlignment="Left"
+                              Margin="1">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />


### PR DESCRIPTION
* Update PreferencesView.xaml

* Close button alignment

### Purpose

Cherry-pick from master branch: https://github.com/DynamoDS/Dynamo/pull/11843

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

Aaron Tang (@QilongTang )