### PR TITLE
Fix Package Search Manager Button Style Bug

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -14,6 +14,7 @@
         MinWidth="460"
         MinHeight="300"
         MaxWidth="600"
+        MaxHeight="700"
         AllowsTransparency="True"
         ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterOwner"
@@ -584,18 +585,69 @@
                                         Content="{Binding CanInstall, Converter={StaticResource InstalledButtonTextConverter}}"
                                         DockPanel.Dock="Right">
                                     <Button.Style>
-                                        <Style BasedOn="{StaticResource CtaButtonStyle}" TargetType="Button">
+                                        <Style TargetType="Button">
                                             <Setter Property="Template">
                                                 <Setter.Value>
                                                     <ControlTemplate TargetType="{x:Type Button}">
-                                                        <TextBlock Name="textBlock"
-                                                                   Padding="4,4,4,3"
-                                                                   VerticalAlignment="Center"
-                                                                   Cursor="Hand"
-                                                                   FontFamily="{StaticResource ArtifaktElementRegular}"
-                                                                   FontSize="11"
-                                                                   Text="{TemplateBinding Content}" />
+                                                        <Border Name="ButtonBorder"
+                                                                Height="25"
+                                                                Padding="5,0"
+                                                                BorderThickness="2"
+                                                                CornerRadius="2">
+                                                            <DockPanel LastChildFill="False">
+                                                                <TextBlock Name="textBlock"
+                                                                           Padding="4,4,4,3"
+                                                                           VerticalAlignment="Center"
+                                                                           Cursor="Hand"
+                                                                           DockPanel.Dock="Right"
+                                                                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                                           FontSize="11"
+                                                                           Text="{TemplateBinding Content}" />
+                                                                <Rectangle Width="10"
+                                                                           Height="10"
+                                                                           VerticalAlignment="Center"
+                                                                           DockPanel.Dock="Left">
+                                                                    <Rectangle.Style>
+                                                                        <Style TargetType="Rectangle">
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
+                                                                                    <Setter Property="Fill">
+                                                                                        <Setter.Value>
+                                                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/Add - disabled.png" />
+                                                                                        </Setter.Value>
+                                                                                    </Setter>
+                                                                                </DataTrigger>
+                                                                                <DataTrigger Binding="{Binding Path=CanInstall}" Value="False">
+                                                                                    <Setter Property="Fill">
+                                                                                        <Setter.Value>
+                                                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
+                                                                                        </Setter.Value>
+                                                                                    </Setter>
+                                                                                </DataTrigger>
+                                                                                <MultiDataTrigger>
+                                                                                    <MultiDataTrigger.Conditions>
+                                                                                        <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
+                                                                                        <Condition Binding="{Binding Path=CanInstall}" Value="True" />
+                                                                                    </MultiDataTrigger.Conditions>
+                                                                                    <Setter Property="Fill">
+                                                                                        <Setter.Value>
+                                                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/Add - default.png" />
+                                                                                        </Setter.Value>
+                                                                                    </Setter>
+                                                                                </MultiDataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </Rectangle.Style>
+                                                                </Rectangle>
+                                                            </DockPanel>
+                                                        </Border>
                                                         <ControlTemplate.Triggers>
+                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#4A4A4A" />
+                                                            </Trigger>
+                                                            <Trigger Property="IsPressed" Value="True">
+                                                                <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#5F5F5F" />
+                                                            </Trigger>
                                                             <Trigger Property="IsEnabled" Value="False">
                                                                 <Setter Property="TextBlock.Foreground" Value="#999999" />
                                                             </Trigger>
@@ -612,43 +664,6 @@
                                         </Style>
                                     </Button.Style>
                                 </Button>
-                                <Rectangle Width="10"
-                                           Height="10"
-                                           Margin="5,0,0,0"
-                                           VerticalAlignment="Center"
-                                           DockPanel.Dock="Right">
-                                    <Rectangle.Style>
-                                        <Style TargetType="Rectangle">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
-                                                    <Setter Property="Fill">
-                                                        <Setter.Value>
-                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/Add - disabled.png" />
-                                                        </Setter.Value>
-                                                    </Setter>
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Path=CanInstall}" Value="False">
-                                                    <Setter Property="Fill">
-                                                        <Setter.Value>
-                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
-                                                        </Setter.Value>
-                                                    </Setter>
-                                                </DataTrigger>
-                                                <MultiDataTrigger>
-                                                    <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
-                                                        <Condition Binding="{Binding Path=CanInstall}" Value="True" />
-                                                    </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Fill">
-                                                        <Setter.Value>
-                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/Add - default.png" />
-                                                        </Setter.Value>
-                                                    </Setter>
-                                                </MultiDataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Rectangle.Style>
-                                </Rectangle>
 
                                 <!--  Contains Package Name and New Label  -->
                                 <Grid Margin="0,0,0,0" DockPanel.Dock="Left">
@@ -718,8 +733,8 @@
                                            Height="9"
                                            Margin="0,0,0,1"
                                            VerticalAlignment="Center"
-                                           Visibility="{Binding Path=Model.Hosts, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}"
-                                           DockPanel.Dock="Left">
+                                           DockPanel.Dock="Left"
+                                           Visibility="{Binding Path=Model.Hosts, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}">
                                     <Rectangle.Fill>
                                         <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/Requirements - disabled.png" />
                                     </Rectangle.Fill>
@@ -728,9 +743,8 @@
                                            Margin="5,0"
                                            DockPanel.Dock="Left"
                                            Style="{StaticResource resultLabelStyle}"
-                                           Visibility="{Binding Path=Model.Hosts, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}"
-                                           Text="{Binding Model.Hosts, Converter={StaticResource DependencyListToStringConverter}}">
-                                </TextBlock>
+                                           Text="{Binding Model.Hosts, Converter={StaticResource DependencyListToStringConverter}}"
+                                           Visibility="{Binding Path=Model.Hosts, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}" />
                             </DockPanel>
 
                             <!--  Bottom Row  -->


### PR DESCRIPTION
### Purpose

This PR fixes a broken button style on the package search view.
It also sets a MaxHeight of 700px to the window, otherwise it can be stretched to an unlimited height.

![XKbnAxWNEB](https://user-images.githubusercontent.com/29973601/136762442-ace59a1c-474e-43c2-9f6b-35645f7698fc.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
