### PR TITLE
Wire Behaviour UI fixes

### DIFF
--- a/src/DynamoCore/Graph/ConnectorPinModel.cs
+++ b/src/DynamoCore/Graph/ConnectorPinModel.cs
@@ -14,7 +14,10 @@ namespace Dynamo.Graph
         /// Required when needing to pull a reliable value for objects of this
         /// type when there is no instances of this object type.
         /// </summary>
-        public static double StaticWidth = width;
+        public static double StaticWidth() 
+        {
+             return  width;
+        }
 
         public override double Height { get => height; }
         public override double Width { get => width; }

--- a/src/DynamoCore/Graph/ConnectorPinModel.cs
+++ b/src/DynamoCore/Graph/ConnectorPinModel.cs
@@ -7,12 +7,17 @@ namespace Dynamo.Graph
 {
     public class ConnectorPinModel : ModelBase
     {
-        private double height = 30;
-        private double width = 30;
+        private const double height = 30;
+        private const double width = 30;
         public Guid ConnectorId { get; set; }
+        /// <summary>
+        /// Required when needing to pull a reliable value for objects of this
+        /// type when there is no instances of this object type.
+        /// </summary>
+        public const double StaticWidth = width;
 
         public override double Height { get => height; }
-        public override double Width { get => width; }
+        public override double Width { get => StaticWidth; }
         public ConnectorPinModel(double x, double y, Guid id, Guid connectorId)
         {
             X = x;

--- a/src/DynamoCore/Graph/ConnectorPinModel.cs
+++ b/src/DynamoCore/Graph/ConnectorPinModel.cs
@@ -14,10 +14,7 @@ namespace Dynamo.Graph
         /// Required when needing to pull a reliable value for objects of this
         /// type when there is no instances of this object type.
         /// </summary>
-        public static double StaticWidth() 
-        {
-             return  width;
-        }
+        public const double StaticWidth = width;
 
         public override double Height { get => height; }
         public override double Width { get => width; }

--- a/src/DynamoCore/Graph/ConnectorPinModel.cs
+++ b/src/DynamoCore/Graph/ConnectorPinModel.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Graph
         public const double StaticWidth = width;
 
         public override double Height { get => height; }
-        public override double Width { get => StaticWidth; }
+        public override double Width { get => width; }
         public ConnectorPinModel(double x, double y, Guid id, Guid connectorId)
         {
             X = x;

--- a/src/DynamoCore/Graph/ConnectorPinModel.cs
+++ b/src/DynamoCore/Graph/ConnectorPinModel.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Graph
         /// Required when needing to pull a reliable value for objects of this
         /// type when there is no instances of this object type.
         /// </summary>
-        public const double StaticWidth = width;
+        public static double StaticWidth = width;
 
         public override double Height { get => height; }
         public override double Width { get => width; }

--- a/src/DynamoCore/Graph/ConnectorPinModel.cs
+++ b/src/DynamoCore/Graph/ConnectorPinModel.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Graph
         /// Required when needing to pull a reliable value for objects of this
         /// type when there is no instances of this object type.
         /// </summary>
-        public const double StaticWidth = width;
+        public static double StaticWidth => width;
 
         public override double Height { get => height; }
         public override double Width { get => width; }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -115,7 +115,7 @@
             <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
               Name="connector"
               Visibility="{Binding BezVisibility, Converter={StaticResource BooleanToVisibilityConverter}}" 
-              Style="{StaticResource SConnector}" Canvas.ZIndex="0" ToolTip="{Binding ConnectorDataTooltip}" Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
+              Style="{StaticResource SConnector}" Canvas.ZIndex="0" Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
                 <i:Interaction.Behaviors>
                     <mouse:MouseBehaviour MouseX="{Binding PanelX, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" MouseY="{Binding PanelY, Mode=OneWayToSource,  UpdateSourceTrigger=PropertyChanged}" />
                 </i:Interaction.Behaviors>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -130,10 +130,20 @@
     <SolidColorBrush x:Key="PinnedIconBackgroundColor" Color="#FF5E5C5A" />
     <SolidColorBrush x:Key="PinnedIconHoverBackgroundColor" Color="#c6c6c6" />
 
-    <!-- Port color -->
-    <SolidColorBrush x:Key="KeepListStructureHighlight" Color="#66AAD7"/>
-    <SolidColorBrush x:Key="NotKeepListStructureHighlight" Color="White"/>
-    
+    <!--  Port color  -->
+    <SolidColorBrush x:Key="PortDefaultBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="PortIsConnectedBackground" Color="#465A63" />
+    <SolidColorBrush x:Key="PortIsNotConnectedBackground" Color="#6B4343" />
+    <SolidColorBrush x:Key="PortKeepListStructureBackground" Color="#5EA5C4" />
+
+    <SolidColorBrush x:Key="PortDefaultBorderBrush" Color="{StaticResource PrimaryCharcoal300}" />
+    <SolidColorBrush x:Key="PortIsConnectedBorderBrush" Color="#6AC0E7" />
+    <SolidColorBrush x:Key="PortIsNotConnectedBorderBrush" Color="#F48686" />
+    <SolidColorBrush x:Key="PortKeepListStructureBorderBrush" Color="#6AC0E7" />
+
+    <SolidColorBrush x:Key="PortUsingDefaultValueMarkerColor" Color="#9BD5EF" />
+    <SolidColorBrush x:Key="PortUseLevelsCheckBoxColor" Color="#808080" />
+
     <!--Connector-->
     <SolidColorBrush x:Key="ConnectorHoverStateOutline" Color="#B6B6B6"/>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -158,8 +158,6 @@ namespace Dynamo.ViewModels
                 isVisible = value;
                 RaisePropertyChanged(nameof(IsVisible));
                 SetVisibilityOfPins(IsVisible);
-                if(connectorAnchorViewModel != null)
-                    connectorAnchorViewModel.IsVisible = isVisible;
             }
         }
 
@@ -593,16 +591,13 @@ namespace Dynamo.ViewModels
         private void MouseUnhoverCommandExecute(object parameter)
         {
             MouseHoverOn = false;
-            if (ConnectorAnchorViewModel != null)
-                ConnectorAnchorViewModel.MouseHoverOn = false;
         }
         /// <summary>
         /// Called from outside during unit tests and thus 'internal' as opposed to 'private'.
         /// </summary>
         internal void FlipOnConnectorAnchor()
         {
-            ConnectorAnchorViewModel = new ConnectorAnchorViewModel(this, workspaceViewModel.DynamoViewModel.Model);
-            ConnectorAnchorViewModel.MouseHoverOn = true;
+            ConnectorAnchorViewModel = new ConnectorAnchorViewModel(this, workspaceViewModel.DynamoViewModel.Model, ConnectorDataTooltip);
             ConnectorAnchorViewModel.CurrentPosition = MousePosition;
             ConnectorAnchorViewModel.IsHalftone = !IsVisible;
             ConnectorAnchorViewModel.IsDataFlowCollection = IsDataFlowCollection;
@@ -704,10 +699,10 @@ namespace Dynamo.ViewModels
         /// <param name="parameters"></param>
         private void PinConnectorCommandExecute(object parameters)
         {
-            MousePosition = new Point(PanelX, PanelY);
+            MousePosition = new Point(PanelX-ConnectorPinModel.StaticWidth, PanelY-ConnectorPinModel.StaticWidth);
             ConnectorAnchorViewModel.CurrentPosition = MousePosition;
             if (MousePosition == new Point(0, 0)) return;
-            var connectorPinModel = new ConnectorPinModel(PanelX, PanelY, Guid.NewGuid(), model.GUID);
+            var connectorPinModel = new ConnectorPinModel(MousePosition.X, MousePosition.Y, Guid.NewGuid(), model.GUID);
             ConnectorModel.AddPin(connectorPinModel);
             workspaceViewModel.Model.RecordCreatedModel(connectorPinModel);
         }
@@ -731,7 +726,7 @@ namespace Dynamo.ViewModels
 
         private bool CanRunMouseHover(object parameter)
         {
-            return !IsConnecting;
+            return !IsConnecting && BezVisibility;
         }
         private bool CanRunMouseUnhover(object parameter)
         {
@@ -1277,7 +1272,7 @@ namespace Dynamo.ViewModels
                 int count = 0;
                 foreach (var wirePin in ConnectorPinViewCollection)
                 {
-                    points[count] = new Point(wirePin.Left+wirePin.Model.Width - (wirePin.HalfWidth * 0.3), wirePin.Top+wirePin.Model.Height - (wirePin.HalfWidth * 0.3));
+                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (wirePin.HalfWidth * 0.3), wirePin.Top+ ConnectorPinModel.StaticWidth - (wirePin.HalfWidth * 0.3));
                     count++;
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -699,7 +699,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameters"></param>
         private void PinConnectorCommandExecute(object parameters)
         {
-            MousePosition = new Point(PanelX-ConnectorPinModel.StaticWidth(), PanelY-ConnectorPinModel.StaticWidth());
+            MousePosition = new Point(PanelX-ConnectorPinModel.StaticWidth, PanelY-ConnectorPinModel.StaticWidth);
             ConnectorAnchorViewModel.CurrentPosition = MousePosition;
             if (MousePosition == new Point(0, 0)) return;
             var connectorPinModel = new ConnectorPinModel(MousePosition.X, MousePosition.Y, Guid.NewGuid(), model.GUID);
@@ -1272,7 +1272,7 @@ namespace Dynamo.ViewModels
                 int count = 0;
                 foreach (var wirePin in ConnectorPinViewCollection)
                 {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth() - (wirePin.HalfWidth * 0.3), wirePin.Top+ ConnectorPinModel.StaticWidth() - (wirePin.HalfWidth * 0.3));
+                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (wirePin.HalfWidth * 0.3), wirePin.Top+ ConnectorPinModel.StaticWidth - (wirePin.HalfWidth * 0.3));
                     count++;
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -699,7 +699,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameters"></param>
         private void PinConnectorCommandExecute(object parameters)
         {
-            MousePosition = new Point(PanelX-ConnectorPinModel.StaticWidth, PanelY-ConnectorPinModel.StaticWidth);
+            MousePosition = new Point(PanelX-ConnectorPinModel.StaticWidth(), PanelY-ConnectorPinModel.StaticWidth());
             ConnectorAnchorViewModel.CurrentPosition = MousePosition;
             if (MousePosition == new Point(0, 0)) return;
             var connectorPinModel = new ConnectorPinModel(MousePosition.X, MousePosition.Y, Guid.NewGuid(), model.GUID);
@@ -1272,7 +1272,7 @@ namespace Dynamo.ViewModels
                 int count = 0;
                 foreach (var wirePin in ConnectorPinViewCollection)
                 {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (wirePin.HalfWidth * 0.3), wirePin.Top+ ConnectorPinModel.StaticWidth - (wirePin.HalfWidth * 0.3));
+                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth() - (wirePin.HalfWidth * 0.3), wirePin.Top+ ConnectorPinModel.StaticWidth() - (wirePin.HalfWidth * 0.3));
                     count++;
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -16,14 +16,13 @@ namespace Dynamo.ViewModels
         #region Properties 
         private Point currentPosition;
         private bool isHalftone;
-        private bool isVisible;
-        private bool mouseHoverOn;
         private bool isPartlyVisible = false;
         private bool isDataFlowCollection;
         private bool canDisplayIcons = false;
 
         private bool watchIconPreviewOn = false;
         private bool pinIconPreviewOn = false;
+        private string dataTooltipText;
 
         private ConnectorViewModel ViewModel { get; set; }
         private DynamoModel DynamoModel { get; set; }
@@ -52,7 +51,7 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-
+        /// Follows the 'isHalftone' visibility of the connector.
         /// </summary>
         public bool IsHalftone
         {
@@ -64,32 +63,6 @@ namespace Dynamo.ViewModels
             {
                 isHalftone = value;
                 RaisePropertyChanged(nameof(IsHalftone));
-            }
-        }
-       
-        public bool IsVisible
-        {
-            get
-            {
-                return isVisible;
-            }
-            set
-            {
-                isVisible = value;
-                RaisePropertyChanged(nameof(IsVisible));
-            }
-        }
-
-        public bool MouseHoverOn
-        {
-            get
-            {
-                return mouseHoverOn;
-            }
-            set
-            {
-                mouseHoverOn = value;
-                RaisePropertyChanged(nameof(MouseHoverOn));
             }
         }
 
@@ -107,6 +80,9 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Is the mouse over one of pin icon? Flag to switch color(binding) of pin button.
+        /// </summary>
         public bool PinIconPreviewOn
         {
             get
@@ -119,6 +95,7 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(PinIconPreviewOn));
             }
         }
+        ///Is the mouse over one of watch icon? Flag to switch color(binding) of watch button.
         public bool WatchIconPreviewOn
         {
             get
@@ -131,8 +108,6 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(WatchIconPreviewOn));
             }
         }
