### PR TITLE
Fix hanging unit tests

### DIFF
--- a/test/Libraries/CommandLineTests/CommandLineTests.cs
+++ b/test/Libraries/CommandLineTests/CommandLineTests.cs
@@ -221,7 +221,7 @@ namespace Dynamo.Tests
         //
         // DynamoWPFCLI Tests
         //
-        [Test]
+        [Test, RequiresSTA]
         public void CanOpenAndRunDynamoModelWithWPFCommandLineRunner()
         {
             string openpath = Path.Combine(TestDirectory, @"core\math\Add.dyn");
@@ -244,7 +244,7 @@ namespace Dynamo.Tests
             AssertPreviewValue("4c5889ac-7b91-4fb5-aaad-a2128b533279", 4.0);
         }
 
-        [Test]
+        [Test, RequiresSTA]
         public void CanOpenAndRunFileWihtListsCorrectlyToOutputFileFromDynamoWPFCLIexe()
         {
             string openpath = Path.Combine(TestDirectory, @"core\commandline\simplelists.dyn");
@@ -261,7 +261,7 @@ namespace Dynamo.Tests
                 output);
         }
 
-        [Test]
+        [Test, RequiresSTA]
         public void CanOpenAndRunFileWithDictionaryCorrectlyToOutputFileFromDynamoWPFCLIexe()
         {
             string openpath = Path.Combine(TestDirectory, @"core\commandline\simpleDict.dyn");
@@ -284,7 +284,7 @@ namespace Dynamo.Tests
                 }, output);
         }
 
-        [Test]
+        [Test, RequiresSTA]
         public void CanOpenAndRunFileWithCustomNodeAndOutputGeometryFromDynamoWPFCLIexe()
         {
             string openpath = Path.Combine(TestDirectory, @"core\commandline\GeometryTest.dyn");


### PR DESCRIPTION
### Purpose

Fixes the hanging CommandLineTests, the issue was the same as we seen with other tests after the NodeRedesign changes, essentially all of the WPF tests require the `RequiresSTA` attribute to run.

![image](https://user-images.githubusercontent.com/13732445/130351865-fc02c1e9-714b-41b1-ba7a-03d764fd51e3.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
