### PR TITLE
[DYN-4076] Group title text doesn't wrap properly

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -481,13 +481,13 @@
                                     Width="{Binding Width}"
                                     MinHeight="20"
                                     Margin="0,0,0,10">
-                        <Grid>
+                        <Grid Margin="0,0,20,0">
                             <TextBlock x:Name="GroupTextBlock"
                                        Text="{Binding AnnotationText, Converter={StaticResource AnnotationTextConverter}, ConverterParameter='TextBlock'}"
                                        FontFamily="Trebuchet"
                                        FontSize="{Binding FontSize}"
                                        LineStackingStrategy="BlockLineHeight"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="WrapWithOverflow"
                                        Visibility="Visible">
                             </TextBlock>
                             <TextBox Name="GroupTextBox"
@@ -495,7 +495,7 @@
                                      MaxLength="30"
                                      Visibility="Collapsed"
                                      Text="{Binding AnnotationText,Converter={StaticResource AnnotationTextConverter}, ConverterParameter='TextBox'}"
-                                     TextWrapping="Wrap"
+                                     TextWrapping="WrapWithOverflow"
                                      FontFamily="Trebuchet"
                                      FontSize="{Binding FontSize}"
                                      IsVisibleChanged="GroupTextBox_OnIsVisibleChanged"


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4076](https://jira.autodesk.com/browse/DYN-4076)

![groupTitleTextWrap](https://user-images.githubusercontent.com/13732445/134886796-2a75671d-bed4-4808-a31a-ec9e389cd34e.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
