### PR TITLE
Fix crash bug when deleting a node with note pinned will crash Dynamo

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -669,6 +669,15 @@ namespace Dynamo.ViewModels
             Selected?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Event to determine when Node is removed
+        /// </summary>
+        internal event EventHandler Removed;
+        internal void OnRemoved(object sender, EventArgs e)
+        {
+            Removed?.Invoke(this, e);
+        }
+
         #endregion
 
         #region constructors
@@ -999,6 +1008,7 @@ namespace Dynamo.ViewModels
         {
             var command = new DynamoModel.DeleteModelCommand(nodeLogic.GUID);
             DynamoViewModel.ExecuteCommand(command);
+            OnRemoved(this, EventArgs.Empty);
         }
 
         private void SetLacingType(object param)

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -362,7 +362,7 @@ namespace Dynamo.ViewModels
             if (PinnedNode != null)
             {
                 PinnedNode.PropertyChanged -= PinnedNodeViewModel_PropertyChanged;
-                PinnedNode.RequestsSelection -= PinnedNodeViewModel_OnPinnedNodeSelected;
+                PinnedNode.Selected -= PinnedNodeViewModel_OnPinnedNodeSelected;
                 PinnedNode.Removed -= PinnedNodeViewModel_OnPinnedNodeRemoved;
 
                 Analytics.TrackEvent(

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -344,9 +344,12 @@ namespace Dynamo.ViewModels
             Model.PinnedNode.PropertyChanged += PinnedNodeModel_PropertyChanged;
             PinnedNode.PropertyChanged += PinnedNodeViewModel_PropertyChanged;
 
-            // Subscribe to pinnedNode.RequestSelection (fires before node is selected)
+            // Subscribe to PinnedNode.Selected (fires before node is selected)
             // so that this note is added to the selection
             PinnedNode.Selected += PinnedNodeViewModel_OnPinnedNodeSelected;
+
+            //Subscribed to PinnedNode.Removed event of Node to remove pinned note when node is removed.
+            PinnedNode.Removed += PinnedNodeViewModel_OnPinnedNodeRemoved;
 
             Analytics.TrackEvent(
                 Actions.Pin,
@@ -360,11 +363,17 @@ namespace Dynamo.ViewModels
             {
                 PinnedNode.PropertyChanged -= PinnedNodeViewModel_PropertyChanged;
                 PinnedNode.RequestsSelection -= PinnedNodeViewModel_OnPinnedNodeSelected;
+                PinnedNode.Removed -= PinnedNodeViewModel_OnPinnedNodeRemoved;
 
                 Analytics.TrackEvent(
                     Actions.Unpin,
                     Categories.NoteOperations, Model.PinnedNode.Name);
             }
+        }
+
+        private void PinnedNodeViewModel_OnPinnedNodeRemoved(object sender, EventArgs e)
+        {
+            WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
         }
 
         private void PinnedNodeModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -399,6 +408,8 @@ namespace Dynamo.ViewModels
 
         private void MoveNoteAbovePinnedNode()
         {
+            if (PinnedNode == null) return;
+
             var distanceToNode = DISTANCE_TO_PINNED_NODE;
             if (Model.PinnedNode.State == ElementState.Error ||
                 Model.PinnedNode.State == ElementState.Warning)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -693,6 +693,7 @@ namespace Dynamo.Controls
             ViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.SelectModelCommand(nodeGuid, Keyboard.Modifiers.AsDynamoType()));
 
+            viewModel.OnSelected(this, EventArgs.Empty);
             grid.ContextMenu.DataContext = viewModel;
             grid.ContextMenu.IsOpen = true;
         }


### PR DESCRIPTION
### Purpose

Fix a crash bug when deleting a node with note pinned will crash Dynamo
(Will attach a snapshot soon)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@DynamoDS/dynamo 