-
-
 
         internal void SwitchWatchPreviewOn()
         {
@@ -164,6 +139,10 @@ namespace Dynamo.ViewModels
             PinIconPreviewOn = false;
         }
 
+        /// <summary>
+        /// This property acts as the main flag that signals whether or not watch icon/pin icon/tooltip
+        /// should be visibile/ hidden.
+        /// </summary>
         public bool CanDisplayIcons
         {
             get { return canDisplayIcons; }
@@ -171,6 +150,23 @@ namespace Dynamo.ViewModels
             {
                 canDisplayIcons = value;
                 RaisePropertyChanged(nameof(CanDisplayIcons));
+            }
+        }
+        /// <summary>
+        /// This property holds the string representation of the data 
+        /// being passed through this connector. It gets relayed from the 
+        /// ConnectorViewModel.
+        /// </summary>
+        public string DataToolTipText
+        {
+            get
+            {
+                return dataTooltipText;
+            }
+            set
+            {
+                dataTooltipText = value;
+                RaisePropertyChanged(nameof(DataToolTipText));
             }
         }
         #endregion
@@ -223,10 +219,11 @@ namespace Dynamo.ViewModels
             OnRequestDispose(this, EventArgs.Empty);
         }
 
-        public ConnectorAnchorViewModel(ConnectorViewModel connectorViewModel, DynamoModel dynamoModel)
+        public ConnectorAnchorViewModel(ConnectorViewModel connectorViewModel, DynamoModel dynamoModel, string tooltipText)
         {
             ViewModel = connectorViewModel;
             DynamoModel = dynamoModel;
+            DataToolTipText = tooltipText;
             InitCommands();
 
             Dispatcher = Dispatcher.CurrentDispatcher;

--- a/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
@@ -15,15 +15,45 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+                <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="Button" x:Key="TransparentButton">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent">
+                                <ContentPresenter/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style TargetType="Button" x:Key="TransparentButtonWithTriggers">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent">
+                                <ContentPresenter/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding CanDisplayIcons}" Value="True">
+                        <Setter Property="Visibility" Value="Visible"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding CanDisplayIcons}" Value="False">
+                        <Setter Property="Visibility" Value="Hidden"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Canvas Canvas.Top="0"
             Canvas.Left="0">
         <!--wire anchor-->
