### PR TITLE
Connector/ ConnectorPins Collapsable with Groups Fixes

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -32,18 +32,18 @@ namespace Dynamo.Graph.Connectors
     public class ConnectorModel : ModelBase
     {
         #region properties
-        private bool isCollapsed = false;
+        private bool isHidden = false;
 
         /// <summary>
-        /// IsCollapsed flag controlling the visibility of a connector
+        /// IsHidden flag controlling the visibility of a connector
         /// </summary>
-        public bool IsCollapsed
+        public bool IsHidden
         {
-            get { return isCollapsed; }
+            get { return isHidden; }
             set
             {
-                isCollapsed = value;
-                RaisePropertyChanged(nameof(IsCollapsed));
+                isHidden = value;
+                RaisePropertyChanged(nameof(IsHidden));
             }
         }
         /// <summary>
@@ -251,8 +251,8 @@ namespace Dynamo.Graph.Connectors
 
             switch (name)
             {
-                case nameof(IsCollapsed):
-                    IsCollapsed = Convert.ToBoolean(value);
+                case nameof(IsHidden):
+                    IsHidden = Convert.ToBoolean(value);
                     break;
                 default:
                     break;
@@ -268,14 +268,14 @@ namespace Dynamo.Graph.Connectors
             helper.SetAttribute("start_index", Start.Index);
             helper.SetAttribute("end", End.Owner.GUID);
             helper.SetAttribute("end_index", End.Index);
-            helper.SetAttribute(nameof(IsCollapsed), IsCollapsed);
+            helper.SetAttribute(nameof(IsHidden), IsHidden);
             //helper.SetAttribute("portType", ((int) End.PortType));
         }
 
         protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
         {
             var helper = new XmlElementHelper(nodeElement);
-            IsCollapsed = helper.ReadBoolean(nameof(IsCollapsed));
+            IsHidden = helper.ReadBoolean(nameof(IsHidden));
             //This is now handled via NodeGraph.LoadConnectorFromXml
         }
 

--- a/src/DynamoCore/Graph/NodeGraph.cs
+++ b/src/DynamoCore/Graph/NodeGraph.cs
@@ -90,8 +90,8 @@ namespace Dynamo.Graph
             var guidEnd = helper.ReadGuid("end");
             int startIndex = helper.ReadInteger("start_index");
             int endIndex = helper.ReadInteger("end_index");
-            bool isCollapsed = helper.HasAttribute(nameof(ConnectorModel.IsCollapsed)) ?
-                helper.ReadBoolean(nameof(ConnectorModel.IsCollapsed)):
+            bool isHidden = helper.HasAttribute(nameof(ConnectorModel.IsHidden)) ?
+                helper.ReadBoolean(nameof(ConnectorModel.IsHidden)) :
                 true;
 
             //find the elements to connect
@@ -104,7 +104,7 @@ namespace Dynamo.Graph
                     var connector = ConnectorModel.Make(start, end, startIndex, endIndex, guid);
                     if(connector != null)
                     {
-                        connector.IsCollapsed = isCollapsed;
+                        connector.IsHidden = isHidden;
                         return connector;
                     }
                 }

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -1187,9 +1187,9 @@ namespace Dynamo.Graph.Workspaces
             var obj = JObject.Load(reader);
             var startId = obj["Start"].Value<string>();
             var endId = obj["End"].Value<string>();
-            var isCollapsedExists = obj[nameof(ConnectorModel.IsCollapsed)];
-            
-            var isCollapsed = isCollapsedExists != null && obj[nameof(ConnectorModel.IsCollapsed)].Value<bool>();
+            var isHiddenExists = obj[nameof(ConnectorModel.IsHidden)];
+
+            var isHidden = isHiddenExists != null && obj[nameof(ConnectorModel.IsHidden)].Value<bool>();
 
             var resolver = (IdReferenceResolver)serializer.ReferenceResolver;
 
