### PR TITLE
PR - Jira Issues: [DYN-4095] Cleanup layout rearranges pin and node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -119,10 +119,10 @@ namespace Dynamo.ViewModels
         /// </summary>
         public double Top
         {
-            get { return model.Y; }
+            get { return model.Y- OneThirdWidth; }
             set
             {
-                model.Y = value;
+                model.Y = value + OneThirdWidth;
                 RaisePropertyChanged(nameof(Top));
             }
         }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -414,7 +414,7 @@ namespace GraphLayout
                     }
                     else if (n.LeftEdges.Count > 0 && AnchorRightEdges.Count == 0)
                     {
-                        n.Y = prevY + 10;
+                        n.Y = prevY;
                         prevY = n.Y;
                         layerUpdated = true;
                     }


### PR DESCRIPTION
### Description
Fixes a previous bug visible when running `Cleanup Layout`. When selecting a single node and running the command multiple
times, any connector pin in the graph moved upwards.

Fixed behaviour: 
![WireIssueFix-CleanLayoutPin](https://user-images.githubusercontent.com/24754290/133456047-36fc1803-6be4-4a11-8b17-415046ba5079.gif)

This PR also adds a `HasUnsavedChanges` flag when calling `BreakConnection` from a port.

Fixed behaviour: 
![WireIssueFix-UndoFlagAddedToBreakConnection-FromPort](https://user-images.githubusercontent.com/24754290/133456063-81153321-b1ee-49d1-bd9e-635aabcdc1ab.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
