### PR TITLE
AGD-2094 : add model state property

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -418,8 +418,23 @@ namespace Dynamo.Models
 
             AnalyticsService.ShutDown();
 
+            State = DynamoModelState.NotStarted;
             OnShutdownCompleted(); // Notify possible event handlers.
         }
+
+        /// <summary>
+        /// Based on the DynamoModelState a dependent component can take certain 
+        /// decisions regarding its UI and functionality.
+        /// In order to be able to run a specified graph , DynamoModel needs to be 
+        /// at least in StartedUIless state. 
+        /// </summary>
+        public enum DynamoModelState { NotStarted, StartedUIless, StartedUI };
+
+        /// <summary>
+        /// The modelState tels us if the RevitDynamoModel was started and if has the
+        /// the Dynamo UI attached to it or not 
+        /// </summary>
+        public DynamoModelState State { get; internal set; } = DynamoModelState.NotStarted;
 
         protected virtual void PreShutdownCore(bool shutdownHost)
         {
@@ -860,6 +875,8 @@ namespace Dynamo.Models
             StartBackupFilesTimer();
 
             TraceReconciliationProcessor = this;
+
+            State = DynamoModelState.StartedUIless;
             // This event should only be raised at the end of this method.
             DynamoReady(new ReadyParams(this));
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -725,6 +725,8 @@ namespace Dynamo.ViewModels
             model.ComputeModelDeserialized += model_ComputeModelDeserialized;
 
             preferencesViewModel = new PreferencesViewModel(this);
+
+            model.State = DynamoModel.DynamoModelState.StartedUI;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose
As an API developer sometimes I want to know the current state of the DynamoModel.
This is needed in Generative Design, Player, and others.
Currently, there is similar state management in DynamoRevit but we want to bring this to a lower level so that all DynamoRevit and Player like clients can benefit from it.
We will further refactor DynamoRevit and declare the existing state management there deprecated.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @sm6srw 

### FYIs

@saintentropy 
