### PR TITLE
DYN-3847-Poupup-Guided-Flow-Fixes

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -38,7 +38,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             dynamoViewModel = dynViewModel;
 
             Guides = new List<Guide>();
-            CreateGuideSteps("UI/GuidedTour/dynamo_guides.json");
+            CreateGuideSteps(@"UI\GuidedTour\dynamo_guides.json");
 
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -43,7 +43,7 @@
 				"Type": "tooltip",
 				"TooltipPointerDirection": "bottom_left",
 				"Width": 480,
-				"Height": 220,
+				"Height": 240,
 				"StepContent": {
 					"Title": "GetStartedGuideRunStatusBarTitle",
 					"FormattedText": "GetStartedGuideRunStatusBarText"


### PR DESCRIPTION
### Purpose

Fixing the problem of Dynamo crashing when opening the Guided Tour (I was using the normal slash so probably that's why in Aabishkar VM computer was happening not in mine)
Fixing the bug reported "The last line of the text in step 2 (Run Status Bar) is hidden"

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
