### PR TITLE
virtual cleanup for linter rule subclasses

### DIFF
--- a/src/DynamoCore/Linting/Rules/LinterRule.cs
+++ b/src/DynamoCore/Linting/Rules/LinterRule.cs
@@ -52,7 +52,7 @@ namespace Dynamo.Linting.Rules
         /// </summary>
         /// <param name="muribundWorkspaceModel"></param>
         /// <returns></returns>
-        internal protected void CleanupRule(WorkspaceModel muribundWorkspaceModel) { }
+        internal protected virtual void CleanupRule(WorkspaceModel muribundWorkspaceModel) { }
 
         /// <summary>
         /// Initializes this rule using the <see cref="InitFunction(WorkspaceModel)"/>


### PR DESCRIPTION
### Purpose
The cleanup method must be virtual for LinterRule base.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

