### PR TITLE
Crash Fix.  Add visibility trigger to empty tooltip strings.

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return "";
+            if (value == null) return string.Empty;
             string incomingString = value as string;
             return incomingString.Split(new[] { '\r', '\n' }, 2)[0].Trim();
         }
@@ -51,7 +51,7 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return "";
+            if (value == null) return string.Empty;
             string incomingString = value as string;
             return incomingString.Split(new[] { '\r', '\n' }, 2)[1].Trim();
         }

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -36,6 +36,7 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == null) return "";
             string incomingString = value as string;
             return incomingString.Split(new[] { '\r', '\n' }, 2)[0].Trim();
         }
@@ -50,6 +51,7 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == null) return "";
             string incomingString = value as string;
             return incomingString.Split(new[] { '\r', '\n' }, 2)[1].Trim();
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -520,7 +520,7 @@ namespace Dynamo.ViewModels
                 var portValue = model.Start.Owner.GetValue(model.Start.Index, workspaceViewModel.DynamoViewModel.EngineController);
                 if (portValue is null)
                 {
-                    ConnectorDataTooltip = "N/A";
+                    ConnectorDataTooltip = "";
                     return;
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -520,7 +520,7 @@ namespace Dynamo.ViewModels
                 var portValue = model.Start.Owner.GetValue(model.Start.Index, workspaceViewModel.DynamoViewModel.EngineController);
                 if (portValue is null)
                 {
-                    ConnectorDataTooltip = "";
+                    ConnectorDataTooltip = string.Empty;
                     return;
                 }
 

--- a/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
@@ -70,7 +70,8 @@
                 Width="{Binding AnchorSize}"
                 ToolTipService.ShowDuration="{x:Static Member=System:Int32.MaxValue}">
             <Button.ToolTip>
-                <ToolTip Style="{StaticResource ConnectorTooltip}">
+                <ToolTip Style="{StaticResource ConnectorTooltip}"
+                         Visibility="{Binding DataToolTipText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EmptyStringToCollapsedConverter}}">
                     <StackPanel Margin="5">
                         <TextBlock Text="{Binding DataToolTipText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToolTipFirstLine}}"
                                    FontWeight="Bold"/>


### PR DESCRIPTION
### Purpose

This PR fixes a crash bug when hovering wires after opening the graph in `Manual` mode.  Specifically it hides the tooltips for the hover menu.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@marimano @QilongTang 
