### PR TITLE
DYN-3875: Restore LocalPackages property in PreferencesViewModel

### DIFF
--- a/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
@@ -5,8 +5,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
-             xmlns:viewmodels="clr-namespace:Dynamo.ViewModels" 
-             d:DataContext="{d:DesignInstance Type=viewmodels:InstalledPackagesViewModel}"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -65,7 +65,7 @@ namespace Dynamo.ViewModels
         private bool isWarningEnabled;
         private GeometryScalingOptions optionsGeometryScale = null;
 
-        private InstalledPackagesViewModel installedPackagesViewModel { get; }
+        private InstalledPackagesViewModel installedPackagesViewModel;
         private string selectedPackagePathForInstall;
         #endregion Private Properties
 

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -65,7 +65,7 @@ namespace Dynamo.ViewModels
         private bool isWarningEnabled;
         private GeometryScalingOptions optionsGeometryScale = null;
 
-        private InstalledPackagesViewModel installedPackagesViewModel;
+        internal InstalledPackagesViewModel InstalledPackagesViewModel { get; }
         private string selectedPackagePathForInstall;
         #endregion Private Properties
 
@@ -150,7 +150,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns all installed packages
         /// </summary>
-        public ObservableCollection<PackageViewModel> LocalPackages => installedPackagesViewModel.LocalPackages;
+        public ObservableCollection<PackageViewModel> LocalPackages => InstalledPackagesViewModel.LocalPackages;
 
         //This includes all the properties that can be set on the General tab
         #region General Properties
@@ -702,7 +702,7 @@ namespace Dynamo.ViewModels
             this.runPreviewEnabled = dynamoViewModel.HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled;
             this.homeSpace = dynamoViewModel.HomeSpace;
             this.dynamoViewModel = dynamoViewModel;
-            this.installedPackagesViewModel = new InstalledPackagesViewModel(dynamoViewModel, 
+            this.InstalledPackagesViewModel = new InstalledPackagesViewModel(dynamoViewModel, 
                 dynamoViewModel.PackageManagerClientViewModel.PackageManagerExtension.PackageLoader);
 
             PythonEnginesList = new ObservableCollection<string>();

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -147,6 +147,11 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Returns all installed packages
+        /// </summary>
+        public ObservableCollection<PackageViewModel> LocalPackages => installedPackagesViewModel.LocalPackages;
+
         //This includes all the properties that can be set on the General tab
         #region General Properties
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -65,7 +65,7 @@ namespace Dynamo.ViewModels
         private bool isWarningEnabled;
         private GeometryScalingOptions optionsGeometryScale = null;
 
-        internal InstalledPackagesViewModel InstalledPackagesViewModel { get; }
+        private InstalledPackagesViewModel installedPackagesViewModel { get; }
         private string selectedPackagePathForInstall;
         #endregion Private Properties
 
@@ -150,7 +150,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns all installed packages
         /// </summary>
-        public ObservableCollection<PackageViewModel> LocalPackages => InstalledPackagesViewModel.LocalPackages;
+        public ObservableCollection<PackageViewModel> LocalPackages => installedPackagesViewModel.LocalPackages;
 
         //This includes all the properties that can be set on the General tab
         #region General Properties
@@ -702,7 +702,7 @@ namespace Dynamo.ViewModels
             this.runPreviewEnabled = dynamoViewModel.HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled;
             this.homeSpace = dynamoViewModel.HomeSpace;
             this.dynamoViewModel = dynamoViewModel;
-            this.InstalledPackagesViewModel = new InstalledPackagesViewModel(dynamoViewModel, 
+            this.installedPackagesViewModel = new InstalledPackagesViewModel(dynamoViewModel, 
                 dynamoViewModel.PackageManagerClientViewModel.PackageManagerExtension.PackageLoader);
 
             PythonEnginesList = new ObservableCollection<string>();

--- a/test/DynamoCoreWpfTests/PackagePathTests.cs
+++ b/test/DynamoCoreWpfTests/PackagePathTests.cs
@@ -215,7 +215,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void AddPackagePathReflectsCorrectInstalledPackages()
+        public void InstalledPackagesContainsCorrectNumberOfPackages()
         {
             var pathManager = new Mock<IPathManager>();
             pathManager.SetupGet(x => x.PackagesDirectories).Returns(
@@ -245,18 +245,11 @@ namespace DynamoCoreWpfTests
             var installedPackagesViewModel = new InstalledPackagesViewModel(ViewModel, loader);
             Assert.AreEqual(18, installedPackagesViewModel.LocalPackages.Count);
 
-            packagesLoaded = false;
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory, BuiltInPackagesTestDir });
-            loadPackageParams.NewPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
+            var installedPackagesView = new Dynamo.Wpf.Controls.InstalledPackagesControl();
+            installedPackagesView.DataContext = installedPackagesViewModel;
+            DispatcherUtil.DoEvents();
 
-            // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(loadPackageParams, ViewModel.Model.CustomNodeManager);
-            Assert.AreEqual(19, loader.LocalPackages.Count());
-
-            // Assert packages are reloaded if there are new package paths.
-            Assert.True(packagesLoaded);
-            Assert.AreEqual(19, installedPackagesViewModel.LocalPackages.Count);
+            Assert.AreEqual(18, installedPackagesView.SearchResultsListBox.Items.Count);
 
         }
 


### PR DESCRIPTION
### Purpose

The `LocalPackages` property was deleted from `PreferencesViewModel` in PR #11835 and is now restored.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

