### PR TITLE
Pinned Node Deletion Bug Fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -704,6 +704,8 @@ namespace Dynamo.Controls
             ViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.SelectModelCommand(nodeGuid, Keyboard.Modifiers.AsDynamoType()));
 
+            viewModel.OnSelected(this, EventArgs.Empty);
+
             grid.ContextMenu.DataContext = viewModel;
             grid.ContextMenu.IsOpen = true;
             


### PR DESCRIPTION
### Purpose
This PR focuses on solving deletion crashes / unwanted behaviors caused by the pinned node. 
A OnSelect() event was missing when left-clicking a node, so the note attached to this pinned node was never receiving that information. 

It follows on bug reported: https://jira.autodesk.com/browse/DYN-3944 

![Untitled Project](https://user-images.githubusercontent.com/25138291/135062576-84f4fa2c-f5c2-49c0-8f48-08785bf43360.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@Amoursol , @QilongTang 

### FYIs

@SHKnudsen 
