### PR TITLE
DYN-3918-Popup-Location

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -73,6 +73,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if (GuideSteps.Any())
             {
                 Step firstStep = (from step in GuideSteps where step.Sequence == 0 select step).FirstOrDefault();
+                CurrentStep = firstStep;
                 firstStep.Show();
             }
         }
@@ -107,16 +108,12 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 nextStep = (from step in GuideSteps where step.Sequence == args.StepSequence + 1 select step).FirstOrDefault();
                 if (nextStep != null)
                 {
+                    CurrentStep = nextStep;
                     nextStep.Show();
                 }
 
             }
-
-            CurrentStep = (from step in GuideSteps where step.Sequence == args.StepSequence select step).FirstOrDefault();
-            if (CurrentStep != null)
-            {
-                CurrentStep.Hide();
-            }             
+            HideOpenedStep(args.StepSequence);
         }
 
 
@@ -133,15 +130,22 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 prevStep = (from step in GuideSteps where step.Sequence == args.StepSequence - 1 select step).FirstOrDefault();
                 if (prevStep != null)
                 {
+                    CurrentStep = prevStep;
                     prevStep.Show();
                 }                   
             }
+            HideOpenedStep(args.StepSequence);
+        }
 
-            CurrentStep = (from step in GuideSteps where step.Sequence == args.StepSequence select step).FirstOrDefault();
-            if (CurrentStep != null)
+        private void HideOpenedStep(int stepSequence)
+        {
+            var OpenStep = (from step in GuideSteps 
+                            where step.Sequence == stepSequence 
+                            select step).FirstOrDefault();
+            if (OpenStep != null)
             {
-                CurrentStep.Hide();
-            }             
+                OpenStep.Hide();
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -31,8 +31,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
         private DynamoViewModel dynamoViewModel;
 
-        private const double ExitTourVerticalOffset = 30;
-        private const double ExitTourHorizontalOffset = 0;
+        private RealTimeInfoWindow exitTourPopup;
+
+        private const double ExitTourVerticalOffset = 10;
+        private const double ExitTourHorizontalOffset = 110;
 
         public static string GuidesExecutingDirectory
         {
@@ -67,6 +69,22 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;
             GuideFlowEvents.GuidedTourFinish += TourFinished;
+        }
+
+        /// <summary>
+        /// This method will be used when the PlacementTarget element of the Popup was moved or resize so we need to update each Step and the ExitTour popup
+        /// </summary>
+        public void UpdateGuideStepsLocation()
+        {
+            if (currentGuide != null)
+            {
+                currentGuide.CurrentStep.UpdateLocation();
+            }
+
+            if(exitTourPopup != null)
+            {
+                exitTourPopup.UpdateLocation();
+            }
         }
 
         /// <summary>
@@ -316,11 +334,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
             UIElement hostUIElement = Guide.FindChild(mainRootElement, "statusBarPanel");
 
             //Creates the RealTimeInfoWindow popup and set up all the needed values to show the popup over the Dynamo workspace
-            var exitTourPopup = new RealTimeInfoWindow()
+            exitTourPopup = new RealTimeInfoWindow()
             {
                 VerticalOffset = ExitTourVerticalOffset,
                 HorizontalOffset = ExitTourHorizontalOffset,
-                Placement = PlacementMode.Center,
+                Placement = PlacementMode.Left,
                 TextContent = Res.ExitTourWindowContent
             };
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -33,7 +33,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
         private RealTimeInfoWindow exitTourPopup;
 
+        //The ExitTour popup will be shown at the top-right section of the Dynamo window (at the left side of the statusBarPanel element) only when the tour is closed
+        //The ExitTourVerticalOffset is used to move vertically the popup (using as a reference the statusBarPanel position)
         private const double ExitTourVerticalOffset = 10;
+        //The ExitTourHorizontalOffset is used to move horizontally the popup (using as a reference the statusBarPanel position)
         private const double ExitTourHorizontalOffset = 110;
 
         public static string GuidesExecutingDirectory

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -153,14 +153,14 @@ namespace Dynamo.Wpf.UI.GuidedTour
         }
 
         /// <summary>
