### PR TITLE
DYN-3909: IsVisibleInDynamoLibrary attribute now honored for ZT constructors as well

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1320,84 +1320,7 @@ namespace ProtoFFI
 
         [Obsolete("This method is deprecated and will be removed in Dynamo 3.0. Use FFIMethodAttributes(MethodBase method, Dictionary<MethodInfo, Attribute[]> getterAttributes = null) instead.")]
         public FFIMethodAttributes(MethodInfo method, Dictionary<MethodInfo, Attribute[]> getterAttributes)
-        {
-            if (method == null)
-                throw new ArgumentNullException("method");
-
-            FFIClassAttributes baseAttributes = null;
-            Type type = method.DeclaringType;
-            if (!CLRModuleType.TryGetTypeAttributes(type, out baseAttributes))
-            {
-                baseAttributes = new FFIClassAttributes(type);
-                CLRModuleType.SetTypeAttributes(type, baseAttributes);
-            }
-
-            if (null != baseAttributes)
-            {
-                HiddenInLibrary = baseAttributes.HiddenInLibrary;
-            }
-
-            Attribute[] atts = null;
-            if (getterAttributes.TryGetValue(method, out atts))
-            {
-                attributes = atts;
-            }
-            else
-            {   
-                attributes = method.GetCustomAttributes(false).Cast<Attribute>().ToArray();
-            }
-            
-            foreach (var attr in attributes)
-            {
-                if (attr is AllowRankReductionAttribute)
-                {
-                    AllowRankReduction = true;
-                }
-                else if (attr is RuntimeRequirementAttribute)
-                {
-                    RequireTracing = (attr as RuntimeRequirementAttribute).RequireTracing;
-                }
-                else if (attr is MultiReturnAttribute)
-                {
-                    var multiReturnAttr = (attr as MultiReturnAttribute);
-                    returnKeys = multiReturnAttr.ReturnKeys.ToList();
-                }
-                else if(attr.HiddenInDynamoLibrary())
-                {
-                    HiddenInLibrary = true;
-                }
-                else if (attr is IsVisibleInDynamoLibraryAttribute)
-                {
-                    HiddenInLibrary = false;
-                }
-                else if (attr is IsObsoleteAttribute)
-                {
-                    HiddenInLibrary = true;
-                    ObsoleteMessage = (attr as IsObsoleteAttribute).Message;
-                    if (string.IsNullOrEmpty(ObsoleteMessage))
-                        ObsoleteMessage = "Obsolete";
-                }
-                else if (attr is ObsoleteAttribute)
-                {
-                    HiddenInLibrary = true;
-                    ObsoleteMessage = (attr as ObsoleteAttribute).Message;
-                    if (string.IsNullOrEmpty(ObsoleteMessage))
-                        ObsoleteMessage = "Obsolete";
-                }
-                else if (attr is CanUpdatePeriodicallyAttribute)
-                {
-                    CanUpdatePeriodically = (attr as CanUpdatePeriodicallyAttribute).CanUpdatePeriodically;
-                }
-                else if (attr is IsLacingDisabledAttribute)
-                {
-                    IsLacingDisabled = true; 
-                }
-                else if (attr is AllowArrayPromotionAttribute)
-                {
-                    AllowArrayPromotion = (attr as AllowArrayPromotionAttribute).IsAllowed;
-                }
-            }
-        }
+            : this(method as MethodBase, getterAttributes) { }
 
         public FFIMethodAttributes(MethodBase method, Dictionary<MethodInfo, Attribute[]> getterAttributes = null)
         {
@@ -1418,7 +1341,7 @@ namespace ProtoFFI
             }
 
             Attribute[] atts;
-            if (method is MethodInfo mInfo && getterAttributes.TryGetValue(mInfo, out atts))
+            if (method is MethodInfo mInfo && getterAttributes != null && getterAttributes.TryGetValue(mInfo, out atts))
             {
                 attributes = atts;
             }

--- a/test/DynamoCoreTests/Engine/CodeCompletion/CodeCompletionServicesTest.cs
+++ b/test/DynamoCoreTests/Engine/CodeCompletion/CodeCompletionServicesTest.cs
@@ -99,5 +99,22 @@ namespace Dynamo.Tests.Engine.CodeCompletion
             Assert.AreEqual(overloads.Count(), 0);
 
         }
+
+
+        [Test]
+        public void Constructor_WithIsVisibleFalseAttribute_HiddenFromSearch()
+        {
+            var className = @"FFITarget.DesignScript.Point";
+
+            var cm = new ClassMirror(className, libraryServicesCore);
+            var ctors = cm.GetConstructors();
+            var ctorNames = ctors.Select(x => x.MethodName);
+            var found = false;
+            foreach(var name in ctorNames)
+            {
+                if (name == nameof(FFITarget.DesignScript.Point)) found = true;
+            }
+            Assert.False(found);
+        }
     }
 }

--- a/test/DynamoCoreTests/ExtensionTests.cs
+++ b/test/DynamoCoreTests/ExtensionTests.cs
@@ -248,7 +248,7 @@ namespace Dynamo.Tests
 
             var entries = model.SearchModel.SearchEntries.ToList();
             var nodesInLib = entries.Where(x => x.Assembly.Contains("SampleLibraryZeroTouch")).Select(y => y.FullName).ToList();
-            Assert.AreEqual(13, nodesInLib.Count());
+            Assert.AreEqual(12, nodesInLib.Count());
             Assert.IsTrue(entries.Count(x => x.FullName == "SampleLibraryZeroTouch.Examples.TransformableExample.TransformObject") == 1);
 
         }

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -972,6 +972,14 @@ namespace FFITarget
     {
         public class Point
         {
+            [IsVisibleInDynamoLibrary(false)]
+            public Point()
+            {
+                dX = 0;
+                dY = 0;
+                dZ = 0;
+            }
+
             public static Point XYZ(double x, double y, double z)
             {
                 var p = new Point { dX = x, dY = y, dZ = z };

--- a/test/Tools/NodeDocumentationMarkdownGeneratorTests/MarkdownGeneratorCommandTests.cs
+++ b/test/Tools/NodeDocumentationMarkdownGeneratorTests/MarkdownGeneratorCommandTests.cs
@@ -317,7 +317,6 @@ namespace NodeDocumentationMarkdownGeneratorTests
                 "Examples.PeriodicUpdateExample.PointField.md",
                 "Examples.TransformableExample.ByGeometry.md",
                 "Examples.TransformableExample.Geometry.md",
-                "Examples.TransformableExample.TransformableExample.md",
                 "Examples.TransformableExample.TransformObject.md",
                 "SampleLibraryUI.Examples.ButtonCustomNodeModel.md",
                 "SampleLibraryUI.Examples.DropDownExample.md",


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-3909
IsVisibleAttribute is now honored for ZT constructors as well.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
