### PR TITLE
[DYN-3975] Fix non clickable textboxes

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -470,7 +470,7 @@ namespace Dynamo.Graph.Annotations
                 case "TextBlockText":
                     AnnotationText = value;
                     break;
-                case "GroupDescriptionTextBlockText":
+                case nameof(AnnotationDescriptionText):
                     AnnotationDescriptionText = value;
                     break;
             }

--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -470,7 +470,7 @@ namespace Dynamo.Graph.Annotations
                 case "TextBlockText":
                     AnnotationText = value;
                     break;
-                case "GroupNameTextBlockText":
+                case "GroupDescriptionTextBlockText":
                     AnnotationDescriptionText = value;
                     break;
             }

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -231,8 +231,8 @@ namespace Dynamo.Models
         private void CreateAnnotationImpl(CreateAnnotationCommand command)
         {
             AnnotationModel annotationModel = currentWorkspace.AddAnnotation(
-                command.AnnotationDescriptionText, 
                 command.AnnotationText, 
+                command.AnnotationDescriptionText, 
                 command.ModelGuid);
     
             CurrentWorkspace.RecordCreatedModel(annotationModel);

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -703,7 +703,7 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;Click here to edit the group description&gt;.
+        ///   Looks up a localized string similar to &lt;Double click here to edit group description&gt;.
         /// </summary>
         public static string GroupDefaultText {
             get {
@@ -712,7 +712,7 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;Click here to edit the group title&gt;.
+        ///   Looks up a localized string similar to &lt;Double click here to edit group title&gt;.
         /// </summary>
         public static string GroupNameDefaultText {
             get {
@@ -1045,12 +1045,22 @@ namespace Dynamo.Properties {
                 return ResourceManager.GetString("NewNoteString", resourceCulture);
             }
         }
-
+        
+        /// <summary>
         ///   Looks up a localized string similar to Node &apos;{0}&apos; is now deprecated..
         /// </summary>
         public static string NodeDeprecatedMsg {
             get {
                 return ResourceManager.GetString("NodeDeprecatedMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show all errors.
+        /// </summary>
+        public static string NodeInformationalStateShowAllErrors {
+            get {
+                return ResourceManager.GetString("NodeInformationalStateShowAllErrors", resourceCulture);
             }
         }
         
@@ -1267,6 +1277,82 @@ namespace Dynamo.Properties {
         public static string PackageManagerUserIsNotAMaintainer {
             get {
                 return ResourceManager.GetString("PackageManagerUserIsNotAMaintainer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error.
+        /// </summary>
+        public static string PackageStateError {
+            get {
+                return ResourceManager.GetString("PackageStateError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unloaded.
+        ///This package has not been loaded due to an unexpected error..
+        /// </summary>
+        public static string PackageStateErrorTooltip {
+            get {
+                return ResourceManager.GetString("PackageStateErrorTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loaded.
+        /// </summary>
+        public static string PackageStateLoaded {
+            get {
+                return ResourceManager.GetString("PackageStateLoaded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loaded.
+        ///This package is loaded and ready to be used..
+        /// </summary>
+        public static string PackageStateLoadedTooltip {
+            get {
+                return ResourceManager.GetString("PackageStateLoadedTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Scheduled to be unloaded.
+        /// </summary>
+        public static string PackageStatePendingUnload {
+            get {
+                return ResourceManager.GetString("PackageStatePendingUnload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Scheduled to be unloaded.
+        ///This package will be unloaded after the next Dynamo restart..
+        /// </summary>
+        public static string PackageStatePendingUnloadTooltip {
+            get {
+                return ResourceManager.GetString("PackageStatePendingUnloadTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unloaded.
+        /// </summary>
+        public static string PackageStateUnloaded {
+            get {
+                return ResourceManager.GetString("PackageStateUnloaded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unloaded.
+        ///This package has not been loaded because another conflicting package was loaded before it..
+        /// </summary>
+        public static string PackageStateUnloadedTooltip {
+            get {
+                return ResourceManager.GetString("PackageStateUnloadedTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -779,10 +779,10 @@ This package is loaded and ready to be used.</value>
 This package has not been loaded because another conflicting package was loaded before it.</value>
   </data>
   <data name="GroupDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group description&gt;</value>
+    <value>&lt;Double click here to edit group description&gt;</value>
   </data>
   <data name="GroupNameDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group title&gt;</value>
+    <value>&lt;Double click here to edit group title&gt;</value>
   </data>
   <data name="OutputPortAlternativeName" xml:space="preserve">
     <value>output</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -793,10 +793,10 @@ This package is loaded and ready to be used.</value>
 This package has not been loaded because another conflicting package was loaded before it.</value>
   </data>
   <data name="GroupDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group description&gt;</value>
+    <value>&lt;Double click here to edit group description&gt;</value>
   </data>
   <data name="GroupNameDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group title&gt;</value>
+    <value>&lt;Double click here to edit group title&gt;</value>
   </data>
   <data name="NodeInformationalStateShowAllErrors" xml:space="preserve">
     <value>Show all errors</value>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2784,15 +2784,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add group to group.
-        /// </summary>
-        public static string GroupContextMenuAddGroupToGroup {
-            get {
-                return ResourceManager.GetString("GroupContextMenuAddGroupToGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>   
         ///   Looks up a localized string similar to The selected save location path is too long. Please change the save location and try again..
         /// </summary>
         public static string GraphIssuesOnSavePath_Description {
@@ -2816,6 +2807,15 @@ namespace Dynamo.Wpf.Properties {
         public static string GraphIssuesOnSavePath_Title {
             get {
                 return ResourceManager.GetString("GraphIssuesOnSavePath_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add group to group.
+        /// </summary>
+        public static string GroupContextMenuAddGroupToGroup {
+            get {
+                return ResourceManager.GetString("GroupContextMenuAddGroupToGroup", resourceCulture);
             }
         }
         
@@ -2865,7 +2865,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;Click here to edit the group description&gt;.
+        ///   Looks up a localized string similar to &lt;Double click here to edit group description&gt;.
         /// </summary>
         public static string GroupDefaultText {
             get {
@@ -2874,7 +2874,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;Click here to edit the group title&gt;.
+        ///   Looks up a localized string similar to &lt;Double click here to edit group title&gt;.
         /// </summary>
         public static string GroupNameDefaultText {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2506,10 +2506,10 @@ Uninstall the following packages: {0}?</value>
     <value>Finished</value>
   </data>
   <data name="GroupDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group description&gt;</value>
+    <value>&lt;Double click here to edit group description&gt;</value>
   </data>
   <data name="GroupNameDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group title&gt;</value>
+    <value>&lt;Double click here to edit group title&gt;</value>
   </data>
   <data name="GroupContextMenuAddGroupToGroup" xml:space="preserve">
     <value>Add group to group</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1628,7 +1628,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Run started with new working range...</value>
   </data>
   <data name="GroupDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group description&gt;</value>
+    <value>&lt;Double click here to edit group description&gt;</value>
   </data>
   <data name="GroupContextMenuBackground" xml:space="preserve">
     <value>Select Background</value>
@@ -2522,7 +2522,7 @@ Uninstall the following packages: {0}?</value>
     <value>Finished</value>
   </data>
   <data name="GroupNameDefaultText" xml:space="preserve">
-    <value>&lt;Click here to edit the group title&gt;</value>
+    <value>&lt;Double click here to edit group title&gt;</value>
   </data>
   <data name="GroupContextMenuAddGroupToGroup" xml:space="preserve">
     <value>Add group to group</value>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -2,7 +2,7 @@
              x:Class="Dynamo.Nodes.AnnotationView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
@@ -11,44 +11,45 @@
              xmlns:viewModels="clr-namespace:Dynamo.ViewModels"
              xmlns:dynui="clr-namespace:Dynamo.UI.Controls"
              xmlns:fa="http://schemas.fontawesome.io/icons/"
-             mc:Ignorable="d"                          
-             Height="Auto" Width="Auto"
+             mc:Ignorable="d"
+             Height="Auto"
+             Width="Auto"
              Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"
-             MouseLeftButtonDown="AnnotationView_OnMouseLeftButtonDown"                                                  
+             MouseLeftButtonDown="AnnotationView_OnMouseLeftButtonDown"
              MouseRightButtonDown="AnnotationView_OnMouseRightButtonDown"
-             Canvas.Left="{Binding Left, Mode=TwoWay}" 
+             Canvas.Left="{Binding Left, Mode=TwoWay}"
              Canvas.Top="{Binding Top, Mode=TwoWay}"
              AllowDrop="True"
              IsHitTestVisible="True"
-             d:DataContext="{d:DesignInstance Type=viewModels:AnnotationViewModel}">   
-    
+             d:DataContext="{d:DesignInstance Type=viewModels:AnnotationViewModel}">
+
     <UserControl.Resources>
         <CornerRadius x:Key="ExpanderCornerRadius"
                       TopLeft="10"
                       TopRight="10" />
-        
+
         <Style x:Key="ColorSelectorListBox"
-           TargetType="ListBox">
+               TargetType="ListBox">
             <Setter Property="SnapsToDevicePixels"
-                Value="true" />
+                    Value="true" />
             <Setter Property="OverridesDefaultStyle"
-                Value="true" />
+                    Value="true" />
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
-                Value="Disabled" />
+                    Value="Disabled" />
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
-                Value="Hidden" />
+                    Value="Hidden" />
             <Setter Property="ScrollViewer.CanContentScroll"
-                Value="true" />
+                    Value="true" />
             <Setter Property="Width"
-                Value="152" />
+                    Value="152" />
             <Setter Property="Height"
-                Value="54" />
+                    Value="54" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ListBox">
                         <Grid Margin="4,8,4,8">
                             <ScrollViewer Margin="0"
-                                      Focusable="false">
+                                          Focusable="false">
                                 <WrapPanel IsItemsHost="True" />
                             </ScrollViewer>
                         </Grid>
@@ -58,20 +59,20 @@
         </Style>
 
         <Style x:Key="ColorSelectorListBoxItem"
-           TargetType="ListBoxItem">
+               TargetType="ListBoxItem">
             <Setter Property="SnapsToDevicePixels"
-                Value="true" />
+                    Value="true" />
             <Setter Property="OverridesDefaultStyle"
-                Value="true" />
+                    Value="true" />
             <Setter Property="Width"
-                Value="18" />
+                    Value="18" />
             <Setter Property="Height"
-                Value="20" />
+                    Value="20" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ListBoxItem">
                         <Grid Margin="3,4,3,4"
-                          SnapsToDevicePixels="true">
+                              SnapsToDevicePixels="true">
                             <Grid.Background>
                                 <SolidColorBrush Color="Transparent" />
                             </Grid.Background>
@@ -81,9 +82,9 @@
                                     <VisualState x:Name="MouseOver">
                                         <Storyboard>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                       Storyboard.TargetProperty="Opacity">
+                                                                           Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame KeyTime="0"
-                                                                  Value="1.0" />
+                                                                      Value="1.0" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
@@ -93,9 +94,9 @@
                                     <VisualState x:Name="Selected">
                                         <Storyboard>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                       Storyboard.TargetProperty="Opacity">
+                                                                           Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame KeyTime="0"
-                                                                  Value="1.0" />
+                                                                      Value="1.0" />
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualState>
@@ -104,10 +105,10 @@
                             </VisualStateManager.VisualStateGroups>
                             <ContentPresenter />
                             <Border x:Name="Border"
-                                Opacity="0.25"
-                                BorderThickness="1"
-                                BorderBrush="Black"
-                                Background="Transparent" />
+                                    Opacity="0.25"
+                                    BorderThickness="1"
+                                    BorderBrush="Black"
+                                    Background="Transparent" />
                         </Grid>
                     </ControlTemplate>
                 </Setter.Value>
@@ -136,7 +137,7 @@
             <ControlTemplate.Triggers>
                 <!--Change the icon when toggled-->
                 <Trigger Property="IsChecked"
-                            Value="True">
+                         Value="True">
                     <Setter Property="Source"
                             TargetName="sign"
                             Value="/DynamoCoreWpf;component/UI/Images/caret_up_grey_48px.png" />
@@ -144,7 +145,7 @@
 
                 <!--MouseOver, Pressed behaviors-->
                 <Trigger Property="IsMouseOver"
-                            Value="True">
+                         Value="True">
                     <Setter Property="Cursor"
                             Value="Hand" />
                 </Trigger>
@@ -175,7 +176,7 @@
                                         <ColumnDefinition Width="Auto" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <ContentPresenter Grid.Column="0"
+                                    <ContentPresenter Grid.ColumnSpan="3"
                                                       Margin="4"
                                                       ContentSource="Header"
                                                       RecognizesAccessKey="True"
@@ -243,7 +244,7 @@
                     Value="0" />
             <Setter Property="IsHitTestVisible"
                     Value="False" />
-        
+
             <Setter Property="ItemContainerStyle">
                 <Setter.Value>
                     <Style TargetType="ListViewItem">
@@ -284,66 +285,6 @@
         </Style>
     </UserControl.Resources>
 
-    <UserControl.Triggers>
-        <EventTrigger  SourceName="GroupNameControl"
-                       RoutedEvent="ContentControl.MouseDoubleClick">
-            <BeginStoryboard>
-                <Storyboard>
-                    <ObjectAnimationUsingKeyFrames Duration="0"
-                                                   Storyboard.TargetName="GroupTextBlock"
-                                                   Storyboard.TargetProperty="(TextBlock.Visibility)">
-                        <DiscreteObjectKeyFrame KeyTime="0"
-                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
-                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextblock}">
-                        </DiscreteObjectKeyFrame>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <ObjectAnimationUsingKeyFrames Duration="0"
-                                                   Storyboard.TargetName="GroupTextBox"
-                                                   Storyboard.TargetProperty="(TextBox.Visibility)">
-                        <DiscreteObjectKeyFrame KeyTime="0"
-                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
-                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextbox}" />
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <BooleanAnimationUsingKeyFrames Storyboard.TargetName="GroupTextBox"
-                                                    Storyboard.TargetProperty="(TextBox.Focusable)">
-                        <DiscreteBooleanKeyFrame KeyTime="0"
-                                                 Value="True" />
-                    </BooleanAnimationUsingKeyFrames>
-                </Storyboard>
-            </BeginStoryboard>
-        </EventTrigger>
-        <EventTrigger SourceName="GroupDescriptionControls"
-                      RoutedEvent="ContentControl.MouseDoubleClick">
-            <BeginStoryboard>
-                <Storyboard>
-                    <ObjectAnimationUsingKeyFrames Duration="0"
-                                                   Storyboard.TargetName="GroupDescriptionTextBlock"
-                                                   Storyboard.TargetProperty="(TextBlock.Visibility)">
-                        <DiscreteObjectKeyFrame KeyTime="0"
-                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
-                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextblock}">
-                        </DiscreteObjectKeyFrame>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Duration="0"
-                                                   Storyboard.TargetName="GroupDescriptionTextBox"
-                                                   Storyboard.TargetProperty="(TextBox.Visibility)">
-                        <DiscreteObjectKeyFrame KeyTime="0"
-                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
-                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextbox}" />
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <BooleanAnimationUsingKeyFrames Storyboard.TargetName="GroupDescriptionTextBox"
-                                                    Storyboard.TargetProperty="(TextBox.Focusable)">
-                        <DiscreteBooleanKeyFrame KeyTime="0"
-                                                 Value="True" />
-                    </BooleanAnimationUsingKeyFrames>
-                </Storyboard>
-            </BeginStoryboard>
-        </EventTrigger>
-    </UserControl.Triggers>
-
     <Grid Name="AnnotationGrid"
           Height="Auto"
           IsHitTestVisible="True">
@@ -354,8 +295,10 @@
                                  Visibility="{Binding IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
                 <StackPanel Orientation="Vertical"
                             MaxWidth="320">
-                    <TextBlock Text="{Binding AnnotationText}" Margin="0,0,0,10" />
-                    <TextBlock Text="{Binding AnnotationDescriptionText}" TextWrapping="WrapWithOverflow" />
+                    <TextBlock Text="{Binding AnnotationText}"
+                               Margin="0,0,0,10" />
+                    <TextBlock Text="{Binding AnnotationDescriptionText}"
+                               TextWrapping="WrapWithOverflow" />
                 </StackPanel>
             </dynui:DynamoToolTip>
         </Grid.ToolTip>
@@ -453,7 +396,7 @@
                 </ListBox>
             </ContextMenu>
         </Grid.ContextMenu>
-        
+
         <!--Selection border shows around the entire group when its selected in the workspace-->
         <Border Name="selectionBorder"
                 Grid.RowSpan="2"
@@ -504,7 +447,7 @@
               when hovering over the bottom right corner.
         -->
         <Expander x:Name="GroupExpander"
-                  Width="{Binding Width}" 
+                  Width="{Binding Width}"
                   IsExpanded="{Binding IsExpanded, Mode=TwoWay}"
                   Grid.Row="0">
             <Expander.Header>
@@ -515,30 +458,31 @@
                       Margin="5,0,5,0"
                       VerticalAlignment="Top">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
+                        <RowDefinition x:Name="GroupNameRow"
+                                       Height="Auto" />
+                        <RowDefinition x:Name="GroupDescriptionRow"
+                                       Height="Auto" />
                     </Grid.RowDefinitions>
                     <ContentControl x:Name="GroupNameControl"
-                                    Grid.Row="0">
+                                    Grid.Row="0"
+                                    Width="{Binding Width}"
+                                    MinHeight="20"
+                                    Margin="0,0,0,10">
                         <Grid>
                             <TextBlock x:Name="GroupTextBlock"
                                        Text="{Binding AnnotationText, Converter={StaticResource AnnotationTextConverter}, ConverterParameter='TextBlock'}"
-                                       MaxWidth="{Binding Width}"
-                                       MinHeight="20"
                                        FontFamily="Trebuchet"
                                        FontSize="{Binding FontSize}"
                                        LineStackingStrategy="BlockLineHeight"
                                        TextWrapping="Wrap"
-                                       Visibility="Visible"
-                                       Margin="0,0,0,0">
+                                       Visibility="Visible">
                             </TextBlock>
                             <TextBox Name="GroupTextBox"
+                                     Grid.Column="0"
                                      MaxLength="30"
                                      Visibility="Collapsed"
                                      Text="{Binding AnnotationText,Converter={StaticResource AnnotationTextConverter}, ConverterParameter='TextBox'}"
                                      TextWrapping="Wrap"
-                                     MaxWidth="{Binding Width}"
-                                     MinHeight="20"
                                      FontFamily="Trebuchet"
                                      FontSize="{Binding FontSize}"
                                      IsVisibleChanged="GroupTextBox_OnIsVisibleChanged"
@@ -551,13 +495,12 @@
                     </ContentControl>
 
                     <ContentControl x:Name="GroupDescriptionControls"
-                                    Grid.Row="1">
+                                    Grid.Row="1"
+                                    MinHeight="20"
+                                    Margin="0,-10,30,0">
                         <Grid>
                             <TextBlock x:Name="GroupDescriptionTextBlock"
-                                       Grid.Row="1"
                                        Text="{Binding AnnotationDescriptionText, Converter={StaticResource AnnotationTextConverter}}"
-                                       MaxWidth="{Binding Width}"
-                                       MinHeight="20"
                                        FontFamily="Trebuchet"
                                        FontSize="12"
                                        LineStackingStrategy="BlockLineHeight"
@@ -567,12 +510,9 @@
                             </TextBlock>
                             <TextBox Name="GroupDescriptionTextBox"
                                      MaxLength="280"
-                                     Grid.Row="1"
                                      Visibility="Collapsed"
                                      Text="{Binding AnnotationDescriptionText, Converter={StaticResource AnnotationTextConverter}}"
                                      TextWrapping="Wrap"
-                                     MaxWidth="{Binding Width}"
-                                     MinHeight="20"
                                      FontFamily="Trebuchet"
                                      FontSize="12"
                                      IsVisibleChanged="GroupDescriptionTextBox_OnIsVisibleChanged"
@@ -604,6 +544,67 @@
                         </ContentControl.Style>
                     </ContentControl>
                     <Grid.Triggers>
+
+                        <EventTrigger  SourceName="GroupNameControl"
+                                       RoutedEvent="ContentControl.MouseDoubleClick">
+                            <BeginStoryboard>
+                                <Storyboard>
+                                    <ObjectAnimationUsingKeyFrames Duration="0"
+                                                                   Storyboard.TargetName="GroupTextBlock"
+                                                                   Storyboard.TargetProperty="(TextBlock.Visibility)">
+                                        <DiscreteObjectKeyFrame KeyTime="0"
+                                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
+                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextblock}">
+                                        </DiscreteObjectKeyFrame>
+                                    </ObjectAnimationUsingKeyFrames>
+
+                                    <ObjectAnimationUsingKeyFrames Duration="0"
+                                                                   Storyboard.TargetName="GroupTextBox"
+                                                                   Storyboard.TargetProperty="(TextBox.Visibility)">
+                                        <DiscreteObjectKeyFrame KeyTime="0"
+                                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
+                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextbox}" />
+                                    </ObjectAnimationUsingKeyFrames>
+
+                                    <BooleanAnimationUsingKeyFrames Storyboard.TargetName="GroupTextBox"
+                                                                    Storyboard.TargetProperty="(TextBox.Focusable)">
+                                        <DiscreteBooleanKeyFrame KeyTime="0"
+                                                                 Value="True" />
+                                    </BooleanAnimationUsingKeyFrames>
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+
+                        <EventTrigger SourceName="GroupDescriptionControls"
+                                      RoutedEvent="ContentControl.MouseDoubleClick">
+                            <BeginStoryboard>
+                                <Storyboard>
+                                    <ObjectAnimationUsingKeyFrames Duration="0"
+                                                                   Storyboard.TargetName="GroupDescriptionTextBlock"
+                                                                   Storyboard.TargetProperty="(TextBlock.Visibility)">
+                                        <DiscreteObjectKeyFrame KeyTime="0"
+                                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
+                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextblock}">
+                                        </DiscreteObjectKeyFrame>
+                                    </ObjectAnimationUsingKeyFrames>
+                                    <ObjectAnimationUsingKeyFrames Duration="0"
+                                                                   Storyboard.TargetName="GroupDescriptionTextBox"
+                                                                   Storyboard.TargetProperty="(TextBox.Visibility)">
+                                        <DiscreteObjectKeyFrame KeyTime="0"
+                                                                Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
+                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextbox}" />
+                                    </ObjectAnimationUsingKeyFrames>
+
+                                    <BooleanAnimationUsingKeyFrames Storyboard.TargetName="GroupDescriptionTextBox"
+                                                                    Storyboard.TargetProperty="(TextBox.Focusable)">
+                                        <DiscreteBooleanKeyFrame KeyTime="0"
+                                                                 Value="True" />
+                                    </BooleanAnimationUsingKeyFrames>
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+
+
                         <EventTrigger  SourceName="GroupTextBox"
                                        RoutedEvent="TextBox.LostKeyboardFocus">
                             <BeginStoryboard>
@@ -686,7 +687,7 @@
                     </Path>
                 </Canvas>
 
-                <Thumb x:Name="ResizeThumb" 
+                <Thumb x:Name="ResizeThumb"
                        Width="10"
                        Height="10"
                        HorizontalAlignment="Right"
@@ -699,8 +700,8 @@
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="{x:Type Thumb}">
-                                        <Border BorderThickness="0" 
-                                                BorderBrush="Transparent" 
+                                        <Border BorderThickness="0"
+                                                BorderBrush="Transparent"
                                                 Background="Transparent" />
                                     </ControlTemplate>
                                 </Setter.Value>
@@ -710,7 +711,7 @@
                 </Thumb>
             </Grid>
         </Expander>
-        
+
         <!--
         The CollapsedAnnotationRectangle is visible whenever the expander is collapsed. In this state the
         expander header is still visible but will hide the group description text. This border has 3 children
@@ -759,7 +760,7 @@
                 </ItemsControl>
 
                 <!--Group content icons-->
-                <Grid x:Name="GroupContentIcons" 
+                <Grid x:Name="GroupContentIcons"
                       Grid.Column="1"
                       Grid.Row="1"
                       Background="Transparent"
@@ -803,4 +804,4 @@
         </Border>
     </Grid>
 </UserControl>
-
+    

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -14,6 +14,7 @@ using Dynamo.ViewModels;
 using DynCmd = Dynamo.Models.DynamoModel;
 using TextBox = System.Windows.Controls.TextBox;
 using Dynamo.Wpf.Utilities;
+using Dynamo.Graph.Annotations;
 
 namespace Dynamo.Nodes
 {
@@ -313,7 +314,7 @@ namespace Dynamo.Nodes
             //Record the value here, this is useful when title is popped from stack during undo
             ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.UpdateModelValueCommand(
-                    Guid.Empty, ViewModel.AnnotationModel.GUID, "GroupDescriptionTextBlockText",
+                    Guid.Empty, ViewModel.AnnotationModel.GUID, nameof(AnnotationModel.AnnotationDescriptionText),
                     GroupDescriptionTextBox.Text));
 
             ViewModel.WorkspaceViewModel.DynamoViewModel.RaiseCanExecuteUndoRedo();

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -103,8 +103,10 @@ namespace Dynamo.Nodes
                 this.GroupTextBlock.FontSize,
                 Brushes.Black);
 
-            this.ViewModel.AnnotationModel.Width = formattedText.Width;
-            this.ViewModel.AnnotationModel.TextMaxWidth = formattedText.Width;
+            var margin = this.TextBlockGrid.Margin.Right + this.TextBlockGrid.Margin.Left;
+
+            this.ViewModel.AnnotationModel.Width = formattedText.Width + margin;
+            this.ViewModel.AnnotationModel.TextMaxWidth = formattedText.Width + margin;
         }
 
         private void OnNodeColorSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -311,7 +313,7 @@ namespace Dynamo.Nodes
             //Record the value here, this is useful when title is popped from stack during undo
             ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.UpdateModelValueCommand(
-                    Guid.Empty, ViewModel.AnnotationModel.GUID, "GroupNameTextBlockText",
+                    Guid.Empty, ViewModel.AnnotationModel.GUID, "GroupDescriptionTextBlockText",
                     GroupDescriptionTextBox.Text));
 
             ViewModel.WorkspaceViewModel.DynamoViewModel.RaiseCanExecuteUndoRedo();
@@ -332,7 +334,6 @@ namespace Dynamo.Nodes
         {
             if (ViewModel is null || !IsLoaded) return;
 
-            SetTextMaxWidth();
             SetTextHeight();
             ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
 

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -61,6 +61,7 @@ namespace DynamoCoreWpfTests
             Open(@"UI\GroupTest.dyn");
 
             var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+            
             //Raise a click event to check whether the group and the models are selected
             annotationView.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, Environment.TickCount, MouseButton.Left)
             {
@@ -69,34 +70,6 @@ namespace DynamoCoreWpfTests
 
             //The group and the node should be selected
             Assert.AreEqual(2, DynamoSelection.Instance.Selection.Count());
-
-            //Clear the selection
-            DynamoSelection.Instance.ClearSelection();
-           
-            //Change the Zoom
-            annotationView.ViewModel.WorkspaceViewModel.SetZoomCommand.Execute(0.4);
-
-            //Group textblock should be collapsed.
-            Assert.IsFalse(annotationView.GroupTextBlock.IsVisible);
-
-            //Change the Zoom
-            annotationView.ViewModel.WorkspaceViewModel.SetZoomCommand.Execute(0.5);
-
-            //Group textblock should be visible.
-            Assert.IsTrue(annotationView.GroupTextBlock.IsVisible);
-
-            //Change the Zoom
-            annotationView.ViewModel.WorkspaceViewModel.SetZoomCommand.Execute(0.4);
-
-            //Group textblock should be collapsed.
-            Assert.IsFalse(annotationView.GroupTextBlock.IsVisible);
-
-            //Now change the font size - note: group textblock is collapsed now
-            annotationView.ViewModel.FontSize = 48;
-
-            //Group textblock should be visible.
-            Assert.IsTrue(annotationView.GroupTextBlock.IsVisible);
-
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

this PR fixes: 
- https://jira.autodesk.com/browse/DYN-3976
- https://jira.autodesk.com/browse/DYN-3975

The event triggers that handle editing the Group textboxes have been moved into the `TextBlockGrid` as they need to handle click events on the `GroupNameControl` and `GroupDescriptionControls` which are both inside this grid. 

![image](https://user-images.githubusercontent.com/13732445/131706588-3b2e3921-f7ef-4738-9a44-f4990d339bd9.png)
![DynamoRefresh_groups_doubleClickBug](https://user-images.githubusercontent.com/13732445/131707118-3736144c-2316-4798-80d1-9ec95a2ad9be.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 