### PR TITLE
Revert Connector Selection Color

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -41,12 +41,12 @@
         x:Key="ConnectionStateToColorConverter"
         ExecutionPreview="#F2930C"
         None="#444"
-        Selection="#0C92DF"
+        Selection="#6AC0E7"
         Hover="#808080"/>
 
     <controls:ConnectionStateToBrushConverter x:Key="ConnectionStateToBrushConverter"
                                               ExecutionPreviewBrush="#F2930C"
-                                              SelectionBrush="#0C92DF"
+                                              SelectionBrush="#6AC0E7"
                                               HoverBrush="#808080"
                                               NoneBrush="#444">
     </controls:ConnectionStateToBrushConverter>


### PR DESCRIPTION
### Purpose

This PR reverts a recent change which undid some of the newer styling on Connectors.xaml. An incorrect color resource led to nodes' section borders and connectors displaying different colors, like so: 

![image](https://user-images.githubusercontent.com/29973601/136800912-80ca3e10-4f99-464f-a9c7-70b24bdea9a4.png)

This change reverts the mistake, reinstating a single, consistent color, like so: 

![image](https://user-images.githubusercontent.com/29973601/136801067-aa08cdab-35fd-4333-8bae-38e6ced02fa9.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
