### PR TITLE
Fix for DYN-4011-Popups-Border Bug

### DIFF
--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -27,18 +27,51 @@
     <Canvas Background="Transparent"
             Name="RootLayout" >
 
-        <Polygon x:Name="TooltipPointer"
-                 Visibility="{Binding ShowPopupPointer, Converter={StaticResource BooleanToVisibilityConverter}}"
-                 Points="{Binding TooltipPointerPoints}" 
-                 Style="{StaticResource PoupPolygonPointerStyle}" />
-
-        <Path x:Name="PopupPathRectangle" 
+        <Path x:Name="PopupPathRectangle"   
               Style="{StaticResource PoupPathRectangleStyle}">
             <Path.Data>
                 <RectangleGeometry x:Name="BackgroundRectangle">
                 </RectangleGeometry>
             </Path.Data>
+            <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 135 grades-->
+            <Path.Effect>
+                <DropShadowEffect Opacity="0.2" 
+                                  Color="Black"
+                                  ShadowDepth="4"
+                                  BlurRadius="4"
+                                  Direction="135"/>
+            </Path.Effect>
         </Path>
+
+        <Path x:Name="PopupPathRectangleShadow"   
+              Style="{StaticResource PoupPathRectangleStyle}">
+            <Path.Data>
+                <RectangleGeometry Rect="{Binding ElementName=BackgroundRectangle, Path=Rect}">
+                </RectangleGeometry>
+            </Path.Data>
+            <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 315 grades-->
+            <Path.Effect>
+                <DropShadowEffect Opacity="0.2" 
+                                  Color="Black"
+                                  ShadowDepth="4"
+                                  BlurRadius="4"
+                                  Direction="315"/>
+            </Path.Effect>
+        </Path>
+
+
+        <Polygon x:Name="TooltipPointer"
+                 Visibility="{Binding ShowPopupPointer, Converter={StaticResource BooleanToVisibilityConverter}}"
+                 Points="{Binding TooltipPointerPoints}" 
+                 Style="{StaticResource PoupPolygonPointerStyle}">
+            <Polygon.BitmapEffect>
+                <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 315 grades by default-->
+                <DropShadowBitmapEffect Color="Black" 
+                                        Direction="135" 
+                                        ShadowDepth="4" 
+                                        Opacity="0.2" />
+            </Polygon.BitmapEffect>
+        </Polygon>
 
         <Grid Width="{Binding Width}"
                 Height="{Binding Height}"
@@ -59,7 +92,7 @@
                 <!--This is the header/title section of the Popup-->
                 <Border Grid.Row="0" 
                         BorderThickness="0,0,0,1"               
-                        Margin="20,0,0,0">
+                        Margin="20,10,0,0">
                     <Border.BorderBrush>
                         <SolidColorBrush Color="{StaticResource PopupTitleBorderColor}" 
                                          Opacity="0.3"/>

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -59,7 +59,7 @@
             </Path.Effect>
         </Path>
 
-
+        <!--This Polygon will draw on the Canvas the pointer (a triangle) that will be available only for tooltips but for the Welcome popup will be hidden-->
         <Polygon x:Name="TooltipPointer"
                  Visibility="{Binding ShowPopupPointer, Converter={StaticResource BooleanToVisibilityConverter}}"
                  Points="{Binding TooltipPointerPoints}" 

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
@@ -10,6 +10,7 @@ namespace Dynamo.Wpf.Views.GuidedTour
     /// </summary>
     public partial class PopupWindow : Popup
     {
+        private const int popupBordersOffSet = 10;
         private PopupWindowViewModel popupViewModel;
 
         public PopupWindow(PopupWindowViewModel viewModel, HostControlInfo hInfo)
@@ -22,21 +23,21 @@ namespace Dynamo.Wpf.Views.GuidedTour
             DataContext = popupViewModel;
 
             //Due that we are drawing the Direction pointers on left and right side of the Canvas (10 width each one) then we need to add 20
-            RootLayout.Width = popupViewModel.Width + 20; 
+            RootLayout.Width = popupViewModel.Width + (popupBordersOffSet * 2); 
             //Also a shadow of 10 pixels in top and 10 pixels at the bottom will be shown then we need to add 20
-            RootLayout.Height = popupViewModel.Height + 20;
+            RootLayout.Height = popupViewModel.Height + (popupBordersOffSet * 2);
 
             //The BackgroundRectangle represent the tooltip background rectangle that is drawn over a Canvas
             //Needs to be moved 10 pixels over the X axis to show the direction pointers (Height was already increased above)
             //Needs to be moved 10 pixels over the Y axis to show the shadow at top and bottom.
-            BackgroundRectangle.Rect = new Rect(10, 10, popupViewModel.Width, popupViewModel.Height);
+            BackgroundRectangle.Rect = new Rect(popupBordersOffSet, popupBordersOffSet, popupViewModel.Width, popupViewModel.Height);
 
             //Setting the host over which the popup will appear and the placement mode
             PlacementTarget = hInfo.HostUIElement;
             Placement = hInfo.PopupPlacement;
 
             //The CustomRichTextBox has a margin of 10 in left and 10 in right, also there is a indentation for drawing the PointerDirection of 10 of each side so that's why we are subtracting 40.
-            ContentRichTextBox.Width = popupViewModel.Width - 40;
+            ContentRichTextBox.Width = popupViewModel.Width - (popupBordersOffSet * 4);
             HorizontalOffset = hInfo.HorizontalPopupOffSet;
             VerticalOffset = hInfo.VerticalPopupOffSet;
         }

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
@@ -23,10 +23,13 @@ namespace Dynamo.Wpf.Views.GuidedTour
 
             //Due that we are drawing the Direction pointers on left and right side of the Canvas (10 width each one) then we need to add 20
             RootLayout.Width = popupViewModel.Width + 20; 
-            RootLayout.Height = popupViewModel.Height;
+            //Also a shadow of 10 pixels in top and 10 pixels at the bottom will be shown then we need to add 20
+            RootLayout.Height = popupViewModel.Height + 20;
 
-            //The BackgroundRectangle represent the tooltip and it need to left 10 at left and 10 at right to show the direction pointers
-            BackgroundRectangle.Rect = new Rect(10, 0, popupViewModel.Width, popupViewModel.Height);
+            //The BackgroundRectangle represent the tooltip background rectangle that is drawn over a Canvas
+            //Needs to be moved 10 pixels over the X axis to show the direction pointers (Height was already increased above)
+            //Needs to be moved 10 pixels over the Y axis to show the shadow at top and bottom.
+            BackgroundRectangle.Rect = new Rect(10, 10, popupViewModel.Width, popupViewModel.Height);
 
             //Setting the host over which the popup will appear and the placement mode
             PlacementTarget = hInfo.HostUIElement;


### PR DESCRIPTION
### Purpose

I updated the PopupWindow in order to add a shadow in the border of the window and the popup pointer also the Popup location and size need to be updated by 10 pixels in the top and bottom so we can show the shadow.
The shadow has the next features:
- Color Black 0xFFFFFF
- Transparency 20%
- Shadow of 4px lenght

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