@@ -1217,7 +1217,7 @@ namespace Dynamo.Graph.Workspaces
             if(startPort != null && endPort != null)
             {
                 var connectorModel = new ConnectorModel(startPort, endPort, connectorId);
-                connectorModel.IsCollapsed = isCollapsed;
+                connectorModel.IsHidden = isHidden;
                 return connectorModel;
             }
             else
@@ -1245,8 +1245,8 @@ namespace Dynamo.Graph.Workspaces
             writer.WriteValue(connector.End.GUID.ToString("N"));
             writer.WritePropertyName("Id");
             writer.WriteValue(connector.GUID.ToString("N"));
-            writer.WritePropertyName(nameof(ConnectorModel.IsCollapsed));
-            writer.WriteValue(connector.IsCollapsed.ToString());
+            writer.WritePropertyName(nameof(ConnectorModel.IsHidden));
+            writer.WriteValue(connector.IsHidden.ToString());
             writer.WriteEndObject();
         }
     }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1791,7 +1791,7 @@ namespace Dynamo.Graph.Workspaces
                             connector.SetAttribute("start_index", c.Start.Index.ToString());
                             connector.SetAttribute("end", c.End.Owner.GUID.ToString());
                             connector.SetAttribute("end_index", c.End.Index.ToString());
-                            connector.SetAttribute(nameof(ConnectorModel.IsCollapsed), c.IsCollapsed.ToString());
+                            connector.SetAttribute(nameof(ConnectorModel.IsHidden), c.IsHidden.ToString());
 
                             if (c.End.PortType == PortType.Input)
                                 connector.SetAttribute("portType", "0");

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1306,7 +1306,7 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if ((bool)value)
+            if ((bool)value == true)
                 return Visibility.Collapsed;
             return Visibility.Visible;
         }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -40,20 +40,6 @@
 
     <Style x:Key="SConnector" TargetType="Path">
         <Style.Triggers>
-            <!--<EventTrigger RoutedEvent="MouseEnter">
-                <BeginStoryboard>
-                    <Storyboard>
-                        <DoubleAnimation From="3" To="6" Duration="0" Storyboard.TargetProperty="StrokeThickness"></DoubleAnimation>
-                    </Storyboard>
-                </BeginStoryboard>
-            </EventTrigger>
-            <EventTrigger RoutedEvent="MouseLeave">
-                <BeginStoryboard>
-                    <Storyboard>
-                        <DoubleAnimation From="6" To="3" Duration="0" Storyboard.TargetProperty="StrokeThickness"></DoubleAnimation>
-                    </Storyboard>
-                </BeginStoryboard>
-            </EventTrigger>-->
             <DataTrigger Binding="{Binding Path=IsConnecting, Mode=OneWay}" Value="True">
                 <Setter Property="StrokeDashArray" Value="2"/>
             </DataTrigger>
@@ -90,7 +76,32 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
-    
+    <Style x:Key="SEllipses" TargetType="Ellipse">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=IsTemporarilyDisplayed, Mode=OneWay}" Value="True"/>
+                    <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Opacity" Value="0.4"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=IsTemporarilyDisplayed, Mode=OneWay}" Value="False"/>
+                    <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Opacity" Value="0.0"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+            <DataTrigger Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="False">
+                <Setter Property="Opacity" Value="1.0"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <DataTemplate DataType="{x:Type viewModels:ConnectorViewModel}">
         <Grid x:Name="MainGrid"
               Visibility="Visible">
@@ -106,9 +117,9 @@
             </Grid.Resources>
 
             <Canvas x:Name="MainCanvas" Canvas.Top="0" Canvas.Left="0" ZIndex="1">
-                <Ellipse  Name="endDot" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
+                <Ellipse  Name="endDot" Style="{StaticResource SEllipses}" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
                           Canvas.Top="{Binding CurvePoint3.Y}" Canvas.Left="{Binding CurvePoint3.X}" Canvas.ZIndex="1"/>
