### PR TITLE
Remove dynamic strings from RecursiveMark hot path

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -431,7 +431,7 @@ namespace ProtoCore.DSASM
                 if (isDuringGCCriticalAsyncCycle && isValidHeapIndex)
                 {
                     var he = heapElements[index];
-                    Validity.Assert(he != null, $"Heap element found at index {index} during AllocateStringInternal cannot be null");
+                    Validity.Assert(he != null, $"Heap element found during AllocateStringInternal cannot be null");
 
                     // If heap element is marked as white then it is either not processed by Propagate step yet or processed and found as garbage.
                     // If the sweepSet does not contain the heap element's index then there is no need to mark it black (since cleanup will not even be tried)
@@ -682,7 +682,7 @@ namespace ProtoCore.DSASM
                 StackValue value = ptrs.Dequeue();
                 int rawPtr = (int)value.RawData;
                 var hp = heapElements[rawPtr];
-                Validity.Assert(hp != null, $"Heap element found at index {rawPtr} during RecursiveMark cannot be null");
+                Validity.Assert(hp != null, $"Heap element found during RecursiveMark cannot be null");
 
                 if (hp.Mark == GCMark.Black)
                     continue;
@@ -777,7 +777,7 @@ namespace ProtoCore.DSASM
             foreach (var ptr in sweepSet)
             {
                 var hp = heapElements[ptr];
-                Validity.Assert(hp != null, $"Heap element found at index {ptr} during GC sweep cannot be null.");
+                Validity.Assert(hp != null, $"Heap element found during GC sweep cannot be null.");
 
                 if (hp.Mark != GCMark.White)
                     continue;

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -431,7 +431,7 @@ namespace ProtoCore.DSASM
                 if (isDuringGCCriticalAsyncCycle && isValidHeapIndex)
                 {
                     var he = heapElements[index];
-                    Validity.Assert(he != null, $"Heap element found during AllocateStringInternal cannot be null");
+                    Validity.Assert(he != null, "Heap element found during AllocateStringInternal cannot be null");
 
                     // If heap element is marked as white then it is either not processed by Propagate step yet or processed and found as garbage.
                     // If the sweepSet does not contain the heap element's index then there is no need to mark it black (since cleanup will not even be tried)
@@ -682,7 +682,7 @@ namespace ProtoCore.DSASM
                 StackValue value = ptrs.Dequeue();
                 int rawPtr = (int)value.RawData;
                 var hp = heapElements[rawPtr];
-                Validity.Assert(hp != null, $"Heap element found during RecursiveMark cannot be null");
+                Validity.Assert(hp != null, "Heap element found during RecursiveMark cannot be null");
 
                 if (hp.Mark == GCMark.Black)
                     continue;
@@ -777,7 +777,7 @@ namespace ProtoCore.DSASM
             foreach (var ptr in sweepSet)
             {
                 var hp = heapElements[ptr];
-                Validity.Assert(hp != null, $"Heap element found during GC sweep cannot be null.");
+                Validity.Assert(hp != null, "Heap element found during GC sweep cannot be null.");
 
                 if (hp.Mark != GCMark.White)
                     continue;


### PR DESCRIPTION
### Purpose

This PR removes dynamic strings from the hot path for `RecursiveMark`.  Resolving these strings can take more time the GC implementation in some situations.  The strings are now resolved to static strings.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@pinzart 

### FYIs

@jasonstratton 
