### PR TITLE
DYN-3834-GeoScaling-GraphRun (#11845)

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using Dynamo.Controls;
 using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.ViewModels;
 using Res = Dynamo.Wpf.Properties.Resources;
 
@@ -21,6 +22,7 @@ namespace Dynamo.Wpf.Views
     {
         private readonly PreferencesViewModel viewModel;
         private readonly DynamoViewModel dynViewModel;
+        private int scaleValue = 0;
 
         // Used for tracking the manage package command event
         // This is not a command any more but we keep it
@@ -50,6 +52,9 @@ namespace Dynamo.Wpf.Views
             }
 
             InitRadioButtonsDescription();
+
+            //We need to store the ScaleFactor value in a temporary variable always when the Preferences dialog is created.
+            scaleValue = dynViewModel.ScaleFactorLog;
         }
 
         /// <summary>
@@ -96,7 +101,38 @@ namespace Dynamo.Wpf.Views
             viewModel.PackagePathsViewModel.SaveSettingCommand.Execute(null);
             viewModel.CommitPackagePathsForInstall();
             PackagePathView.Dispose();
+
+            RunGraphWhenScaleFactorUpdated();
+
             Close();
+        }
+
+        /// <summary>
+        /// This method will run the graph only if the Geometry Scaling was updated otherwise will not be executed
+        /// </summary>
+        private void RunGraphWhenScaleFactorUpdated()
+        {
+            //If the new radio button selected (ScaleValue) is different than the current one in Dynamo, we update the current one
+            if (dynViewModel.ScaleFactorLog != scaleValue)
+            {
+                dynViewModel.ScaleFactorLog = scaleValue;
+                dynViewModel.CurrentSpace.HasUnsavedChanges = true;
+
+                //Due that binding are done before the contructor of this class we need to execute the Log only if the viewModel was assigned previously
+                if (viewModel != null)
+                {
+                    Log(String.Format("Geometry working range changed to {0} ({1}, {2})",
+                    viewModel.ScaleRange.Item1, viewModel.ScaleRange.Item2, viewModel.ScaleRange.Item3));
+                    viewModel.UpdateSavedChangesLabel();
+                    Dynamo.Logging.Analytics.TrackEvent(
+                        Actions.Switch,
+                        Categories.Preferences,
+                        Res.PreferencesViewVisualSettingsGeoScaling);
+                }
+
+                var allNodes = dynViewModel.HomeSpace.Nodes;
+                dynViewModel.HomeSpace.MarkNodesAsModifiedAndRequestRun(allNodes, forceExecute: true);
+            }
         }
 
         /// <summary>
@@ -189,6 +225,7 @@ namespace Dynamo.Wpf.Views
 
         /// <summary>
         /// This event is generated every time the user clicks a Radio Button in the Geometry Scaling section
+        /// The method just get the Radio Button clicked and saves the ScaleValue selected
         /// This are the values used for the scales:
         /// - 2 - Small
         ///   0 - Medium (Default)
@@ -202,8 +239,7 @@ namespace Dynamo.Wpf.Views
             RadioButton selectedScaling = sender as RadioButton;
             var radioButtons = GeometryScalingRadiosPanel.Children.OfType<RadioButton>();
 
-            int index = 0;
-            int scaleValue = 0;
+            int index = 0;      
 
             //We need to loop all the radiobuttons in the GeometryScaling section in order to find the index of the selected one
             foreach (var radio in radioButtons)
@@ -214,28 +250,6 @@ namespace Dynamo.Wpf.Views
                     break;
                 }
                 index++;
-            }
-
-            //If the new radio button selected (ScaleValue) is different than the current one in Dynamo, we update the current one
-            if (dynViewModel.ScaleFactorLog != scaleValue)
-            {
-                dynViewModel.ScaleFactorLog = scaleValue;
-                dynViewModel.CurrentSpace.HasUnsavedChanges = true;
-
-                //Due that binding are done before the contructor of this class we need to execute the Log only if the viewModel was assigned previously
-                if (viewModel != null)
-                {
-                    Log(String.Format("Geometry working range changed to {0} ({1}, {2})",
-                    viewModel.ScaleRange.Item1, viewModel.ScaleRange.Item2, viewModel.ScaleRange.Item3));
-                    viewModel.UpdateSavedChangesLabel();
-                    Dynamo.Logging.Analytics.TrackEvent(
-                        Actions.Switch,
-                        Categories.Preferences,
-                        Res.PreferencesViewVisualSettingsGeoScaling);
-                }                 
-
-                var allNodes = dynViewModel.HomeSpace.Nodes;
-                dynViewModel.HomeSpace.MarkNodesAsModifiedAndRequestRun(allNodes, forceExecute: true);
             }
         }
 


### PR DESCRIPTION
* DYN-3834-GeoScaling-GraphRun

There was an issue that when the Geometry Scaling was updated in a very large graph the Preferences panel was blocked not allowing the user to close it. I think this behavior was because when the Preference panel was opened immediately a graph run was executed (without changing anything in the Preferences panel).
I was NOT able to reproduce the Preferences panel freezing behavior but we noticed that the graph execution was always happening when the Preferences panel was opened (when nothing was changed), then I did a fix in a way that the selected radio button (in geometry scaling section) is updated every time a new workspace is created or a dyn file is loaded (as is happening with the WorkspaceModel.ScaleFactor), so the graph run will be executed just when the ScaleFactor is changed.

* DYN-3834-GeoScaling-GraphRun Code Review

Unsubscribing from the WorkspaceSettingsChanged when the PreferencesViewModel is cleared.

* DYN-3834-GeoScaling-GraphRun Code Review

Making method private due that is just used in the same class.

* DYN-3834-GeoScaling-GraphRun Code Review

I did some changes so only when the ScaleFactor was changed a graph run will be executed when the Preferences dialog is closed

* DYN-3834-GeoScaling-GraphRun Code Review2

Replacing the call to ForceRunCancelCommand method for MarkNodesAsModifiedAndRequestRun due that the first one was executing the graph when the RunMode = Manual at the moment of updating the Geometry Scaling in the other hand with the MarkNodesAsModifiedAndRequestRun doesn't happen that behavior.

Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Cherry-pick https://github.com/DynamoDS/Dynamo/pull/11845

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