-                <Ellipse  Name="startDot" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
+                <Ellipse  Name="startDot"  Style="{StaticResource SEllipses}" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
                           Canvas.Top="{Binding CurvePoint0.Y}" Canvas.Left="{Binding CurvePoint0.X}" Canvas.ZIndex="1"/>
             </Canvas>
 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -50,7 +50,7 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=IsTemporarilyDisplayed, Mode=OneWay}" Value="True"/>
-                    <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
+                    <Condition Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
                     <Setter Property="IsHitTestVisible" Value="True"/>
@@ -61,7 +61,7 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=IsTemporarilyDisplayed, Mode=OneWay}" Value="False"/>
-                    <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
+                    <Condition Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
                     <Setter Property="IsHitTestVisible" Value="False"/>
@@ -69,7 +69,7 @@
                     <Setter Property="ToolTipService.IsEnabled" Value="False"/>
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
-            <DataTrigger Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="False">
+            <DataTrigger Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="False">
                 <Setter Property="IsHitTestVisible" Value="True"/>
                 <Setter Property="Opacity" Value="1.0"/>
                 <Setter Property="ToolTipService.IsEnabled" Value="True"/>
@@ -81,7 +81,7 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=IsTemporarilyDisplayed, Mode=OneWay}" Value="True"/>
-                    <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
+                    <Condition Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
                     <Setter Property="Opacity" Value="0.4"/>
@@ -90,13 +90,13 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=IsTemporarilyDisplayed, Mode=OneWay}" Value="False"/>
-                    <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
+                    <Condition Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
                     <Setter Property="Opacity" Value="0.0"/>
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
-            <DataTrigger Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="False">
+            <DataTrigger Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="False">
                 <Setter Property="Opacity" Value="1.0"/>
             </DataTrigger>
         </Style.Triggers>
@@ -117,16 +117,18 @@
             </Grid.Resources>
 
             <Canvas x:Name="MainCanvas" Canvas.Top="0" Canvas.Left="0" ZIndex="1">
-                <Ellipse  Name="endDot" Style="{StaticResource SEllipses}" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
+                <Ellipse  Name="endDot" Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" 
+                          Style="{StaticResource SEllipses}" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
                           Canvas.Top="{Binding CurvePoint3.Y}" Canvas.Left="{Binding CurvePoint3.X}" Canvas.ZIndex="1"/>
-                <Ellipse  Name="startDot"  Style="{StaticResource SEllipses}" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
+                <Ellipse  Name="startDot" Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"
+                          Style="{StaticResource SEllipses}" Width="8" Height="8" Margin="-5"  Fill="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}" IsHitTestVisible="False"
                           Canvas.Top="{Binding CurvePoint0.Y}" Canvas.Left="{Binding CurvePoint0.X}" Canvas.ZIndex="1"/>
             </Canvas>
 
             <!--Bezier Path-->
             <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
               Name="connector"
-              Visibility="{Binding BezVisibility, Converter={StaticResource BooleanToVisibilityConverter}}" 
+              Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" 
               Style="{StaticResource SConnector}" Canvas.ZIndex="-1" 
                   Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
                 <i:Interaction.Behaviors>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -144,13 +144,16 @@
                 </i:Interaction.Triggers>
             </Path>
             <ContentControl Content="{Binding ConnectorContextMenuViewModel}"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"/>
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Panel.ZIndex="1"/>
             <ContentControl Content="{Binding ConnectorAnchorViewModel}"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"/>
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Panel.ZIndex="2"/>
             <ContentControl Content="{Binding ConnectorPinViewCollection}"
-                            ContentTemplate="{StaticResource ShowPinCollection}"/>
+                            ContentTemplate="{StaticResource ShowPinCollection}"
+                            Panel.ZIndex="3"/>
         </Grid>
         <DataTemplate.Triggers>
             <DataTrigger Binding="{Binding Path=IsFrozen, Mode=OneWay}" Value="True">               

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -67,6 +67,7 @@
                     <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
