### PR TITLE
Graph Layout regression fixed.

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -358,8 +358,8 @@ namespace Dynamo.Graph.Workspaces
                 // If any of the incident edges are connected to unselected (outside) nodes
                 // then mark these edges as anchors.
 
-                graph.AnchorRightEdges.UnionWith(currentNode.RightEdges.Where(e => e.EndNode != null || !e.EndNode.IsSelected));
-                graph.AnchorLeftEdges.UnionWith(currentNode.LeftEdges.Where(e => e.StartNode != null || !e.StartNode.IsSelected));
+                graph.AnchorRightEdges.UnionWith(currentNode.RightEdges.Where(e => e.EndNode != null && !e.EndNode.IsSelected));
+                graph.AnchorLeftEdges.UnionWith(currentNode.LeftEdges.Where(e => e.StartNode != null && !e.StartNode.IsSelected));
 
                 foreach (var node in selectedNodes)
                 {
@@ -522,7 +522,7 @@ namespace Dynamo.Graph.Workspaces
                         double offsetY = graph.OffsetY;
 
                         pin.CenterX = n.X;
-                        pin.CenterY = n.Y + offsetY;
+                        pin.CenterY = n.Y + offsetY - (pin.Width * 0.3);
                         pin.ReportPosition();
                         workspace.HasUnsavedChanges = true;
                     }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -828,13 +828,17 @@ namespace GraphLayout
             OwnerGraph = ownerGraph;
 
             StartNode = OwnerGraph.FindNode(startId);
-            if(StartNode is null) { return; }
-            StartNode.RightEdges.Add(this);
+            if(StartNode!= null)
+            {
+                StartNode.RightEdges.Add(this);
+            }       
 
             EndNode = OwnerGraph.FindNode(endId);
-            if(EndNode is null) { return; }
-            EndNode.LeftEdges.Add(this);
-
+            if (EndNode != null)
+            {
+                EndNode.LeftEdges.Add(this);
+            }
+                
             NodeStartOffsetY = startY - StartNode.Y;
             NodeEndOffsetY = endY - EndNode.Y;
         }


### PR DESCRIPTION
### Description

This PR fixes the following regression: 
`8) Failed : Dynamo.Tests.GraphLayoutTests.GraphLayoutTwoConnectedNodes
  Expected: less than 0.0d
  But was:  0.0d
   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression, String message, Object[] args)
   at Dynamo.Tests.GraphLayoutTests.GraphLayoutTwoConnectedNodes() in E:\Builds\DynamoDS_Dynamo\DynamoNodeRedesign\Dynamo\test\DynamoCoreWpfTests\GraphLayoutTests.cs:line 81`

Other graph-layout-related regressions (if any) will have to be revisited once node resizing fixes are done.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
@Amoursol 
