### PR TITLE
harden GeneratedGraphicItems methods

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
@@ -101,9 +101,12 @@ namespace Dynamo.Graph.Nodes
 
         internal static List<IGraphicItem> GeneratedGraphicItems(this NodeModel node, EngineController engineController)
         {
-            var ids = node.GetAllOutportAstIdentifiers();
-
             var results = new List<IGraphicItem>();
+            if (node is null || engineController is null)
+            {
+                return results;
+            }
+            var ids = node.GetAllOutportAstIdentifiers();
 
             foreach (var id in ids)
             {


### PR DESCRIPTION
### Purpose

I was not able to reproduce this crash, but my guess is that somehow engineController has been disposed/set to null temporarily, which does happen from time to time when reseting the vm, opening a new graph, or at shutdown.

Check for nulls, and bail. 

```
System.NullReferenceException in
 Dynamo.Graph.Nodes.NodeModelExtensions.GeneratedGraphicItems(NodeModel node,
EngineController engineController) in System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext() in
Dynamo.Applications.ViewModel.RevitWatch3DViewModel.Draw(NodeModel node) in
System.EventHandler`1.Invoke(Object sender, TEventArgs e) in
Dynamo.Models.DynamoModel.OnEvaluationCompleted(Object sender, EvaluationCompletedEventArgs e) in
System.EventHandler`1.Invoke(Object sender, TEventArgs e) in
Dynamo.Graph.Workspaces.HomeWorkspaceModel.OnEvaluationCompleted(EvaluationCompletedEventArgs e) in 

```

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
