### PR TITLE
Fix nodeManipulator persistent warnings issue

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.13.0.2305")]
+[assembly: AssemblyVersion("2.13.0.2104")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.13.0.2305")]
+[assembly: AssemblyFileVersion("2.13.0.2104")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.13.0.2104")]
+[assembly: AssemblyVersion("2.13.0.2305")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.13.0.2104")]
+[assembly: AssemblyFileVersion("2.13.0.2305")]

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1595,6 +1595,7 @@ namespace Dynamo.Graph.Nodes
                     if (string.Compare(t, transientWarning) == 0)
                     {
                         transientWarning = string.Empty;
+                        SetNodeStateBasedOnConnectionAndDefaults();
                         ToolTipText = persistentWarning;
                     }
                     // if no match is found, we do nothing.
@@ -1604,9 +1605,12 @@ namespace Dynamo.Graph.Nodes
                 if(persistentWarnings.Any())
                 {
                     // If persistent warnings still exists, then we simply set the tooltip without any transient
+                    SetNodeStateBasedOnConnectionAndDefaults();
                     ToolTipText = persistentWarning;
                     return;
                 }
+                // called with null argument or no persistent warnings remain
+                // in this case we just reset everything
                 ClearErrorsAndWarnings();
             }
         }
@@ -1621,15 +1625,25 @@ namespace Dynamo.Graph.Nodes
             if (State == ElementState.PersistentWarning)
             {
                 if (!string.IsNullOrEmpty(p))
-                {
-                    persistentWarnings.Remove(p);
-                    ToolTipText = persistentWarning;
-
-                    if (persistentWarnings.Any())
+                {// Called with valid argument
+                    if (persistentWarnings.Remove(p))
+                    {// p was found among the existing persistent warnings
+                        if (persistentWarnings.Any())
+                        {
+                            // If any persistent warnings remain then we just set the tooltip
+                            ToolTipText = persistentWarning;
+                            return;
+                        }
+                    }
+                    else
                     {
+                        // p was not found among the existing persistent warnings then there is
+                        // nothing to do further
                         return;
                     }
                 }
+                // called with null argument or no more persistent warnings remain
+                // in this case we just reset everything
                 ClearErrorsAndWarnings();
             }
         }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1595,6 +1595,7 @@ namespace Dynamo.Graph.Nodes
                     if (string.Compare(t, transientWarning) == 0)
                     {
                         transientWarning = string.Empty;
+                        State = ElementState.Dead;
                         SetNodeStateBasedOnConnectionAndDefaults();
                         ToolTipText = persistentWarning;
                     }
@@ -1603,8 +1604,8 @@ namespace Dynamo.Graph.Nodes
                 } 
 
                 if(persistentWarnings.Any())
