### PR TITLE
Fix Port Value Marker Color Bug

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -20,7 +20,7 @@ namespace Dynamo.ViewModels
 
         private bool showUseLevelMenu;
 
-        private static SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
+        private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
         private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
         private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
 
@@ -261,7 +261,7 @@ namespace Dynamo.ViewModels
             // Port isn't connected and has no default value (or isn't using it)
             else
             {
-                PortValueMarkerColor = !port.IsConnected ? PortValueMarkerRed : PortValueMarkerBlue;
+                PortValueMarkerColor = port.IsConnected ? PortValueMarkerBlue : PortValueMarkerRed;
                 PortBackgroundColor = PortBackgroundColorDefault;
                 PortBorderBrushColor = PortBorderBrushColorDefault;
             }


### PR DESCRIPTION
### Purpose

This PR fixes a recent bug where node input ports weren't updating their styles in relation to their connected status, default value status or list level status when the graph first loads. The bug appears to stem from the private property `portValueMarkerColor` being set to static. This PR undoes this change, which appears to fix the bug.

Note: As an aside, I simplified the double-negative logic I spotted in a ternary statement.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang  

### FYIs

@saintentropy 