### PR TITLE
gc crash fix

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -433,7 +433,7 @@ namespace ProtoCore.DSASM
                 if (isDuringGCCriticalAsyncCycle && isValidHeapIndex)
                 {
                     var he = heapElements[index];
-                    Validity.Assert(he != null, $"Null heap element found at index {index} during AllocateStringInternal");
+                    Validity.Assert(he != null, $"Heap element found at index {index} during AllocateStringInternal cannot be null");
 
                     // If heap element is marked as white then it is either not processed by Propagate step yet or processed and found as garbage.
                     // If the sweepSet does not contain the heap element's index then there is no need to mark it black (since cleanup will not even be tried)
@@ -684,7 +684,7 @@ namespace ProtoCore.DSASM
                 StackValue value = ptrs.Dequeue();
                 int rawPtr = (int)value.RawData;
                 var hp = heapElements[rawPtr];
-                Validity.Assert(hp != null, $"Null heap element found at index {rawPtr} during garbage collection");
+                Validity.Assert(hp != null, $"Heap element found at index {rawPtr} during RecursiveMark cannot be null");
 
                 if (hp.Mark == GCMark.Black)
                     continue;
@@ -798,7 +798,7 @@ namespace ProtoCore.DSASM
             foreach (var ptr in sweepSet)
             {
                 var hp = heapElements[ptr];
-                Validity.Assert(hp != null, $"Null heap element found at index {ptr} during garbage collection");
+                Validity.Assert(hp != null, $"Heap element found at index {ptr} during GC sweep cannot be null.");
 
                 if (hp.Mark != GCMark.White)
                     continue;

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -424,7 +424,8 @@ namespace ProtoCore.DSASM
         private StackValue AllocateStringInternal(string str, bool isConstant)
         {
             int index;
-            if (stringTable.TryGetPointer(str, out index)) {
+            if (stringTable.TryGetPointer(str, out index))
+            {
                 // Any existing heap elements, marked as white, that are in the sweepSet and that are referenced during the sweep cycle will be marked as Black.
                 // This will ensure that no reachable data is mistakenly cleaned up.
                 bool isDuringGCCriticalAsyncCycle = gcState != GCState.Pause;// Between the time the GC takes a snapshot of the stack and heap untill GC cycle is over.

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -433,7 +433,7 @@ namespace ProtoCore.DSASM
                     {
                         throw new NullReferenceException($"Null heap element found at index {index} during AllocateStringInternal");
                     }
-                    bool isHeapElementMarkedAsWhite = he.Mark == GCMark.White;// Either not processed by Propage step yet or processed and found as garbage.
+                    bool isHeapElementMarkedAsWhite = he.Mark == GCMark.White;// Either not processed by Propagate step yet or processed and found as garbage.
                     bool isHeapElementConsideredForCleanup = sweepSet.Contains(index);
                     if (isHeapElementMarkedAsWhite && isHeapElementConsideredForCleanup)
                     {

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -279,7 +279,7 @@ namespace ProtoCore.DSASM
     // The Garbage Collection strategy employed here is based on the an incremental Tri-Color Snapshot-at-the-Beggining algorithm
     // Incremental: An incremental collector does small chunks of work and in between allows the mutator (i.e vm execution) to resume.
     // Tri-Color: 3 colors (white, gray, black) are used to mark all heap elements and denote their GC state.
-    // SatB: GC uses a snapshot of the heap when deciding what heap elements need to be collected.
+    // SatB: GC uses a snapshot of the stack and heap when deciding what heap elements need to be collected.
     public class Heap
     {
         private enum GCState

--- a/test/Engine/ProtoTest/DSASM/HeapMarkSweepTests.cs
+++ b/test/Engine/ProtoTest/DSASM/HeapMarkSweepTests.cs
@@ -59,6 +59,58 @@ namespace ProtoTest.DSASM
         }
 
         /// <summary>
+        /// Test the GC string management when the stack references the same string multiple times.
+        /// </summary>
+        [Test]
+        public void TestGCStringCleanup()
+        {
+            // Simulating the following graph
+            /*
+            def generateString() {
+                return 1+"@" +2;
+            };
+
+            vv = [Imperative]{
+                generateString();
+            // "1@2" will be on the heap
+            // current stack has no reference type elements
+            //  --------------------------------GC kicks in due to mem threshold----------------------------
+            // "1@2" on the heap will be marked as white - since no stack elements have a reference to it
+            //
+            // Async VM execution computes a new generateString() fn Call
+                cc = generateString();
+            //
+            // cc is pushed on the stack and holds a reference to the "1@2" heap element
+            //
+            // GC starts the sweep process in which it deletes "1@2" heap element
+            // ----------------------------------GC is finished---------------------------------------------
+                return cc;
+            };
+            //
+            // vv is still on the stack with a reference to a now null heap element
+            */
+            var heap = new Heap();
+
+            string sseValue = "hello world";
+
+            // Allocate a string on the heap.
+            // Similar to what would happen if a string stack element was pushed on the stack and then popped (due to out of scope).
+            heap.AllocateString(sseValue);
+
+            StackValue someStackValue = StackValue.BuildNull();
+            heap.AddNotifier(Heap.GCState.Sweep, () => {
+                // Simulate a new string (with the same value as existing one on heap) stack element being created while GC is propagating or sweeping
+                someStackValue = heap.AllocateString(sseValue);
+            }, () => { });
+
+            // Start GC with a random stack value as gcRoot (not the string stack element, because it was pushed out of the stack)
+            heap.FullGC(new List<StackValue>() { StackValue.BuildInt(1) }, testExecutive);
+
+            // The stack element that was pushed after GC start should be valid.
+            Assert.IsNotNull(heap.ToHeapObject<DSString>(someStackValue));
+        }
+
+        /// <summary>
         /// Test multi dimensional array could be released properly
         /// </summary>
         [Test]


### PR DESCRIPTION
How GC works and why:


When a certain memory threshold is reached (or at the end of a graph execution), GC will start up.
Initially all heap elements are marked as white (potentially good for cleanup).
GC works incrementally so that the VM execution does not have long periods of wait time. 
When GC starts up, it will first take a snapshot of the stack -> get all the elements on the stack that are of reference type (pointer, heap, string).
These active stack elements will be marked as gray (meaning that they should not be cleaned up and that they have not yet been fully processed).
After this step, the async process of tracing all references to heap elements begins. During this time the VM execution can startup and modify the stack and the heap (that is the async part).
Tracing heap references means that all the captured, active stack elements are parsed for references to heap elements (ex. an array on the stack that has heap elements as items) and marked as Black (not to be touched by the current cycle of GC).
Once all tracing is done, the remaining heap elements (still marked as white) will be cleaned up.
One important note: The GC algorithm preserves (should preserve) an important invariant – no black objects reference white objects

![Animation_of_tri-color_garbage_collection](https://user-images.githubusercontent.com/46732933/127199506-dacce4b4-0e78-45fd-a59f-0e8d18188709.gif)
https://en.wikipedia.org/wiki/Tracing_garbage_collection#Tri-color_marking

The problem:
Strings have a special status in Dynamo. New stack elements (black) can reference white heap strings (marked for cleanup by current GC cycle) because strings can be referenced even if they are out of scope (not on the stack anymore)

As an example:
```
def generateString() {
  return 1+"@" +2;
};

vv = [Imperative]{
  generateString();
// "1@2" will be on the heap
// current stack has no reference type elements
//  --------------------------------GC kicks in due to mem threshold----------------------------
// "1@2" on the heap will be marked as white - since no stack elements have a reference to it
//
// Async VM execution computes a new generateString() fn Call
  cc = generateString();
//
// cc is pushed on the stack and holds a reference to the "1@2" heap element
//
// GC starts the sweep process in which it deletes "1@2" heap element
// ----------------------------------GC is finished---------------------------------------------
  return cc;
};
//
// vv is still on the stack with a reference to a now null heap element
```
Note: I could not reproduce a similar scenario for pointers and arrays.

The proposed fix:
During a GC cycle, if a new string heap allocation is tried and if we match it with an already existing (White) string on the heap, then we mark the existing heap element as black so that it is not collected by the current GC cycle.