-                {
-                    // If persistent warnings still exists, then we simply set the tooltip without any transient
+                {// If persistent warnings still exists, then we simply reset the state and set the tooltip without any transient
+                    State = ElementState.Dead;
                     SetNodeStateBasedOnConnectionAndDefaults();
                     ToolTipText = persistentWarning;
                     return;

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1572,7 +1572,7 @@ namespace Dynamo.Graph.Nodes
         public virtual void ClearErrorsAndWarnings()
         {
             State = ElementState.Dead;
-            ClearPersistentWarnings();
+            persistentWarnings.Clear();
 
             SetNodeStateBasedOnConnectionAndDefaults();
             ClearTooltipText();
@@ -1589,24 +1589,16 @@ namespace Dynamo.Graph.Nodes
                 if (p != null)
                 {
                     persistentWarnings.Remove(p);
-                }
-                else
-                {
-                    persistentWarnings.Clear();
-                }
-
-                State = ElementState.Dead;
-
-                SetNodeStateBasedOnConnectionAndDefaults();
-
-                if (State == ElementState.PersistentWarning)
-                {
                     ToolTipText = persistentWarning;
                 }
                 else
                 {
+                    persistentWarnings.Clear();
                     ClearTooltipText();
                 }
+
+                State = ElementState.Dead;
+                SetNodeStateBasedOnConnectionAndDefaults();
             }
         }
 
@@ -1705,7 +1697,7 @@ namespace Dynamo.Graph.Nodes
             {
                 State = ElementState.Warning;
                 ToolTipText = string.IsNullOrEmpty(persistentWarning) ? p : string.Format("{0}\n{1}", persistentWarning, p);
-                ClearPersistentWarnings();
+                persistentWarnings.Clear();
             }
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1586,7 +1586,7 @@ namespace Dynamo.Graph.Nodes
         /// Clears the transient warning only if the current state is ElementState.Warning.
         /// If an argument is specified, then the transient warning will be cleared only if it matches the argument value.
         /// If no argument is specified (i.e null or empty value), then the transient warning will be cleared no matter its value.
-        /// PersistentWarning  warnings will be kept. If no persistent warning is found, then the default state will be assigned. 
+        /// PersistentWarning warnings will be kept. If no persistent warnings are found, then the default state will be assigned. 
         /// </summary>
         internal void ClearTransientWarning(string t = null)
         {

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1572,7 +1572,7 @@ namespace Dynamo.Graph.Nodes
         public virtual void ClearErrorsAndWarnings()
         {
             State = ElementState.Dead;
-            ClearPersistentWarning();
+            ClearPersistentWarnings();
 
             SetNodeStateBasedOnConnectionAndDefaults();
             ClearTooltipText();
@@ -1582,7 +1582,7 @@ namespace Dynamo.Graph.Nodes
         /// Clears a specific persistent warning that was added before.
         /// The State will remain as ElementState.PersistentWarning if other warnings remain.
         /// </summary>
-        internal void ClearPersistentWarning(string p = null)
+        internal void ClearPersistentWarnings(string p = null)
         {
             if (State == ElementState.PersistentWarning)
             {
@@ -1708,7 +1708,7 @@ namespace Dynamo.Graph.Nodes
             {
                 State = ElementState.Warning;
                 ToolTipText = string.IsNullOrEmpty(persistentWarning) ? p : string.Format("{0}\n{1}", persistentWarning, p);
-                ClearPersistentWarning();
+                ClearPersistentWarnings();
             }
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1583,15 +1583,14 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Clears the transient warning only if the current state is ElementState.Warning or ElementState.PersistentWarning.
+        /// Clears the transient warning only if the current state is ElementState.Warning.
         /// If an argument is specified, then the transient warning will be cleared only if it matches the argument value.
         /// If no argument is specified (i.e null or empty value), then the transient warning will be cleared no matter its value.
         /// PersistentWarning  warnings will be kept. If no persistent warning is found, then the default state will be assigned. 
         /// </summary>
         internal void ClearTransientWarning(string t = null)
         {
-            if (State == ElementState.Warning ||
-                State == ElementState.PersistentWarning)
+            if (State == ElementState.Warning)
             {
                 if (string.IsNullOrEmpty(t) || string.Compare(t, transientWarning) == 0)
                 {// Called with null (or empty argument) or argument matched the existing transient warning

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1685,7 +1685,7 @@ namespace Dynamo.Graph.Nodes
 
             if (State == ElementState.PersistentWarning) return;
 
-            if (!persistentWarnings.Any())
+            if (persistentWarnings.Any())
             {
                 State = ElementState.PersistentWarning;
                 return;

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1698,10 +1698,7 @@ namespace Dynamo.Graph.Nodes
             if (isPersistent)
             {
                 State = ElementState.PersistentWarning;
-                if (!persistentWarnings.Contains(p))
-                {
-                    persistentWarnings.Add(p);
-                }
+                persistentWarnings.Add(p);
                 ToolTipText = persistentWarning;
             }
             else

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1697,7 +1697,10 @@ namespace Dynamo.Graph.Nodes
             if (isPersistent)
             {
                 State = ElementState.PersistentWarning;
-                persistentWarning += p;
+                if (!string.Equals(persistentWarning, p))
+                {
+                    persistentWarning += p;
+                }
                 ToolTipText = persistentWarning;
             }
             else

--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -41,3 +41,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DynamoPythonTests")]
 [assembly: InternalsVisibleTo("GraphMetadataViewExtension")]
 [assembly: InternalsVisibleTo("SystemTestServices")]
+[assembly: InternalsVisibleTo("DynamoManipulation")]

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -548,7 +548,11 @@ namespace Dynamo.Manipulation
         {
             Dispose(true);
 
-            Node.ClearPersistentWarnings(persistentWarning);
+            if (!string.IsNullOrEmpty(persistentWarning))
+            {
+                Node.ClearPersistentWarnings(persistentWarning);
+            }
+            
             DeleteGizmos();
             DetachHandlers();
         }

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -42,7 +42,7 @@ namespace Dynamo.Manipulation
         private const double NewNodeOffsetX = 350;
         private const double NewNodeOffsetY = 50;
         private bool active;
-        private string persistentWarning = "";
+        private string warning = string.Empty;
 
         protected const double gizmoScale = 1.2;
 
@@ -552,11 +552,11 @@ namespace Dynamo.Manipulation
             // When the owner Node is deselected and the manipulator is disposed,
             // we cleanup the manipulator warning from the owner Node.
             // See PR 7623 for more details
-            if (!string.IsNullOrEmpty(persistentWarning))
+            if (!string.IsNullOrEmpty(warning))
             {
-                Node.ClearPersistentWarnings(persistentWarning);
+                Node.ClearTransientWarning(warning);
             }
-            
+
             DeleteGizmos();
             DetachHandlers();
         }
@@ -568,7 +568,7 @@ namespace Dynamo.Manipulation
         public RenderPackageCache BuildRenderPackage()
         {
             Debug.Assert(IsMainThread());
-            persistentWarning = null;
+            warning = string.Empty;
             var packages = new RenderPackageCache();
             try
             {
@@ -580,10 +580,9 @@ namespace Dynamo.Manipulation
             }
             catch (Exception e)
             {
-                persistentWarning = Properties.Resources.DirectManipulationError + ": " + e.Message;
-                Node.Warning(persistentWarning);
+                warning = Properties.Resources.DirectManipulationError + ": " + e.Message;
+                Node.Warning(warning);
             }
-
             return packages;
         }
 

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -548,7 +548,7 @@ namespace Dynamo.Manipulation
         {
             Dispose(true);
 
-            Node.ClearPersistentWarning(persistentWarning);
+            Node.ClearPersistentWarnings(persistentWarning);
             DeleteGizmos();
             DetachHandlers();
         }

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -42,6 +42,7 @@ namespace Dynamo.Manipulation
         private const double NewNodeOffsetX = 350;
         private const double NewNodeOffsetY = 50;
         private bool active;
+        private string persistentWarning = "";
 
         protected const double gizmoScale = 1.2;
 
@@ -547,7 +548,7 @@ namespace Dynamo.Manipulation
         {
             Dispose(true);
 
-            Node.ClearErrorsAndWarnings();
+            Node.ClearPersistentWarning(persistentWarning);
             DeleteGizmos();
             DetachHandlers();
         }
@@ -559,7 +560,7 @@ namespace Dynamo.Manipulation
         public RenderPackageCache BuildRenderPackage()
         {
             Debug.Assert(IsMainThread());
-
+            persistentWarning = null;
             var packages = new RenderPackageCache();
             try
             {
@@ -571,7 +572,8 @@ namespace Dynamo.Manipulation
             }
             catch (Exception e)
             {
-                Node.Warning(Properties.Resources.DirectManipulationError +": " + e.Message);
+                persistentWarning = Properties.Resources.DirectManipulationError + ": " + e.Message;
+                Node.Warning(persistentWarning);
             }
 
             return packages;

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -548,6 +548,10 @@ namespace Dynamo.Manipulation
         {
             Dispose(true);
 
+            // We only show the manipulator warning while the manipulator is alive.
+            // When the owner Node is deselected and the manipulator is disposed,
+            // we cleanup the manipulator warning from the owner Node.
+            // See PR 7623 for more details
             if (!string.IsNullOrEmpty(persistentWarning))
             {
                 Node.ClearPersistentWarnings(persistentWarning);

--- a/src/DynamoManipulation/Properties/AssemblyInfo.cs
+++ b/src/DynamoManipulation/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -9,3 +10,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7d1c274e-66f1-412b-abf1-c8f98b7cf364")]
+
+[assembly: InternalsVisibleTo("DynamoCoreWpfTests")]

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1088,7 +1088,7 @@ namespace Dynamo.Tests
             // change to
             // def foo() { return = 42; }
             var cbnGuid = Guid.Parse("6a260ba7-d658-4350-a777-49511f725454");
-            var command = new Models.DynamoModel.UpdateModelValueCommand(Guid.Empty, cbnGuid, "Code", @"def foo() { return = 42; }");
+            var command = new Dynamo.Models.DynamoModel.UpdateModelValueCommand(Guid.Empty, cbnGuid, "Code", @"def foo() { return = 42; }");
             CurrentDynamoModel.ExecuteCommand(command);
             RunCurrentModel();
 
@@ -1196,7 +1196,7 @@ namespace Dynamo.Tests
             var guidCodeBlock = Guid.Parse("b9dec880d99347eb8a203783f54763e6");
             AssertPreviewValue(guidCurveLength, new object[] { new object[] { }, new object[] { 6.283185 } });
 
-            var command = new Models.DynamoModel.UpdateModelValueCommand(Guid.Empty, guidCodeBlock, "Code", @"[[c],[]]");
+            var command = new Dynamo.Models.DynamoModel.UpdateModelValueCommand(Guid.Empty, guidCodeBlock, "Code", @"[[c],[]]");
             CurrentDynamoModel.ExecuteCommand(command);
             RunCurrentModel();
             AssertPreviewValue(guidCurveLength, new object[] { new object[] { 6.283185 }, new object[] { } });

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Models\GroupModelCommandTests.cs" />
     <Compile Include="Models\ModelEventCommandTest.cs" />
     <Compile Include="Models\MutateTestCommandTest.cs" />
+    <Compile Include="Models\NodeModelWarnings.cs" />
     <Compile Include="Models\OpenFileCommandTest.cs" />
     <Compile Include="Models\PausePlaybackCommandTest.cs" />
     <Compile Include="Models\PresetCommandTests.cs" />

--- a/test/DynamoCoreTests/Models/NodeModelWarnings.cs
+++ b/test/DynamoCoreTests/Models/NodeModelWarnings.cs
@@ -67,5 +67,44 @@ namespace Dynamo.Tests.Models
             Assert.AreEqual(ElementState.Active, cbn.State);
             Assert.AreEqual("", cbn.ToolTipText);
         }
+
+        /// <summary>
+        /// This test case will test transition between transient and persistent warnings
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void KeepTransitionBetweenWarningTypes()
+        {
+            var cbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
+            var command = new DynamoModel.CreateNodeCommand(cbn, 0, 0, true, false);
+
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            Assert.IsNotNull(cbn);
+
+            cbn.Warning("TestPermanent0", true);
+
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0" }), cbn.ToolTipText);
+
+            cbn.Warning("TestTransient0", false);
+
+            Assert.AreEqual(ElementState.Warning, cbn.State);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestTransient0" }), cbn.ToolTipText);
+
+            cbn.Warning("TestPermanent1", true);
+  
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1" }), cbn.ToolTipText);
+
+            cbn.Warning("TestTransient1", false);
+
+            Assert.AreEqual(ElementState.Warning, cbn.State);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "\nTestTransient1" }), cbn.ToolTipText);
+
+            cbn.ClearErrorsAndWarnings();
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual("", cbn.ToolTipText);
+        }
     }
 }

--- a/test/DynamoCoreTests/Models/NodeModelWarnings.cs
+++ b/test/DynamoCoreTests/Models/NodeModelWarnings.cs
@@ -30,25 +30,21 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent2", true);
 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
 
             cbn.Warning("TestTransient0", false);
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "TestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning("TestTransientOther");
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "TestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning("TestTransient0");
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
 
-            cbn.ClearPermanentWarning("TestPermanent2");
-            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1" }), cbn.ToolTipText);
-
-            cbn.ClearPermanentWarning();
+            cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);
             Assert.AreEqual("", cbn.ToolTipText);
 
@@ -57,15 +53,15 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent2", true);
 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
 
             cbn.Warning("TestTransient0", false);
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "TestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning();
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);

--- a/test/DynamoCoreTests/Models/NodeModelWarnings.cs
+++ b/test/DynamoCoreTests/Models/NodeModelWarnings.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using Dynamo.Graph.Nodes;
+using Dynamo.Models;
+using NUnit.Framework;
+
+
+namespace Dynamo.Tests.Models
+{
+    [TestFixture]
+    class NodeModelWarningsTest : DynamoModelTestBase
+    {
+        /// <summary>
+        /// This test case will execute the method void ExecuteCore(DynamoModel dynamoModel) from the CreateAndConnectNodeCommand class
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void CreateAndConnectNodeCommand_ExecuteCore()
+        {
+            //Arrange
+            var cbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);
+            var command = new DynamoModel.CreateNodeCommand(cbn, 0, 0, true, false);
+
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            Assert.IsNotNull(cbn);
+
+            cbn.Warning("TestPermanent0", true);
+            cbn.Warning("TestPermanent1", true);
+            cbn.Warning("TestPermanent2", true);
+
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+
+            cbn.Warning("TestTransient0", false);
+            Assert.AreEqual(ElementState.Warning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "TestTransient0" }), cbn.ToolTipText);
+
+            cbn.ClearTransientWarning("TestTransientOther");
+            Assert.AreEqual(ElementState.Warning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "TestTransient0" }), cbn.ToolTipText);
+
+            cbn.ClearTransientWarning("TestTransient0");
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+
+            cbn.ClearPermanentWarning("TestPermanent2");
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1" }), cbn.ToolTipText);
+
+            cbn.ClearPermanentWarning();
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual("", cbn.ToolTipText);
+
+            cbn.Warning("TestPermanent0", true);
+            cbn.Warning("TestPermanent1", true);
+            cbn.Warning("TestPermanent2", true);
+
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+
+            cbn.Warning("TestTransient0", false);
+            Assert.AreEqual(ElementState.Warning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "TestTransient0" }), cbn.ToolTipText);
+
+            cbn.ClearTransientWarning();
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
+            Assert.AreEqual(string.Join("\n", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+
+            cbn.ClearErrorsAndWarnings();
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual("", cbn.ToolTipText);
+        }
+    }
+}

