### PR TITLE
Update connector anchor tooltip to persist

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
@@ -9,6 +9,7 @@
              xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:props="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
              MouseLeave="OnMouseLeave">
 
     <UserControl.Resources>
@@ -68,7 +69,8 @@
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
                 Height="{Binding AnchorSize}"
-                Width="{Binding AnchorSize}">
+                Width="{Binding AnchorSize}"
+                ToolTipService.ShowDuration="{x:Static Member=System:Int32.MaxValue}">
             <Button.ToolTip>
                 <ToolTip Style="{StaticResource ConnectorTooltip}">
                     <StackPanel Margin="5">


### PR DESCRIPTION
### Description

Ensures that connector anchor tooltip persists for as long as the user is hover over.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
