### PR TITLE
[DYN-4081] Fix nested groups copy-paste

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2424,8 +2424,7 @@ namespace Dynamo.Models
             // or does not belong to a group here.
             // We handle creation of nested groups when creating the
             // parent group.
-            var annotations = ClipBoard.OfType<AnnotationModel>()
-                .Where(x=>x.HasNestedGroups || !currentWorkspace.Annotations.ContainsModel(x));
+            var annotations = ClipBoard.OfType<AnnotationModel>();
 
             var xmlDoc = new XmlDocument();
 
@@ -2539,8 +2538,13 @@ namespace Dynamo.Models
                 //so adding the group after nodes / notes are added to workspace.
                 //select only those nodes that are part of a group.
                 var newAnnotations = new List<AnnotationModel>();
-                foreach (var annotation in annotations)
+                foreach (var annotation in annotations.OrderByDescending(a=>a.HasNestedGroups))
                 {
+                    if (modelLookup.ContainsKey(annotation.GUID))
+                    {
+                        continue;
+                    }
+
                     // If this group has nested group we need to create them first
                     if (annotation.HasNestedGroups)
                     {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -916,10 +916,18 @@ namespace Dynamo.ViewModels
                     // if annotation is selected its children should be added to selection too
                     foreach (var m in n.Nodes)
                     {
+                        if (m is AnnotationModel nestedGroup)
+                        {
+                            foreach (var model in nestedGroup.Nodes)
+                            {
+                                selection.AddUnique(model);
+                            }
+                        }
                         selection.AddUnique(m);
                     }
                 }
-                else if (n.IsSelected)
+                else if (n.IsSelected &&
+                    !Model.Annotations.ContainsModel(n))
                 {
                     selection.Remove(n);
                 }


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4081](https://jira.autodesk.com/browse/DYN-4081).

After the first fix for this, it was noticed that copying nested groups would only paste its content and not the group itself, that should be fixed in this.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