+                    <Setter Property="IsHitTestVisible" Value="True"/>
                     <Setter Property="Opacity" Value="0.4"/>
                     <Setter Property="ToolTipService.IsEnabled" Value="True"/>
                 </MultiDataTrigger.Setters>
@@ -77,11 +78,13 @@
                     <Condition Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
+                    <Setter Property="IsHitTestVisible" Value="False"/>
                     <Setter Property="Opacity" Value="0.0"/>
                     <Setter Property="ToolTipService.IsEnabled" Value="False"/>
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
             <DataTrigger Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="False">
+                <Setter Property="IsHitTestVisible" Value="True"/>
                 <Setter Property="Opacity" Value="1.0"/>
                 <Setter Property="ToolTipService.IsEnabled" Value="True"/>
             </DataTrigger>

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -135,7 +135,7 @@ namespace Dynamo.ViewModels
             get { return model.IsSelected; }
         }
 
-        private bool isCollapsed;
+        private bool isCollapsed = false;
         [JsonIgnore]
         public override bool IsCollapsed
         {
@@ -151,6 +151,23 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(IsCollapsed));
             }
         }
+
+        private bool isHidden;
+        public bool IsHidden
+        {
+            get => isHidden;
+            set
+            {
+                if (isHidden == value)
+                {
+                    return;
+                }
+
+                isHidden = value;
+                RaisePropertyChanged(nameof(IsHidden));
+            }
+        }
+
 
         private bool isTemporarilyVisible;
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -126,6 +126,11 @@ namespace Dynamo.ViewModels
             }
         }
         public bool isHoveredOver = false;
+        /// <summary>
+        /// This flag let's the ConnectorViewModel when it can and cannot run a ConnectorContextMenu. It CANNOT
+        /// do so when IsHoveredOver for any pin is set to true, as in that case we want only that ConnectorPins 
+        /// ContextMenu to be enabled on right click.
+        /// </summary>
         public bool IsHoveredOver
         {
             get => isHoveredOver;

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -125,6 +125,21 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(Top));
             }
         }
+        public bool isHoveredOver = false;
+        public bool IsHoveredOver
+        {
+            get => isHoveredOver;
+            set
+            {
+                if (isHoveredOver == value)
+                {
+                    return;
+                }
+
+                isHoveredOver = value;
+                RaisePropertyChanged(nameof(IsHoveredOver));
+            }
+        }
 
         /// <summary>
         /// Provides the ViewModel (this) with the selected state of the ConnectorPinModel.

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -175,6 +175,7 @@ namespace Dynamo.ViewModels
 
                 isCollapsed = value;
                 RaisePropertyChanged(nameof(IsCollapsed));
+                SetCollapseOfPins(IsCollapsed);
             }
         }
 
@@ -212,6 +213,15 @@ namespace Dynamo.ViewModels
             }
         }
 
+        private void SetCollapseOfPins(bool isCollapsed)
+        {
+            if (ConnectorPinViewCollection is null) { return; }
+
+            foreach (var pin in ConnectorPinViewCollection)
+            {
+                pin.IsCollapsed = isCollapsed;
+            }
+        }
         private void SetVisibilityOfPins(bool isHidden)
         {
             if (ConnectorPinViewCollection is null) { return; }
@@ -665,6 +675,8 @@ namespace Dynamo.ViewModels
                 CurrentPosition = MousePosition,
                 IsCollapsed = this.IsHidden
             };
+            //Updates PreviewState of connector.
+            ConnectorSelectionCommand.Execute(null);
             ConnectorContextMenuViewModel.RequestDispose += DisposeContextMenu;
         }
 
