### PR TITLE
collapse group content if group is not expanded

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -532,6 +532,13 @@ namespace Dynamo.ViewModels
             ViewModelBases.OfType<AnnotationViewModel>()
                 .ToList()
                 .ForEach(x => AddToCutGeometryDictionary(x));
+
+            if (!IsExpanded)
+            {
+                SetGroupInputPorts();
+                SetGroupOutPorts();
+                CollapseGroupContents(true);
+            }
         }
 
         /// <summary>
@@ -732,6 +739,11 @@ namespace Dynamo.ViewModels
 
         private void CollapseConnectors()
         {
+            if (originalInPorts is null)
+            {
+                return;
+            }
+
             var excludedPorts = originalInPorts.Concat(originalOutPorts);
 
             var allNodes = this.Nodes

--- a/src/DynamoCoreWpf/ViewModels/ViewModelBase.cs
+++ b/src/DynamoCoreWpf/ViewModels/ViewModelBase.cs
@@ -21,6 +21,7 @@ namespace Dynamo.ViewModels
         }
 
         private bool isCollapsed;
+        [JsonIgnore]
         public virtual bool IsCollapsed
         {
             get => isCollapsed;


### PR DESCRIPTION
### Purpose

This PR fixes (DYN-4078)[https://jira.autodesk.com/browse/DYN-4078]

On initialization, the AnnotationViewModel will collapse all its content if it isnt expanded.
Removed serialization of `IsCollapsed`

![nestedGroupsBugFix](https://user-images.githubusercontent.com/13732445/132884985-6280f588-b236-4fe0-95a9-dc92e1ebc942.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