--- a/test/DynamoCoreTests/Models/NodeModelWarnings.cs
+++ b/test/DynamoCoreTests/Models/NodeModelWarnings.cs
@@ -11,11 +11,11 @@ namespace Dynamo.Tests.Models
     class NodeModelWarningsTest : DynamoModelTestBase
     {
         /// <summary>
-        /// This test case will execute the method void ExecuteCore(DynamoModel dynamoModel) from the CreateAndConnectNodeCommand class
+        /// This test case will test adding and removing persistent and transient warnings on a node model
         /// </summary>
         [Test]
         [Category("UnitTests")]
-        public void CreateAndConnectNodeCommand_ExecuteCore()
+        public void TestWarningsOnNodeModel()
         {
             //Arrange
             var cbn = new CodeBlockNodeModel(CurrentDynamoModel.LibraryServices);

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -1014,7 +1014,7 @@ namespace Dynamo.Tests
                                     "of the graph will not execute; skipping test ...");
             }
 
-            if (((HomeWorkspaceModel)ws1).RunSettings.RunType == Models.RunType.Manual)
+            if (((HomeWorkspaceModel)ws1).RunSettings.RunType == Dynamo.Models.RunType.Manual)
             {
                 RunCurrentModel();
             }

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -187,6 +187,7 @@
     <Compile Include="UpdateManagerUITests.cs" />
     <Compile Include="ViewExtensions\GraphMetadataViewExtensionTests.cs" />
     <Compile Include="ViewExtensions\NodeAutoCompleteViewExtensionTests.cs" />
