### PR TITLE
[DYN-3984] More than three icons in a collapsed group

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.13.0.2443")]
+[assembly: AssemblyVersion("2.13.0.2733")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.13.0.2443")]
+[assembly: AssemblyFileVersion("2.13.0.2733")]

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -991,7 +991,12 @@ namespace Dynamo.ViewModels
                 case NotifyCollectionChangedAction.Add:
                     foreach (PortViewModel item in e.NewItems)
                     {
-                        if (OutputNodes.Contains(item.NodeViewModel)) continue;
+                        if (OutputNodes.Contains(item.NodeViewModel) ||
+                            OutputNodes.Count == 3)
+                        {
+                            continue;
+                        }
+
                         OutputNodes.Add(item.NodeViewModel);
                     }
                     break;
@@ -1014,7 +1019,12 @@ namespace Dynamo.ViewModels
                 case NotifyCollectionChangedAction.Add:
                     foreach (PortViewModel item in e.NewItems)
                     {
-                        if (InputNodes.Contains(item.NodeViewModel)) continue;
+                        if (InputNodes.Contains(item.NodeViewModel) ||
+                            InputNodes.Count == 3)
+                        {
+                            continue;
+                        }
+
                         InputNodes.Add(item.NodeViewModel);
                     }
                     break;

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -550,6 +550,7 @@ namespace Dynamo.ViewModels
         internal void SetGroupInputPorts()
         {
             InPorts.Clear();
+            InputNodes.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
             if (!AnnotationModel.HasNestedGroups)
@@ -600,6 +601,7 @@ namespace Dynamo.ViewModels
         internal void SetGroupOutPorts()
         {
             OutPorts.Clear();
+            OutputNodes.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
             if (!AnnotationModel.HasNestedGroups)
@@ -728,6 +730,8 @@ namespace Dynamo.ViewModels
                     // we collapse that and all of its content.
                     annotationViewModel.IsCollapsed = true;
                     annotationViewModel.CollapseGroupContents(false);
+                    annotationViewModel.SetGroupInputPorts();
+                    annotationViewModel.SetGroupOutPorts();
                 }
 
                 viewModel.IsCollapsed = true;
@@ -1000,13 +1004,6 @@ namespace Dynamo.ViewModels
                         OutputNodes.Add(item.NodeViewModel);
                     }
                     break;
-                case NotifyCollectionChangedAction.Remove:
-                    foreach (PortViewModel item in e.OldItems)
-                    {
-                        if (!OutputNodes.Contains(item.NodeViewModel)) continue;
-                        OutputNodes.Remove(item.NodeViewModel);
-                    }
-                    break;
                 default:
                     break;
             }
@@ -1026,13 +1023,6 @@ namespace Dynamo.ViewModels
                         }
 
                         InputNodes.Add(item.NodeViewModel);
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    foreach (PortViewModel item in e.OldItems)
-                    {
-                        if (!InputNodes.Contains(item.NodeViewModel)) continue;
-                        InputNodes.Remove(item.NodeViewModel);
                     }
                     break;
                 default:

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -227,87 +227,6 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <Style x:Key="InputOutputNodesListViewTemplate"
-               TargetType="{x:Type ListView}">
-            <Setter Property="Background"
-                    Value="Transparent" />
-            <Setter Property="VerticalContentAlignment"
-                    Value="Center" />
-            <Setter Property="VerticalAlignment"
-                    Value="Center" />
-            <Setter Property="HorizontalAlignment"
-                    Value="Center" />
-            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
-                    Value="Disabled" />
-            <Setter Property="BorderThickness"
-                    Value="0" />
-            <Setter Property="IsHitTestVisible"
-                    Value="True" />
-            <Setter Property="ItemContainerStyle">
-                <Setter.Value>
-                    <Style TargetType="ListViewItem">
-                        <Setter Property="Background"
-                                Value="Transparent" />
-                        <Setter Property="BorderBrush"
-                                Value="Transparent" />
-                        <Setter Property="BorderThickness"
-                                Value="0" />
-                        <Setter Property="Margin"
-                                Value="0" />
-                        <Setter Property="Padding"
-                                Value="0" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type ListViewItem}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <Canvas Width="22"
-                                                Height="26.6">
-                                            <ContentPresenter />
-                                        </Canvas>
-                                    </StackPanel>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="ItemsPanel">
-                <Setter.Value>
-                    <ItemsPanelTemplate>
-                        <StackPanel Orientation="Horizontal"
-                                    Margin="0,0,4.6,0" />
-                    </ItemsPanelTemplate>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="ItemTemplate">
-                <Setter.Value>
-                    <DataTemplate DataType="{x:Type viewModels:NodeViewModel}">
-                        <Border x:Name="circularBorder"
-                                BorderBrush="#CFE4B3"
-                                BorderThickness="1"
-                                Background="#4a4a4a"
-                                CornerRadius="{Binding Path=ActualHeight, ElementName=circularBorder}"
-                                Width="{Binding Path=ActualHeight, ElementName=circularBorder}"
-                                Padding="2">
-                            <Border.ToolTip>
-                                <dynui:DynamoToolTip AttachmentSide="Bottom"
-                                                     Style="{DynamicResource ResourceKey=SLightToolTip}"
-                                                     Margin="5,0,0,0"
-                                                     Visibility="{Binding IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
-                                    <StackPanel Orientation="Vertical">
-                                        <TextBlock Text="{Binding Name}" />
-                                    </StackPanel>
-                                </dynui:DynamoToolTip>
-                            </Border.ToolTip>
-                            <Image Width="20"
-                                   Source="{Binding ImageSource}">
-                            </Image>
-                        </Border>
-                    </DataTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
     </UserControl.Resources>
 
     <Grid Name="AnnotationGrid"
