### PR TITLE
Split Port Views and ViewModels

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -300,6 +300,8 @@
     <Compile Include="ViewModels\Core\DynamoViewModelBranding.cs" />
     <Compile Include="ViewModels\Core\GalleryViewModel.cs" />
     <Compile Include="ViewModels\Core\HomeWorkspaceViewModel.cs" />
+    <Compile Include="ViewModels\Core\InPortViewModel.cs" />
+    <Compile Include="ViewModels\Core\OutPortViewModel.cs" />
     <Compile Include="ViewModels\Core\SerializationExtensions.cs" />
     <Compile Include="ViewModels\GuidedTour\PopupWindowViewModel.cs" />
     <Compile Include="ViewModels\GuidedTour\SurveyPopupViewModel.cs" />
@@ -475,6 +477,14 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <None Include="UI\Themes\Modern\InPorts.xaml">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="UI\Themes\Modern\OutPorts.xaml">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Page Include="Views\GuidedTour\RealTimeInfoWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/DynamoCoreWpf/UI/SharedResourceDictionary.cs
+++ b/src/DynamoCoreWpf/UI/SharedResourceDictionary.cs
@@ -64,6 +64,8 @@ namespace Dynamo.UI
         private static ResourceDictionary _connectorsDictionary;
         private static ResourceDictionary _portsDictionary;
         private static ResourceDictionary _sidebarGridDictionary;
