### PR TITLE
add logging to intermittent pkgloader tests

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -421,7 +421,7 @@ namespace Dynamo.Core
         /// <param name="isTestMode">
         ///     Flag specifying whether or not this should operate in "test mode".
         /// </param>
-        /// <param name="PackageInfo">
+        /// <param name="packageInfo">
         ///     Info about the package that requested this customNode to be loaded or to which the customNode belongs.
         ///     Is PackageMember property will be true if this property is not null.
         /// </param>

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -298,7 +298,6 @@ namespace DynamoCoreWpfTests
             var loader = new PackageLoader(pathManager.Object);
             var libraryLoader = new ExtensionLibraryLoader(dynamoModel);
 
-            loader.PackagesLoaded += libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary += libraryLoader.LoadNodeLibrary;
             var loadPackageParams = new LoadPackageParams
             {
@@ -316,6 +315,8 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(uiassembly.IsNodeLibrary);
             //verify that the customization was added to the customization library
             Assert.IsTrue(View.nodeViewCustomizationLibrary.ContainsCustomizationForNodeModel(nodeModelAssembly.Assembly.GetType("NodeModelAssembly.NodeModelDerivedClass")));
+
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadNodeLibrary;
 
         }
 

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -1203,6 +1203,9 @@ namespace Dynamo.PackageManager.Tests
             //verify customization assembly was added to nodeModelAssemblyLoader
             Assert.IsTrue(CurrentDynamoModel.Loader.LoadedAssemblies.Select(x=>x.FullName.Contains("NodeViewCustomizationAssembly")).Any());
             Assert.IsTrue(CurrentDynamoModel.Loader.LoadedAssemblies.Select(x => x.FullName.Contains("NodeModelAssembly")).Any());
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadNodeLibrary;
         }
 
         [Test]

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -377,8 +377,10 @@ namespace Dynamo.PackageManager.Tests
 
             // This test needs the "isTestMode" flag to be turned off as an exception to be able 
             // to test duplicate custom node def loading.
-            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
-            CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) => {
+                Console.WriteLine($"packageInfo reqLoadCNDelegate :pkginfo");
+                return CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+                };
             loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
 
             loader.LoadAll(new LoadPackageParams
@@ -387,7 +389,15 @@ namespace Dynamo.PackageManager.Tests
             });
 
             var packageInfo = new PackageInfo("EvenOdd", new System.Version(1,0,0));
-            var matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x => x.Value.PackageInfo.Equals(packageInfo)).ToList();
+
+            //this test fails randomly - log some info to help debug it.
+            Console.WriteLine($"pathmanager.PackagesDirectories{String.Join(",",pathManager.Object.PackagesDirectories)}");
+            var matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x =>
+            {
+                Console.WriteLine($"val{x.Value}, name{x.Value.Name}, pkginfo{x.Value.PackageInfo}, packagemember{x.Value.IsPackageMember}");
+                return x.Value.PackageInfo.Equals(packageInfo);
+            }
+            ).ToList();
             //the node should have the correct package info and should be marked a packageMember.
             Assert.AreEqual(1, matchingNodes.Count);
             Assert.IsTrue(matchingNodes.All(x=>x.Value.IsPackageMember == true));
@@ -412,7 +422,14 @@ namespace Dynamo.PackageManager.Tests
 
 
             var packageInfo = new PackageInfo("EvenOdd", new System.Version(1, 0, 0));
-            var matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x => x.Value.PackageInfo.Equals(packageInfo)).ToList();
+            //this test fails randomly - log some info to help debug it.
+            Console.WriteLine($"pathmanager.PackagesDirectories{String.Join(",", CurrentDynamoModel.PathManager.PackagesDirectories)}");
+            var matchingNodes = CurrentDynamoModel.CustomNodeManager.NodeInfos.Where(x =>
+            {
+                Console.WriteLine($"val{x.Value}, name{x.Value.Name}, pkginfo{x.Value.PackageInfo}, packagemember{x.Value.IsPackageMember}");
+                return x.Value.PackageInfo.Equals(packageInfo);
+            }
+            ).ToList();
             //the node should have the correct package info and should be marked a packageMember.
             Assert.AreEqual(1, matchingNodes.Count);
             Assert.IsTrue(matchingNodes.All(x => x.Value.IsPackageMember == true));


### PR DESCRIPTION
* Attempting to catch some more information when these tests fail.
* Also made tests I added recently consistent with other package loading tests by unsubscribing loading events.