@@ -798,52 +717,24 @@
                               Margin="0,10">
                 </ItemsControl>
 
-                <!--Group content icons-->
-                <Grid x:Name="GroupContentIcons"
-                      Grid.ColumnSpan="3"
-                      Grid.Row="1"
-                      Background="Transparent"
-                      HorizontalAlignment="Center"
-                      Margin="10">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <ListView x:Name="InputPortIcons"
-                              Grid.Column="0"
-                              ItemsSource="{Binding InputNodes}"
-                              Style="{StaticResource InputOutputNodesListViewTemplate}"
-                              Margin="0"
-                              Panel.ZIndex="2">
-                    </ListView>
-
-                    <Border x:Name="AddtionalNodesCount"
-                            Grid.Column="1"
-                            VerticalAlignment="Center"
-                            BorderThickness="1"
-                            BorderBrush="#CFE4B3"
-                            Background="#EEEEEE"
-                            CornerRadius="{Binding Path=ActualHeight, ElementName=AddtionalNodesCount}"
-                            Width="{Binding Path=ActualHeight, ElementName=AddtionalNodesCount}"
-                            Height="26"
-                            Padding="0"
-                            Margin="-4.6">
-                        <TextBlock Text="{Binding InbetweenNodesCount, Mode=OneWay, StringFormat='+{0}'}"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   FontSize="10" />
-                    </Border>
-
-                    <ListView x:Name="OutputPortIcons"
-                              Grid.Column="2"
-                              ItemsSource="{Binding OutputNodes}"
-                              Style="{StaticResource InputOutputNodesListViewTemplate}"
-                              Panel.ZIndex="2">
-                    </ListView>
-                </Grid>
+                <Border x:Name="NodeCount"
+                        Grid.Row="1"
+                        Grid.ColumnSpan="3"
+                        VerticalAlignment="Center"
+                        BorderThickness="1"
+                        BorderBrush="#FFFFFF"
+                        Background="#EEEEEE"
+                        CornerRadius="{Binding Path=ActualHeight, ElementName=NodeCount}"
+                        Width="{Binding Path=ActualHeight, ElementName=NodeCount}"
+                        Height="32"
+                        Padding="0"
+                        Margin="10">
+                    <TextBlock Text="{Binding NodeContentCount, Mode=OneWay, StringFormat='+{0}'}"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="14" />
+                </Border>
             </Grid>
-
         </Border>
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -291,7 +291,7 @@
                                 Width="{Binding Path=ActualHeight, ElementName=circularBorder}"
                                 Padding="2">
                             <Border.ToolTip>
-                                <dynui:DynamoToolTip AttachmentSide="Top"
+                                <dynui:DynamoToolTip AttachmentSide="Bottom"
                                                      Style="{DynamicResource ResourceKey=SLightToolTip}"
                                                      Margin="5,0,0,0"
                                                      Visibility="{Binding IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -243,8 +243,7 @@
             <Setter Property="BorderThickness"
                     Value="0" />
             <Setter Property="IsHitTestVisible"
-                    Value="False" />
-
+                    Value="True" />
             <Setter Property="ItemContainerStyle">
                 <Setter.Value>
                     <Style TargetType="ListViewItem">
@@ -258,27 +257,53 @@
                                 Value="0" />
                         <Setter Property="Padding"
                                 Value="0" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Canvas Width="22"
+                                                Height="26.6">
+                                            <ContentPresenter />
+                                        </Canvas>
+                                    </StackPanel>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
                     </Style>
                 </Setter.Value>
             </Setter>
             <Setter Property="ItemsPanel">
                 <Setter.Value>
                     <ItemsPanelTemplate>
-                        <StackPanel Orientation="Horizontal" />
+                        <StackPanel Orientation="Horizontal"
+                                    Margin="0,0,4.6,0" />
                     </ItemsPanelTemplate>
                 </Setter.Value>
             </Setter>
             <Setter Property="ItemTemplate">
                 <Setter.Value>
                     <DataTemplate DataType="{x:Type viewModels:NodeViewModel}">