-        /// This method will update the Popup offset so it will be re-drawn in the new location (just when the PlacementTarget is moved or resized).
+        /// This method will update the Popup location by calling the private method UpdatePosition using reflection (just when the PlacementTarget is moved or resized).
         /// </summary>
         public void UpdateLocation()
         {
             if(stepUIPopup.IsOpen == true)
             {
-                stepUIPopup.HorizontalOffset = stepUIPopup.HorizontalOffset + 1;
-                stepUIPopup.HorizontalOffset = stepUIPopup.HorizontalOffset - 1;
+                var positionMethod = typeof(Popup).GetMethod("UpdatePosition", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                positionMethod.Invoke(stepUIPopup, null);
             }         
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -149,6 +150,18 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 ExecuteUIAutomationStep(UIAutomation, false);
             }
+        }
+
+        /// <summary>
+        /// This method will update the Popup offset so it will be re-drawn in the new location (just when the PlacementTarget is moved or resized).
+        /// </summary>
+        public void UpdateLocation()
+        {
+            if(stepUIPopup.IsOpen == true)
+            {
+                stepUIPopup.HorizontalOffset = stepUIPopup.HorizontalOffset + 1;
+                stepUIPopup.HorizontalOffset = stepUIPopup.HorizontalOffset - 1;
+            }         
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -3657,11 +3657,9 @@
 
     <Style x:Key="PoupPathRectangleStyle" TargetType="{x:Type Path}">
         <Setter Property="Fill" Value="{StaticResource PopupWhiteColor}"/>
-        <Setter Property="Stroke" Value="Black"/>
     </Style>
 
     <Style x:Key="PoupPolygonPointerStyle" TargetType="{x:Type Polygon}">
-        <Setter Property="Stroke" Value="Black"/>
         <Setter Property="Fill" Value="{StaticResource PopupWhiteColor}"/>
     </Style>
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -91,6 +91,8 @@ namespace Dynamo.Controls
         internal ViewExtensionManager viewExtensionManager;
         internal Watch3DView BackgroundPreview { get; private set; }
 
+        internal GuidesManager mainGuideManager;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -731,12 +733,20 @@ namespace Dynamo.Controls
         {
             dynamoViewModel.Model.PreferenceSettings.WindowX = Left;
             dynamoViewModel.Model.PreferenceSettings.WindowY = Top;
+
+            //When the Dynamo window is moved to another place we need to update the Steps location
+            if(mainGuideManager != null)
+                mainGuideManager.UpdateGuideStepsLocation();
         }
 
         private void DynamoView_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             dynamoViewModel.Model.PreferenceSettings.WindowW = e.NewSize.Width;
             dynamoViewModel.Model.PreferenceSettings.WindowH = e.NewSize.Height;
+
+            //When the Dynamo window size is changed then we need to update the Steps location
+            if (mainGuideManager != null)
+                mainGuideManager.UpdateGuideStepsLocation();
         }
 
         private void InitializeLogin()
@@ -2336,8 +2346,8 @@ namespace Dynamo.Controls
         private void ShowGetStartedGuidedTour()
         {
             //We pass the root UIElement to the GuidesManager so we can found other child UIElements
-            var testGuide = new GuidesManager(_this, dynamoViewModel);
-            testGuide.LaunchTour(Res.GetStartedGuide);
+            mainGuideManager = new GuidesManager(_this, dynamoViewModel);
+            mainGuideManager.LaunchTour(Res.GetStartedGuide);
         }
 
         private void RightExtensionSidebar_DragCompleted(object sender, DragCompletedEventArgs e)

--- a/src/DynamoCoreWpf/Views/GuidedTour/RealTimeInfoWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/RealTimeInfoWindow.xaml.cs
@@ -66,9 +66,9 @@ namespace Dynamo.Wpf.Views.GuidedTour
         {
             if (IsOpen == true)
             {
-                //Uodating the Offset will produce that the Popup will update the position(that's the only way I found).
-                HorizontalOffset = HorizontalOffset + 1;
-                HorizontalOffset = HorizontalOffset - 1;
+                //This section will update the Popup location by calling the private method UpdatePosition using reflection
+                var positionMethod = typeof(Popup).GetMethod("UpdatePosition", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                positionMethod.Invoke(this, null);
             }
         }
     }

--- a/src/DynamoCoreWpf/Views/GuidedTour/RealTimeInfoWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/RealTimeInfoWindow.xaml.cs
@@ -58,5 +58,18 @@ namespace Dynamo.Wpf.Views.GuidedTour
         {
             CleanRealTimeInfoWindow();
         }
+
+        /// <summary>
+        /// This method will update the current location of the RealTimeInfo window due that probably the window was moved or resized
+        /// </summary>
+        public void UpdateLocation()
+        {
+            if (IsOpen == true)
+            {
+                //Uodating the Offset will produce that the Popup will update the position(that's the only way I found).
+                HorizontalOffset = HorizontalOffset + 1;
+                HorizontalOffset = HorizontalOffset - 1;
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose

I added some methods to update the Popups location for when the Dynamo window is resized or moved, also I fixed the same problem for the ExitTour popup.
In the DynamoModern,xml I removed the black border in popups due that this behavior was just temporary (previously we did't have a dark overlay).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

