### PR TITLE
PR - Jira issues: [DYN-3890] | [DYN-3963] 

### DIFF
--- a/src/DynamoCore/Core/UndoRedoRecorder.cs
+++ b/src/DynamoCore/Core/UndoRedoRecorder.cs
@@ -488,6 +488,7 @@ namespace Dynamo.Core
 
                 this.models = new List<ModelBase>(models);
                 existingConnectors = new Dictionary<Guid, XmlElement>();
+                existingPins = new Dictionary<Guid, XmlElement>();
                 remainingConnectors = new Dictionary<Guid, ConnectorModel>();
 
                 var allConnectors = new List<ConnectorModel>();

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -282,6 +282,7 @@ namespace Dynamo.Graph.Workspaces
                         var matchingConnector = Connectors.FirstOrDefault(c => c.GUID == connectorPinModel.ConnectorId);
                         if (matchingConnector is null) return;
                         matchingConnector.ConnectorPinModels.Remove(connectorPinModel);
+                        HasUnsavedChanges = true;
                     }
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -51,7 +51,7 @@ namespace Dynamo.ViewModels
         #region Properties
 
         [JsonIgnore]
-        public readonly WorkspaceViewModel WorkspaceViewModel;
+        private readonly WorkspaceViewModel WorkspaceViewModel;
         /// initialize the start Z-Index of a pin to a default
         /// zIndex is mutable depending on mouse behaviour
         private int zIndex = Configurations.NodeStartZIndex; 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -51,7 +51,7 @@ namespace Dynamo.ViewModels
         #region Properties
 
         [JsonIgnore]
-        private readonly WorkspaceViewModel WorkspaceViewModel;
+        public readonly WorkspaceViewModel WorkspaceViewModel;
         /// initialize the start Z-Index of a pin to a default
         /// zIndex is mutable depending on mouse behaviour
         private int zIndex = Configurations.NodeStartZIndex; 
@@ -196,6 +196,7 @@ namespace Dynamo.ViewModels
         private void UnpinWireCommandExecute(object parameter)
         {
             OnRequestRemove(this, EventArgs.Empty);
+            WorkspaceViewModel.Model.HasUnsavedChanges = true;
         }
 
         private void InitializeCommands()

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -704,6 +704,7 @@ namespace Dynamo.ViewModels
             {
                 IsPartlyVisible = false;
             }
+            workspaceViewModel.Model.HasUnsavedChanges = true;
         }
         /// <summary>
         /// Selects nodes connected to this wire.
@@ -729,6 +730,7 @@ namespace Dynamo.ViewModels
             var connectorPinModel = new ConnectorPinModel(MousePosition.X, MousePosition.Y, Guid.NewGuid(), model.GUID);
             ConnectorModel.AddPin(connectorPinModel);
             workspaceViewModel.Model.RecordCreatedModel(connectorPinModel);
+            workspaceViewModel.Model.HasUnsavedChanges = true;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

This PR addresses and fixes the following Jira issues:

- [DYN-3890] Pin add/delete should set workspace `hasunsavedchanges = true`. https://jira.autodesk.com/browse/DYN-3890
- [DYN-3963] Dynamo crashes when freezing a node with pinned wire. https://jira.autodesk.com/browse/DYN-3963

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
