### PR TITLE
DYN-3977-Aligment-Popup-Navigation

### DIFF
--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -138,6 +138,7 @@
                 <StackPanel x:Name="TooltipNavigationControls"
                             Orientation="Horizontal" 
                             HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
                             Grid.Column="0"
                             Visibility="{Binding ShowTooltipNavigationControls, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Button x:Name="BackButton"


### PR DESCRIPTION
### Purpose

I modified the vertical alignment for the Stack panel that contains the Back and Next buttons and also the label so the Vertical Alignment = Center will be applied to all of them.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