-        <Button Background="Transparent"
-                BorderBrush="Transparent"
+        <Button Style="{StaticResource TransparentButton}"
                 x:Name="AnchorButton"
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
@@ -51,9 +81,8 @@
         </Button>
 
         <!--watch icon-->
-        <Button Background="Transparent"
-                BorderBrush="Transparent"
-                x:Name="WatchIconButton"
+        <Button x:Name="WatchIconButton"
+                Style="{StaticResource TransparentButtonWithTriggers}"
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
                 Height="{Binding MarkerSize}"
@@ -61,18 +90,6 @@
                 Command="{Binding PlaceWatchNodeCommand}"
                 MouseEnter="OnWatchIconHover"
                 MouseLeave="OnWatchIconUnhover">
-            <Button.Style>
-                <Style TargetType="{x:Type Button}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="False">
-                            <Setter Property="Visibility" Value="Hidden"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Button.Style>
             <StackPanel Background="Transparent">
                 <Image>
                     <Image.Style>
@@ -97,9 +114,8 @@
             </Button.RenderTransform>
         </Button>
         <!--pin icon-->
-        <Button Background="Transparent"
-                BorderBrush="Transparent"
-                x:Name="PinIconButton"
+        <Button x:Name="PinIconButton"
+                Style="{StaticResource TransparentButtonWithTriggers}"
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
                 Height="{Binding MarkerSize}"