+        private static ResourceDictionary _outPortsDictionary;
+        private static ResourceDictionary _inPortsDictionary;
 
         public static string ThemesDirectory 
         {
@@ -117,6 +119,16 @@ namespace Dynamo.UI
         public static Uri PortsDictionaryUri
         {
             get { return new Uri(Path.Combine(ThemesDirectory, "Ports.xaml")); }
+        }
+
+        public static Uri OutPortsDictionaryUri
+        {
+            get { return new Uri(Path.Combine(ThemesDirectory, "OutPorts.xaml")); }
+        }
+
+        public static Uri InPortsDictionaryUri
+        {
+            get { return new Uri(Path.Combine(ThemesDirectory, "InPorts.xaml")); }
         }
 
         public static Uri SidebarGridDictionaryUri
@@ -192,6 +204,22 @@ namespace Dynamo.UI
         {
             get {
                 return _portsDictionary ?? (_portsDictionary = new ResourceDictionary() {Source = PortsDictionaryUri});
+            }
+        }
+
+        public static ResourceDictionary OutPortsDictionary
+        {
+            get
+            {
+                return _outPortsDictionary ?? (_outPortsDictionary = new ResourceDictionary() { Source = OutPortsDictionaryUri });
+            }
+        }
+
+        public static ResourceDictionary InPortsDictionary
+        {
+            get
+            {
+                return _inPortsDictionary ?? (_inPortsDictionary = new ResourceDictionary() { Source = InPortsDictionaryUri });
             }
         }
 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -1,0 +1,378 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:command="clr-namespace:GalaSoft.MvvmLight.Command;assembly=GalaSoft.MvvmLight.Platform"
+                    xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore"
+                    xmlns:controls="clr-namespace:Dynamo.Views;assembly=DynamoCore"
+                    xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
+                    xmlns:dynui="clr-namespace:Dynamo.UI.Controls;assembly=DynamoCoreWpf"
+                    xmlns:fa="http://schemas.fontawesome.io/icons/"
+                    xmlns:interactivity="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+                    xmlns:nodes="clr-namespace:Dynamo.Graph.Nodes;assembly=DynamoCore"
+                    xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+                    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+                    xmlns:viewModels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
+                    xmlns:views="clr-namespace:Dynamo.UI.Views;assembly=DynamoCoreWpf">
+
+    <!-- Templates
+
+    Use this to add color resources:
+    ==========================================
+    <Color x:Key="ColorKey" >#FFFFFFAE</Color>
+
+    You can use this to create a style for a button, just change the TargetType or add
+    other control separated by commas and add setter nodes to change properties:
+    ==========================================
+    <Style x:Key="SimpleStyle" TargetType="Button">
+        <Setter Property="Background" Value="Red" />
+    </Style>
+
+    -->
+
+    <!--  Add your resources here  -->
+
+    <ResourceDictionary.MergedDictionaries>
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+    </ResourceDictionary.MergedDictionaries>
+    <DataTemplate DataType="{x:Type viewModels:InPortViewModel}">
+        <!--  Grid that contains the entire port  -->
+        <Grid Name="mainGrid" 
+              HorizontalAlignment="Stretch"
+              Height="35px">
+            <!--
+                The main border shows rounded edges and changes color according to multiple conditions
+                This logic is defined in the ViewModel. None of the elements in this Border are interactive, so they
+                can live in the lowest level of Z-Order
+            -->
+            <Border x:Name="mainBorder"
+                    SnapsToDevicePixels="True"
+                    Height="29px"
+                    Background="{Binding PortBackgroundColor, UpdateSourceTrigger=PropertyChanged}"
+                    BorderBrush="{Binding PortBorderBrushColor, UpdateSourceTrigger=PropertyChanged}"
+                    CornerRadius="0,11,11,0"
+                    BorderThickness="0,1,1,1">
+                <!--  DockPanel that positions the visible port name and the UseLevelArrow  -->
+                <DockPanel x:Name="mainDockPanel" FlowDirection="LeftToRight">
+                    <Grid Name="portNameGrid"
+                          DockPanel.Dock="Left"
+                          IsEnabled="{Binding Path=IsEnabled}"
+                          IsHitTestVisible="True"
+                          Height="{Binding Path=Height}"
+                          Margin="{Binding Path=MarginThickness}"
+                          ToolTipService.ShowDuration="60000">
+                        <Rectangle Fill="Transparent"
+                                   IsHitTestVisible="{Binding IsHitTestVisible}"
+                                   SnapsToDevicePixels="True">
+                            <interactivity:Interaction.Triggers>
+                                <views:HandlingEventTrigger EventName="MouseEnter">
+                                    <interactivity:InvokeCommandAction Command="{Binding Path=MouseEnterCommand}" CommandParameter="{Binding}" />
+                                </views:HandlingEventTrigger>
+                                <views:HandlingEventTrigger EventName="MouseLeave">
+                                    <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeaveCommand}" CommandParameter="{Binding}" />
+                                </views:HandlingEventTrigger>
+                                <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
+                                    <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeftButtonDownCommand}" CommandParameter="{Binding}" />
+                                </views:HandlingEventTrigger>
+                            </interactivity:Interaction.Triggers>
+                            <Rectangle.Margin>
+                                <MultiBinding Converter="{StaticResource SnapRegionMarginConverter}">
+                                    <Binding ElementName="portNameTb" Path="ActualWidth" />
+                                    <Binding Path="PortModel" />
+                                </MultiBinding>
+                            </Rectangle.Margin>
+                        </Rectangle>
+                        <TextBlock Name="portNameTb"
+                                   Width="Auto"
+                                   HorizontalAlignment="Left"
+                                   VerticalAlignment="Center"
+                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                   FontSize="12px"
+                                   FontWeight="Medium"
+                                   Foreground="#DCDCDC"
+                                   IsHitTestVisible="False"
+                                   Margin="13,0,10,5"
+                                   Text="{Binding Path=PortName}">
+                        </TextBlock>
+                    </Grid>
+                    <Grid Width="50"
+                          DockPanel.Dock="Left"
+                          Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    <Grid Name="useLevelArrowGrid"
+                          HorizontalAlignment="Right"
+                          Height="{Binding Path=Height}"
+                          Margin="0,1,6,0"
+                          Visibility="{Binding Path=UseLevelVisibility}">
+                        <Label x:Name="useLevelArrow"
+                               Height="{Binding Path=Height}"
+                               Margin="0,0,0,8"
+                               Padding="0"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               HorizontalContentAlignment="Center"
+                               VerticalContentAlignment="Center"
+                               Content="&gt;"
+                               FontSize="16px"
+                               FontWeight="Medium"
+                               Foreground="{StaticResource PrimaryCharcoal200Brush}"
+                               IsHitTestVisible="False"/>
+                    </Grid>
+                </DockPanel>
+            </Border>
+            <!--  Marker that appears to the left side of an input port  -->
+            <Rectangle x:Name="portValueMarker"
+                       Width="6px"
+                       Height="29px"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"
+                       Fill="{Binding PortValueMarkerColor, UpdateSourceTrigger=PropertyChanged}"
+                       SnapsToDevicePixels="True">
+            </Rectangle>
+            <!--
+                Interactive overlay for the port, highlights the port on MouseOver and
+                contains MouseClick event handling and ToolTip logic. Since the overlay is interactive, it needs to
+                live higher up in the Z-Order than the non-interactive elements in the mainBorder for MouseOver and
+                MouseClick events to fire.
+            -->
+            <Border x:Name="mainBorderHighlightOverlay"
+                    BorderBrush="Transparent"
+                    Opacity="0.2"
+                    CornerRadius="0,11,11,0"
+                    BorderThickness="0,1,1,1"
+                    Height="29px"
+                    SnapsToDevicePixels="True">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="White" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="False">
+                                <Setter Property="Background" Value="Transparent" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <interactivity:Interaction.Triggers>
+                    <!--  Bind Connect command to left click  -->
+                    <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
+                        <interactivity:InvokeCommandAction Command="{Binding Path=ConnectCommand}" />
+                    </views:HandlingEventTrigger>
+                </interactivity:Interaction.Triggers>
+
+                <Border.ToolTip>
+                    <dynui:DynamoToolTip AttachmentSide="Left" Style="{DynamicResource ResourceKey=SLightToolTip}">
+                        <Grid>
+                            <TextBlock MaxWidth="320"
+                                       Text="{Binding Path=ToolTipContent}"
+                                       TextWrapping="Wrap" />
+                        </Grid>
+                    </dynui:DynamoToolTip>
+                </Border.ToolTip>
+
+                <!--  Bind NodeAutoComplete to double left click  -->
+                <Border.InputBindings>
+                    <MouseBinding Command="{Binding Path=NodeAutoCompleteCommand}" MouseAction="LeftDoubleClick" />
+                </Border.InputBindings>
+
+                <!--
+                    We could have changed the Grid opacity directly here but didn't
+                    The reason is that if the opacity of the Grid is modified, the
+                    internal text box will also appear semi-transparent. This is why an
+                    intermediary Border is required just for mouse-over highlighting.
+                -->
+
+                <!--
+                    Port is contained in another rectangle to ensure that hit area is extended outside the grid.
+                    Minimum Width is specified on the rectangle, rather than the grid. Otherwise, if the port's width is less than
+                    the grid's width, the outside rectangle is shrinked to fit the grid. Port snapping cannot occur in that case
+                    as no mouse events are generated.This happens only for codeblock node.
+                -->
+            </Border>
+            <!--
+                Contains the interactive elements which need to have the highest-level of Z-Order so that they
+                may be interacted with *above* the mainBorderHighlightOverlay layer.
+                This is the UseLevelsSpinner and UseLevelsControl.
+            -->
+            <DockPanel Name="interactionControlsDockPanel"
+                       Height="29px"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Center"
+                       FlowDirection="LeftToRight"
+                       IsHitTestVisible="True"
+                       Visibility="{Binding Path=UseLevelVisibility}">
+                <Rectangle x:Name="useLevelArrowHighlightOverlay"
+                           Width="15"
+                           Height="15px"
+                           HorizontalAlignment="Right"
+                           DockPanel.Dock="Right"
+                           IsHitTestVisible="True"
+                           Margin="3,0,5,0">
+                            <!--Visibility="{Binding Path=UseLevelVisibility}"-->
+                    <interactivity:Interaction.Triggers>
+                        <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
+                            <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeftButtonDownOnLevelCommand}" CommandParameter="{Binding}" />
+                        </views:HandlingEventTrigger>
+                    </interactivity:Interaction.Triggers>
+                    <Rectangle.Style>
+                        <Style TargetType="{x:Type Rectangle}">
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Fill" Value="#E5E2DE" />
+                                    <Setter Property="Opacity" Value="0.3" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="False">
+                                    <Setter Property="Fill" Value="#E5E2DE" />
+                                    <Setter Property="Opacity" Value="0.0" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Rectangle.Style>
+                </Rectangle>
+                <TextBlock Name="fakePortNameTb"
+                           Width="Auto"
+                           Margin="13,0,10,5"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Center"
+                           DockPanel.Dock="Left"
+                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                           FontSize="12px"
+                           FontWeight="Medium"
+                           Foreground="Transparent"
+                           IsHitTestVisible="False"
+                           Opacity="0.4"
+                           Style="{StaticResource SZoomFadeText}"
+                           Text="{Binding Path=PortName}" />
+                <dynui:UseLevelSpinner x:Name="useLevelControl"
+                                       Width="50"
+                                       Height="25"
+                                       Margin="0,0,0,0"
+                                       Background="{Binding UseLevelsMenuColor, UpdateSourceTrigger=PropertyChanged}"
+                                       HorizontalAlignment="Right"
+                                       VerticalAlignment="Center"
+                                       DockPanel.Dock="Right"
+                                       KeepListStructure="{Binding Path=ShouldKeepListStructure}"
+                                       Level="{Binding Path=Level, Mode=TwoWay}"
+                                       Visibility="{Binding UseLevelSpinnerVisible, UpdateSourceTrigger=PropertyChanged}" />
+                <dynui:UseLevelPopup x:Name="UseLevelPopup"
+                                     AllowsTransparency="True"
+                                     IsOpen="{Binding Path=ShowUseLevelMenu}"
+                                     Placement="Right"
+                                     StaysOpen="False">
+                    <Grid Background="Transparent">
+                        <Grid.Resources>
+                            <ResourceDictionary>
+                                <Style TargetType="CheckBox">
+                                    <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
+                                    <Setter Property="Foreground" Value="{StaticResource DarkGreyBrush}" />
+                                    <Setter Property="Margin" Value="0" />
+                                    <Setter Property="FontSize" Value="14px" />
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="{x:Type CheckBox}">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="20px" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <Rectangle x:Name="outerRectangle"
+                                                               Grid.Column="0"
+                                                               Width="14px"
+                                                               Height="14px"
+                                                               Stroke="{StaticResource PrimaryCharcoal300Brush}"
+                                                               StrokeThickness="1" />
+                                                    <Rectangle x:Name="highlightRectangle"
+                                                               Grid.Column="0"
+                                                               Width="14px"
+                                                               Height="14px"
+                                                               Fill="Transparent"
+                                                               Stroke="{StaticResource PrimaryCharcoal300Brush}"
+                                                               StrokeThickness="1" />
+                                                    <Path x:Name="tick"
+                                                          Grid.Column="0"
+                                                          Width="14px"
+                                                          Height="14px"
+                                                          Data="M3,7 l3,3 l5,-6"
+                                                          Opacity="0"
+                                                          Stretch="None"
+                                                          Stroke="White"
+                                                          StrokeThickness="2" />
+                                                    <ContentPresenter x:Name="content"
+                                                                      Grid.Column="1"
+                                                                      Margin="4,0,0,0"
+                                                                      HorizontalAlignment="Center"
+                                                                      VerticalAlignment="Center"
+                                                                      TextBlock.Foreground="{StaticResource DarkGreyBrush}" />
+                                                </Grid>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="highlightRectangle" Property="Fill" Value="LightGray" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter TargetName="outerRectangle" Property="Fill" Value="{StaticResource PortUseLevelsCheckBoxColor}" />
+                                                        <Setter TargetName="tick" Property="Opacity" Value="1.0" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter TargetName="outerRectangle" Property="Fill" Value="Transparent" />
+                                                        <Setter TargetName="tick" Property="Opacity" Value="0.0" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsEnabled" Value="False">
+                                                        <Setter TargetName="highlightRectangle" Property="Stroke" Value="LightGray" />
+                                                        <Setter TargetName="content" Property="TextBlock.Foreground" Value="LightGray" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </ResourceDictionary>
+                        </Grid.Resources>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="10" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Path Grid.Column="0"
+                              Margin="1,0,0,0"
+                              Data="M 0,10 L 12,5 12,15 Z"
+                              Fill="White"
+                              Stroke="#999999" />
+                        <Border Grid.Column="1"
+                                Padding="5"
+                                Background="White"
+                                BorderBrush="#999999 "
+                                BorderThickness="1"
+                                CornerRadius="2">
+                            <StackPanel>
+                                <CheckBox Name="UseLevel"
+                                          Margin="0,3,5,3"
+                                          HorizontalAlignment="Left"
+                                          Command="{Binding Path=UseLevelsCommand}"
+                                          CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}"
+                                          Content="{x:Static p:Resources.UseLevelPopupMenuItem}"
+                                          IsChecked="{Binding Path=UseLevels, Mode=OneWay}"
+                                          Visibility="{Binding UseLevelCheckBoxVisibility, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <CheckBox Margin="0,3,5,3"
+                                          HorizontalAlignment="Left"
+                                          Command="{Binding Path=KeepListStructureCommand}"
+                                          CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}"
+                                          Content="{x:Static p:Resources.UseLevelKeepListStructurePopupMenuItem}"
+                                          IsChecked="{Binding Path=ShouldKeepListStructure, Mode=OneWay}"
+                                          IsEnabled="{Binding ElementName=UseLevel, Path=IsChecked}"
+                                          Visibility="{Binding UseLevelCheckBoxVisibility, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <CheckBox Margin="0,3,5,3"
+                                          HorizontalAlignment="Left"
+                                          Content="{x:Static p:Resources.PortViewContextMenuUserDefaultValue}"
+                                          IsChecked="{Binding Path=UsingDefaultValue, Mode=TwoWay}"
+                                          Visibility="{Binding UseDefaultValueCheckBoxVisibility, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                            </StackPanel>
+                        </Border>
+                        <Path Grid.Column="1"
+                              Data="M 0,7.5 L 1,7.5 L 1,12.5 L0,12.5 Z"
+                              Fill="White"
+                              Stroke="White" />
+                    </Grid>
+                </dynui:UseLevelPopup>
+            </DockPanel>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -1,0 +1,341 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:command="clr-namespace:GalaSoft.MvvmLight.Command;assembly=GalaSoft.MvvmLight.Platform"
+                    xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore"
+                    xmlns:controls="clr-namespace:Dynamo.Views;assembly=DynamoCore"
+                    xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
+                    xmlns:dynui="clr-namespace:Dynamo.UI.Controls;assembly=DynamoCoreWpf"
+                    xmlns:fa="http://schemas.fontawesome.io/icons/"
+                    xmlns:interactivity="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+                    xmlns:nodes="clr-namespace:Dynamo.Graph.Nodes;assembly=DynamoCore"
+                    xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+                    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+                    xmlns:viewModels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
+                    xmlns:views="clr-namespace:Dynamo.UI.Views;assembly=DynamoCoreWpf">
+
+    <!-- Templates
+
+    Use this to add color resources:
+    ==========================================
+    <Color x:Key="ColorKey" >#FFFFFFAE</Color>
+
+    You can use this to create a style for a button, just change the TargetType or add
+    other control separated by commas and add setter nodes to change properties:
+    ==========================================
+    <Style x:Key="SimpleStyle" TargetType="Button">
+        <Setter Property="Background" Value="Red" />
+    </Style>
+
+    -->
+
+    <!--  Add your resources here  -->
+
+    <ResourceDictionary.MergedDictionaries>
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+    </ResourceDictionary.MergedDictionaries>
+    <DataTemplate DataType="{x:Type viewModels:OutPortViewModel}">
+        <!--  Grid that contains the entire port  -->
+        <Grid Name="mainGrid" HorizontalAlignment="Stretch">
+            <!--
+                The main border shows rounded edges and changes color according to multiple conditions
+                This logic is defined in the ViewModel. None of the elements in this Border are interactive, so they
+                can live in the lowest level of Z-Order
+            -->
+            <Border x:Name="mainBorder" 
+                    SnapsToDevicePixels="True"
+                    Height="29px"
+                    CornerRadius="11,0,0,11"
+                    BorderThickness="1,1,0,1">
+                <!--  DockPanel that positions the visible port name and the ContextArrowGrid  -->
+                <DockPanel x:Name="mainDockPanel" FlowDirection="LeftToRight">
+                    <Grid Name="portNameGrid"
+                          DockPanel.Dock="Left"
+                          IsEnabled="{Binding Path=IsEnabled}"
+                          IsHitTestVisible="True"
+                          ToolTipService.ShowDuration="60000">
+                        <Rectangle Fill="Transparent"
+                                   IsHitTestVisible="{Binding IsHitTestVisible}"
+                                   SnapsToDevicePixels="True">
+                            <interactivity:Interaction.Triggers>
+                                <views:HandlingEventTrigger EventName="MouseEnter">
+                                    <interactivity:InvokeCommandAction Command="{Binding Path=MouseEnterCommand}" CommandParameter="{Binding}" />
+                                </views:HandlingEventTrigger>
+                                <views:HandlingEventTrigger EventName="MouseLeave">
+                                    <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeaveCommand}" CommandParameter="{Binding}" />
+                                </views:HandlingEventTrigger>
+                                <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
+                                    <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeftButtonDownCommand}" CommandParameter="{Binding}" />
+                                </views:HandlingEventTrigger>
+                            </interactivity:Interaction.Triggers>
+                            <Rectangle.Margin>
+                                <MultiBinding Converter="{StaticResource SnapRegionMarginConverter}">
+                                    <Binding ElementName="portNameTb" Path="ActualWidth" />
+                                    <Binding Path="PortModel" />
+                                </MultiBinding>
+                            </Rectangle.Margin>
+                        </Rectangle>
+                        <TextBlock Name="portNameTb"
+                                   Width="Auto"
+                                   HorizontalAlignment="Left"
+                                   VerticalAlignment="Center"
+                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                   FontSize="12px"
+                                   FontWeight="Medium"
+                                   Foreground="#DCDCDC"
+                                   IsHitTestVisible="False"
+                                   Text="{Binding Path=PortName}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Margin" Value="13,0,10,5" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
+                                            <Setter Property="Margin" Value="7,0,0,0" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <Grid.Style>
+                            <Style>
+                                <Setter Property="Grid.Height" Value="{Binding Path=Height}" />
+                                <Setter Property="Grid.Margin" Value="{Binding Path=MarginThickness}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
+                                        <Setter Property="Grid.Height" Value="14px" />
+                                        <Setter Property="Grid.Margin" Value="0,1,2,0" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                    </Grid>
+                    <Grid Name="ContextArrowGrid"
+                          HorizontalAlignment="Right"
+                          Height="{Binding Path=Height}"
+                          Margin="0,1,10,0"
+                          Visibility="{Binding Path=UseContextMenuVisibility}">
+                        <Label x:Name="contextMenuArrow"
+                               Height="{Binding Path=Height}"
+                               Margin="0,0,0,8"
+                               Padding="0"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               HorizontalContentAlignment="Center"
+                               VerticalContentAlignment="Center"
+                               Content="&gt;"
+                               FontSize="16px"
+                               FontWeight="Medium"
+                               Foreground="{StaticResource PrimaryCharcoal200Brush}"
+                               IsHitTestVisible="False"/>
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Height" Value="{Binding Path=Height}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
+                                        <Setter Property="Grid.Height" Value="{Binding Source={x:Static configuration:Configurations.CodeBlockOutputPortHeightInPixels}}" />
+                                        <Setter Property="Grid.Margin" Value="0" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                    </Grid>
+                </DockPanel>
+                <!--  Inputs and outputs have different corner radius and border conditions  -->
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="{Binding PortBackgroundColor, UpdateSourceTrigger=PropertyChanged}" />
+                        <Setter Property="BorderBrush" Value="{Binding PortBorderBrushColor, UpdateSourceTrigger=PropertyChanged}" />
+                        <Style.Triggers>
+                            <!--  Used for styling output ports when they are 'condensed' i.e. on a code block  -->
+                            <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
+                                <Setter Property="CornerRadius" Value="0" />
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="Height" Value="14px" />
+                                <Setter Property="Width" Value="20px" />
+                                <Setter Property="Background" Value="#666666" />
+                                <Setter Property="BorderBrush" Value="Transparent" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
+            <!--
+                Interactive overlay for the port, highlights the port on MouseOver and
+                contains MouseClick event handling and ToolTip logic. Since the overlay is interactive, it needs to
+                live higher up in the Z-Order than the non-interactive elements in the mainBorder for MouseOver and
+                MouseClick events to fire.
+            -->
+            <Border x:Name="mainBorderHighlightOverlay"
+                    BorderBrush="Transparent"
+                    Opacity="0.2"
+                    CornerRadius="11,0,0,11"
+                    BorderThickness="1,1,0,1"
+                    SnapsToDevicePixels="True">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Height" Value="29px" />
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="White" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="False">
+                                <Setter Property="Background" Value="Transparent" />
+                            </Trigger>
+                            <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
+                                <Setter Property="CornerRadius" Value="0" />
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="Height" Value="{Binding Source={x:Static configuration:Configurations.CodeBlockOutputPortHeightInPixels}}" />
+                                <Setter Property="Margin" Value="0" />
+                                <Setter Property="Width" Value="20px" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <interactivity:Interaction.Triggers>
+                    <!--  Bind Connect command to left click  -->
+                    <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
+                        <interactivity:InvokeCommandAction Command="{Binding Path=ConnectCommand}" />
+                    </views:HandlingEventTrigger>
+                </interactivity:Interaction.Triggers>
+
+                <Border.ToolTip>
+                    <dynui:DynamoToolTip AttachmentSide="Right" Style="{DynamicResource ResourceKey=SLightToolTip}">
+                        <Grid>
+                            <TextBlock MaxWidth="320"
+                                       Text="{Binding Path=ToolTipContent}"
+                                       TextWrapping="Wrap" />
+                        </Grid>
+                    </dynui:DynamoToolTip>
+                </Border.ToolTip>
+
+                <!--  Bind NodeAutoComplete to double left click  -->
+                <Border.InputBindings>
+                    <MouseBinding Command="{Binding Path=NodeAutoCompleteCommand}" MouseAction="LeftDoubleClick" />
+                </Border.InputBindings>
+
+                <!--
+                    We could have changed the Grid opacity directly here but didn't
+                    The reason is that if the opacity of the Grid is modified, the
+                    internal text box will also appear semi-transparent. This is why an
+                    intermediary Border is required just for mouse-over highlighting.
+                -->
+
+                <!--
+                    Port is contained in another rectangle to ensure that hit area is extended outside the grid.
+                    Minimum Width is specified on the rectangle, rather than the grid. Otherwise, if the port's width is less than
+                    the grid's width, the outside rectangle is shrinked to fit the grid. Port snapping cannot occur in that case
+                    as no mouse events are generated.This happens only for codeblock node.
+                -->
+            </Border>
+            <!--
+                Contains the interactive elements which need to have the highest-level of Z-Order so that they
+                may be interacted with *above* the mainBorderHighlightOverlay layer.
+            -->
+            <DockPanel Name="interactionControlsDockPanel"
+                       Height="29px"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Center"
+                       FlowDirection="LeftToRight"
+                       IsHitTestVisible="True"
+                       Visibility="{Binding Path=UseContextMenuVisibility}">
+                <Rectangle x:Name="ContextMenuArrowHighlightOverlay"
+                           Width="15"
+                           Height="15px"
+                           HorizontalAlignment="Right"
+                           DockPanel.Dock="Right"
+                           IsHitTestVisible="True"
+                           Margin="0,0,8,0"
+                           Visibility="{Binding Path=UseContextMenuVisibility}">
+                    <interactivity:Interaction.Triggers>
+                        <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
+                            <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeftButtonDownOnContextCommand}" CommandParameter="{Binding}" />
+                        </views:HandlingEventTrigger>
+                    </interactivity:Interaction.Triggers>
+                    <Rectangle.Style>
+                        <Style TargetType="{x:Type Rectangle}">
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Fill" Value="#E5E2DE" />
+                                    <Setter Property="Opacity" Value="0.3" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="False">
+                                    <Setter Property="Fill" Value="#E5E2DE" />
+                                    <Setter Property="Opacity" Value="0.0" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Rectangle.Style>
+                </Rectangle>
+                <TextBlock Name="fakePortNameTb"
+                           Width="Auto"
+                           Margin="13,0,10,5"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Center"
+                           DockPanel.Dock="Left"
+                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                           FontSize="12px"
+                           FontWeight="Medium"
+                           Foreground="Transparent"
+                           IsHitTestVisible="False"
+                           Opacity="0.4"
+                           Style="{StaticResource SZoomFadeText}"
+                           Text="{Binding Path=PortName}" />
+                <dynui:UseLevelPopup x:Name="ContextMenu"
+                                     AllowsTransparency="True"
+                                     IsOpen="{Binding Path=ShowContextMenu}"
+                                     Placement="Right"
+                                     StaysOpen="False">
+                    <Grid Background="Transparent">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="10" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Path Grid.Column="0"
+                              Margin="1,0,0,0"
+                              Data="M 0,10 L 12,5 12,15 Z"
+                              Fill="White"
+                              Stroke="#999999" />
+                        <Border Grid.Column="1"
+                                Padding="5"
+                                Background="White"
+                                BorderBrush="#999999 "
+                                BorderThickness="1"
+                                CornerRadius="2">
+                            <StackPanel>
+                                <Button Margin="0,3"
+                                        HorizontalAlignment="Left"
+                                        Command="{Binding Path=BreakConnectionsCommand}"
+                                        Content="{x:Static p:Resources.BreakConnectionPopupMenuItem}"
+                                        IsEnabled="{Binding OutputPortBreakConnectionsButtonEnabled, UpdateSourceTrigger=PropertyChanged}"
+                                        Style="{StaticResource PopupButtonStyle}"
+                                        Visibility="{Binding OutputPortConnectionsButtonsVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <Button Margin="0,3"
+                                        HorizontalAlignment="Left"
+                                        Command="{Binding Path=HideConnectionsCommand}"
+                                        Content="{Binding ShowHideWiresButtonContent, UpdateSourceTrigger=PropertyChanged}"
+                                        IsEnabled="{Binding HideWiresButtonEnabled, UpdateSourceTrigger=PropertyChanged}"
+                                        Style="{StaticResource PopupButtonStyle}"
+                                        Visibility="{Binding OutputPortConnectionsButtonsVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                            </StackPanel>
+                        </Border>
+                        <Path Grid.Column="1"
+                              Data="M 0,7.5 L 1,7.5 L 1,12.5 L0,12.5 Z"
+                              Fill="White"
+                              Stroke="White" />
+                    </Grid>
+                </dynui:UseLevelPopup>
+            </DockPanel>
+            <Grid.Style>
+                <Style>
+                    <Setter Property="Grid.Height" Value="35px" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
+                            <Setter Property="Grid.Height" Value="14px" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -562,7 +562,7 @@ namespace Dynamo.ViewModels
                 // visually add them to the group but they
                 // should still reference their NodeModel
                 // owner
