### PR TITLE
Can not unhide wires

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -234,7 +234,7 @@ namespace Dynamo.ViewModels
                 return false;
             }
 
-            return connectorViewModel.IsCollapsed;
+            return connectorViewModel.IsHidden;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

https://github.com/DynamoDS/Dynamo/pull/12113 moved the wire hidden property object to `IsHidden`.  This instance of `IsCollapsed` was not not migrated to `IsHidden` and consequently does not set the node menu to "Show Wires" after hiding the wires.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@M-JULIANI @QilongTang 

### FYIs