+    <Compile Include="ViewExtensions\NodeManipulatorExtensionTests.cs" />
     <Compile Include="ViewExtensions\PythonMigrationViewExtensionTests.cs" />
     <Compile Include="ViewExtensions\ViewExtensionTests.cs" />
     <Compile Include="ViewExtensions\DocumentationBrowserViewExtensionTests.cs" />
@@ -206,6 +207,10 @@
       <Project>{51bb6014-43f7-4f31-b8d3-e3c37ebedaf4}</Project>
       <Name>DynamoCoreWpf</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DynamoManipulation\DynamoManipulation.csproj">
+      <Project>{33f88e8c-cc3c-4237-8aa9-cc891efcabfa}</Project>
+      <Name>DynamoManipulation</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\DynamoPackagesWPF\DynamoPackagesWPF.csproj">
       <Project>{47D2166C-5261-4093-9660-E72B7035E666}</Project>

--- a/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
@@ -1,0 +1,64 @@
+﻿using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Manipulation;
+using Dynamo.Models;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DynamoCoreWpfTests.ViewExtensions
+{
+    public class MousePointManipulatorTest : MousePointManipulator
+    {
+        internal MousePointManipulatorTest(DSFunction node, DynamoManipulationExtension manipulatorContext)
+            : base(node, manipulatorContext)
+        {
+        }
+        protected override IEnumerable<IGizmo> GetGizmos(bool createOrUpdate)
+        {
+            //Don't create a new gizmo if not requested
+            if (createOrUpdate)
+            {
+                throw new Exception();
+            }
+            return base.GetGizmos(createOrUpdate);
+        }
+    }
+    public class NodeManipulatorExtensionTests : DynamoTestUIBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("ProtoGeometry.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        public void GizmoWarningTest()
+        {
+            RaiseLoadedEvent(this.View);
+
+            var pntNode = new DSFunction(Model.LibraryServices.GetFunctionDescriptor("Autodesk.DesignScript.Geometry.Point.ByCoordinates"));
+            Model.ExecuteCommand(new DynamoModel.CreateNodeCommand(pntNode, 0, 0, true, false));
+
+            pntNode.IsSelected = true;
+
+            var dme = View.viewExtensionManager.ViewExtensions.OfType<DynamoManipulationExtension>().FirstOrDefault();
+
+            pntNode.Warning("TestPersistentWarning", true);
+            Assert.AreEqual(ElementState.PersistentWarning, pntNode.State);
+            Assert.AreEqual("TestPersistentWarning", pntNode.ToolTipText);
+
+            using (new MousePointManipulatorTest(pntNode, dme))
+            {
+                Assert.AreEqual(ElementState.Warning, pntNode.State);
+                Assert.AreEqual("TestPersistentWarning" + "\n" + 
+                    "Failed to create manipulator for Direct Manipulation of geometry: Exception of type 'System.Exception' was thrown.", 
+                    pntNode.ToolTipText);
+            }
+
+            Assert.AreEqual(ElementState.PersistentWarning, pntNode.State);
+            Assert.AreEqual("TestPersistentWarning", pntNode.ToolTipText);
+        }
+    }
+}


### PR DESCRIPTION
NodeManipulator can add a persistent warning for the Node it corresponds to.
https://github.com/DynamoDS/Dynamo/pull/7623

In this PR we are enhancing the Warning framework so that we can better manage transient warnings
0. No longer clean up persistent warnings when adding a transient warning.
1. Added 1 new cleanup method: CleanTransientWarning
2. Now we will store the transient warning so that we can later find it and only clean it if it matches some value.
3. Manipulator will only clean the transient warning if it matches the the one it added.

As a side note:
Looks to me like some of the Warning infrastructure behavior is not well defined. I tried to refactor the whole thing...but quickly got at a stage where we would probably need UX input. I have since simplified my changes to the current state.