@@ -794,8 +806,6 @@ namespace Dynamo.ViewModels
         /// <param name="parameters"></param>
         private void InstantiateContextMenuCommandExecute(object parameters)
         {
-            //Updates PreviewState of connector.
-            ConnectorSelectionCommand.Execute(null);
             CreateContextMenu();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -670,6 +670,7 @@ namespace Dynamo.ViewModels
 
         internal void CreateContextMenu()
         {
+            ConnectorContextMenuViewModel = null;
             ConnectorContextMenuViewModel = new ConnectorContextMenuViewModel(this)
             {
                 CurrentPosition = MousePosition,
@@ -1049,6 +1050,11 @@ namespace Dynamo.ViewModels
             workspaceViewModel.Model.RecordAndDeleteModels(
                 new List<ModelBase>() { viewModelSender.Model });
             ConnectorModel.ConnectorPinModels.Remove(viewModelSender.Model);
+
+            if(ConnectorContextMenuViewModel!= null)
+            {
+                ConnectorContextMenuViewModel.RequestDispose += DisposeContextMenu;
+            }
         }
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -45,6 +45,7 @@ namespace Dynamo.ViewModels
         private bool connectorAnchorViewModelExists;
         private bool isDataFlowCollection;
         private bool anyPinSelected;
+        private bool anyPinHoveredOver = false;
         private double dotTop;
         private double dotLeft;
         private double endDotSize = 6;
@@ -495,7 +496,23 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(AnyPinSelected));
             }
         }
-
+        /// <summary>
+        /// This flag let's the ConnectorViewModel when it can and cannot run a ConnectorContextMenu. It CANNOT
+        /// do so when IsHoveredOver for any pin is set to true, as in that case we want only that ConnectorPins 
+        /// ContextMenu to be enabled on right click.
+        /// </summary>
+        public bool AnyPinHoveredOver
+        {
+            get
+            {
+                return anyPinHoveredOver;
+            }
+            set
+            {
+                anyPinHoveredOver = value;
+                RaisePropertyChanged(nameof(AnyPinHoveredOver));
+            }
+        }
         public bool IsFrozen
         {
             get { return model == null ? activeStartPort.Owner.IsFrozen : Nodevm.IsFrozen; }
@@ -849,7 +866,7 @@ namespace Dynamo.ViewModels
             MouseHoverCommand = new DelegateCommand(MouseHoverCommandExecute, CanRunMouseHover);
             MouseUnhoverCommand = new DelegateCommand(MouseUnhoverCommandExecute, CanRunMouseUnhover);
             PinConnectorCommand = new DelegateCommand(PinConnectorCommandExecute, x => true);
-            InstantiateContextMenuCommand = new DelegateCommand(InstantiateContextMenuCommandExecute, x => !IsConnecting);
+            InstantiateContextMenuCommand = new DelegateCommand(InstantiateContextMenuCommandExecute, x => !IsConnecting && !AnyPinHoveredOver);
             ConnectorSelectionCommand = new DelegateCommand(ConnectorSelectionCommandExecute, x => !IsConnecting);
         }
 
