### PR TITLE
Callsite ExecWithZeroRI optimizations to improve Cross Product replication performance 

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1530,7 +1530,7 @@ namespace ProtoCore
 
 
         private StackValue Execute(
-            List<FunctionEndPoint> functionEndPoint,
+            List<FunctionEndPoint> functionEndPoints,
             Context c,
             List<StackValue> formalParameters,
             List<ReplicationInstruction> replicationInstructions,
@@ -1544,12 +1544,12 @@ namespace ProtoCore
             if (replicationInstructions.Count == 0)
             {
                 c.IsReplicating = false;
-                ret = ExecWithZeroRI(functionEndPoint, c, formalParameters, stackFrame, runtimeCore, singleRunTraceData, newTraceData);
+                ret = ExecWithZeroRI(functionEndPoints, c, formalParameters, stackFrame, runtimeCore, singleRunTraceData, newTraceData);
             }
             else //replicated call
             {
                 c.IsReplicating = true;
-                ret = ExecWithRISlowPath(functionEndPoint, c, formalParameters, replicationInstructions, stackFrame, runtimeCore, singleRunTraceData, newTraceData);
+                ret = ExecWithRISlowPath(functionEndPoints, c, formalParameters, replicationInstructions, stackFrame, runtimeCore, singleRunTraceData, newTraceData);
             }
 
             //Do a trace save here
@@ -1569,7 +1569,7 @@ namespace ProtoCore
         /// <summary>
         /// Execute an arbitrary depth replication using the full slow path algorithm
         /// </summary>
-        /// <param name="functionEndPoint"></param>
+        /// <param name="functionEndPoints"></param>
         /// <param name="c"></param>
         /// <param name="formalParameters"></param>
         /// <param name="replicationInstructions"></param>
@@ -1580,7 +1580,7 @@ namespace ProtoCore
         /// <param name="finalFunctionEndPoint"></param>
         /// <returns></returns>
         private StackValue ExecWithRISlowPath(
-            List<FunctionEndPoint> functionEndPoint,
+            List<FunctionEndPoint> functionEndPoints,
             Context c,
             List<StackValue> formalParameters,
             List<ReplicationInstruction> replicationInstructions,
@@ -1596,7 +1596,7 @@ namespace ProtoCore
             //Recursion base case
             if (replicationInstructions.Count == 0)
             {
-                return ExecWithZeroRI(functionEndPoint, c, formalParameters, stackFrame, runtimeCore, previousTraceData, newTraceData, finalFunctionEndPoint);
+                return ExecWithZeroRI(functionEndPoints, c, formalParameters, stackFrame, runtimeCore, previousTraceData, newTraceData, finalFunctionEndPoint);
             }
 
             //Get the replication instruction that this call will deal with
@@ -1721,7 +1721,7 @@ namespace ProtoCore
 
                     SingleRunTraceData cleanRetTrace = new SingleRunTraceData();
 
-                    retSVs[i] = ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore, lastExecTrace, cleanRetTrace, finalFunctionEndPoint);
+                    retSVs[i] = ExecWithRISlowPath(functionEndPoints, c, newFormalParams, newRIs, stackFrame, runtimeCore, lastExecTrace, cleanRetTrace, finalFunctionEndPoint);
 
                     runtimeCore.AddCallSiteGCRoot(CallSiteID, retSVs[i]);
 
@@ -1782,7 +1782,7 @@ namespace ProtoCore
 
                     List<StackValue> newFormalParams = formalParameters.ToList();
 
-                    return ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore, previousTraceData, newTraceData, finalFunctionEndPoint);
+                    return ExecWithRISlowPath(functionEndPoints, c, newFormalParams, newRIs, stackFrame, runtimeCore, previousTraceData, newTraceData, finalFunctionEndPoint);
                 }
 
                 //Now iterate over each of these options
@@ -1823,7 +1823,7 @@ namespace ProtoCore
                     //previousTraceData = lastExecTrace;
                     SingleRunTraceData cleanRetTrace = new SingleRunTraceData();
 
-                    retSVs[i] = ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore, lastExecTrace, cleanRetTrace, finalFunctionEndPoint);
+                    retSVs[i] = ExecWithRISlowPath(functionEndPoints, c, newFormalParams, newRIs, stackFrame, runtimeCore, lastExecTrace, cleanRetTrace, finalFunctionEndPoint);
 
                     runtimeCore.AddCallSiteGCRoot(CallSiteID, retSVs[i]);
 

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1599,6 +1599,11 @@ namespace ProtoCore
                 return ExecWithZeroRI(functionEndPoints, c, formalParameters, stackFrame, runtimeCore, previousTraceData, newTraceData, finalFunctionEndPoint);
             }
 
