### PR TITLE
[DYN-4127] Nested collapsed groups can cause nested group to move up

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -510,7 +510,9 @@
                     <ContentControl x:Name="GroupDescriptionControls"
                                     Grid.Row="1"
                                     MinHeight="20"
-                                    Margin="0,-10,30,0">
+                                    Margin="0,-10,30,0"
+                                    SizeChanged="GroupDescriptionControls_SizeChanged"
+                                    IsVisibleChanged="GroupDescriptionTextBlock_IsVisibleChanged">
                         <Grid>
                             <TextBlock x:Name="GroupDescriptionTextBlock"
                                        Text="{Binding AnnotationDescriptionText, Converter={StaticResource AnnotationTextConverter}}"
@@ -518,8 +520,7 @@
                                        FontSize="12"
                                        LineStackingStrategy="BlockLineHeight"
                                        TextWrapping="Wrap"
-                                       Visibility="Visible"
-                                       IsVisibleChanged="GroupDescriptionTextBlock_IsVisibleChanged">
+                                       Visibility="Visible">
                             </TextBlock>
                             <TextBox Name="GroupDescriptionTextBox"
                                      MaxLength="280"

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -423,5 +423,10 @@ namespace Dynamo.Nodes
         {
             SetTextHeight();
         }
+
+        private void GroupDescriptionControls_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            SetTextHeight();
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -21,7 +21,7 @@
           HorizontalAlignment="Left"
           x:FieldModifier="public"
           ContextMenuService.IsEnabled="false"
-          Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
+          Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityConverter}}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4127](https://jira.autodesk.com/projects/DYN/issues/DYN-4127)

As `IsCollapsed` previously Collapsed the nodes their size would be 0, this was an issue when opening graphs where collapsed groups had been saved, as the groups uses the nodes sizes to determine its own size. To fix this `IsCollapsed` will only hide nodes, which means it is still possible to get their size.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
