### PR TITLE
[DYN-4105] Make sure nodes gets added to parent group

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2157,7 +2157,18 @@ namespace Dynamo.Models
         internal void AddToGroup(List<ModelBase> modelsToAdd)
         {
             var workspaceAnnotations = Workspaces.SelectMany(ws => ws.Annotations);
-            var selectedGroup = workspaceAnnotations.FirstOrDefault(x => x.IsSelected);
+            var selectedGroups = workspaceAnnotations
+                .Where(x => x.IsSelected);
+
+            // If multiple groups are selected, chances are that we
+            // have a group that contains a nested group.
+            // If this is the case we want to make sure that we add the
+            // node to the parent folder.
+            var selectedGroup = selectedGroups.Count() > 1 ?
+                selectedGroups.FirstOrDefault(x => x.HasNestedGroups) :
+                selectedGroups.FirstOrDefault();
+
+            //var selectedGroup = workspaceAnnotations.FirstOrDefault(x => x.IsSelected);
             if (selectedGroup != null)
             {
                 foreach (var model in modelsToAdd)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2168,7 +2168,6 @@ namespace Dynamo.Models
                 selectedGroups.FirstOrDefault(x => x.HasNestedGroups) :
                 selectedGroups.FirstOrDefault();
 
-            //var selectedGroup = workspaceAnnotations.FirstOrDefault(x => x.IsSelected);
             if (selectedGroup != null)
             {
                 foreach (var model in modelsToAdd)


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4105](https://jira.autodesk.com/projects/DYN/issues/DYN-4105).

When using the context menu to add a node to a group, we now check if multiple groups are selected and if so prioritize parent groups to make sure that nodes are added to the parent group.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
