### PR TITLE
Set HasUnsavedChanges to true when a node is pinned or unpinned

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -298,6 +298,8 @@ namespace Dynamo.ViewModels
 
             SubscribeToPinnedNode();
 
+            WorkspaceViewModel.HasUnsavedChanges = true;
+
         }
 
         private bool CanPinToNode(object parameters)
@@ -334,6 +336,7 @@ namespace Dynamo.ViewModels
         {
             UnsuscribeFromPinnedNode();
             Model.PinnedNode = null;
+            WorkspaceViewModel.HasUnsavedChanges = true;
         }
 
         private void SubscribeToPinnedNode()

--- a/test/DynamoCoreWpfTests/NoteViewTests.cs
+++ b/test/DynamoCoreWpfTests/NoteViewTests.cs
@@ -245,5 +245,32 @@ namespace DynamoCoreWpfTests
             var canPinNodsToNotes = noteBView.ViewModel.PinToNodeCommand.CanExecute(null);
             Assert.IsFalse(canPinNodesToANote);
         }
+
+        /// <summary>
+        /// Check that workspace model is aware that changes were made 
+        /// when a node is pinned to a note.
+        /// </summary>
+        [Test]
+        public void HasUnsavedChangesWhenPinToNode()
+        {
+            // Open document and get node and note view
+            Open(@"UI\UI_PinNodeToNote.dyn");
+            var nodeAGUID = "cf46488c-6631-458e-bba0-25098e2273f5";
+            var noteAGUID = "c589c7ff-a481-4a21-bb18-ac01ed9486fc";
+            var nodeAView = NodeViewWithGuid(nodeAGUID);
+            var noteAView = NoteViewWithGuid(noteAGUID);
+
+            //Assert that workspace doesn't have unsaved changes
+            var workspace = nodeAView.ViewModel.WorkspaceViewModel;
+            Assert.IsFalse(workspace.HasUnsavedChanges);
+
+            // Select node, note and pin
+            DynamoSelection.Instance.Selection.AddUnique(nodeAView.ViewModel.NodeModel);
+            DynamoSelection.Instance.Selection.AddUnique(noteAView.ViewModel.Model);
+            noteAView.ViewModel.PinToNodeCommand.Execute(null);
+
+            //Assert that workspace has unsaved changes
+            Assert.IsTrue(nodeAView.ViewModel.WorkspaceViewModel.HasUnsavedChanges);
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR makes sure that the workspace model is aware that changes were made when a node is pinned/unpinned to a note.

It follows a suggestion reported on: https://jira.autodesk.com/projects/DYN/issues/DYN-3890

![Untitled Project](https://user-images.githubusercontent.com/25138291/135102129-05ee4590-8921-410d-8f86-109e6ada7b10.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@Amoursol @QilongTang 

### FYIs

@SHKnudsen 
