### PR TITLE
Fix For Loading Json File

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -45,7 +45,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
             guideBackgroundElement = Guide.FindChild(root, "GuidesBackground") as GuideBackground;
 
             Guides = new List<Guide>();
-            CreateGuideSteps(@"UI\GuidedTour\dynamo_guides.json");
+            string binPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string guidesJsonPath = Path.Combine(binPath, @"UI\GuidedTour\dynamo_guides.json");
+            CreateGuideSteps(guidesJsonPath);
 
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -34,6 +34,22 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private const double ExitTourVerticalOffset = 30;
         private const double ExitTourHorizontalOffset = 0;
 
+        public static string GuidesExecutingDirectory
+        {
+            get
+            {
+                return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            }
+        }
+
+        public static string GuidesJsonFilePath
+        {
+            get
+            {
+                return Path.Combine(GuidesExecutingDirectory, @"UI\GuidedTour\dynamo_guides.json");
+            }
+        }
+
         /// <summary>
         /// GuidesManager Constructor that will read all the guides/steps from and json file and subscribe handlers for the Start and Finish events
         /// </summary>
@@ -45,9 +61,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
             guideBackgroundElement = Guide.FindChild(root, "GuidesBackground") as GuideBackground;
 
             Guides = new List<Guide>();
-            string binPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string guidesJsonPath = Path.Combine(binPath, @"UI\GuidedTour\dynamo_guides.json");
-            CreateGuideSteps(guidesJsonPath);
+          
+            CreateGuideSteps(GuidesJsonFilePath);
 
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -123,6 +123,7 @@
     </Compile>
     <Compile Include="ColorPaletteTests.cs" />
     <Compile Include="ConverterViewModelTests.cs" />
+    <Compile Include="GuidedTourTests.cs" />
     <Compile Include="InfoBubbleTests.cs" />
     <Compile Include="Libraries\LabelTests.cs" />
     <Compile Include="ListAtLevelTest.cs" />

--- a/test/DynamoCoreWpfTests/GuidedTourTests.cs
+++ b/test/DynamoCoreWpfTests/GuidedTourTests.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using Dynamo.Wpf.UI.GuidedTour;
+using NUnit.Framework;
+using SystemTestServices;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    public class GuidedTourTests : SystemTestBase
+    {
+        [Test]
+        public void CanReadGuidedTourJsonFile()
+        {
+            //Initialize the GuideManager to null to later we can verify that it was created correctly
+            GuidesManager testGuide = null;
+
+            //Check that the directory location where the assembly is created already exists
+            string failMessageDirectory = string.Format("The assembly directory path doesn't exits: {0}", GuidesManager.GuidesExecutingDirectory);
+            Assert.IsTrue(Directory.Exists(GuidesManager.GuidesExecutingDirectory), failMessageDirectory);
+
+            //Check that the Guides Json file location exists
+            string failMessageFile = string.Format("The guides JSON file: {0} couldn't be located or doesn't exits", GuidesManager.GuidesJsonFilePath);
+            Assert.IsTrue(File.Exists(GuidesManager.GuidesJsonFilePath), failMessageFile);
+
+            //Creates the Guides Manager passing the Dynamo Window and ViewModel and validates that no exception is thrown
+            Assert.DoesNotThrow( () => testGuide = new GuidesManager(View._this, ViewModel));
+
+            //Validate that the Guides were read correctly from the json file
+            Assert.NotNull(testGuide);
+            Assert.NotNull(testGuide.Guides);
+            Assert.That(testGuide.Guides.Count > 0,"No guides read from the JSON file");
+
+            //Validates that each Guide read from the Json file has at least one step
+            foreach(var guide in testGuide.Guides)
+            {
+                Assert.That(guide.GuideSteps.Count > 0, "No steps read from the JSON file"); 
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

During the testing of the task related to the exit tour popup DYN-3817, Aabishkar reported that when trying to open the "Get Started" tour a message appear saying Could not find a part of the path 'C:\Windows\system32\UI\GuidedTour\dynamo_guides.json'
Then I modified the code that is loading the json,file, in the past was a relative path and now we are using an absolute path.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
