### PR TITLE
[DYN-3984] Handle nested groups breadcrumb

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -841,6 +842,34 @@ namespace Dynamo.Controls
         {
             List<object> list = (List<object>)value;
             return list.Count > 0; //spacing for Inputs + title space + bottom space
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Check if the collection has more items than the provided
+    /// parameter. If no parameter is provided the converter will
+    /// check if the collection has more than 1 item.
+    /// </summary>
+    public class CollectionHasMoreThanNItemsToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (!(value is ICollection collection))
+            {
+                return false;
+            }
+
+            if (parameter is int n)
+            {
+                return collection.Count > n;
+            }
+
+            return collection.Count > 1;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
@@ -3148,6 +3177,37 @@ namespace Dynamo.Controls
             }
 
             return Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Converts an ICollection<AnnotationViewModel> to a string
+    /// that displays how many AnnotationViewModels there is in the
+    /// Collection.
+    /// </summary>
+    [ValueConversion(typeof(ICollection<AnnotationViewModel>), typeof(string))]
+    public class NestedGroupsLabelConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is ICollection<AnnotationViewModel> viewModels) ||
+                !viewModels.Any())
+            {
+                return string.Empty;
+            }
+
+            var numberOfNestedGroups = viewModels.Count;
+            if (numberOfNestedGroups > 1)
+            {
+                return $"{numberOfNestedGroups} Groups";
+            }
+
+            return viewModels.FirstOrDefault().AnnotationText;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -171,4 +171,6 @@
         x:Key="PinIconForegroundConverter"
         FalseBrush="{StaticResource UnpinnedIconForegroundColor}"
         TrueBrush="{StaticResource PinnedIconForegroundColor}" />
+    <controls:NestedGroupsLabelConverter x:Key="NestedGroupsLabelConverter" />
+    <controls:CollectionHasMoreThanNItemsToBoolConverter x:Key="CollectionHasMoreThanNItemsToBoolConverter" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -276,6 +276,21 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Collection of the nested groups in this group.
+        /// This is used for displaying nested groups info
+        /// when this group is collapsed.
+        /// </summary>
+        public ICollection<AnnotationViewModel> NestedGroups
+        {
+            get => nestedGroups;
+            set
+            {
+                nestedGroups = value;
+                RaisePropertyChanged(nameof(NestedGroups));
+            }
+        }
+
+        /// <summary>
         /// Counter of all nodes in the group that
         /// aren't either an input or output node.
         /// This is used to display the amount of nodes
@@ -359,6 +374,8 @@ namespace Dynamo.ViewModels
         }
 
         private DelegateCommand removeGroupFromGroup;
+        private ICollection<AnnotationViewModel> nestedGroups;
+
         /// <summary>
         /// Command to remove this group from the group it
         /// belongs to.
