### PR TITLE
[DYN-4079] Nested groups show strange transparency

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -681,7 +681,8 @@
                          Height="{Binding ModelAreaHeight}"
                          IsHitTestVisible="True"
                          Background="Transparent"
-                         Opacity="0.5">
+                         Opacity="0.5"
+                         Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                     <Path Stroke="Transparent"
                           StrokeThickness="0">
                         <Path.Fill>
@@ -740,6 +741,9 @@
                 Width="{Binding Width}"
                 Visibility="{Binding ElementName=GroupExpander, Path=IsExpanded, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"
                 Grid.Row="1">
+            <Border.Background>
+                <SolidColorBrush Color="{Binding Background}" Opacity="0.5" />
+            </Border.Background>
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -814,7 +818,6 @@
                     </ListView>
                 </Grid>
             </Grid>
-
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4079](https://jira.autodesk.com/browse/DYN-4079)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
