### PR TITLE
Triggering Node AutoComplete on input port should not destroy the connection.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -4,7 +4,6 @@ using System.Windows.Controls.Primitives;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.UI.Commands;
-using Dynamo.UI.Controls;
 using Dynamo.Utilities;
 
 namespace Dynamo.ViewModels
@@ -19,6 +18,7 @@ namespace Dynamo.ViewModels
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
         private const double autocompletePopupSpacing = 2.5;
+        internal bool inputPortDisconnectedByConnectCommand = false;
 
         /// <summary>
         /// Port model.
@@ -409,6 +409,13 @@ namespace Dynamo.ViewModels
         {
             var wsViewModel = _node.WorkspaceViewModel;
             wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
+
+            // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
+            if (this.inputPortDisconnectedByConnectCommand)
+            {
+                wsViewModel.DynamoViewModel.Model.CurrentWorkspace.Undo();
+            }
+
             // Bail out from connect state
             wsViewModel.CancelActiveState();
             wsViewModel.OnRequestNodeAutoCompleteSearch(ShowHideFlags.Show);

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -798,6 +798,10 @@ namespace Dynamo.ViewModels
 
                 var portModel = portViewModel.PortModel;
 
+                // When the connect command is triggered, set portDisconnectedByConnectCommand flag based on the port connectors.
+                // If the current port has any connectors, then it will be disconnected. Otherwise a new connection will be made. 
+                portViewModel.inputPortDisconnectedByConnectCommand = portViewModel.PortType == PortType.Input && portModel.Connectors.Count > 0;
+
                 var workspaceViewModel = owningWorkspace.DynamoViewModel.CurrentSpaceViewModel;
 
                 if (this.currentState != State.Connection) // Not in a connection attempt...


### PR DESCRIPTION
### Purpose

After using the LeftDoubleClick to trigger Node AutoComplete, we were running into an issue where the input port connection would be destroyed upon triggering the Node AutoComplete on that port. This was happening because, the first LeftClick will trigger the Connect command on the port and if the port has any connection, it will be disconnected. 

As there is no direct solution to stop the first click when the double click is activated, we have implemented a workaround. 
As a workaround, during the Node AutoComplete step, we will be undo the disconnection triggered by the Connect command. Note that this applies only for input ports. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @zeusongit 