@@ -1023,9 +1040,13 @@ namespace Dynamo.ViewModels
         {
             switch (e.PropertyName)
             {
-                case nameof(ConnectorPinModel.IsSelected):
+                case nameof(ConnectorPinViewModel.IsSelected):
                     var vm = sender as ConnectorPinViewModel;
                     AnyPinSelected = vm.IsSelected;
+                    break;
+                case nameof(ConnectorPinViewModel.IsHoveredOver):
+                    vm = sender as ConnectorPinViewModel;
+                    AnyPinHoveredOver = vm.IsHoveredOver;
                     break;
                 default:
                     break;
@@ -1053,7 +1074,7 @@ namespace Dynamo.ViewModels
 
             if(ConnectorContextMenuViewModel!= null)
             {
-                ConnectorContextMenuViewModel.RequestDispose += DisposeContextMenu;
+                ConnectorContextMenuViewModel.DisposeViewModel();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -712,7 +712,7 @@ namespace Dynamo.ViewModels
                 .FirstOrDefault(x => x.Nodevm.NodeModel.GUID == _port.Owner.GUID);
 
             if (connectorViewModel == null) return false;
-            return connectorViewModel.IsCollapsed;
+            return connectorViewModel.IsHidden;
         }
 
 

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
@@ -22,7 +22,7 @@
             <Button.ContextMenu>
             <ContextMenu Name="MainContextMenu"
                          Style="{StaticResource ContextMenuStyle}"
-                         MouseLeave="OnMouseLeave"
+                         MouseLeave="OnMouseLeaveContextMenu"
                          ContextMenuClosing="OnContextMenuClosing">
                 <MenuItem x:Name="BreakItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderBreakConnections}" 
                           Command="{Binding BreakConnectionsSurrogateCommand}"/>

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:props="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-             mc:Ignorable="d">
+             mc:Ignorable="d"
+             MouseLeave="OnMouseLeave">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -17,11 +18,12 @@
     <Canvas Canvas.Top="0"
             Canvas.Left="0">
         <Button Canvas.Top="{Binding CurrentPosition.Y}"
-            Canvas.Left="{Binding CurrentPosition.X}" Height="10" Width="10" Visibility="Hidden" MouseLeave="OnMouseLeave">
+            Canvas.Left="{Binding CurrentPosition.X}" Height="2" Width="2" Visibility="Hidden">
             <Button.ContextMenu>
             <ContextMenu Name="MainContextMenu"
                          Style="{StaticResource ContextMenuStyle}"
-                         MouseLeave="OnMouseLeave">
+                         MouseLeave="OnMouseLeave"
+                         ContextMenuClosing="OnContextMenuClosing">
                 <MenuItem x:Name="BreakItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderBreakConnections}" 
                           Command="{Binding BreakConnectionsSurrogateCommand}"/>
                     <MenuItem x:Name="SelectItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderSelectConnected}" 

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml.cs
@@ -18,7 +18,6 @@ namespace Dynamo.Controls
             InitializeComponent();
             this.Loaded += InitializeCommands;
         }
-
         private void InitializeCommands(object sender, RoutedEventArgs e)
         {
             this.Loaded -= InitializeCommands;
@@ -26,13 +25,11 @@ namespace Dynamo.Controls
             MainContextMenu.DataContext = ViewModel;
             MainContextMenu.IsOpen = true;
         }
-
         private void OnMouseLeave(object sender, MouseEventArgs e)
         {
             MainContextMenu.MouseLeave -= OnMouseLeave;
             ViewModel.DisposeViewModel();
         }
-
         private void OnContextMenuClosing(object sender, ContextMenuEventArgs e)
         {
             MainContextMenu.ContextMenuClosing -= OnContextMenuClosing;

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml.cs
@@ -32,5 +32,11 @@ namespace Dynamo.Controls
             MainContextMenu.MouseLeave -= OnMouseLeave;
             ViewModel.DisposeViewModel();
         }
+
+        private void OnContextMenuClosing(object sender, ContextMenuEventArgs e)
+        {
+            MainContextMenu.ContextMenuClosing -= OnContextMenuClosing;
+            ViewModel.DisposeViewModel();
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml.cs
@@ -27,12 +27,18 @@ namespace Dynamo.Controls
         }
         private void OnMouseLeave(object sender, MouseEventArgs e)
         {
-            MainContextMenu.MouseLeave -= OnMouseLeave;
+            this.MouseLeave -= OnMouseLeave;
             ViewModel.DisposeViewModel();
         }
         private void OnContextMenuClosing(object sender, ContextMenuEventArgs e)
         {
             MainContextMenu.ContextMenuClosing -= OnContextMenuClosing;
+            ViewModel.DisposeViewModel();
+        }
+
+        private void OnMouseLeaveContextMenu(object sender, MouseEventArgs e)
+        {
+            MainContextMenu.MouseLeave -= OnMouseLeave;
             ViewModel.DisposeViewModel();
         }
     }

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -10,7 +10,6 @@
              MouseLeftButtonDown="OnPinMouseDown"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
              MouseLeave="OnPinViewMouseLeave"
-             Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"
              d:DataContext="{d:DesignInstance Type=viewModels:ConnectorViewModel}">
 
     <UserControl.Resources>
