### PR TITLE
[DYN-3773] Fix right sidebar extension bug

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1787,6 +1787,7 @@
                       VerticalAlignment="Stretch"
                       Margin="0"
                       Background="Transparent"
+                      DragCompleted="RightExtensionSidebar_DragCompleted"
                       Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur" />
 
         <!--Start Page-->

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2461,6 +2461,12 @@ namespace Dynamo.Controls
             resourcesTooltip.Show();
         }
 
+        private void RightExtensionSidebar_DragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            //Setting the width of right extension after resize to
+            extensionsColumnWidth = RightExtensionsViewColumn.Width;
+        }
+
         public void Dispose()
         {
             viewExtensionManager.Dispose();


### PR DESCRIPTION
### Purpose

Fix the bug with right sidebar extension that collapsed the extensions opened after we resize the first extension.

Before:
![ex-be](https://user-images.githubusercontent.com/32665108/125836066-d666b004-f137-4a30-a51b-059acd400cd6.gif)

After:
![ex-af](https://user-images.githubusercontent.com/32665108/125836075-be21ac00-873b-450f-9e1e-d33629d04578.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@DynamoDS/dynamo 