+            if (finalFunctionEndPoint == null && functionEndPoints.Count == 1)
+            {
+                finalFunctionEndPoint = SelectFinalFep(c, functionEndPoints, formalParameters, stackFrame, runtimeCore);
+            }
+
             //Get the replication instruction that this call will deal with
             ReplicationInstruction ri = replicationInstructions[0];
 

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1771,7 +1771,7 @@ namespace ProtoCore
                 StackValue[] retSVs = new StackValue[retSize];
 
                 SingleRunTraceData retTrace = newTraceData;
-                retTrace.NestedData = new List<SingleRunTraceData>(); //this will shadow the SVs as they are created
+                retTrace.NestedData = new List<SingleRunTraceData>(retSize); //this will shadow the SVs as they are created
 
                 //Populate out the size of the list with default values
                 //@TODO:Luke perf optimisation here

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1781,11 +1781,12 @@ namespace ProtoCore
                     retTrace.NestedData.Add(new SingleRunTraceData());
                 }
 
+                //Build the call
+                List<StackValue> newFormalParams = formalParameters.ToList();
+
                 if (supressArray)
                 {
                     List<ReplicationInstruction> newRIs = replicationInstructions.GetRange(1, replicationInstructions.Count - 1);
-
-                    List<StackValue> newFormalParams = formalParameters.ToList();
 
                     return ExecWithRISlowPath(functionEndPoints, c, newFormalParams, newRIs, stackFrame, runtimeCore, previousTraceData, newTraceData, finalFunctionEndPoint);
                 }
@@ -1793,8 +1794,6 @@ namespace ProtoCore
                 //Now iterate over each of these options
                 for (int i = 0; i < retSize; i++)
                 {
-                    //Build the call
-                    List<StackValue> newFormalParams = formalParameters.ToList();
 
                     if (parameters != null)
                     {

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1755,13 +1755,12 @@ namespace ProtoCore
                 //this will hold the heap elements for all the arrays that are going to be replicated over
                 bool supressArray = false;
                 int retSize;
-                StackValue[] parameters = null;
+                DSArray array = null;
 
                 if (formalParameters[cartIndex].IsArray)
                 {
-                    DSArray array = runtimeCore.Heap.ToHeapObject<DSArray>(formalParameters[cartIndex]);
-                    parameters = array.Values.ToArray();
-                    retSize = parameters.Length;
+                    array = runtimeCore.Heap.ToHeapObject<DSArray>(formalParameters[cartIndex]);
+                    retSize = array.Count;
                 }
                 else
                 {
@@ -1794,12 +1793,8 @@ namespace ProtoCore
                 //Now iterate over each of these options
                 for (int i = 0; i < retSize; i++)
                 {
-
-                    if (parameters != null)
-                    {
-                        //It was an array pack the arg with the current value
-                        newFormalParams[cartIndex] = parameters[i];
-                    }
+                    //It was an array pack the arg with the current value
+                    newFormalParams[cartIndex] = array.GetValueFromIndex(i, runtimeCore);
 
                     List<ReplicationInstruction> newRIs = replicationInstructions.GetRange(1, replicationInstructions.Count - 1);
 

--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -141,7 +141,7 @@ namespace ProtoCore.Mirror
             return null;
         }
 
-        //Store marshaler for repeated calls to GetCLRObject.  Use these to short-circuit repeated calls of the same same stack value type. 
+        //Store marshaller for repeated calls to GetCLRObject.  Used for short-circuit of re-allocation of marshaller / interpreter object.
         private static int previousStackValueType;
         private static Interpreter interpreter;
         private static ProtoFFI.FFIObjectMarshaler marshaler;


### PR DESCRIPTION
### Purpose

This PR is follow up to some previous optimizations within the Callsite class, specifically to the ExecWithZeroRI method related to Cross Product replication.  A majority of these changes reduce temporary object allocations and associated GC time.  The larger the data set the larger the impact of the optimization.  This task covers:

- Removing the `AreParametersHomogeneousTypes` method check as we can more efficiently depend on the FunctionEndPoint count.  If the count is equal to 1 then we can directly resolve the `finalFunctionEndPoint` and cache it.  The optimization was already in place but based on the `AreParametersHomogeneousTypes` which appears to be extraneous. 
- Rename `FunctionEndPoint` list variable name to plural for clarity
- Adjust allocation of temporary parameter arrays outside of replication loop to save allocation and GC time.
- Use `DSArray` directly to access parameters vs copying items to temporary arrays.
- Set list capacity directly vs resizing dynamically after initialization.

todo => validate test
 
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers



### FYIs

@jasonstratton @QilongTang 