### PR TITLE
[DYN-3966] Background color on unconnected output ports

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -788,7 +788,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    PortBackgroundColor = new SolidColorBrush(Colors.Transparent);
+                    PortBackgroundColor = new SolidColorBrush(Color.FromRgb(60, 60, 60));
                     PortBorderBrushColor = new SolidColorBrush(Color.FromRgb(204, 204, 204));
                 }
             }


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-3966](https://jira.autodesk.com/browse/DYN-3966)

Unconnected ports were given a transparent background, this was no issue as long as the port is on a node, but was unexpected when the ports are on a Group. The output ports have been updated to use the same background as the nodes.

![image](https://user-images.githubusercontent.com/13732445/132191894-c6c639f3-742b-4908-9b63-5a97cd8c47d5.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Jingyi-Wen 