-                        <Image Width="20"
-                               Source="/DynamoCoreWpf;component/UI/Images/NodeIcon_placeholder.png">
-                            <Image.Clip>
-                                <RectangleGeometry RadiusX="5"
-                                                   RadiusY="5"
-                                                   Rect="0,0,20,20"></RectangleGeometry>
-                            </Image.Clip>
-                        </Image>
+                        <Border x:Name="circularBorder"
+                                BorderBrush="#CFE4B3"
+                                BorderThickness="1"
+                                Background="#4a4a4a"
+                                CornerRadius="{Binding Path=ActualHeight, ElementName=circularBorder}"
+                                Width="{Binding Path=ActualHeight, ElementName=circularBorder}"
+                                Padding="2">
+                            <Border.ToolTip>
+                                <dynui:DynamoToolTip AttachmentSide="Top"
+                                                     Style="{DynamicResource ResourceKey=SLightToolTip}"
+                                                     Margin="5,0,0,0"
+                                                     Visibility="{Binding IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock Text="{Binding Name}" />
+                                    </StackPanel>
+                                </dynui:DynamoToolTip>
+                            </Border.ToolTip>
+                            <Image Width="20"
+                                   Source="{Binding ImageSource}">
+                            </Image>
+                        </Border>
                     </DataTemplate>
                 </Setter.Value>
             </Setter>
@@ -742,9 +767,9 @@
                 Grid.Row="1">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="auto" />
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="auto" />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -775,7 +800,7 @@
 
                 <!--Group content icons-->
                 <Grid x:Name="GroupContentIcons"
-                      Grid.Column="1"
+                      Grid.ColumnSpan="3"
                       Grid.Row="1"
                       Background="Transparent"
                       HorizontalAlignment="Center"
@@ -788,19 +813,22 @@
                     <ListView x:Name="InputPortIcons"
                               Grid.Column="0"
                               ItemsSource="{Binding InputNodes}"
-                              Style="{StaticResource InputOutputNodesListViewTemplate}">
+                              Style="{StaticResource InputOutputNodesListViewTemplate}"
+                              Margin="0"
+                              Panel.ZIndex="2">
                     </ListView>
 
                     <Border x:Name="AddtionalNodesCount"
                             Grid.Column="1"
                             VerticalAlignment="Center"
-                            BorderThickness="0.5"
-                            BorderBrush="#FFFFFF"
+                            BorderThickness="1"
+                            BorderBrush="#CFE4B3"
                             Background="#EEEEEE"
                             CornerRadius="{Binding Path=ActualHeight, ElementName=AddtionalNodesCount}"
                             Width="{Binding Path=ActualHeight, ElementName=AddtionalNodesCount}"
-                            Height="20"
-                            Padding="0">
+                            Height="26"
+                            Padding="0"
+                            Margin="-4.6">
                         <TextBlock Text="{Binding InbetweenNodesCount, Mode=OneWay, StringFormat='+{0}'}"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
@@ -810,7 +838,8 @@
                     <ListView x:Name="OutputPortIcons"
                               Grid.Column="2"
                               ItemsSource="{Binding OutputNodes}"
-                              Style="{StaticResource InputOutputNodesListViewTemplate}">
+                              Style="{StaticResource InputOutputNodesListViewTemplate}"
+                              Panel.ZIndex="2">
                     </ListView>
                 </Grid>
             </Grid>

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -880,7 +880,6 @@ namespace DynamoCoreWpfTests
             var group1ViewModel = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == groupName);
             var inPortsBefore = group1ViewModel.InPorts.ToList();
             var outPortsBefore = group1ViewModel.OutPorts.ToList();
-            var inbetweenNodesBefore = group1ViewModel.InbetweenNodesCount;
 
             var expectedInPortNames = new List<string>
             {
@@ -904,10 +903,9 @@ namespace DynamoCoreWpfTests
             // Assert
             Assert.That(inPortsBefore.Count != group1ViewModel.InPorts.Count);
             Assert.That(outPortsBefore.Count != group1ViewModel.OutPorts.Count);
-            Assert.That(inbetweenNodesBefore != group1ViewModel.InbetweenNodesCount);
             CollectionAssert.AreEquivalent(expectedInPortNames, group1ViewModel.InPorts.Select(x => x.PortModel.Name));
             CollectionAssert.AreEquivalent(expectedOutPortNames, group1ViewModel.OutPorts.Select(x => x.PortModel.Name));
-            Assert.That(group1ViewModel.InbetweenNodesCount == 1);
+            Assert.That(group1ViewModel.NodeContentCount == 5);
 
         }
 


### PR DESCRIPTION
### Purpose

This PR partially handles [DYN-3984](https://jira.autodesk.com/browse/DYN-3984).
The solution here is build based on the mockup provided here: https://www.figma.com/file/rET1Ey29lUcTspVAwoJ9Vg/Group-New?node-id=0%3A1

Will handle nested groups in a separate PR.

![image](https://user-images.githubusercontent.com/13732445/135596682-42ffae97-5485-48ce-a572-d6373ccfef3b.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Jingyi-Wen 
@Amoursol 