@@ -865,6 +882,10 @@ namespace Dynamo.ViewModels
 
         private void HandleNodesCollectionChanges()
         {
+            NestedGroups = ViewModelBases
+                .OfType<AnnotationViewModel>()
+                .ToList();
+
             var allGroupedGroups = Nodes.OfType<AnnotationModel>();
             var removedFromGroup = GroupIdToCutGeometry.Keys
                 .ToList()

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -291,6 +291,21 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Collection of the nested groups in this group.
+        /// This is used for displaying nested groups info
+        /// when this group is collapsed.
+        /// </summary>
+        public ICollection<AnnotationViewModel> NestedGroups
+        {
+            get => nestedGroups;
+            set
+            {
+                nestedGroups = value;
+                RaisePropertyChanged(nameof(NestedGroups));
+            }
+        }
+
+        /// <summary>
         /// Counter of all nodes in the group that
         /// aren't either an input or output node.
         /// This is used to display the amount of nodes
@@ -886,6 +901,10 @@ namespace Dynamo.ViewModels
 
         private void HandleNodesCollectionChanges()
         {
+            NestedGroups = ViewModelBases
+                .OfType<AnnotationViewModel>()
+                .ToList();
+
             var allGroupedGroups = Nodes.OfType<AnnotationModel>();
             var removedFromGroup = GroupIdToCutGeometry.Keys
                 .ToList()

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -517,6 +517,7 @@ namespace Dynamo.ViewModels
         internal void SetGroupInputPorts()
         {
             InPorts.Clear();
+            InputNodes.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
             // we need to store the original ports here
@@ -554,6 +555,7 @@ namespace Dynamo.ViewModels
         internal void SetGroupOutPorts()
         {
             OutPorts.Clear();
+            OutputNodes.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
             // we need to store the original ports here

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -517,7 +517,6 @@ namespace Dynamo.ViewModels
         internal void SetGroupInputPorts()
         {
             InPorts.Clear();
-            InputNodes.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
             // we need to store the original ports here
@@ -555,7 +554,6 @@ namespace Dynamo.ViewModels
         internal void SetGroupOutPorts()
         {
             OutPorts.Clear();
-            OutputNodes.Clear();
             List<ProxyPortViewModel> newPortViewModels;
 
             // we need to store the original ports here

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -679,6 +679,10 @@ namespace Dynamo.ViewModels
         /// <param name="collapseConnectors"></param>
         private void CollapseGroupContents(bool collapseConnectors)
         {
+            NestedGroups = ViewModelBases
+                .OfType<AnnotationViewModel>()
+                .ToList();
+
             foreach (var viewModel in ViewModelBases)
             {
                 if (viewModel is AnnotationViewModel annotationViewModel)
@@ -882,10 +886,6 @@ namespace Dynamo.ViewModels
 
         private void HandleNodesCollectionChanges()
         {
-            NestedGroups = ViewModelBases
-                .OfType<AnnotationViewModel>()
-                .ToList();
-
             var allGroupedGroups = Nodes.OfType<AnnotationModel>();
             var removedFromGroup = GroupIdToCutGeometry.Keys
                 .ToList()

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -291,21 +291,6 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Collection of the nested groups in this group.
-        /// This is used for displaying nested groups info
-        /// when this group is collapsed.
-        /// </summary>
-        public ICollection<AnnotationViewModel> NestedGroups
-        {
-            get => nestedGroups;
-            set
-            {
-                nestedGroups = value;
-                RaisePropertyChanged(nameof(NestedGroups));
-            }
-        }
-
-        /// <summary>
         /// Counter of all nodes in the group that
         /// aren't either an input or output node.
         /// This is used to display the amount of nodes
@@ -901,10 +886,6 @@ namespace Dynamo.ViewModels
 
         private void HandleNodesCollectionChanges()
         {
-            NestedGroups = ViewModelBases
-                .OfType<AnnotationViewModel>()
-                .ToList();
-
             var allGroupedGroups = Nodes.OfType<AnnotationModel>();
             var removedFromGroup = GroupIdToCutGeometry.Keys
                 .ToList()

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -166,10 +166,24 @@
                                     Grid.Row="0"
                                     CornerRadius="{StaticResource ExpanderCornerRadius}"
                                     Padding="0"
-                                    Margin="0">
+                                    Margin="0"
+                                    ToolTipService.IsEnabled="{TemplateBinding IsExpanded, Converter={StaticResource InverseBooleanConverter}}">
                                 <Border.Background>
                                     <SolidColorBrush Color="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.Background}"></SolidColorBrush>
                                 </Border.Background>
+                                <Border.ToolTip>
+                                    <dynui:DynamoToolTip AttachmentSide="Top"
+                                                         Style="{DynamicResource ResourceKey=SLightToolTip}"
+                                                         Margin="5,0,0,0">
+                                        <StackPanel Orientation="Vertical"
+                                                    MaxWidth="320">
+                                            <TextBlock Text="{Binding AnnotationText}"
+                                                       Margin="0,0,0,10" />
+                                            <TextBlock Text="{Binding AnnotationDescriptionText}"
+                                                       TextWrapping="WrapWithOverflow" />
+                                        </StackPanel>
+                                    </dynui:DynamoToolTip>
+                                </Border.ToolTip>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -232,20 +246,6 @@
     <Grid Name="AnnotationGrid"
           Height="Auto"
           IsHitTestVisible="True">
-        <Grid.ToolTip>
-            <dynui:DynamoToolTip AttachmentSide="Top"
-                                 Style="{DynamicResource ResourceKey=SLightToolTip}"
-                                 Margin="5,0,0,0"
-                                 Visibility="{Binding IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
-                <StackPanel Orientation="Vertical"
-                            MaxWidth="320">
-                    <TextBlock Text="{Binding AnnotationText}"
-                               Margin="0,0,0,10" />
-                    <TextBlock Text="{Binding AnnotationDescriptionText}"
-                               TextWrapping="WrapWithOverflow" />
-                </StackPanel>
-            </dynui:DynamoToolTip>
-        </Grid.ToolTip>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
@@ -721,23 +721,69 @@
                               Margin="0,10">
                 </ItemsControl>
 
-                <Border x:Name="NodeCount"
-                        Grid.Row="1"
-                        Grid.ColumnSpan="3"
-                        VerticalAlignment="Center"
-                        BorderThickness="1"
-                        BorderBrush="#FFFFFF"
-                        Background="#EEEEEE"
-                        CornerRadius="{Binding Path=ActualHeight, ElementName=NodeCount}"
-                        Width="{Binding Path=ActualHeight, ElementName=NodeCount}"
-                        Height="32"
-                        Padding="0"
-                        Margin="10">
-                    <TextBlock Text="{Binding NodeContentCount, Mode=OneWay, StringFormat='+{0}'}"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               FontSize="14" />
-                </Border>
+                <Grid x:Name="GroupContent"
+                      Grid.Row="1"
+                      Grid.ColumnSpan="3">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label x:Name="NestedGroups"
+                           Grid.Column="0"
+                           Content="{Binding NestedGroups, Converter={StaticResource NestedGroupsLabelConverter}}"
+                           Margin="0"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Right"
+                           ToolTipService.ShowOnDisabled="False"
+                           ToolTipService.IsEnabled="{Binding NestedGroups, Converter={StaticResource CollectionHasMoreThanNItemsToBoolConverter}}">
+                        <Label.ToolTip>
+                            <dynui:DynamoToolTip AttachmentSide="Bottom"
+                                                 Style="{DynamicResource ResourceKey=SLightToolTip}"
+                                                 Margin="5,0,0,0">
+                                <ListView ItemsSource="{Binding NestedGroups}">
+                                    <ListView.Resources>
+                                        <DataTemplate x:Key="MultipleItems"
+                                                      DataType="{x:Type viewModels:AnnotationViewModel}">
+                                            <TextBlock Text="{Binding AnnotationText}" />
+                                        </DataTemplate>
+                                    </ListView.Resources>
+                                    <ListView.Style>
+                                        <Style TargetType="{x:Type ListView}">
+                                            <Setter Property="Background"
+                                                    Value="Transparent" />
+                                            <Setter Property="BorderThickness"
+                                                    Value="0" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding NestedGroups, 
+                                                                        Converter={StaticResource CollectionHasMoreThanNItemsToBoolConverter}}"
+                                                             Value="True">
+                                                    <Setter Property="ItemTemplate"
+                                                            Value="{StaticResource MultipleItems}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ListView.Style>
+                                </ListView>
+                            </dynui:DynamoToolTip>
+                        </Label.ToolTip>
+                    </Label>
+
+                    <Border x:Name="NodeCount"
+                            Grid.Column="1"
+                            BorderThickness="1"
+                            BorderBrush="#FFFFFF"
+                            Background="#EEEEEE"
+                            CornerRadius="{Binding Path=ActualHeight, ElementName=NodeCount}"
+                            Width="{Binding Path=ActualHeight, ElementName=NodeCount}"
+                            Height="32"
+                            Margin="10">
+                        <TextBlock Text="{Binding NodeContentCount, Mode=OneWay, StringFormat='+{0}'}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontSize="14" />
+                    </Border>
+                </Grid>
             </Grid>
         </Border>
     </Grid>

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -906,7 +906,6 @@ namespace DynamoCoreWpfTests
             CollectionAssert.AreEquivalent(expectedInPortNames, group1ViewModel.InPorts.Select(x => x.PortModel.Name));
             CollectionAssert.AreEquivalent(expectedOutPortNames, group1ViewModel.OutPorts.Select(x => x.PortModel.Name));
             Assert.That(group1ViewModel.NodeContentCount == 5);
-
         }
 
 


### PR DESCRIPTION
### NOTE
**This PR is based on #12094 so please merge that before this.**

### Purpose

This PR handles last part of [DYN-3984](https://jira.autodesk.com/browse/DYN-3984), by adding nested groups breadcrumbs to the parent group.

![image](https://user-images.githubusercontent.com/13732445/135617605-9d8e959b-9bb2-4bc8-b873-1a9caee18539.png)
![image](https://user-images.githubusercontent.com/13732445/135617668-d5231e95-1e23-453e-a0e2-42809873f455.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Jingyi-Wen 
@Amoursol 
