### PR TITLE
validity assert improvements

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1521,7 +1521,7 @@ namespace ProtoCore.DSASM
                             }
 
                             bool found = exe.CompleteCodeBlockDict.TryGetValue(currentLangBlock, out CodeBlock cb);
-                            Validity.Assert(found, $"Could not find code block with codeBlockId {currentLangBlock}");
+                            Validity.Assert(found, "Could not find code block with codeBlockId {0}", currentLangBlock);
 
                             if (cb.IsMyAncestorBlock(graphNode.languageBlockId))
                             {

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -431,7 +431,7 @@ namespace ProtoCore.DSASM
                 if (isDuringGCCriticalAsyncCycle && isValidHeapIndex)
                 {
                     var he = heapElements[index];
-                    Validity.Assert(he != null, "Heap element found during AllocateStringInternal cannot be null");
+                    Validity.Assert(he != null, "Heap element found at index {0} cannot be null", index);
 
                     // If heap element is marked as white then it is either not processed by Propagate step yet or processed and found as garbage.
                     // If the sweepSet does not contain the heap element's index then there is no need to mark it black (since cleanup will not even be tried)
@@ -682,7 +682,7 @@ namespace ProtoCore.DSASM
                 StackValue value = ptrs.Dequeue();
                 int rawPtr = (int)value.RawData;
                 var hp = heapElements[rawPtr];
-                Validity.Assert(hp != null, "Heap element found during RecursiveMark cannot be null");
+                Validity.Assert(hp != null, "Heap element found at index {0} cannot be null", rawPtr);
 
                 if (hp.Mark == GCMark.Black)
                     continue;
@@ -777,7 +777,7 @@ namespace ProtoCore.DSASM
             foreach (var ptr in sweepSet)
             {
                 var hp = heapElements[ptr];
-                Validity.Assert(hp != null, "Heap element found during GC sweep cannot be null.");
+                Validity.Assert(hp != null, "Heap element found at index {0} cannot be null.", ptr);
 
                 if (hp.Mark != GCMark.White)
                     continue;

--- a/src/Engine/ProtoCore/Exceptions/CompilerInternalException.cs
+++ b/src/Engine/ProtoCore/Exceptions/CompilerInternalException.cs
@@ -4,7 +4,7 @@ namespace ProtoCore.Exceptions
 {
     class CompilerInternalException : Exception
     {
-        public CompilerInternalException(String message)
+        public CompilerInternalException(String message) : base(message)
         {
 
         }

--- a/src/Engine/ProtoCore/Utils/Validity.cs
+++ b/src/Engine/ProtoCore/Utils/Validity.cs
@@ -11,7 +11,19 @@
         public static void Assert(bool cond, string message)
         {
             if (!cond)
+            {
                 throw new Exceptions.CompilerInternalException(message);
+            }
+        }
+
+        // Will throw a compiler exception if the boolean "cond" is true
+        // The exception will containt a formatted string (i.e string.Format(format, items))
+        internal static void Assert(bool cond, string format, params object[] items)
+        {
+            if (!cond)
+            {
+                throw new Exceptions.CompilerInternalException(string.Format(format, items));
+            }
         }
     }
 }


### PR DESCRIPTION
Add extra constructor to Validity so that we can avoid string Format calls when the condition is not met
Add Validity assert message to the Exception base class

Previously, Validity.Assert was able to format strings only by interpolation (which called into string.Format even if the assert condition was not met)
see https://github.com/DynamoDS/Dynamo/pull/11922 for details