### PR TITLE
[DYN-4106] Ports should not be populated on parent group from nested group

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -552,45 +552,32 @@ namespace Dynamo.ViewModels
             InPorts.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
-            if (!AnnotationModel.HasNestedGroups)
+            // we need to store the original ports here
+            // as we need those later for when we
+            // need to collapse the groups content
+            if (this.AnnotationModel.HasNestedGroups)
             {
-                // we need to store the original ports here
-                // as we need thoese later for when we
-                // need to collapse the groups content
+                var ownerNodes = Nodes
+                    .OfType<AnnotationModel>()
+                    .SelectMany(x => x.Nodes.OfType<NodeModel>())
+                    .Concat(Nodes.OfType<NodeModel>());
+
+                originalInPorts = GetGroupInPorts(ownerNodes);
+            }
+            else
+            {
                 originalInPorts = GetGroupInPorts();
-
-                // Create proxies of the ports so we can
-                // visually add them to the group but they
-                // should still reference their NodeModel
-                // owner
-                newPortViewModels = CreateProxyPorts(originalInPorts);
-
-                if (newPortViewModels == null) return;
-                InPorts.AddRange(newPortViewModels);
-                return;
             }
 
-            // We need to get all NodeModels for the nested groups 
-            // here, as we will have to show any ports belonging to a
-            // node that are either unconnected or connected to outside
-            // of the owner group.
-            var ownerGroupNodes = Nodes.OfType<AnnotationModel>()
-                .SelectMany(x=>x.Nodes.OfType<NodeModel>())
-                .Concat(Nodes.OfType<NodeModel>());
-
-            // Find the needed input ports of all the nested groups
-            var groupedGroupsInPorts = new List<PortModel>();
-            foreach (var group in ViewModelBases.OfType<AnnotationViewModel>())
-            {
-                groupedGroupsInPorts.AddRange(group.GetGroupInPorts(ownerGroupNodes));
-            }
-
-            originalInPorts = GetGroupInPorts().Concat(groupedGroupsInPorts);
-
+            // Create proxies of the ports so we can
+            // visually add them to the group but they
+            // should still reference their NodeModel
+            // owner
             newPortViewModels = CreateProxyPorts(originalInPorts);
 
             if (newPortViewModels == null) return;
             InPorts.AddRange(newPortViewModels);
+            return;
         }
 
         /// <summary>
@@ -602,44 +589,32 @@ namespace Dynamo.ViewModels
             OutPorts.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
-            if (!AnnotationModel.HasNestedGroups)
+            // we need to store the original ports here
+            // as we need thoese later for when we
+            // need to collapse the groups content
+            if (this.AnnotationModel.HasNestedGroups)
             {
-                // we need to store the original ports here
-                // as we need thoese later for when we
-                // need to collapse the groups content
+                var ownerNodes = Nodes
+                    .OfType<AnnotationModel>()
+                    .SelectMany(x => x.Nodes.OfType<NodeModel>())
+                    .Concat(Nodes.OfType<NodeModel>());
+
+                originalOutPorts = GetGroupOutPorts(ownerNodes);
+            }
+            else
+            {
                 originalOutPorts = GetGroupOutPorts();
-
-                // Create proxies of the ports so we can
-                // visually add them to the group but they
-                // should still reference their NodeModel
-                // owner
-                newPortViewModels = CreateProxyPorts(originalOutPorts);
-
-                if (newPortViewModels == null) return;
-                OutPorts.AddRange(newPortViewModels);
-                return;
             }
 
-            // We need to get all NodeModels for the nested groups 
-            // here, as we will have to show any ports belonging to a
-            // node that are either unconnected or connected to outside
-            // of the owner group.
-            var ownerGroupNodes = Nodes.OfType<AnnotationModel>()
-                .SelectMany(x => x.Nodes.OfType<NodeModel>())
-                .Concat(Nodes.OfType<NodeModel>());
-
-            var groupedGroupsOutPorts = new List<PortModel>();
-            foreach (var group in ViewModelBases.OfType<AnnotationViewModel>())
-            {
-                groupedGroupsOutPorts.AddRange(group.GetGroupOutPorts(ownerGroupNodes));
-            }
-
-            originalOutPorts = GetGroupOutPorts().Concat(groupedGroupsOutPorts);
-
+            // Create proxies of the ports so we can
+            // visually add them to the group but they
+            // should still reference their NodeModel
+            // owner
             newPortViewModels = CreateProxyPorts(originalOutPorts);
 
             if (newPortViewModels == null) return;
             OutPorts.AddRange(newPortViewModels);
+            return;
         }
 
         internal IEnumerable<PortModel> GetGroupInPorts(IEnumerable<NodeModel> ownerNodes = null)


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4106](https://jira.autodesk.com/projects/DYN/issues/DYN-4106)

![OnlyShowParentNodesPorts](https://user-images.githubusercontent.com/13732445/135130186-dc7b4636-1738-4b28-bc3f-2fd0723d5d33.gif)

### Declarations
Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