@@ -107,18 +123,6 @@
                 Command="{Binding PinConnectorCommand}"
                 MouseEnter="OnPinIconHover"
                 MouseLeave="OnPinIconUnhover">
-            <Button.Style>
-                <Style TargetType="{x:Type Button}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Path=CanDisplayIcons, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Path=CanDisplayIcons, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="False">
-                            <Setter Property="Visibility" Value="Hidden"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Button.Style>
             <StackPanel Background="Transparent">
                 <Image>
                     <Image.Style>
@@ -142,6 +146,48 @@
                 <TranslateTransform X="0" Y="-37" />
             </Button.RenderTransform>
         </Button>
+        <!--toolTipBox-->
+        <Border x:Name="borderToolTipBox"
+                BorderThickness="1"
+                BorderBrush="{StaticResource FilterPopupBorderColor}"
+                Canvas.Top="{Binding CurrentPosition.Y}"
+                Canvas.Left="{Binding CurrentPosition.X}">
+            <Border.Style>
+                <Style TargetType="{x:Type Border}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="False">
+                            <Setter Property="Visibility" Value="Hidden"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <TextBlock x:Name="toolTipBox"
+                       Background="{StaticResource SearchTextBoxBackground}"
+                       Foreground="Gray"
+                       Text="{Binding DataToolTipText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                       Padding="5"
+                       Canvas.Top="{Binding CurrentPosition.Y}"
+                       Canvas.Left="{Binding CurrentPosition.X}">
+            <TextBlock.Style>
+                <Style TargetType="{x:Type TextBlock}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="False">
+                            <Setter Property="Visibility" Value="Hidden"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+            </TextBlock>
+            <Border.RenderTransform>
+                <TranslateTransform X="0" Y="15" />
+            </Border.RenderTransform>
+        </Border>
     </Canvas>
 </UserControl>
 


### PR DESCRIPTION
### Description 
UI fixes addressing some of the recent deviations in expected behaviour:
- Button rectangular border removed from connector hover icon buttons (watch/ pin/ anchor).
- Connector tooltip behaviour to match that of temporary hover icons.
- Hover state for polyline connectors disabled.
- Instantiation location of pins fixed.

*Node layout regression test fixes will be addressed in a different PR.

![WireBehaviour-UI Fixes PR](https://user-images.githubusercontent.com/24754290/130076200-1ea53005-33cb-46c6-ab35-528b7bd9a69b.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
@Amoursol 
