### PR TITLE
Force Dynamo to run on nvidia graphics card to address helix crash with multiple monitors

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -32,6 +32,7 @@ using Dynamo.Wpf.Rendering;
 using DynamoUtilities;
 using HelixToolkit.Wpf.SharpDX;
 using HelixToolkit.Wpf.SharpDX.Shaders;
+using HelixToolkit.Wpf.SharpDX.Utilities;
 using Newtonsoft.Json;
 using SharpDX;
 using Color = SharpDX.Color;
@@ -206,7 +207,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private readonly Dictionary<string, List<Tuple<string, Vector3>>> labelPlaces
             = new Dictionary<string, List<Tuple<string, Vector3>>>();
 
-
+        // This makes sure the NVidia graphics card is used for rendering when available. In the absence of this
+        // there are found to be issues with Helix crashing when the app is used with external monitors. 
+        // See: https://github.com/helix-toolkit/helix-toolkit/wiki/Tips-on-performance-optimization-(WPF.SharpDX-and-UWP)#2-laptops-with-nvidia-optimus-dual-graphics-cardhelixtoolkitsharpdx-only
+        static NVOptimusEnabler nvEnabler = new NVOptimusEnabler();
 
 #if DEBUG
         private readonly Stopwatch renderTimer = new Stopwatch();

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -210,7 +210,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         // This makes sure the NVidia graphics card is used for rendering when available. In the absence of this
         // there are found to be issues with Helix crashing when the app is used with external monitors. 
         // See: https://github.com/helix-toolkit/helix-toolkit/wiki/Tips-on-performance-optimization-(WPF.SharpDX-and-UWP)#2-laptops-with-nvidia-optimus-dual-graphics-cardhelixtoolkitsharpdx-only
-        static NVOptimusEnabler nvEnabler = new NVOptimusEnabler();
+        private static NVOptimusEnabler nvEnabler = new NVOptimusEnabler();
 
 #if DEBUG
         private readonly Stopwatch renderTimer = new Stopwatch();


### PR DESCRIPTION
### Purpose

DYN-3848: Force Dynamo to use nvidia graphics card to address helix crash with multiple monitors and with system with NVidia card of course.

Refer to related issue and solution: 
https://github.com/helix-toolkit/helix-toolkit/issues/1600
https://github.com/helix-toolkit/helix-toolkit/wiki/Tips-on-performance-optimization-(WPF.SharpDX-and-UWP)#2-laptops-with-nvidia-optimus-dual-graphics-cardhelixtoolkitsharpdx-only

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