@@ -30,7 +29,8 @@
             </Canvas.ContextMenu>
 
         <Grid  x:Name="PinBtn"  Background="Transparent">
-            <Image Width="{Binding Model.Width}" Height="{Binding Model.Width}">
+            <Image Width="{Binding Model.Width}" Height="{Binding Model.Width}" Panel.ZIndex="10"
+                    Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
                 <Image.Style>
                     <Style TargetType="Image">
                         <Style.Triggers>

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:props="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-             xmlns:viewModels="clr-namespace:Dynamo.ViewModels"
              mc:Ignorable="d" 
              xmlns:ui="clr-namespace:Dynamo.UI"
              MouseLeftButtonDown="OnPinMouseDown"

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -27,8 +27,10 @@
             </Canvas.ContextMenu>
 
         <Grid  x:Name="PinBtn"  Background="Transparent">
-            <Image Width="{Binding Model.Width}" Height="{Binding Model.Width}" Panel.ZIndex="10"
-                    Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
+            <Image Width="{Binding Model.Width}" Height="{Binding Model.Width}"
+                    Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"
+                   MouseRightButtonDown="OnPinRightMouseButtonDown"
+                   MouseRightButtonUp ="OnPinRightMouseButtonUp">
                 <Image.Style>
                     <Style TargetType="Image">
                         <Style.Triggers>

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -10,20 +10,21 @@
              MouseLeftButtonDown="OnPinMouseDown"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
              MouseLeave="OnPinViewMouseLeave"
-             Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"
+             Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"
              d:DataContext="{d:DesignInstance Type=viewModels:ConnectorViewModel}">
 
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+                <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Canvas Left="{Binding Left, Mode=TwoWay}" Top="{Binding Top, Mode=TwoWay}">
         <Canvas.ContextMenu>
-                <ContextMenu>
+            <ContextMenu Style="{StaticResource ContextMenuStyle}">
                     <MenuItem Header="{x:Static props:Resources.ConnectorContextMenuHeaderUnpinConnector}" Command="{Binding UnpinConnectorCommand}"/>
                 </ContextMenu>
             </Canvas.ContextMenu>
@@ -33,11 +34,11 @@
                 <Image.Style>
                     <Style TargetType="Image">
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="True">
+                            <DataTrigger Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="True">
                                 <Setter Property="Opacity" Value="0.0"/>
                                 <Setter Property="ToolTipService.IsEnabled" Value="False"/>
                             </DataTrigger>
-                            <DataTrigger Binding="{Binding Path=IsCollapsed, Mode=OneWay}" Value="False">
+                            <DataTrigger Binding="{Binding Path=IsHidden, Mode=OneWay}" Value="False">
                                 <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/pin_default_48_48.png"/>
                                 <Setter Property="ToolTipService.IsEnabled" Value="True"/>
                             </DataTrigger>

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -9,8 +9,7 @@
              xmlns:ui="clr-namespace:Dynamo.UI"
              MouseLeftButtonDown="OnPinMouseDown"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
-             MouseLeave="OnPinViewMouseLeave"
-             d:DataContext="{d:DesignInstance Type=viewModels:ConnectorViewModel}">
+             MouseLeave="OnPinViewMouseLeave">
 
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml.cs
@@ -1,22 +1,11 @@
-﻿using System;
-using System.Linq;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Forms;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Threading;
 using Dynamo.Configuration;
-using Dynamo.Controls;
-using Dynamo.Graph.Connectors;
 using Dynamo.Selection;
 using Dynamo.UI;
-using Dynamo.UI.Controls;
-using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
-using DynCmd = Dynamo.Models.DynamoModel;
 using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 
 namespace Dynamo.Nodes

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml.cs
@@ -94,5 +94,14 @@ namespace Dynamo.Nodes
                 }
             }
         }
