### PR TITLE
Node Renamed Badge Vertical Center Alignment

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -434,7 +434,7 @@
                 <Ellipse Name="nodeRenamedBlueDot"
                          Width="8"
                          Height="8"
-                         Margin="0,0,6,0"
+                         Margin="0,2,6,0"
                          Fill="{StaticResource Blue300Brush}"
                          Visibility="{Binding IsRenamed, Converter={StaticResource BooleanToVisibilityConverter}}" />
                 <Grid.ToolTip>


### PR DESCRIPTION
### Purpose

![Realignment](https://user-images.githubusercontent.com/29973601/135610855-2332316c-baf3-4474-82f9-202495151f87.jpg)

Vertically aligns the blue dot in the node header, indicating it has been renamed.
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
