### PR TITLE
Wire Behaviour UI fixes

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -108,6 +108,11 @@ namespace Dynamo.Configuration
         public bool ShowConnector { get; set; }
 
         /// <summary>
+        /// Should connector tooltip be visible?
+        /// </summary>
+        public bool ShowConnectorToolTip { get; set; }
+
+        /// <summary>
         /// The types of connector: Bezier or Polyline.
         /// </summary>
         public ConnectorType ConnectorType { get; set; }
@@ -443,6 +448,7 @@ namespace Dynamo.Configuration
             ShowPreviewBubbles = true;
             ShowCodeBlockLineNumber = true;
             ShowConnector = true;
+            ShowConnectorToolTip = true;
             ConnectorType = ConnectorType.BEZIER;
             IsBackgroundGridVisible = true;
             PackageDirectoriesToUninstall = new List<string>();

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -322,6 +322,18 @@ namespace Dynamo.Models
             }
         }
 
+        public bool IsShowingConnectorTooltip
+        {
+            get
+            {
+                return PreferenceSettings.ShowConnectorToolTip;
+            }
+            set
+            {
+                PreferenceSettings.ShowConnectorToolTip = value;
+            }
+        }
+
         /// <summary>
         ///     Specifies how connectors are displayed in Dynamo.
         /// </summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -321,7 +321,11 @@ namespace Dynamo.Models
                 PreferenceSettings.ShowConnector = value;
             }
         }
