### PR TITLE
add inner exceptions to crash report

### DIFF
--- a/src/DynamoCore/Core/CrashPromptArgs.cs
+++ b/src/DynamoCore/Core/CrashPromptArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Dynamo.Core
 {
@@ -60,6 +61,28 @@ namespace Dynamo.Core
             {
                 FilePath = filePath;
                 Options |= DisplayOptions.HasFilePath;
+            }
+        }
+
+        internal CrashPromptArgs(Exception e)
+        {
+            if (e != null)
+            {
+                var eDetails = new List<string>();
+                GetDetailsFromException(e, ref eDetails);
+
+                Details = string.Join($"\n\n-------- {nameof(Exception.InnerException)} --------\n\n", eDetails);
+                Options |= DisplayOptions.HasDetails;
+            }
+        }
+
+        private void GetDetailsFromException(Exception e, ref List<string> details)
+        {
+            details.Add(e.Message + "\n\n" + e.StackTrace);
+
+            if (e.InnerException != null)
+            {
+                GetDetailsFromException(e.InnerException, ref details);
             }
         }
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -90,7 +90,7 @@ namespace DynamoSandbox
                         // Show the unhandled exception dialog so user can copy the 
                         // crash details and report the crash if she chooses to.
                         viewModel.Model.OnRequestsCrashPrompt(null,
-                            new CrashPromptArgs(e.Message + "\n\n" + e.StackTrace));
+                            new CrashPromptArgs(e));
 
                         // Give user a chance to save (but does not allow cancellation)
                         viewModel.Exit(allowCancel: false);


### PR DESCRIPTION
https://jira.autodesk.com/browse/DYN-3945

Wpf control initialization crash usually wraps Exceptions.
In this PR I added inner exceptions in the crash prompt