### PR TITLE
DYN-777 : performance improvements demo

### DIFF
--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -170,7 +170,7 @@ namespace Dynamo.Graph
             set
             {
                 height = value;
-                //RaisePropertyChanged("Height");
+                RaisePropertyChanged("Height");
             }
         }
 
@@ -184,7 +184,7 @@ namespace Dynamo.Graph
             set
             {
                 width = value;
-                //RaisePropertyChanged("Width");
+                RaisePropertyChanged("Width");
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -563,6 +563,30 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        ///     Returns or set the X position of the Node.
+        /// </summary>
+        public double Height
+        {
+            get { return NodeModel.Height; }
+            set
+            {
+                NodeModel.Height = value;
+            }
+        }
+
+        /// <summary>
+        ///     Returns or set the Y position of the Node.
+        /// </summary>
+        public double Width
+        {
+            get { return NodeModel.Width; }
+            set
+            {
+                NodeModel.Width = value;
+            }
+        }
+
         internal double ActualHeight { get; set; }
         internal double ActualWidth { get; set; }
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -5,11 +5,11 @@
              xmlns:dynui="clr-namespace:Dynamo.UI.Controls"
              xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
              xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore"
-             Height="Auto"
-             Width="Auto"
              Name="topControl"
              MouseLeftButtonDown="topControl_MouseLeftButtonDown"
              MouseRightButtonDown="topControl_MouseRightButtonDown"
+             Width="Auto"
+             Height="Auto"
              MouseEnter="OnNodeViewMouseEnter"
              MouseLeave="OnNodeViewMouseLeave"
              PreviewMouseMove="OnNodeViewMouseMove"
@@ -416,12 +416,8 @@
 
         </StackPanel>
 
-        
-
-
-
-
         <!-- INPUT PORTS -->
+        <!--
         <ItemsControl Name="inputPortControl"
                       Grid.Row="2"
                       Grid.Column="0"
@@ -430,8 +426,10 @@
                       Style="{StaticResource InOutPortControlStyle}"
                       ItemsSource="{Binding Path=InPorts}">
         </ItemsControl>
-
+        -->
+       
         <!-- OUTPUT PORTS -->
+        <!--
         <ItemsControl Name="outputPortControl"
                       Grid.Row="2"
                       Grid.Column="2"
@@ -440,7 +438,8 @@
                       Style="{StaticResource InOutPortControlStyle}"
                       ItemsSource="{Binding Path=OutPorts}">
         </ItemsControl>
-
+        -->
+       
         <Grid Name="centralGrid"
               Grid.Column="1"
               Grid.Row="2"

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -28,17 +28,38 @@ namespace CoreNodeModelsWpf.Nodes
         {
             viewNode = nodeView;
             colorPaletteNode = model;
+
+            viewNode.MouseEnter += ViewNode_MouseEnter;
+        }
+
+        private void ViewNode_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            ConstructView();
+        }
+
+        private void ConstructView()
+        {
+            if (viewNode is null || colorPaletteNode is null )
+            {
+                return;
+            }
+
+            if (ColorPaletteUINode != null)
+            {
+                return;
+            }
+
             converter = new Converters.MediatoDSColorConverter();
             ColorPaletteUINode = new ColorPaletteUI();
             ColorPaletteUINode.xceedColorPickerControl.Closed += ColorPickerControl_Closed;
             colorPaletteNode.PropertyChanged += ColorPaletteNode_PropertyChanged;
-            nodeView.ContentGrid.Children.Add(ColorPaletteUINode);
-
+            viewNode.ContentGrid.Children.Add(ColorPaletteUINode);
 
             var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
             WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
             //kick off ui to match initial model state.
             this.ColorPaletteNode_PropertyChanged(ColorPaletteUINode, new PropertyChangedEventArgs("DsColor"));
+            viewNode.MouseEnter -= ViewNode_MouseEnter;
         }
 
         private void ColorPaletteNode_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -83,6 +104,7 @@ namespace CoreNodeModelsWpf.Nodes
         {
             ColorPaletteUINode.xceedColorPickerControl.Closed -= ColorPickerControl_Closed; ;
             colorPaletteNode.PropertyChanged -= ColorPaletteNode_PropertyChanged;
+            viewNode.MouseEnter -= ViewNode_MouseEnter;
 
         }
     }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleSlider.cs
