### PR TITLE
[DYN-3988] dragging and dropping a node into group breaks group

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -717,6 +717,7 @@ namespace Dynamo.ViewModels
                             owningWorkspace.DynamoViewModel.AddModelsToGroupModelCommand.Execute(null);
                         }
                         dropGroup.NodeHoveringState = false;
+                        dropGroup.SelectAll();
                     }
 
                     SetCurrentState(State.None); // Dragging operation ended.


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-3988](https://jira.autodesk.com/browse/DYN-3988)

Issue was that after adding the node to the group only the group and the added node was selected, this caused some weird behaviour with the group if the added node was dragged

The solution, after the node is dropped into the group we select the group and all its content, this gives the expected behaviour when dragging the node afterwards.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
