### PR TITLE
Fix flaky tests in SerializationTests.cs

### DIFF
--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1021,7 +1021,7 @@ namespace DynamoCoreWpfTests
             Assert.NotNull(nodeingraph);
             Assert.IsTrue(nodeingraph.State == ElementState.Active);
             //remove custom node from definitions folder
-            var savePath = Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoadDir", "Packages", "NewCustomNodeSaveAndLoad", "NewCustomNodeSaveAndLoad.dyf");
+            var savePath = Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad", "NewCustomNodeSaveAndLoad.dyf");
             File.Delete(savePath);
         }
 

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -14,6 +14,7 @@ using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
+using Dynamo.PackageManager;
 using Dynamo.Tests;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
@@ -959,7 +960,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void NewCustomNodeSaveAndLoadPt1()
         {
-
             var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");
             //first create a new custom node.
             var ws = this.ViewModel.Model.CustomNodeManager.CreateCustomNode("testnode", "testcategory", "atest", funcguid);
@@ -979,8 +979,14 @@ namespace DynamoCoreWpfTests
             new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode1.InPorts.FirstOrDefault(), Guid.NewGuid());
             new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode2.InPorts.FirstOrDefault(), Guid.NewGuid());
 
+            var saveDir = Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad");
+            System.IO.Directory.CreateDirectory(saveDir);
 
-            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefaultUserDefinitions, "NewCustomNodeSaveAndLoad.dyf");
+            var savePath = Path.Combine(saveDir, "NewCustomNodeSaveAndLoad.dyf");
+            if (File.Exists(savePath))
+            {
+                File.Delete(savePath);
+            }
             //save it to the definitions folder so it gets loaded at startup.
             ws.Save(savePath);
 
@@ -992,6 +998,15 @@ namespace DynamoCoreWpfTests
         [Test]
         public void NewCustomNodeSaveAndLoadPt2()
         {
+            this.ViewModel.Model.PreferenceSettings.CustomPackageFolders = new List<string>() { Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad") };
+
+            var loader = this.ViewModel.Model.GetPackageManagerExtension().PackageLoader;
+            var loadPackageParams = new LoadPackageParams
+            {
+                Preferences = this.ViewModel.Model.PreferenceSettings,
+                NewPaths = new List<string>() { }
+            };
+            loader.LoadCustomNodesAndPackages(loadPackageParams, this.ViewModel.Model.CustomNodeManager);
             // This unit test is a follow-up of NewCustomNodeSaveAndLoadPt1 test to make sure the newly created
             // custom node will be loaded once DynamoCore restarted
             var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");
@@ -1006,9 +1021,8 @@ namespace DynamoCoreWpfTests
             Assert.NotNull(nodeingraph);
             Assert.IsTrue(nodeingraph.State == ElementState.Active);
             //remove custom node from definitions folder
-            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefaultUserDefinitions, "NewCustomNodeSaveAndLoad.dyf");
+            var savePath = Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoadDir", "Packages", "NewCustomNodeSaveAndLoad", "NewCustomNodeSaveAndLoad.dyf");
             File.Delete(savePath);
-
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -987,7 +987,7 @@ namespace DynamoCoreWpfTests
             {
                 File.Delete(savePath);
             }
-            //save it to the definitions folder so it gets loaded at startup.
+            //save it to a temp location so that we can safely load it in NewCustomNodeSaveAndLoadPt2
             ws.Save(savePath);
 
             //assert the filesaved


### PR DESCRIPTION
https://jira.autodesk.com/browse/DYN-3913

Rest of the tests (that save files on disk) seem to already use the tmp path