+        private void OnPinRightMouseButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            ViewModel.IsHoveredOver = true;
+        }
+
+        private void OnPinRightMouseButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            ViewModel.IsHoveredOver = false;
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/ConnectorContextMenuTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorContextMenuTests.cs
@@ -22,7 +22,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(contextMenuViewModel);
 
             //Assert 'IsCollapsed' property matches that of connectorViewModel.
-            Assert.AreEqual(connectorViewModel.IsCollapsed, contextMenuViewModel.IsCollapsed);
+            Assert.AreEqual(connectorViewModel.IsHidden, contextMenuViewModel.IsCollapsed);
 
             //Assert position between the same is the same.
             Assert.AreEqual(connectorViewModel.MousePosition, contextMenuViewModel.CurrentPosition);
@@ -80,13 +80,13 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorContextMenuTestFile.dyn");
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
-            bool initialVisibility = connectorViewModel.IsCollapsed;
+            bool initialVisibility = connectorViewModel.IsHidden;
             //Creates contextMenu.
             connectorViewModel.InstantiateContextMenuCommand.Execute(null);
             var contextMenuViewModel = connectorViewModel.ConnectorContextMenuViewModel;
             ///Toggles hide (visibility == off)
             contextMenuViewModel.HideConnectorSurrogateCommand.Execute(null);
-            Assert.AreEqual(connectorViewModel.IsCollapsed, !initialVisibility);
+            Assert.AreEqual(connectorViewModel.IsHidden, !initialVisibility);
         }
 
   

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -21,7 +21,7 @@ namespace DynamoCoreWpfTests
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
             // Default collapse state should be false when opening legacy graph
-            Assert.AreEqual(connectorViewModel.IsCollapsed, false);
+            Assert.AreEqual(connectorViewModel.IsHidden, false);
         }
 
         /// <summary>
@@ -120,10 +120,10 @@ namespace DynamoCoreWpfTests
         {
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
-            bool initialVisibility = connectorViewModel.IsCollapsed;
+            bool initialVisibility = connectorViewModel.IsHidden;
             ///Toggles hide (visibility == off)
             connectorViewModel.HideConnectorCommand.Execute(null);
-            Assert.AreEqual(connectorViewModel.IsCollapsed, !initialVisibility);
+            Assert.AreEqual(connectorViewModel.IsHidden, !initialVisibility);
         }
 
         /// <summary>
@@ -135,13 +135,13 @@ namespace DynamoCoreWpfTests
         {
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
-            bool initialVisibility = connectorViewModel.IsCollapsed;
+            bool initialVisibility = connectorViewModel.IsHidden;
             ///Toggles hide (visibility == off)
             connectorViewModel.HideConnectorCommand.Execute(null);
-            Assert.AreEqual(connectorViewModel.IsCollapsed, !initialVisibility);
+            Assert.AreEqual(connectorViewModel.IsHidden, !initialVisibility);
             ///Toggles hide on/off (visibility == on)
             connectorViewModel.HideConnectorCommand.Execute(null);
-            Assert.AreEqual(connectorViewModel.IsCollapsed, initialVisibility);
+            Assert.AreEqual(connectorViewModel.IsHidden, initialVisibility);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

This PR adds mostly focuses on getting connectors and connector pins to work correctly with groups. They now collapse/expand with groups. An additional flag is added to the ConnectorModel(`IsHidden`) to work in tandem with `IsCollapsed` (which now lives exclusively in the ConnectorViewModel). `IsCollapsed` comes from groups and thus doesn't require serialization whereas `IsHidden` is required for serialization as it tells the graph how to render any and all connectors when a graph is re-opened.

This PR also fixes the following:

- Connectors that are hidden/collapsed are no longer right-clickable.
- Correct styling for ConnectorPinView context menu for unpinning pin.
![ConnectorPins-GroupCollapsable-05 10 2021](https://user-images.githubusercontent.com/24754290/136059988-adc5f616-9b77-485f-b01b-d3b055842663.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 
@saintentropy 

### FYIs
@SHKnudsen 
@Amoursol 
