### PR TITLE
DYN-3834-GeoScaling-UnitTest

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Libraries\LabelTests.cs" />
     <Compile Include="ListAtLevelTest.cs" />
     <Compile Include="MediatoDSColorConverterTest.cs" />
+    <Compile Include="PreferencesGeometryScalingTests.cs" />
     <Compile Include="PreferencesViewModelTests.cs" />
     <Compile Include="UnitsUITests.cs" />
     <Compile Include="NodeAutoCompleteSearchTests.cs" />

--- a/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using Dynamo.Graph.Nodes;
-using Dynamo.Tests;
-using Dynamo.ViewModels;
 using Dynamo.Wpf.Views;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
@@ -13,7 +11,7 @@ using NUnit.Framework;
 namespace DynamoCoreWpfTests
 {
     [TestFixture]
-    class PreferencesGeometryScalingTests : DynamoTestUIBase
+    public class PreferencesGeometryScalingTests : DynamoTestUIBase
     {
         public override void Open(string path)
         {
@@ -25,28 +23,21 @@ namespace DynamoCoreWpfTests
         {
             libraries.Add("VMDataBridge.dll");
             libraries.Add("ProtoGeometry.dll");
-            libraries.Add("DesignScriptBuiltin.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
         /// <summary>
         /// The test validates that when RunType=Automatic and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is kicked off
-        /// The test validates that when RunType=Manual and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is NOT kicked off
         /// </summary>
         [Test]
-        [TestCase("Automatic", ElementState.Warning)]
-        [TestCase("Manual", ElementState.Active)]
-        public void PreferencesGeoScaling_RunGraph_Automatic_Mode(string runMode, ElementState expectedNodeState)
+        public void PreferencesGeoScaling_RunGraph_Automatic()
         {
             //The GeometryScalingCodeBlock.dyn contains a CodeBlock with a large number that needs ScaleFactor > Medium
             Open(@"core\GeometryScalingCodeBlock.dyn");
 
-            if (runMode.Equals("Automatic"))
-            {
-                //Change the RunType to Automatic, so when the MarkNodesAsModifiedAndRequestRun() is called a graph execution will be kicked off 
-                View.RunSettingsControl.RunTypesComboBox.SelectedItem = View.RunSettingsControl.RunTypesComboBox.Items[1];
-                DispatcherUtil.DoEvents();
-            }
+            //Change the RunType to Automatic, so when the MarkNodesAsModifiedAndRequestRun() is called a graph execution will be kicked off 
+            View.RunSettingsControl.RunTypesComboBox.SelectedItem = View.RunSettingsControl.RunTypesComboBox.Items[1];
+            DispatcherUtil.DoEvents();
 
             //Creates the Preferences dialog and the ScaleFactor = 2 ( Medium)
             var preferencesWindow = new PreferencesView(View);
@@ -65,8 +56,36 @@ namespace DynamoCoreWpfTests
             var nodeView = NodeViewWithGuid("bcf1c893-5311-4dff-9a04-203ffb9d426c");
 
             //When RunType = Automatic when the graph is executed the ByCenterPointRadius node change status to Warning due that ScaleFactor = Small
-            //When RunType = Manual when the graph is NOT executed then the ByCenterPointRadius status will be Active
-            Assert.AreEqual(nodeView.ViewModel.State, expectedNodeState);
+            Assert.AreEqual(nodeView.ViewModel.State, ElementState.Warning);
+        }
+
+        /// <summary>
+        /// The test validates that when RunType=Manual and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is NOT kicked off
+        /// </summary>
+        [Test]
+        public void PreferencesGeoScaling_RunGraph_Manual_Mode()
+        {
+            //The GeometryScalingCodeBlock.dyn contains a CodeBlock with a large number that needs ScaleFactor > Medium
+            Open(@"core\GeometryScalingCodeBlock.dyn");
+
+            //Creates the Preferences dialog and the ScaleFactor = 2 ( Medium)
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            //Change the RadioButton checked so the ScaleFactor is updated to -2 (Small)
+            preferencesWindow.RadioSmall.IsChecked = true;
+            DispatcherUtil.DoEvents();
+
+            //Close the Preferences Dialog and due that the ScaleFactor was updated the MarkNodesAsModifiedAndRequestRun() method will be called
+            preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            //This will get the Circle.ByCenterPointRadius node (connected to the CodeBlock)
+            var nodeView = NodeViewWithGuid("bcf1c893-5311-4dff-9a04-203ffb9d426c");
+
+            //When RunType = Automatic when the graph is executed the ByCenterPointRadius node change status to Warning due that ScaleFactor = Small
+            Assert.AreEqual(nodeView.ViewModel.State, ElementState.Active);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
@@ -39,6 +39,12 @@ namespace DynamoCoreWpfTests
             View.RunSettingsControl.RunTypesComboBox.SelectedItem = View.RunSettingsControl.RunTypesComboBox.Items[1];
             DispatcherUtil.DoEvents();
 
+            //This will get the Circle.ByCenterPointRadius node (connected to the CodeBlock)
+            var nodeView = NodeViewWithGuid("bcf1c893-5311-4dff-9a04-203ffb9d426c");
+
+            //Checking that the node is not in a warning state before changing the scale factor
+            Assert.AreEqual(nodeView.ViewModel.State, ElementState.Active);
+
             //Creates the Preferences dialog and the ScaleFactor = 2 ( Medium)
             var preferencesWindow = new PreferencesView(View);
             preferencesWindow.Show();
@@ -50,10 +56,7 @@ namespace DynamoCoreWpfTests
 
             //Close the Preferences Dialog and due that the ScaleFactor was updated the MarkNodesAsModifiedAndRequestRun() method will be called
             preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
-            DispatcherUtil.DoEvents();
-
-            //This will get the Circle.ByCenterPointRadius node (connected to the CodeBlock)
-            var nodeView = NodeViewWithGuid("bcf1c893-5311-4dff-9a04-203ffb9d426c");
+            DispatcherUtil.DoEvents();        
 
             //When RunType = Automatic when the graph is executed the ByCenterPointRadius node change status to Warning due that ScaleFactor = Small
             Assert.AreEqual(nodeView.ViewModel.State, ElementState.Warning);
@@ -84,7 +87,7 @@ namespace DynamoCoreWpfTests
             //This will get the Circle.ByCenterPointRadius node (connected to the CodeBlock)
             var nodeView = NodeViewWithGuid("bcf1c893-5311-4dff-9a04-203ffb9d426c");
 
-            //When RunType = Automatic when the graph is executed the ByCenterPointRadius node change status to Warning due that ScaleFactor = Small
+            //When RunType = Manual and the MarkNodesAsModifiedAndRequestRun() method is called, the graph won't be executed and the node state will remain in Active
             Assert.AreEqual(nodeView.ViewModel.State, ElementState.Active);
         }
     }

--- a/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using Dynamo.Graph.Nodes;
+using Dynamo.Tests;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Views;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    class PreferencesGeometryScalingTests : DynamoTestUIBase
+    {
+        public override void Open(string path)
+        {
+            base.Open(path);
+            DispatcherUtil.DoEvents();
+        }
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        /// <summary>
+        /// The test validates that when RunType=Automatic and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is kicked off
+        /// The test validates that when RunType=Manual and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is NOT kicked off
+        /// </summary>
+        [Test]
+        [TestCase("Automatic", ElementState.Warning)]
+        [TestCase("Manual", ElementState.Active)]
+        public void PreferencesGeoScaling_RunGraph_Automatic_Mode(string runMode, ElementState expectedNodeState)
+        {
+            //The GeometryScalingCodeBlock.dyn contains a CodeBlock with a large number that needs ScaleFactor > Medium
+            Open(@"core\GeometryScalingCodeBlock.dyn");
+
+            if (runMode.Equals("Automatic"))
+            {
+                //Change the RunType to Automatic, so when the MarkNodesAsModifiedAndRequestRun() is called a graph execution will be kicked off 
+                View.RunSettingsControl.RunTypesComboBox.SelectedItem = View.RunSettingsControl.RunTypesComboBox.Items[1];
+                DispatcherUtil.DoEvents();
+            }
+
+            //Creates the Preferences dialog and the ScaleFactor = 2 ( Medium)
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            //Change the RadioButton checked so the ScaleFactor is updated to -2 (Small)
+            preferencesWindow.RadioSmall.IsChecked = true;
+            DispatcherUtil.DoEvents();
+
+            //Close the Preferences Dialog and due that the ScaleFactor was updated the MarkNodesAsModifiedAndRequestRun() method will be called
+            preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            //This will get the Circle.ByCenterPointRadius node (connected to the CodeBlock)
+            var nodeView = NodeViewWithGuid("bcf1c893-5311-4dff-9a04-203ffb9d426c");
+
+            //When RunType = Automatic when the graph is executed the ByCenterPointRadius node change status to Warning due that ScaleFactor = Small
+            //When RunType = Manual when the graph is NOT executed then the ByCenterPointRadius status will be Active
+            Assert.AreEqual(nodeView.ViewModel.State, expectedNodeState);
+        }
+    }
+}

--- a/test/core/GeometryScalingCodeBlock.dyn
+++ b/test/core/GeometryScalingCodeBlock.dyn
@@ -1,0 +1,131 @@
+{
+  "Uuid": "036288cd-da3b-4c7d-a1b4-cb370a045013",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "TestGeometryScaling",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "bcf1c89353114dff9a04203ffb9d426c",
+      "Inputs": [
+        {
+          "Id": "2ec1e886e80744a283abbeb017072a83",
+          "Name": "centerPoint",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "34882a36bde147cfbaa01a6df0e304ab",
+          "Name": "radius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d580bf0fd5264d69b53c5c4e47953998",
+          "Name": "Circle",
+          "Description": "Circle",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "100000;",
+      "Id": "a7e3c25d800a49f7852b6b28e1564863",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5eece3def8ad4cf286fb2175351e5ca8",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "5eece3def8ad4cf286fb2175351e5ca8",
+      "End": "34882a36bde147cfbaa01a6df0e304ab",
+      "Id": "1b9ab8a2f70d4b3ebdefc2c7a491b235"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "ExtensionWorkspaceData": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 100.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.11.0.4146",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Circle.ByCenterPointRadius",
+        "Id": "bcf1c89353114dff9a04203ffb9d426c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 480.5,
+        "Y": 360.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "a7e3c25d800a49f7852b6b28e1564863",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 225.5,
+        "Y": 377.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

I added one unit tests with two parameters, one is for validating that when RunMode=Manual and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is NOT kicked off.
The other when the RunMode=Automatic and the MarkNodesAsModifiedAndRequestRun() method is called the graph execution is kicked off.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
@mjkkirschner 

### FYIs

