### PR TITLE
Updates resource strings from Remove to Delete

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -511,7 +511,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove.
+        ///   Looks up a localized string similar to Delete.
         /// </summary>
         public static string ContextMenuDelete {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -254,7 +254,7 @@
     <comment>Context menu item</comment>
   </data>
   <data name="ContextMenuDelete" xml:space="preserve">
-    <value>Remove</value>
+    <value>Delete</value>
     <comment>Context menu for selected node - delete selected node</comment>
   </data>
   <data name="ContextMenuEditCustomNode" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -705,7 +705,7 @@
     <comment>View menu | Zoom out</comment>
   </data>
   <data name="ContextMenuDelete" xml:space="preserve">
-    <value>Remove</value>
+    <value>Delete</value>
     <comment>Context menu for selected node - delete selected node</comment>
   </data>
   <data name="NodeContextMenuHelp" xml:space="preserve">


### PR DESCRIPTION
### Purpose

This PR changes the node context menu item string from 'Remove' to 'Delete'. This is felt to be more clear to users. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@Jingyi-Wen 

