### PR TITLE
Fix node lacing tooltip

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -525,7 +525,7 @@
                    FontSize="10px"
                    Foreground="{StaticResource NodeLacingGlyphBackground}"
                    Style="{StaticResource SZoomFadeLabel}"
-                   ToolTip="For two lists {a,b,c}{1,2,3} returns {a1,a2,a3}{b1,b2,b3}{c1,c2,c3} pattern."
+                   ToolTip="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToTooltipConverter}}"
                    Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter}}" />
             <Grid Name="AlertsGlyph"
                   Width="Auto"


### PR DESCRIPTION
### Purpose

This bug reinstates the proper functionality of the node lacing tooltip, which appears when the user hovers their mouse over the lacing icon of a node (e.g. 'xxx').

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
 

### Reviewers

@QilongTang 

### FYIs

None

