### PR TITLE
Fix for DYN-3950: Remove "and close it" from the string

### DIFF
--- a/src/Libraries/PythonNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/PythonNodeModels/Properties/Resources.Designer.cs
@@ -250,7 +250,7 @@ namespace PythonNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Save the changes made to current Python node editor and close it..
+        ///   Looks up a localized string similar to Save the changes made to current Python node editor..
         /// </summary>
         public static string PythonScriptEditorSaveChangesButtonTooltip {
             get {

--- a/src/Libraries/PythonNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/PythonNodeModels/Properties/Resources.en-US.resx
@@ -178,7 +178,7 @@
     <value>Save current code in Python node editor and run graph with it.</value>
   </data>
   <data name="PythonScriptEditorSaveChangesButtonTooltip" xml:space="preserve">
-    <value>Save the changes made to current Python node editor and close it.</value>
+    <value>Save the changes made to current Python node editor.</value>
   </data>
   <data name="PythonScriptFromStringDescription" xml:space="preserve">
     <value>Runs a Python script from a string.</value>

--- a/src/Libraries/PythonNodeModels/Properties/Resources.resx
+++ b/src/Libraries/PythonNodeModels/Properties/Resources.resx
@@ -179,7 +179,7 @@
     <value>Save current code in Python node editor and run graph with it.</value>
   </data>
   <data name="PythonScriptEditorSaveChangesButtonTooltip" xml:space="preserve">
-    <value>Save the changes made to current Python node editor and close it.</value>
+    <value>Save the changes made to current Python node editor.</value>
   </data>
   <data name="PythonScriptFromStringDescription" xml:space="preserve">
     <value>Runs a Python script from a string.</value>


### PR DESCRIPTION
### Purpose

This pull request does:

* fix DYN-3950 by removing "and close it" from the string

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

