### PR TITLE
Inserts orange box around dynamo menu and sets opacity to 1 to the box lines

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -186,7 +186,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         {
             if (string.IsNullOrEmpty(highlightColor))
             {
-                GuideBackgroundElement.HolePath.Stroke = Brushes.Black;
+                GuideBackgroundElement.HolePath.Stroke = Brushes.Transparent;
             }
             else
             {

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -90,6 +90,8 @@
 					"PopupPlacement": "right",
 					"HostUIElementString": "dynamoMenu",
 					"VerticalPopupOffset": 50,
+					"HighlightColor": "#EF9362",
+
 					"HorizontalPopupOffset": 230
 				},
 				"UIAutomation":{

--- a/src/DynamoCoreWpf/Views/GuidedTour/GuideBackground.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/GuideBackground.xaml
@@ -23,7 +23,7 @@
                 </Path.Data>
             </Path>
 
-            <Path Name="HolePath" Stroke="Black" StrokeThickness="3" Fill="Transparent" Opacity="0.5">
+            <Path Name="HolePath" Stroke="Black" StrokeThickness="3" Fill="Transparent" Opacity="1">
                 <Path.Data>
                     <RectangleGeometry Rect="{Binding HoleRect}" RadiusX="1" RadiusY="1"/>
                 </Path.Data>


### PR DESCRIPTION
### Purpose

Inserts orange box around dynamo menu and sets the opacity to 1 to the box lines.
Related to the bug DYN-4093

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
