### PR TITLE
remove libG 225 from files to sign

### DIFF
--- a/tools/install/Extra/additional-files-to-sign.txt
+++ b/tools/install/Extra/additional-files-to-sign.txt
@@ -12,13 +12,6 @@ ProtoGeometry.customization.dll
 ProtoGeometry.dll
 .\en-US\ProtoGeometry.resources.dll
 
-.\libg_225_0_0\LibG.AsmPreloader.Managed.dll
-.\libg_225_0_0\LibG.AsmPreloader.Unmanaged.dll
-.\libg_225_0_0\LibG.dll
-.\libg_225_0_0\LibG.Managed.dll
-.\libg_225_0_0\LibG.ProtoInterface.dll
-.\libg_225_0_0\LibGCore.dll
-
 .\libg_226_0_0\LibG.AsmPreloader.Managed.dll
 .\libg_226_0_0\LibG.AsmPreloader.Unmanaged.dll
 .\libg_226_0_0\LibG.dll


### PR DESCRIPTION
### Purpose
LibG225 nuget package reference was removed in this PR: https://github.com/DynamoDS/Dynamo/pull/12036
so we need to remove libG 225 from distributed /signed files list or the build on master-15 will fail.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

