### PR TITLE
[DYN-3989] Add border around groups

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -397,6 +397,19 @@
             </ContextMenu>
         </Grid.ContextMenu>
 
+        <!--Persistent border shows around the entire group at all time-->
+        <Border Name="persistentBorder"
+                Grid.RowSpan="2"
+                BorderThickness="2"
+                CornerRadius="{StaticResource ExpanderCornerRadius}"
+                IsHitTestVisible="False"
+                Canvas.ZIndex="41"
+                Margin="-1">
+            <Border.BorderBrush>
+                <SolidColorBrush Color="{Binding Background}" />
+            </Border.BorderBrush>
+        </Border>
+
         <!--Selection border shows around the entire group when its selected in the workspace-->
         <Border Name="selectionBorder"
                 Grid.RowSpan="2"


### PR DESCRIPTION
### Purpose

This PR adds a new persistent border around groups so its easier to distinguish grouped groups.
![image](https://user-images.githubusercontent.com/13732445/132472425-b6ec43df-8631-42f8-95bd-845a8a67deb9.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Jingyi-Wen @Amoursol 