-                newPortViewModels = CreateProxyPorts(originalInPorts);
+                newPortViewModels = CreateProxyInPorts(originalInPorts);
 
                 if (newPortViewModels == null) return;
                 InPorts.AddRange(newPortViewModels);
@@ -586,7 +586,7 @@ namespace Dynamo.ViewModels
 
             originalInPorts = GetGroupInPorts().Concat(groupedGroupsInPorts);
 
-            newPortViewModels = CreateProxyPorts(originalInPorts);
+            newPortViewModels = CreateProxyInPorts(originalInPorts);
 
             if (newPortViewModels == null) return;
             InPorts.AddRange(newPortViewModels);
@@ -612,7 +612,7 @@ namespace Dynamo.ViewModels
                 // visually add them to the group but they
                 // should still reference their NodeModel
                 // owner
-                newPortViewModels = CreateProxyPorts(originalOutPorts);
+                newPortViewModels = CreateProxyOutPorts(originalOutPorts);
 
                 if (newPortViewModels == null) return;
                 OutPorts.AddRange(newPortViewModels);
@@ -635,7 +635,7 @@ namespace Dynamo.ViewModels
 
             originalOutPorts = GetGroupOutPorts().Concat(groupedGroupsOutPorts);
 
-            newPortViewModels = CreateProxyPorts(originalOutPorts);
+            newPortViewModels = CreateProxyOutPorts(originalOutPorts);
 
             if (newPortViewModels == null) return;
             OutPorts.AddRange(newPortViewModels);