-
+        /// <summary>
+        /// Flag specifying the current state of whether or not to show 
+        /// tooltips in the graph. In addition to this toggle, tooltip is only
+        /// available when connectors are set to 'bezier' mode.
+        /// </summary>
         public bool IsShowingConnectorTooltip
         {
             get

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2133,6 +2133,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Show Tooltip.
+        /// </summary>
+        public static string DynamoViewViewMenuConnectorShowTooltip {
+            get {
+                return ResourceManager.GetString("DynamoViewViewMenuConnectorShowTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Connector Type.
         /// </summary>
         public static string DynamoViewViewMenuConnectorType {
@@ -6351,24 +6360,6 @@ namespace Dynamo.Wpf.Properties {
         public static string UnhideWiresPopupMenuItem {
             get {
                 return ResourceManager.GetString("UnhideWiresPopupMenuItem", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Uninstall Failure.
-        /// </summary>
-        public static string UninstallFailureMessageBoxTitle {
-            get {
-                return ResourceManager.GetString("UninstallFailureMessageBoxTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Uninstalling Package.
-        /// </summary>
-        public static string UninstallingPackageMessageBoxTitle {
-            get {
-                return ResourceManager.GetString("UninstallingPackageMessageBoxTitle", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2606,10 +2606,10 @@ This package will be deleted after the next Dynamo restart.</value>
   <data name="PackageContextMenuUnmarkUnloadPackageTooltip" xml:space="preserve">
     <value>Remove the scheduled unload status</value>
   </data>
-  <data name="PackageViewContextMenuLoadText">
+  <data name="PackageViewContextMenuLoadText" xml:space="preserve">
     <value>Load</value>
   </data>
-  <data name="PackageViewContextMenuLoadTooltip">
+  <data name="PackageViewContextMenuLoadTooltip" xml:space="preserve">
     <value>Load this package into Dynamo. Other packages with the same name will be automatically deleted</value>
   </data>
   <data name="CannotLoadPackageMessageBoxTitle" xml:space="preserve">
@@ -2647,5 +2647,8 @@ Delete the following packages: {2}?
   </data>
   <data name="UnloadFailureMessageBoxTitle" xml:space="preserve">
     <value>Unload Failure</value>
+  </data>
+  <data name="DynamoViewViewMenuConnectorShowTooltip" xml:space="preserve">
+    <value>_Show Tooltip</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2607,11 +2607,11 @@ This package will be deleted after the next Dynamo restart.</value>
   <data name="PackageContextMenuUnmarkUnloadPackageTooltip" xml:space="preserve">
     <value>Remove the scheduled unload status</value>
   </data>
-  <data name="PackageViewContextMenuLoadText">
-      <value>Load</value>
+  <data name="PackageViewContextMenuLoadText" xml:space="preserve">
+    <value>Load</value>
   </data>
-  <data name="PackageViewContextMenuLoadTooltip">
-      <value>Load this package into Dynamo. Other packages with the same name will be automatically deleted</value>
+  <data name="PackageViewContextMenuLoadTooltip" xml:space="preserve">
+    <value>Load this package into Dynamo. Other packages with the same name will be automatically deleted</value>
   </data>
   <data name="CannotLoadPackageMessageBoxTitle" xml:space="preserve">
     <value>Cannot Load Package</value>
@@ -2648,5 +2648,8 @@ Delete the following packages: {2}?
   </data>
   <data name="UnloadFailureMessageBoxTitle" xml:space="preserve">
     <value>Unload Failure</value>
+  </data>
+  <data name="DynamoViewViewMenuConnectorShowTooltip" xml:space="preserve">
+    <value>_Show Tooltip</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -32,6 +32,34 @@ using Thickness = System.Windows.Thickness;
 
 namespace Dynamo.Controls
 {
+    public class ToolTipFirstLineOnly : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string incomingString = value as string;
+            return incomingString.Split(new[] { '\r', '\n' }, 2)[0].Trim();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class ToolTipAllLinesButFirst : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string incomingString = value as string;
+            return incomingString.Split(new[] { '\r', '\n' }, 2)[1].Trim();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public class TooltipLengthTruncater : IValueConverter
     {
         private const int MaxChars = 100;

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -115,7 +115,8 @@
             <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
               Name="connector"
               Visibility="{Binding BezVisibility, Converter={StaticResource BooleanToVisibilityConverter}}" 
-              Style="{StaticResource SConnector}" Canvas.ZIndex="0" Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
+              Style="{StaticResource SConnector}" Canvas.ZIndex="0" 
+                  Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
                 <i:Interaction.Behaviors>
                     <mouse:MouseBehaviour MouseX="{Binding PanelX, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" MouseY="{Binding PanelY, Mode=OneWayToSource,  UpdateSourceTrigger=PropertyChanged}" />
                 </i:Interaction.Behaviors>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -8,6 +8,8 @@
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
     </ResourceDictionary.MergedDictionaries>
 
+    <controls:ToolTipFirstLineOnly x:Key="ToolTipFirstLine" />
+    <controls:ToolTipAllLinesButFirst x:Key="ToolTipFirstLineNot" />
     <controls:WorkspaceTypeConverter x:Key="WorkspaceTypeConverter" />
     <controls:WorkspaceBackgroundColorConverter
         x:Key="WorkspaceBackgroundColorConverter"

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -37,6 +37,7 @@ namespace Dynamo.ViewModels
         private bool isVisible = true;
         private bool isPartlyVisible = false;
         private string connectorDataToolTip;
+        private bool canShowConnectorTooltip = true;
         private bool mouseHoverOn;
         private bool connectorAnchorViewModelExists;
         private bool isDataFlowCollection;
@@ -214,6 +215,21 @@ namespace Dynamo.ViewModels
             {
                 connectorDataToolTip = value;
                 RaisePropertyChanged(nameof(ConnectorDataTooltip));
+            }
+        }
+        /// <summary>
+        /// Flag controlling whether the connector tooltip is visible.
+        /// </summary>
+        public bool CanShowConnectorTooltip
+        {
+            get
+            {
+                return canShowConnectorTooltip;
+            }
+            set
+            {
+                canShowConnectorTooltip = value;
+                RaisePropertyChanged(nameof(CanShowConnectorTooltip));
             }
         }
 
@@ -598,6 +614,7 @@ namespace Dynamo.ViewModels
         internal void FlipOnConnectorAnchor()
         {
             ConnectorAnchorViewModel = new ConnectorAnchorViewModel(this, workspaceViewModel.DynamoViewModel.Model, ConnectorDataTooltip);
+            ConnectorAnchorViewModel.CanShowTooltip = CanShowConnectorTooltip;
             ConnectorAnchorViewModel.CurrentPosition = MousePosition;
             ConnectorAnchorViewModel.IsHalftone = !IsVisible;
             ConnectorAnchorViewModel.IsDataFlowCollection = IsDataFlowCollection;
@@ -1048,6 +1065,10 @@ namespace Dynamo.ViewModels
                     {
                         IsPartlyVisible = false;
                     }
+                    break;
+                case nameof(DynamoViewModel.IsShowingConnectorTooltip):
+                    dynModel = sender as DynamoViewModel;
+                    CanShowConnectorTooltip = dynModel.IsShowingConnectorTooltip;
                     break;
                 default: break;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -219,6 +219,9 @@ namespace Dynamo.ViewModels
         }
         /// <summary>
         /// Flag controlling whether the connector tooltip is visible.
+        /// Worth noting that in addition to this flag, connector tooltip
+        /// is only visible when the connectors are set to
+        /// 'bezier' mode.
         /// </summary>
         public bool CanShowConnectorTooltip
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -368,8 +368,19 @@ namespace Dynamo.ViewModels
             set
             {
                 model.IsShowingConnectors = value;
-
-                RaisePropertyChanged("IsShowingConnectors");
+                RaisePropertyChanged(nameof(IsShowingConnectors));
+            }
+        }
+        public bool IsShowingConnectorTooltip
+        {
+            get
+            {
+                return model.IsShowingConnectorTooltip;
+            }
+            set
+            {
+                model.IsShowingConnectorTooltip = value;
+                RaisePropertyChanged(nameof(IsShowingConnectorTooltip));
             }
         }
 
@@ -2348,15 +2359,6 @@ namespace Dynamo.ViewModels
         }
 
         internal bool CanSelectNeighbors(object parameters)
-        {
-            return true;
-        }
-
-        public void ShowConnectors(object parameter)
-        {
-        }
-
-        internal bool CanShowConnectors(object parameter)
         {
             return true;
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -371,6 +371,10 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(IsShowingConnectors));
             }
         }
+        /// <summary>
+        /// Relaying the flag `IsShowingConnectorTooltip' coming from
+        /// the Dynamo model.
+        /// </summary>
         public bool IsShowingConnectorTooltip
         {
             get

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -64,7 +64,6 @@ namespace Dynamo.ViewModels
             PublishCurrentWorkspaceCommand = new DelegateCommand(PackageManagerClientViewModel.PublishCurrentWorkspace, PackageManagerClientViewModel.CanPublishCurrentWorkspace);
             PublishSelectedNodesCommand = new DelegateCommand(PackageManagerClientViewModel.PublishSelectedNodes, PackageManagerClientViewModel.CanPublishSelectedNodes);
             PublishCustomNodeCommand = new DelegateCommand<Function>(PackageManagerClientViewModel.PublishCustomNode, PackageManagerClientViewModel.CanPublishCustomNode);
-            ShowHideConnectorsCommand = new DelegateCommand(ShowConnectors, CanShowConnectors);
             SelectNeighborsCommand = new DelegateCommand(SelectNeighbors, CanSelectNeighbors);
             ClearLogCommand = new DelegateCommand(ClearLog, CanClearLog);
             PanCommand = new DelegateCommand(Pan, CanPan);
@@ -136,7 +135,6 @@ namespace Dynamo.ViewModels
         public DelegateCommand GoToDictionaryCommand { get; set; }
         public DelegateCommand GoToSourceCodeCommand { get; set; }
         public DelegateCommand DisplayStartPageCommand { get; set; }
-        public DelegateCommand ShowHideConnectorsCommand { get; set; }
         public DelegateCommand SelectNeighborsCommand { get; set; }
         public DelegateCommand ClearLogCommand { get; set; }
         public DelegateCommand SubmitCommand { get; set; }

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -19,6 +19,7 @@ namespace Dynamo.ViewModels
         private bool isPartlyVisible = false;
         private bool isDataFlowCollection;
         private bool canDisplayIcons = false;
+        private bool canShowTooltip = true;
 
         private bool watchIconPreviewOn = false;
         private bool pinIconPreviewOn = false;
@@ -137,6 +138,19 @@ namespace Dynamo.ViewModels
         internal void SwitchPinPreviewOff()
         {
             PinIconPreviewOn = false;
+        }
+
+        public bool CanShowTooltip
+        {
+            get
+            {
+                return canShowTooltip;
+            }
+            set
+            {
+                canShowTooltip = value;
+                RaisePropertyChanged(nameof(CanShowTooltip));
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -140,6 +140,11 @@ namespace Dynamo.ViewModels
             PinIconPreviewOn = false;
         }
 
+        /// <summary>
+        /// This flag's final destination, (dynamomodel -> dynamoviewmodel -> connectorviewmodel-> connectoranchorviewmodel)
+        /// where it tells the view whether or not it can
+        /// show the tooltip.
+        /// </summary>
         public bool CanShowTooltip
         {
             get

--- a/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
@@ -47,6 +47,16 @@
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
+            <Style x:Key="ConnectorTooltip" TargetType="ToolTip">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding CanShowTooltip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                        <Setter Property="Visibility" Value="Visible"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding CanShowTooltip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="False">
+                        <Setter Property="Visibility" Value="Hidden"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -59,6 +69,16 @@
                 Canvas.Left="{Binding CurrentPosition.X}"
                 Height="{Binding AnchorSize}"
                 Width="{Binding AnchorSize}">
+            <Button.ToolTip>
+                <ToolTip Style="{StaticResource ConnectorTooltip}">
+                    <StackPanel Margin="5">
+                        <TextBlock Text="{Binding DataToolTipText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToolTipFirstLine}}"
+                                   FontWeight="Bold"/>
+                        <TextBlock Text="{Binding DataToolTipText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToolTipFirstLineNot}}"
+                                   FontWeight="Regular"/>
+                    </StackPanel>
+                </ToolTip>
+            </Button.ToolTip>
             <StackPanel Background="Transparent">
                 <Image>
                     <Image.Style>
@@ -146,48 +166,6 @@
                 <TranslateTransform X="0" Y="-37" />
             </Button.RenderTransform>
         </Button>
-        <!--toolTipBox-->
-        <Border x:Name="borderToolTipBox"
-                BorderThickness="1"
-                BorderBrush="{StaticResource FilterPopupBorderColor}"
-                Canvas.Top="{Binding CurrentPosition.Y}"
-                Canvas.Left="{Binding CurrentPosition.X}">
-            <Border.Style>
-                <Style TargetType="{x:Type Border}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="False">
-                            <Setter Property="Visibility" Value="Hidden"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Border.Style>
-            <TextBlock x:Name="toolTipBox"
-                       Background="{StaticResource SearchTextBoxBackground}"
-                       Foreground="Gray"
-                       Text="{Binding DataToolTipText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                       Padding="5"
-                       Canvas.Top="{Binding CurrentPosition.Y}"
-                       Canvas.Left="{Binding CurrentPosition.X}">
-            <TextBlock.Style>
-                <Style TargetType="{x:Type TextBlock}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding CanDisplayIcons}" Value="False">
-                            <Setter Property="Visibility" Value="Hidden"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </TextBlock.Style>
-            </TextBlock>
-            <Border.RenderTransform>
-                <TranslateTransform X="0" Y="15" />
-            </Border.RenderTransform>
-        </Border>
     </Canvas>
 </UserControl>
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -560,9 +560,12 @@
                                       Header="{x:Static p:Resources.DynamoViewViewMenuShowConnectors}"
                                       IsCheckable="True"
                                       Name="ShowHideConnectorsMenuItem"
-                                      IsChecked="{Binding Path=IsShowingConnectors}"
-                                      Command="{Binding ShowHideConnectorsCommand}">
-                            </MenuItem>
+                                      IsChecked="{Binding Path=IsShowingConnectors}"/>
+                            <MenuItem Focusable="False"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuConnectorShowTooltip}"
+                                      IsCheckable="True"
+                                      Name="ShowHideConnectorTooltipMenuItem"
+                                      IsChecked="{Binding Path=IsShowingConnectorTooltip}"/>
                         </MenuItem>
 
                         <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenu3DPreview}"


### PR DESCRIPTION
### Description
UI fixes addressing connector tooltip behaviour.

- Made wire tooltip highest ZIndex. Note: while the tooltip automatically jumps through nested ZIndex to the very top, the anchor icons are hosted by connectors (which have a nested ZIndex which is lower than that of nodes), and thus those will not jump to the front.
- Made first line of tooltip bold, the rest is regular.
- Added a clickable menu item under View-> Connectors to turn tooltip on/off.

*Node layout regression test fixes will be addressed in a different PR.

![WireBehaviour-UI Fixes Tooltip PR](https://user-images.githubusercontent.com/24754290/130321422-4726bbbc-ee27-4149-a02e-74f5516a0a5f.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)
@QilongTang 

### FYIs
@SHKnudsen 