### PR TITLE
CRASH: NullReferenceException when mouse is released on the dynamoworkspace view

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -896,12 +896,13 @@ namespace Dynamo.ViewModels
 
             private void CancelWindowSelection()
             {
-                // visualization unpause
-                owningWorkspace.OnDragSelectionEnded(this, EventArgs.Empty);
-
-                SelectionBoxUpdateArgs args = null;
-                args = new SelectionBoxUpdateArgs(Visibility.Collapsed);
-                this.owningWorkspace.RequestSelectionBoxUpdate(this, args);
+                if (owningWorkspace != null)
+                {
+                    // visualization unpause
+                    owningWorkspace.OnDragSelectionEnded(this, EventArgs.Empty);
+                    SelectionBoxUpdateArgs args = new SelectionBoxUpdateArgs(Visibility.Collapsed);
+                    this.owningWorkspace.RequestSelectionBoxUpdate(this, args);
+                }
             }
 
             #endregion
@@ -912,8 +913,7 @@ namespace Dynamo.ViewModels
             {
                 foreach (var selectable in DynamoSelection.Instance.Selection)
                 {
-                    var locatable = selectable as ILocatable;
-                    if (locatable == null || (!locatable.Rect.Contains(point.AsDynamoType())))
+                    if (!(selectable is ILocatable locatable) || (!locatable.Rect.Contains(point.AsDynamoType())))
                         continue;
 
                     return selectable;


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-3855, guarding for null exception. Notice that I was not able to reproduce the crash but by reading the code it seems only `owningWorkspace` being null could cause the crash. Let me know if you have other thoughts. Since state machine is strictly private under WorkspaceViewModel, seems no way to unit test it.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
