### PR TITLE
[DYN-3981] Clicking on the output port of a group crashes dynamo

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -680,20 +680,16 @@ namespace Dynamo.ViewModels
 
         private List<PortViewModel> CreateProxyPorts(IEnumerable<PortModel> groupPortModels)
         {
-            var proxyModels = groupPortModels
-                .Select(x => new ProxyPortModel(x))
-                .ToList();
-
             var originalPortViewModels = WorkspaceViewModel.Nodes
                 .SelectMany(x => x.InPorts.Concat(x.OutPorts))
                 .Where(x => groupPortModels.Contains(x.PortModel))
                 .ToList();
 
             var newPortViewModels = new List<PortViewModel>();
-            for (int i = 0; i < proxyModels.Count(); i++)
+            for (int i = 0; i < groupPortModels.Count(); i++)
             {
-                var proxyModel = proxyModels[i];
-                newPortViewModels.Add(originalPortViewModels[i].CreateProxyPortViewModel(proxyModel));
+                var model = groupPortModels.ElementAt(i);
+                newPortViewModels.Add(originalPortViewModels[i].CreateProxyPortViewModel(model));
             }
 
             return newPortViewModels;

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -402,9 +402,9 @@ namespace Dynamo.ViewModels
             _node.WorkspaceViewModel.PropertyChanged -= Workspace_PropertyChanged;
         }
 
-        internal PortViewModel CreateProxyPortViewModel(ProxyPortModel proxyPortModel)
+        internal PortViewModel CreateProxyPortViewModel(PortModel portModel)
         {
-            return new PortViewModel(_node, proxyPortModel);
+            return new PortViewModel(_node, portModel);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This PR handles [DYN-3981](https://jira.autodesk.com/projects/DYN/issues/DYN-3981).

The issue here was that the creating a ProxyPortModel will no currently work as the proxyModel won't be a part of the nodeModels port collections and therefore it wont be able to return a valid port index, which is what was causing the crash.

The solution, for now, was to remove the ProxyPortModel creation and simply pass the PortModel to the ProxyPortViewModel instead.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