@@ -685,10 +685,27 @@ namespace Dynamo.ViewModels
                 );
         }
 
-        private List<PortViewModel> CreateProxyPorts(IEnumerable<PortModel> groupPortModels)
+        private List<PortViewModel> CreateProxyInPorts(IEnumerable<PortModel> groupPortModels)
         {
             var originalPortViewModels = WorkspaceViewModel.Nodes
-                .SelectMany(x => x.InPorts.Concat(x.OutPorts))
+                .SelectMany(x => x.InPorts)
+                .Where(x => groupPortModels.Contains(x.PortModel))
+                .ToList();
+
+            var newPortViewModels = new List<PortViewModel>();
+            for (int i = 0; i < groupPortModels.Count(); i++)
+            {
+                var model = groupPortModels.ElementAt(i);
+                newPortViewModels.Add(originalPortViewModels[i].CreateProxyPortViewModel(model));
+            }
+
+            return newPortViewModels;
+        }
+
+        private List<PortViewModel> CreateProxyOutPorts(IEnumerable<PortModel> groupPortModels)
+        {
+            var originalPortViewModels = WorkspaceViewModel.Nodes
+                .SelectMany(x => x.OutPorts)
                 .Where(x => groupPortModels.Contains(x.PortModel))
                 .ToList();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -1,0 +1,314 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using Dynamo.Graph.Nodes;
+using Dynamo.Models;
+using Dynamo.UI.Commands;
+using Dynamo.Utilities;
+
+namespace Dynamo.ViewModels
+{
+    public partial class InPortViewModel : PortViewModel
+    {
+        #region Properties/Fields
+
+        private DelegateCommand _useLevelsCommand;
+        private DelegateCommand _keepListStructureCommand;
+        private DelegateCommand portMouseLeftButtonOnLevelCommand;
+
+        private bool _showUseLevelMenu;
+
+        private static SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
+        private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
+        private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
+
+        private static readonly SolidColorBrush PortBackgroundColorKeepListStructure = new SolidColorBrush(Color.FromRgb(83, 126, 145));
+        private static readonly SolidColorBrush PortBorderBrushColorKeepListStructure = new SolidColorBrush(Color.FromRgb(168, 181, 187));
+
+        /// <summary>
+        /// Returns whether this port has a default value that can be used.
+        /// </summary>
+        public bool DefaultValueEnabled
+        {
+            get { return _port.DefaultValue != null; }
+        }
+        
+        /// <summary>
+        /// Returns whether the port is using its default value, or whether this been disabled
+        /// </summary>
+        public bool UsingDefaultValue
+        {
+            get { return _port.UsingDefaultValue; }
+            set
+            {
+                _port.UsingDefaultValue = value;
+            }
+        }
+
+        /// <summary>
+        /// If should display Use Levels popup menu. 
+        /// </summary>
+        public bool ShowUseLevelMenu
+        {
+            get
+            {
+                return _showUseLevelMenu;
+            }
+            set
+            {
+                _showUseLevelMenu = value;
+                RaisePropertyChanged("ShowUseLevelMenu");
+            }
+        }
+
+        /// <summary>
+        /// If UseLevel is enabled on this port.
+        /// </summary>
+        public bool UseLevels
+        {
+            get { return _port.UseLevels; }
+        }
+
+        /// <summary>
+        /// Determines whether or not the UseLevelsSpinner is visible on the port.
+        /// </summary>
+        public Visibility UseLevelSpinnerVisible
+        {
+            get
+            {
+                if (PortType == PortType.Output) return Visibility.Collapsed;
+                if (UseLevels) return Visibility.Visible;
+                return Visibility.Hidden;
+            }
+        }
+
+        /// <summary>
+        /// If should keep list structure on this port.
+        /// </summary>
+        public bool ShouldKeepListStructure
+        {
+            get { return _port.KeepListStructure; }
+        }
+
+        /// <summary>
+        /// Levle of list.
+        /// </summary>
+        public int Level
+        {
+            get { return _port.Level; }
+            set
+            {
+                ChangeLevel(value);
+            }
+        }
+
+        /// <summary>
+        /// The visibility of Use Levels menu.
+        /// </summary>
+        public Visibility UseLevelVisibility
+        {
+            get
+            {
+                if (_node.ArgumentLacing != LacingStrategy.Disabled)
+                {
+                    return Visibility.Visible;
+                }
+                else
+                {
+                    return Visibility.Collapsed;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Shows or hides the Use Default Value checkbox in the node chevron popup menu.
+        /// </summary>
+        public bool UseDefaultValueCheckBoxVisibility
+        {
+            get => _port.PortType == PortType.Input && DefaultValueEnabled;
+        }
+
+        /// <summary>
+        /// Sets the color of the small rectangular marker on each input port.
+        /// </summary>
+        public SolidColorBrush PortValueMarkerColor
+        {
+            get => portValueMarkerColor;
+            set
+            {
+                portValueMarkerColor = value;
+                RaisePropertyChanged(nameof(PortValueMarkerColor));
+            }
+        }
+
+        /// <summary>
+        /// Sets the color of the use levels popup in the input port context menu.
+        /// This changes when the Keep List Structure option is activated and the port
+        /// is connected, upon which it turns blue.
+        /// </summary>
+        public SolidColorBrush UseLevelsMenuColor
+        {
+            get
+            {
+                return ShouldKeepListStructure && _port.IsConnected
+                    ? new SolidColorBrush(Color.FromArgb(255, 60, 60, 60))
+                    : new SolidColorBrush(Color.FromArgb(255, 83, 83, 83));
+            }
+        }
+
+        #endregion
+
+        public InPortViewModel(NodeViewModel node, PortModel port) : base(node, port)
+        {
+            _port.PropertyChanged += _port_PropertyChanged;
+        }
+
+        public override void Dispose()
+        {
+            _port.PropertyChanged -= _port_PropertyChanged;
+            base.Dispose();
+        }
+
+        internal override PortViewModel CreateProxyPortViewModel(PortModel portModel)
+        {
+            return new InPortViewModel(_node, portModel);
+        }
+
+        void _port_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "DefaultValue":
+                    RaisePropertyChanged("DefaultValue");
+                    break;
+                case "UsingDefaultValue":
+                    RaisePropertyChanged("UsingDefaultValue");
+                    RefreshPortColors();
+                    break;
+                case "UseLevels":
+                    RaisePropertyChanged("UseLevels");
+                    RaisePropertyChanged(nameof(UseLevelsMenuColor));
+                    break;
+                case "Level":
+                    RaisePropertyChanged("Level");
+                    break;
+                case "KeepListStructure":
+                    RaisePropertyChanged("ShouldKeepListStructure");
+                    RefreshPortColors();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// UseLevels command
+        /// </summary>
+        public DelegateCommand UseLevelsCommand
+        {
+            get
+            {
+                if (_useLevelsCommand == null)
+                {
+                    _useLevelsCommand = new DelegateCommand(UseLevel, p => true);
+                }
+                return _useLevelsCommand;
+            }
+        }
+
+        private void UseLevel(object parameter)
+        {
+            var useLevel = (bool)parameter;
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, _node.NodeLogic.GUID, "UseLevels", string.Format("{0}:{1}", _port.Index, useLevel));
+            
+            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
+            RaisePropertyChanged(nameof(UseLevelSpinnerVisible));
+        }
+
+        /// <summary>
+        /// ShouldKeepListStructure command
+        /// </summary>
+        public DelegateCommand KeepListStructureCommand
+        {
+            get
+            {
+                if (_keepListStructureCommand == null)
+                {
+                    _keepListStructureCommand = new DelegateCommand(KeepListStructure, p => true);
+                }
+                return _keepListStructureCommand;
+            }
+        }
+
+        private void KeepListStructure(object parameter)
+        {
+            bool keepListStructure = (bool)parameter;
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, _node.NodeLogic.GUID, "KeepListStructure", string.Format("{0}:{1}", _port.Index, keepListStructure));
+            
+            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
+        }
+
+        private void ChangeLevel(int level)
+        {
+            var command = new DynamoModel.UpdateModelValueCommand(
+                            Guid.Empty, _node.NodeLogic.GUID, "ChangeLevel", string.Format("{0}:{1}", _port.Index, level));
+
+            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
+        }
+
+        public DelegateCommand MouseLeftButtonDownOnLevelCommand
+        {
+            get
+            {
+                if (portMouseLeftButtonOnLevelCommand == null)
+                    portMouseLeftButtonOnLevelCommand = new DelegateCommand(OnMouseLeftButtonDownOnLevel, CanConnect);
+
+                return portMouseLeftButtonOnLevelCommand;
+            }
+        }
+
+        /// <summary>
+        /// Handles the Mouse left button down on the level.
+        /// </summary>
+        /// <param name="parameter"></param>
+        private void OnMouseLeftButtonDownOnLevel(object parameter)
+        {
+            ShowUseLevelMenu = true;
+        }
+
+        /// <summary>
+        /// Handles the logic for updating the PortBackgroundColor and PortBackgroundBrushColor
+        /// </summary>
+        protected override void RefreshPortColors()
+        {
+            // The visual appearance of ports can be affected by many different logical states
+            // Inputs have more display styles than outputs
+
+            // Special case for keeping list structure visual appearance
+            if (_port.UseLevels && _port.KeepListStructure && _port.IsConnected)
+            {
+                PortValueMarkerColor = PortValueMarkerBlue;
+                PortBackgroundColor = PortBackgroundColorKeepListStructure;
+                PortBorderBrushColor = PortBorderBrushColorKeepListStructure;
+            }
+            // Port has a default value, shows blue marker
+            else if (UsingDefaultValue && DefaultValueEnabled)
+            {
+                PortValueMarkerColor = PortValueMarkerBlue;
+                PortBackgroundColor = PortBackgroundColorDefault;
+                PortBorderBrushColor = PortBorderBrushColorDefault;
+            }
+            // Port isn't connected and has no default value (or isn't using it)
+            else
+            {
+                PortValueMarkerColor = !_port.IsConnected ? PortValueMarkerRed : PortValueMarkerBlue;
+                PortBackgroundColor = PortBackgroundColorDefault;
+                PortBorderBrushColor = PortBorderBrushColorDefault;
+            }
+
+            RaisePropertyChanged(nameof(UseLevelsMenuColor));
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -832,13 +832,13 @@ namespace Dynamo.ViewModels
         {
             foreach (var item in nodeLogic.InPorts)
             {
-                PortViewModel inportViewModel = SubscribePortEvents(item);
+                PortViewModel inportViewModel = SubscribeInPortEvents(item);
                 InPorts.Add(inportViewModel);
             }
 
             foreach (var item in nodeLogic.OutPorts)
             {
-                PortViewModel outportViewModel = SubscribePortEvents(item);
+                PortViewModel outportViewModel = SubscribeOutPortEvents(item);
                 OutPorts.Add(outportViewModel);
             }
         }
@@ -1048,7 +1048,7 @@ namespace Dynamo.ViewModels
                 //create a new port view model
                 foreach (var item in e.NewItems)
                 {
-                    PortViewModel inportViewModel = SubscribePortEvents(item as PortModel);
+                    PortViewModel inportViewModel = SubscribeInPortEvents(item as PortModel);
                     InPorts.Add(inportViewModel);
                 }
             }
@@ -1084,7 +1084,7 @@ namespace Dynamo.ViewModels
                 //create a new port view model
                 foreach (var item in e.NewItems)
                 {
-                    PortViewModel outportViewModel = SubscribePortEvents(item as PortModel);
+                    PortViewModel outportViewModel = SubscribeOutPortEvents(item as PortModel);
                     OutPorts.Add(outportViewModel);
                 }
             }
@@ -1110,13 +1110,27 @@ namespace Dynamo.ViewModels
 
 
         /// <summary>
-        /// Registers the port events.
+        /// Registers the in port events.
         /// </summary>
         /// <param name="item">PortModel.</param>
         /// <returns></returns>
-        private PortViewModel SubscribePortEvents(PortModel item)
+        protected virtual PortViewModel SubscribeInPortEvents(PortModel item)
         {
-            PortViewModel portViewModel = new PortViewModel(this, item);
+            InPortViewModel portViewModel = new InPortViewModel(this, item);
+            portViewModel.MouseEnter += OnRectangleMouseEnter;
+            portViewModel.MouseLeave += OnRectangleMouseLeave;
+            portViewModel.MouseLeftButtonDown += OnMouseLeftButtonDown;
+            return portViewModel;
+        }
+
+        /// <summary>
+        /// Registers the out port events.
+        /// </summary>
+        /// <param name="item">PortModel.</param>
+        /// <returns></returns>
+        protected virtual PortViewModel SubscribeOutPortEvents(PortModel item)
+        {
+            OutPortViewModel portViewModel = new OutPortViewModel(this, item);
             portViewModel.MouseEnter += OnRectangleMouseEnter;
             portViewModel.MouseLeave += OnRectangleMouseLeave;
             portViewModel.MouseLeftButtonDown += OnMouseLeftButtonDown;

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -1,0 +1,296 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using Dynamo.Graph.Nodes;
+using Dynamo.Models;
+using Dynamo.UI.Commands;
+using Dynamo.Utilities;
+
+namespace Dynamo.ViewModels
+{
+    public partial class OutPortViewModel : PortViewModel
+    {
+        #region Properties/Fields
+
+        private DelegateCommand _breakConnectionsCommand;
+        private DelegateCommand _hideConnectionsCommand;
+        private DelegateCommand portMouseLeftButtonOnContextCommand;
+
+        private bool _showContextMenu;
+        private bool areConnectorsHidden;
+        private string showHideWiresButtonContent = "";
+        private bool hideWiresButtonEnabled;
+
+        /// <summary>
+        /// Sets the condensed styling on Code Block output ports.
+        /// This is used to style the output ports on Code Blocks to be smaller.
+        /// </summary>
+        public bool IsPortCondensed
+        {
+            get
+            {
+                return this.PortModel.Owner is CodeBlockNodeModel && PortType == PortType.Output;
+            }
+        }
+
+        /// <summary>
+        /// If should display Use Levels popup menu. 
+        /// </summary>
+        public bool ShowContextMenu
+        {
+            get
+            {
+                return _showContextMenu;
+            }
+            set
+            {
+                _showContextMenu = value;
+                RaisePropertyChanged("ShowContextMenu");
+            }
+        }
+
+        /// <summary>
+        /// The visibility of Use Levels menu.
+        /// </summary>
+        public Visibility UseContextMenuVisibility
+        {
+            get
+            {
+                if (IsPortCondensed)
+                {
+                    return Visibility.Collapsed;
+                }
+                else
+                {
+                    return Visibility.Visible;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Shows or hides the Break Connections, Hide Wires and UnhideWires buttons in the node chevron popup menu.
+        /// </summary>
+        public bool OutputPortConnectionsButtonsVisible
+        {
+            get => _port.PortType == PortType.Output;
+        }
+
+        /// <summary>
+        /// Enables or disables the Break Connections button on the node output port context menu.
+        /// </summary>
+        public bool OutputPortBreakConnectionsButtonEnabled
+        {
+            get => OutputPortConnectionsButtonsVisible && IsConnected;
+        }
+
+        /// <summary>
+        /// Determines whether the output port button says 'Hide Wires' or 'Show Wires'
+        /// </summary>
+        public string ShowHideWiresButtonContent
+        {
+            get => showHideWiresButtonContent;
+            set
+            {
+                showHideWiresButtonContent = value;
+                RaisePropertyChanged(nameof(ShowHideWiresButtonContent));
+            }
+        }
+
+        /// <summary>
+        /// Sets the visibility of the connectors from the port. This will overwrite the 
+        /// individual visibility of the connectors. However when visibility is controlled 
+        /// from the connector, that connector's visibility will overwrite its previous state.
+        /// In order to overwrite visibility of all connectors associated with a port, us this 
+        /// flag again.
+        /// </summary>
+        public bool SetConnectorsVisibility
+        {
+            get => areConnectorsHidden;
+            set
+            {
+                areConnectorsHidden = value; 
+                RaisePropertyChanged(nameof(SetConnectorsVisibility));
+            }
+        }
+
+        /// <summary>
+        /// Enables or disables the Hide Wires button on the node output port context menu.
+        /// </summary>
+        public bool HideWiresButtonEnabled
+        {
+            get => hideWiresButtonEnabled;
+            set
+            {
+                hideWiresButtonEnabled = value; 
+                RaisePropertyChanged(nameof(HideWiresButtonEnabled));
+            }
+        }
+
+        /// <summary>
+        /// Takes care of the multiple UI concerns when dealing with the Unhide/Hide Wires button
+        /// on the output port's context menu.
+        /// </summary>
+        private void RefreshHideWiresButton()
+        {
+            HideWiresButtonEnabled = _port.Connectors.Count > 0;
+            SetConnectorsVisibility = CheckIfConnectorsAreHidden();
+
+            ShowHideWiresButtonContent = SetConnectorsVisibility
+                ? Properties.Resources.UnhideWiresPopupMenuItem
+                : Properties.Resources.HideWiresPopupMenuItem;
+
+            RaisePropertyChanged(nameof(ShowHideWiresButtonContent));
+        }
+
+        #endregion
+
+        public OutPortViewModel(NodeViewModel node, PortModel port) :base(node, port)
+        {
+            _node.PropertyChanged += _node_PropertyChanged;
+            _port.PropertyChanged += _port_PropertyChanged;
+            RefreshHideWiresButton();
+        }
+
+        public override void Dispose()
+        {
+            _port.PropertyChanged -= _port_PropertyChanged;
+            _node.PropertyChanged -= _node_PropertyChanged;
+            base.Dispose();
+        }
+
+        internal override PortViewModel CreateProxyPortViewModel(PortModel portModel)
+        {
+            return new OutPortViewModel(_node, portModel);
+        }
+
+        void _node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(NodeViewModel.ZIndex):
+                    RefreshHideWiresButton();
+                    break;
+            }
+        }
+
+        void _port_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "IsConnected":
+                    RaisePropertyChanged(nameof(OutputPortBreakConnectionsButtonEnabled));
+                    RefreshHideWiresButton();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Used by the 'Break Connection' button in the node output context menu.
+        /// Removes any current connections this port has.
+        /// </summary>
+        public DelegateCommand BreakConnectionsCommand
+        {
+            get
+            {
+                if (_breakConnectionsCommand == null)
+                {
+                    _breakConnectionsCommand = new DelegateCommand(BreakConnections);
+                }
+                return _breakConnectionsCommand;
+            }
+        }
+
+        /// <summary>
+        /// Used by the 'Break Connection' button in the node output context menu.
+        /// Removes any current connections this port has.
+        /// </summary>
+        public DelegateCommand HideConnectionsCommand
+        {
+            get
+            {
+                if (_hideConnectionsCommand == null)
+                {
+                    _hideConnectionsCommand = new DelegateCommand(HideConnections);
+                }
+                return _hideConnectionsCommand;
+            }
+        }
+
+        /// <summary>
+        /// Used by the 'Break Connection' button in the node output context menu.
+        /// Removes any current connections this port has.
+        /// </summary>
+        /// <param name="parameter"></param>
+        private void BreakConnections(object parameter)
+        {
+            for (int i = _port.Connectors.Count - 1; i >= 0; i--)
+            {
+                // Attempting to get the relevant ConnectorViewModel via matching GUID
+                ConnectorViewModel connectorViewModel = _node.WorkspaceViewModel.Connectors
+                    .FirstOrDefault(x => x.ConnectorModel.GUID == _port.Connectors[i].GUID);
+
+                if (connectorViewModel == null) continue;
+
+                connectorViewModel.BreakConnectionCommand.Execute(null);
+            }
+        }
+
+        /// <summary>
+        /// Used by the 'Hide Wires' button in the node output context menu.
+        /// Turns of the visibility of any connections this port has.
+        /// </summary>
+        /// <param name="parameter"></param>
+        private void HideConnections(object parameter)
+        {
+            for (int i = _port.Connectors.Count - 1; i >= 0; i--)
+            {
+                // Attempting to get the relevant ConnectorViewModel via matching GUID
+                ConnectorViewModel connectorViewModel = _node.WorkspaceViewModel.Connectors
+                    .FirstOrDefault(x => x.ConnectorModel.GUID == _port.Connectors[i].GUID);
+
+                if (connectorViewModel == null) continue;
+
+                connectorViewModel.HideConnectorCommand.Execute(!SetConnectorsVisibility);
+            }
+            RefreshHideWiresButton();
+        }
+
+        /// <summary>
+        /// Returns true if they are hidden.
+        /// </summary>
+        /// <returns></returns>
+        private bool CheckIfConnectorsAreHidden()
+        {
+            if (_port.Connectors.Count < 1 || _node.WorkspaceViewModel.Connectors.Count < 1) return false;
+
+            // Attempting to get a relevant ConnectorViewModel via matching NodeModel GUID
+            ConnectorViewModel connectorViewModel = _node.WorkspaceViewModel.Connectors
+                .FirstOrDefault(x => x.Nodevm.NodeModel.GUID == _port.Owner.GUID);
+
+            if (connectorViewModel == null) return false;
+            return connectorViewModel.IsCollapsed;
+        }
+
+        public DelegateCommand MouseLeftButtonDownOnContextCommand
+        {
+            get
+            {
+                if (portMouseLeftButtonOnContextCommand == null)
+                    portMouseLeftButtonOnContextCommand = new DelegateCommand(OnMouseLeftButtonDownOnContext, CanConnect);
+
+                return portMouseLeftButtonOnContextCommand;
+            }
+        }
+
+        /// <summary>
+        /// Handles the Mouse left button down on the level.
+        /// </summary>
+        /// <param name="parameter"></param>
+        private void OnMouseLeftButtonDownOnContext(object parameter)
+        {
+            ShowContextMenu = true;
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -14,30 +14,18 @@ namespace Dynamo.ViewModels
     {
         #region Properties/Fields
 
-        private readonly PortModel _port;
-        private readonly NodeViewModel _node;
+        protected readonly PortModel _port;
+        protected readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
-        private DelegateCommand _breakConnectionsCommand;
-        private DelegateCommand _hideConnectionsCommand;
-        private const double autocompletePopupSpacing = 2.5;
-        private SolidColorBrush portBorderBrushColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
-        private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
-        private SolidColorBrush portBackgroundColor = new SolidColorBrush(Color.FromArgb(0, 60, 60, 60));
-        internal bool inputPortDisconnectedByConnectCommand = false;
         private bool _showUseLevelMenu;
-        private bool areConnectorsHidden;
-        private string showHideWiresButtonContent = "";
-        private bool hideWiresButtonEnabled;
+        private const double autocompletePopupSpacing = 2.5;
+        internal bool inputPortDisconnectedByConnectCommand = false;
+        protected static SolidColorBrush portBorderBrushColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
+        protected static SolidColorBrush portBackgroundColor = new SolidColorBrush(Color.FromArgb(0, 60, 60, 60));
 
-        public static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
-        public static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
-
-        public static SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
-        public static SolidColorBrush PortBackgroundColorKeepListStructure = new SolidColorBrush(Color.FromRgb(83, 126, 145));
-
-        public static SolidColorBrush PortBorderBrushColorDefault = new SolidColorBrush(Color.FromRgb(161, 161, 161));
-        public static SolidColorBrush PortBorderBrushColorKeepListStructure = new SolidColorBrush(Color.FromRgb(168, 181, 187));
+        protected static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
+        protected static readonly SolidColorBrush PortBorderBrushColorDefault = new SolidColorBrush(Color.FromRgb(161, 161, 161));
 
         /// <summary>
         /// Port model.
@@ -135,6 +123,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns whether this port has a default value that can be used.
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public bool DefaultValueEnabled
         {
             get { return _port.DefaultValue != null; }
@@ -143,6 +132,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns whether the port is using its default value, or whether this been disabled
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public bool UsingDefaultValue
         {
             get { return _port.UsingDefaultValue; }
@@ -177,6 +167,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If should display Use Levels popup menu. 
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public bool ShowUseLevelMenu
         {
             get
@@ -193,27 +184,16 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If UseLevel is enabled on this port.
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public bool UseLevels
         {
             get { return _port.UseLevels; }
         }
 
         /// <summary>
-        /// Determines whether or not the UseLevelsSpinner is visible on the port.
-        /// </summary>
-        public Visibility UseLevelSpinnerVisible
-        {
-            get
-            {
-                if (PortType == PortType.Output) return Visibility.Collapsed;
-                if (UseLevels) return Visibility.Visible;
-                return Visibility.Hidden;
-            }
-        }
-
-        /// <summary>
         /// If should keep list structure on this port.
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public bool ShouldKeepListStructure
         {
             get { return _port.KeepListStructure; }
@@ -255,98 +235,6 @@ namespace Dynamo.ViewModels
         }
         
         /// <summary>
-        /// Shows or hides the Use Levels and Keep List Structure checkboxes
-        /// in the node chevron popup menu.
-        /// </summary>
-        public bool UseLevelCheckBoxVisibility
-        {
-            get => _port.PortType == PortType.Input;
-        }
-
-        /// <summary>
-        /// Shows or hides the Use Default Value checkbox in the node chevron popup menu.
-        /// </summary>
-        public bool UseDefaultValueCheckBoxVisibility
-        {
-            get => _port.PortType == PortType.Input && DefaultValueEnabled;
-        }
-
-        /// <summary>
-        /// Shows or hides the Break Connections, Hide Wires and UnhideWires buttons in the node chevron popup menu.
-        /// </summary>
-        public bool OutputPortConnectionsButtonsVisible
-        {
-            get => _port.PortType == PortType.Output;
-        }
-
-        /// <summary>
-        /// Enables or disables the Break Connections button on the node output port context menu.
-        /// </summary>
-        public bool OutputPortBreakConnectionsButtonEnabled
-        {
-            get => OutputPortConnectionsButtonsVisible && IsConnected;
-        }
-
-        /// <summary>
-        /// Determines whether the output port button says 'Hide Wires' or 'Show Wires'
-        /// </summary>
-        public string ShowHideWiresButtonContent
-        {
-            get => showHideWiresButtonContent;
-            set
-            {
-                showHideWiresButtonContent = value;
-                RaisePropertyChanged(nameof(ShowHideWiresButtonContent));
-            }
-        }
-
-        /// <summary>
-        /// Sets the visibility of the connectors from the port. This will overwrite the 
-        /// individual visibility of the connectors. However when visibility is controlled 
-        /// from the connector, that connector's visibility will overwrite its previous state.
-        /// In order to overwrite visibility of all connectors associated with a port, us this 
-        /// flag again.
-        /// </summary>
-        public bool SetConnectorsVisibility
-        {
-            get => areConnectorsHidden;
-            set
-            {
-                areConnectorsHidden = value; 
-                RaisePropertyChanged(nameof(SetConnectorsVisibility));
-            }
-        }
-
-        /// <summary>
-        /// Enables or disables the Hide Wires button on the node output port context menu.
-        /// </summary>
-        public bool HideWiresButtonEnabled
-        {
-            get => hideWiresButtonEnabled;
-            set
-            {
-                hideWiresButtonEnabled = value; 
-                RaisePropertyChanged(nameof(HideWiresButtonEnabled));
-            }
-        }
-
-        /// <summary>
-        /// Takes care of the multiple UI concerns when dealing with the Unhide/Hide Wires button
-        /// on the output port's context menu.
-        /// </summary>
-        private void RefreshHideWiresButton()
-        {
-            HideWiresButtonEnabled = _port.Connectors.Count > 0;
-            SetConnectorsVisibility = CheckIfConnectorsAreHidden();
-
-            ShowHideWiresButtonContent = SetConnectorsVisibility
-                ? Properties.Resources.UnhideWiresPopupMenuItem
-                : Properties.Resources.HideWiresPopupMenuItem;
-
-            RaisePropertyChanged(nameof(ShowHideWiresButtonContent));
-        }
-
-        /// <summary>
         /// Sets the color of the port's border brush
         /// </summary>
         public SolidColorBrush PortBorderBrushColor
@@ -356,19 +244,6 @@ namespace Dynamo.ViewModels
             {
                 portBorderBrushColor = value;
                 RaisePropertyChanged(nameof(PortBorderBrushColor));
-            }
-        }
-
-        /// <summary>
-        /// Sets the color of the small rectangular marker on each input port.
-        /// </summary>
-        public SolidColorBrush PortValueMarkerColor
-        {
-            get => portValueMarkerColor;
-            set
-            {
-                portValueMarkerColor = value;
-                RaisePropertyChanged(nameof(PortValueMarkerColor));
             }
         }
 
@@ -383,21 +258,6 @@ namespace Dynamo.ViewModels
             {
                 portBackgroundColor = value;
                 RaisePropertyChanged(nameof(PortBackgroundColor));
-            }
-        }
-
-        /// <summary>
-        /// Sets the color of the use levels popup in the input port context menu.
-        /// This changes when the Keep List Structure option is activated and the port
-        /// is connected, upon which it turns blue.
-        /// </summary>
-        public SolidColorBrush UseLevelsMenuColor
-        {
-            get
-            {
-                return ShouldKeepListStructure && _port.IsConnected
-                    ? new SolidColorBrush(Color.FromArgb(255, 60, 60, 60))
-                    : new SolidColorBrush(Color.FromArgb(255, 83, 83, 83));
             }
         }
 
@@ -420,7 +280,6 @@ namespace Dynamo.ViewModels
             _node.WorkspaceViewModel.PropertyChanged += Workspace_PropertyChanged;
 
             RefreshPortColors();
-            RefreshHideWiresButton();
         }
 
         public override void Dispose()
@@ -430,9 +289,9 @@ namespace Dynamo.ViewModels
             _node.WorkspaceViewModel.PropertyChanged -= Workspace_PropertyChanged;
         }
 
-        internal PortViewModel CreateProxyPortViewModel(PortModel portModel)
+        internal virtual PortViewModel CreateProxyPortViewModel(PortModel portModel)
         {
-            return new PortViewModel(_node, portModel);
+            throw new Exception("Don't do this");
         }
 
         /// <summary>
@@ -495,9 +354,6 @@ namespace Dynamo.ViewModels
                 case "ToolTipContent":
                     RaisePropertyChanged("ToolTipContent");
                     break;
-                case nameof(NodeViewModel.ZIndex):
-                    RefreshHideWiresButton();
-                    break;
             }
         }
 
@@ -516,9 +372,7 @@ namespace Dynamo.ViewModels
                     break;
                 case "IsConnected":
                     RaisePropertyChanged(nameof(IsConnected));
-                    RaisePropertyChanged(nameof(OutputPortBreakConnectionsButtonEnabled));
                     RefreshPortColors();
-                    RefreshHideWiresButton();
                     break;
                 case "IsEnabled":
                     RaisePropertyChanged("IsEnabled");
@@ -526,26 +380,8 @@ namespace Dynamo.ViewModels
                 case "Center":
                     RaisePropertyChanged("Center");
                     break;
-                case "DefaultValue":
-                    RaisePropertyChanged("DefaultValue");
-                    break;
-                case "UsingDefaultValue":
-                    RaisePropertyChanged("UsingDefaultValue");
-                    RefreshPortColors();
-                    break;
                 case "MarginThickness":
                     RaisePropertyChanged("MarginThickness");
-                    break;
-                case "UseLevels":
-                    RaisePropertyChanged("UseLevels");
-                    RaisePropertyChanged(nameof(UseLevelsMenuColor));
-                    break;
-                case "Level":
-                    RaisePropertyChanged("Level");
-                    break;
-                case "KeepListStructure":
-                    RaisePropertyChanged("ShouldKeepListStructure");
-                    RefreshPortColors();
                     break;
             }
         }
@@ -553,146 +389,43 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// UseLevels command
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public DelegateCommand UseLevelsCommand
         {
             get
             {
                 if (_useLevelsCommand == null)
                 {
-                    _useLevelsCommand = new DelegateCommand(UseLevel, p => true);
+                    _useLevelsCommand = new DelegateCommand(null, p => true);
                 }
                 return _useLevelsCommand;
             }
         }
 
-        private void UseLevel(object parameter)
-        {
-            var useLevel = (bool)parameter;
-            var command = new DynamoModel.UpdateModelValueCommand(
-                Guid.Empty, _node.NodeLogic.GUID, "UseLevels", string.Format("{0}:{1}", _port.Index, useLevel));
-            
-            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
-            RaisePropertyChanged(nameof(UseLevelSpinnerVisible));
-        }
-
         /// <summary>
         /// ShouldKeepListStructure command
         /// </summary>
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         public DelegateCommand KeepListStructureCommand
         {
             get
             {
                 if (_keepListStructureCommand == null)
                 {
-                    _keepListStructureCommand = new DelegateCommand(KeepListStructure, p => true);
+                    _keepListStructureCommand = new DelegateCommand(null, p => true);
                 }
                 return _keepListStructureCommand;
             }
         }
 
-        /// <summary>
-        /// Used by the 'Break Connection' button in the node output context menu.
-        /// Removes any current connections this port has.
-        /// </summary>
-        public DelegateCommand BreakConnectionsCommand
-        {
-            get
-            {
-                if (_breakConnectionsCommand == null)
-                {
-                    _breakConnectionsCommand = new DelegateCommand(BreakConnections);
-                }
-                return _breakConnectionsCommand;
-            }
-        }
-
-        /// <summary>
-        /// Used by the 'Break Connection' button in the node output context menu.
-        /// Removes any current connections this port has.
-        /// </summary>
-        public DelegateCommand HideConnectionsCommand
-        {
-            get
-            {
-                if (_hideConnectionsCommand == null)
-                {
-                    _hideConnectionsCommand = new DelegateCommand(HideConnections);
-                }
-                return _hideConnectionsCommand;
-            }
-        }
-
-        private void KeepListStructure(object parameter)
-        {
-            bool keepListStructure = (bool)parameter;
-            var command = new DynamoModel.UpdateModelValueCommand(
-                Guid.Empty, _node.NodeLogic.GUID, "KeepListStructure", string.Format("{0}:{1}", _port.Index, keepListStructure));
-            
-            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
-        }
-
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the InPortViewModel")]
         private void ChangeLevel(int level)
         {
             var command = new DynamoModel.UpdateModelValueCommand(
-                            Guid.Empty, _node.NodeLogic.GUID, "ChangeLevel", string.Format("{0}:{1}", _port.Index, level));
+                Guid.Empty, _node.NodeLogic.GUID, "ChangeLevel", string.Format("{0}:{1}", _port.Index, level));
 
             _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
         }
-
-        /// <summary>
-        /// Used by the 'Break Connection' button in the node output context menu.
-        /// Removes any current connections this port has.
-        /// </summary>
-        /// <param name="parameter"></param>
-        private void BreakConnections(object parameter)
-        {
-            for (int i = _port.Connectors.Count - 1; i >= 0; i--)
-            {
-                // Attempting to get the relevant ConnectorViewModel via matching GUID
-                ConnectorViewModel connectorViewModel = _node.WorkspaceViewModel.Connectors
-                    .FirstOrDefault(x => x.ConnectorModel.GUID == _port.Connectors[i].GUID);
-
-                if (connectorViewModel == null) continue;
-
-                connectorViewModel.BreakConnectionCommand.Execute(null);
-            }
-        }
-
-        /// <summary>
-        /// Used by the 'Hide Wires' button in the node output context menu.
-        /// Turns of the visibility of any connections this port has.
-        /// </summary>
-        /// <param name="parameter"></param>
-        private void HideConnections(object parameter)
-        {
-            for (int i = _port.Connectors.Count - 1; i >= 0; i--)
-            {
-                // Attempting to get the relevant ConnectorViewModel via matching GUID
-                ConnectorViewModel connectorViewModel = _node.WorkspaceViewModel.Connectors
-                    .FirstOrDefault(x => x.ConnectorModel.GUID == _port.Connectors[i].GUID);
-
-                if (connectorViewModel == null) continue;
-
-                connectorViewModel.HideConnectorCommand.Execute(!SetConnectorsVisibility);
-            }
-            RefreshHideWiresButton();
-        }
-        /// <summary>
-        /// Returns true if they are hidden.
-        /// </summary>
-        /// <returns></returns>
-        private bool CheckIfConnectorsAreHidden()
-        {
-            if (_port.Connectors.Count < 1 || _node.WorkspaceViewModel.Connectors.Count < 1) return false;
-
-            // Attempting to get a relevant ConnectorViewModel via matching NodeModel GUID
-            ConnectorViewModel connectorViewModel = _node.WorkspaceViewModel.Connectors
-                .FirstOrDefault(x => x.Nodevm.NodeModel.GUID == _port.Owner.GUID);
-
-            if (connectorViewModel == null) return false;
-            return connectorViewModel.IsCollapsed;
-        }
-
 
         private void Connect(object parameter)
         {
@@ -701,7 +434,7 @@ namespace Dynamo.ViewModels
             workspaceViewModel.HandlePortClicked(this);
         }
 
-        private bool CanConnect(object parameter)
+        protected bool CanConnect(object parameter)
         {
             return true;
         }
@@ -778,41 +511,10 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Handles the logic for updating the PortBackgroundColor and PortBackgroundBrushColor
         /// </summary>
-        private void RefreshPortColors()
+        protected virtual void RefreshPortColors()
         {
-            // The visual appearance of ports can be affected by many different logical states
-            // Inputs have more display styles than outputs
-            if (_port.PortType == PortType.Input)
-            {
-                // Special case for keeping list structure visual appearance
-                if (_port.UseLevels && _port.KeepListStructure && _port.IsConnected)
-                {
-                    PortValueMarkerColor = PortValueMarkerBlue;
-                    PortBackgroundColor = PortBackgroundColorKeepListStructure;
-                    PortBorderBrushColor = PortBorderBrushColorKeepListStructure;
-                }
-                // Port has a default value, shows blue marker
-                else if (UsingDefaultValue && DefaultValueEnabled)
-                {
-                    PortValueMarkerColor = PortValueMarkerBlue;
-                    PortBackgroundColor = PortBackgroundColorDefault;
-                    PortBorderBrushColor = PortBorderBrushColorDefault;
-                }
-                // Port isn't connected and has no default value (or isn't using it)
-                else
-                {
-                    PortValueMarkerColor = !_port.IsConnected ? PortValueMarkerRed : PortValueMarkerBlue;
-                    PortBackgroundColor = PortBackgroundColorDefault;
-                    PortBorderBrushColor = PortBorderBrushColorDefault;
-                }
-            }
-            // It's an output port, which either displays a connected style or a disconnected style
-            else
-            {
-                PortBackgroundColor = PortBackgroundColorDefault;
-                PortBorderBrushColor = PortBorderBrushColorDefault;
-            }
-            RaisePropertyChanged(nameof(UseLevelsMenuColor));
+            PortBackgroundColor = PortBackgroundColorDefault;
+            PortBorderBrushColor = PortBorderBrushColorDefault;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -31,7 +31,8 @@ namespace Dynamo.Nodes
             Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoColorsAndBrushesDictionary);
             Resources.MergedDictionaries.Add(SharedDictionaryManager.DataTemplatesDictionary);
             Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoConvertersDictionary);
-            Resources.MergedDictionaries.Add(SharedDictionaryManager.PortsDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.InPortsDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.OutPortsDictionary);
 
             InitializeComponent();
             Unloaded += AnnotationView_Unloaded;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -114,7 +114,8 @@ namespace Dynamo.Controls
             Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoColorsAndBrushesDictionary);
             Resources.MergedDictionaries.Add(SharedDictionaryManager.DataTemplatesDictionary);
             Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoConvertersDictionary);
-            Resources.MergedDictionaries.Add(SharedDictionaryManager.PortsDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.InPortsDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.OutPortsDictionary);
 
             InitializeComponent();
 


### PR DESCRIPTION
### Purpose

The purpose of this PR is to split up the Port View and ViewModels.  As the difference between In Ports and Out Ports has grown in UX and Code complexity it is putting a high burden on implementation and a net drag on memory and performance of the Workspace View.  This PR allows the port views to be implemented and styled independently.  This PR should maintain feature capability with existing 2.13 WIP.   This does introduce a 10% gain in start up time and similar for memory allocation. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @OliverEGreen @QilongTang 

### FYIs

@SHKnudsen 