@@ -7,18 +7,39 @@ namespace CoreNodeModelsWpf.NodeViewCustomizations
 {
     public class DoubleSliderNodeViewCustomization : INodeViewCustomization<DoubleSlider>
     {
+        private NodeView viewNode;
+        private DoubleSlider sliderModel;
+        private DynamoSlider sliderDynamo;
         public void CustomizeView(DoubleSlider model, NodeView nodeView)
         {
-            var slider = new DynamoSlider(model, nodeView)
+            viewNode = nodeView;
+            sliderModel = model;
+            viewNode.MouseEnter += ViewNode_MouseEnter;
+        }
+
+        private void ViewNode_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            ConstructView();
+        }
+
+        private void ConstructView()
+        {
+            if (viewNode is null || sliderModel is null || sliderDynamo!= null)
             {
-                DataContext = new SliderViewModel<double>(model)
+                return;
+            }
+
+            sliderDynamo = new DynamoSlider(sliderModel, viewNode)
+            {
+                DataContext = new SliderViewModel<double>(sliderModel)
             };
 
-            nodeView.inputGrid.Children.Add(slider);
+            viewNode.inputGrid.Children.Add(sliderDynamo);
         }
 
         public void Dispose()
         {
+            viewNode.MouseEnter -= ViewNode_MouseEnter;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -256,7 +256,7 @@ namespace DynamoCoreWpfTests
             var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            var inputPortControl = nodeView.inputPortControl;
+            var inputPortControl = nodeView.CreateInOutPortsControls("inputPortControl", 0, nodeView.ViewModel.InPorts);
             Assert.AreEqual(6, inputPortControl.ChildrenOfType<TextBlock>().Count());
         }
 
@@ -270,7 +270,7 @@ namespace DynamoCoreWpfTests
             var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            var inputPortControl = nodeView.inputPortControl;
+            var inputPortControl = nodeView.CreateInOutPortsControls("inputPortControl", 0, nodeView.ViewModel.InPorts);
             Assert.AreEqual(8, inputPortControl.ChildrenOfType<TextBlock>().Count());
         }
 
@@ -341,7 +341,7 @@ namespace DynamoCoreWpfTests
             var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            var inputPortControl = nodeView.inputPortControl;
+            var inputPortControl = nodeView.CreateInOutPortsControls("inputPortControl", 0, nodeView.ViewModel.InPorts);
             Assert.AreEqual(6, inputPortControl.ChildrenOfType<TextBlock>().Count());
 
             nodeView = NodeViewWithGuid("2f031397-539e-4df4-bfca-d94d0bd02bc1"); // String.Concat node
@@ -349,7 +349,6 @@ namespace DynamoCoreWpfTests
             eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            inputPortControl = nodeView.inputPortControl;
             Assert.AreEqual(4, inputPortControl.ChildrenOfType<TextBlock>().Count());
 
             nodeView = NodeViewWithGuid("0cb04cce-1b05-47e0-a73f-ee81af4b7f43"); // List.Join node
@@ -357,7 +356,6 @@ namespace DynamoCoreWpfTests
             eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            inputPortControl = nodeView.inputPortControl;
             Assert.AreEqual(4, inputPortControl.ChildrenOfType<TextBlock>().Count());
         }
 


### PR DESCRIPTION
We don't always need to execute UI-related code and render UI components.
So we are going to load UI elements for nodes ( main content plus ports ) on demand when the user sets focus on a specific control.
If we are doing this Dynamo is ~= 50% faster when we are opening a graph and consumes ~= 50% less memory.
UI-less performance should be improved as well but probably not that much.
Note that even if full UI components are not loaded and a node looks empty graph execution works as expected.
Another nice aspect of this is that this work can be done incrementally one control after another.
