### PR TITLE
Fix_Welcome_Popup Height

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -7,7 +7,7 @@
 				"Name": "welcome",
 				"Type": "welcome",
 				"Width": 480,
-				"Height": 180,
+				"Height": 200,
 				"StepContent": {
 					"Title": "GetStartedGuideWelcomeTitle",
 					"FormattedText": "GetStartedGuideWelcomeText"


### PR DESCRIPTION
### Purpose

During Testing Aabishkar found a bug in the Welcome popup because the last line of the content was hidden, then I increased the Height value for the Welcome popup.


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs


