### PR TITLE
Update searchMethod invocation in LibraryMSWebBrowserExtension

### DIFF
--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -353,7 +353,8 @@ namespace Dynamo.Search
         }
 
         /// <summary>
-        /// Search for elements in the dictionary or subset based on the query
+        /// Search for elements in the dictionary or subset based on the query. PLEASE NOTE - this method is called using reflection from the
+	/// MSLibraryWebBrowserUIExtension - if its signature is modified, please update its use in that extension.
         /// </summary>
         /// <param name="query"> The query </param>
         /// <param name="minResultsForTolerantSearch">Minimum number of results in the original search strategy to justify doing more tolerant search</param>

--- a/src/LibraryViewExtensionMSWebBrowser/Handlers/SearchResultDataProvider.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/Handlers/SearchResultDataProvider.cs
@@ -55,7 +55,7 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser.Handlers
 
             var text = Uri.UnescapeDataString(searchText);
             //TODO replace this with direct call.
-            var elements = searchMethod.Invoke(model,new object[] { text,0 }) as IEnumerable<NodeSearchElement>;
+            var elements = searchMethod.Invoke(model,new object[] { text,0,null }) as IEnumerable<NodeSearchElement>;
 
             extension = "json";
             return GetNodeItemDataStream(elements, true);


### PR DESCRIPTION
Update searchMethod invocation  to use correct number of parameters

### Purpose
in this PR - this internal method had its number of parameters changed: https://github.com/DynamoDS/Dynamo/pull/11613
because we call it with reflection, our invocation broke.

Update it to pass 3 parameters.

After this is merged we'll kick off a new build of this job:
https://master-5.jenkins.autodesk.com/job/Dynamo/job/LibraryExtension_MSFTWebBrowser-Build/job/master/

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
