### PR TITLE
Initialize elements everytime the Guided tour starts

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -93,7 +93,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         }
 
         /// <summary>
-        /// Creates the background for the 
+        /// Creates the background for the GuidedTour
         /// </summary>
         private void CreateBackground()
         {

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -47,8 +47,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private const string mainGridName = "mainGrid";
         private const string libraryViewName = "Browser";
 
-
-
         internal static string GuidesExecutingDirectory
         {
             get
@@ -66,7 +64,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         }
 
         /// <summary>
-        /// GuidesManager Constructor that will read all the guides/steps from and json file and subscribe handlers for the Start and Finish events
+        /// GuidesManager Constructor 
         /// </summary>
         /// <param name="root">root item of the main Dynamo Window </param>
         /// <param name="dynViewModel"></param>
@@ -75,9 +73,31 @@ namespace Dynamo.Wpf.UI.GuidedTour
             mainRootElement = root;
             dynamoViewModel = dynViewModel;
             guideBackgroundElement = Guide.FindChild(root, guideBackgroundName) as GuideBackground;
-            Guides = new List<Guide>();
-            Window mainWindow = Window.GetWindow(mainRootElement);
+        }
 
+        /// <summary>
+        /// Initializator that will read all the guides/steps from and json file and subscribe handlers for the Start and Finish events
+        /// </summary>
+        private void Initialize()
+        {
+            //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
+            GuideFlowEvents.GuidedTourStart += TourStarted;
+            GuideFlowEvents.GuidedTourFinish += TourFinished;
+
+            Guides = new List<Guide>();
+
+            CreateGuideSteps(GuidesJsonFilePath);
+            CreateBackground();
+
+            guideBackgroundElement.HoleRect = new Rect();
+        }
+
+        /// <summary>
+        /// Creates the background for the 
+        /// </summary>
+        private void CreateBackground()
+        {
+            Window mainWindow = Window.GetWindow(mainRootElement);
 
             if (guideBackgroundElement == null)
             {
@@ -89,18 +109,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
                     Visibility = Visibility.Hidden
                 };
 
-                Grid mainGrid = Guide.FindChild(root, mainGridName) as Grid;
+                Grid mainGrid = Guide.FindChild(mainRootElement, mainGridName) as Grid;
                 mainGrid.Children.Add(guideBackgroundElement);
                 Grid.SetColumnSpan(guideBackgroundElement, 5);
                 Grid.SetRowSpan(guideBackgroundElement, 6);
             }
-
-            guideBackgroundElement.HoleRect = new Rect();
-            CreateGuideSteps(GuidesJsonFilePath);
-
-            //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
-            GuideFlowEvents.GuidedTourStart += TourStarted;
-            GuideFlowEvents.GuidedTourFinish += TourFinished;
         }
 
         /// <summary>
@@ -126,7 +139,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
         internal void LaunchTour(string tourName)
         {
             if (!tourStarted)
+            {
+                Initialize();
                 GuideFlowEvents.OnGuidedTourStart(tourName);
+            }
         }
 
         /// <summary>
@@ -222,11 +238,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                     if (newStep != null)
                     {
-                        //The step is added to the new Guide being created
-                        newGuide.GuideSteps.Add(newStep);
-
                         //We subscribe the handler to the StepClosed even, so every time the popup is closed then this method will be called.
                         newStep.StepClosed += Popup_StepClosed;
+
+                        //The step is added to the new Guide being created
+                        newGuide.GuideSteps.Add(newStep);
                     }
                 }
                 Guides.Add(newGuide);


### PR DESCRIPTION
### Purpose

This PR is to fix the subscriptions of the Started Guide and Finished Guide

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 


