### PR TITLE
Accidental deletion of xaml code reverted.

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -130,10 +130,20 @@
     <SolidColorBrush x:Key="PinnedIconBackgroundColor" Color="#FF5E5C5A" />
     <SolidColorBrush x:Key="PinnedIconHoverBackgroundColor" Color="#c6c6c6" />
 
-    <!-- Port color -->
-    <SolidColorBrush x:Key="KeepListStructureHighlight" Color="#66AAD7"/>
-    <SolidColorBrush x:Key="NotKeepListStructureHighlight" Color="White"/>
-    
+    <!--  Port color  -->
+    <SolidColorBrush x:Key="PortDefaultBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="PortIsConnectedBackground" Color="#465A63" />
+    <SolidColorBrush x:Key="PortIsNotConnectedBackground" Color="#6B4343" />
+    <SolidColorBrush x:Key="PortKeepListStructureBackground" Color="#5EA5C4" />
+
+    <SolidColorBrush x:Key="PortDefaultBorderBrush" Color="{StaticResource PrimaryCharcoal300}" />
+    <SolidColorBrush x:Key="PortIsConnectedBorderBrush" Color="#6AC0E7" />
+    <SolidColorBrush x:Key="PortIsNotConnectedBorderBrush" Color="#F48686" />
+    <SolidColorBrush x:Key="PortKeepListStructureBorderBrush" Color="#6AC0E7" />
+
+    <SolidColorBrush x:Key="PortUsingDefaultValueMarkerColor" Color="#9BD5EF" />
+    <SolidColorBrush x:Key="PortUseLevelsCheckBoxColor" Color="#808080" />
+
     <!--Connector-->
     <SolidColorBrush x:Key="ConnectorHoverStateOutline" Color="#B6B6B6"/>
 </ResourceDictionary>


### PR DESCRIPTION
### Description 
Accidentally deleted some important xaml ( in DynamoColorsAndBrushes.xaml) having to do with the styling of the node redesign. This PR reverts that accidental deletion.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
