### PR TITLE
Updates StartPage Fonts

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml
@@ -45,7 +45,7 @@
             <TextBlock Margin="8,0,0,0"
                        FontSize="11"
                        Width="172"
-                       FontFamily="{StaticResource OpenSansRegular}"
+                       FontFamily="{StaticResource ArtifaktElementRegular}"
                        Text="{x:Static p:Resources.StartPageStart}"
                        Foreground="#888888"
                        VerticalAlignment="Center" />
@@ -104,8 +104,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{x:Static p:Resources.StartPageFiles}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#3395a2"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -120,8 +120,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{x:Static p:Resources.StartPageRecent}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#62895b"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -138,8 +138,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{Binding Path=BackupTitle}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#ad5446"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -163,7 +163,7 @@
 
                         <Label Grid.Column="0"
                            Name ="openAll"
-                           FontFamily="{StaticResource OpenSansRegular}"
+                           FontFamily="{StaticResource ArtifaktElementRegular}"
                            Margin="0,0,0,0"
                            HorizontalAlignment="Left"
                            Style="{StaticResource StartPageLabel}"
@@ -171,7 +171,7 @@
                            MouseLeftButtonUp="OpenAllFilesOnCrash" />
                         <Label Grid.Column="1"
                            Name ="backupLocation"
-                           FontFamily="{StaticResource OpenSansRegular}"
+                           FontFamily="{StaticResource ArtifaktElementRegular}"
                            Margin="0,0,0,0"
                            HorizontalAlignment="Right"
                            Style="{StaticResource StartPageLabel}"
@@ -190,8 +190,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{x:Static p:Resources.StartPageAsk}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#a55553"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -206,8 +206,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{x:Static p:Resources.StartPageReference}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#6f4c76"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -222,8 +222,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{x:Static p:Resources.StartPageCode}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#4b9dbf"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -238,8 +238,8 @@
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{x:Static p:Resources.StartPageSamples}"
-                                   FontSize="13"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontSize="18"
+                                   FontFamily="{StaticResource ArtifaktElementBold}"
                                    Foreground="#5e8f80"
                                    Margin="0,0,12,0"
                                    HorizontalAlignment="Right" />
@@ -250,7 +250,7 @@
                               Grid.Row="3"
                               Grid.ColumnSpan="2"
                               BorderThickness="0"
-                              FontSize="15"
+                              FontSize="16"
                               ItemContainerStyle="{StaticResource StartPageTreeViewItem}"
                               Style="{StaticResource StartPageTreeView}">
                         <TreeView.ItemTemplate>
@@ -263,7 +263,7 @@
                         </TreeView.ItemTemplate>
                     </TreeView>
 
-                    <Label FontFamily="{StaticResource OpenSansRegular}"
+                    <Label FontFamily="{StaticResource ArtifaktElementBold}"
                            Margin="0,0,12,0"
                            HorizontalAlignment="Left"
                            Style="{StaticResource StartPageLabel}"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1529,7 +1529,7 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="true" />
-        <Setter Property="MaxHeight" Value="190" />
+        <Setter Property="MaxHeight" Value="220" />
         <Setter Property="Margin" Value="0,0,0,60" />
         <Setter Property="Template">
             <Setter.Value>
@@ -1554,13 +1554,13 @@
                                    Visibility="{Binding IconVisibility}" />
                             <TextBlock Margin="6,7,0,8"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource OpenSansRegular}"
-                                       FontSize="14"
+                                       FontFamily="{StaticResource ArtifaktElementRegular}"
+                                       FontSize="16"
                                        Text="{Binding Caption}" />
                             <TextBlock Margin="16,0,0,0"
                                        VerticalAlignment="Center"
-                                       FontFamily="{StaticResource OpenSansRegular}"
-                                       FontSize="10"
+                                       FontFamily="{StaticResource ArtifaktElementRegular}"
+                                       FontSize="12"
                                        Foreground="#888"
                                        Text="{Binding SubScript}" />
                         </StackPanel>
@@ -1616,8 +1616,8 @@
                             <ContentControl />
                             <Label x:Name="label"
                                    Content="{TemplateBinding Content}"
-                                   FontFamily="{StaticResource OpenSansRegular}"
-                                   FontSize="12"
+                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                   FontSize="16"
                                    Foreground="#888888" />
                         </StackPanel>
                     </Border>


### PR DESCRIPTION
### Purpose

This PR updates the FontFamily and FontSize properties for labels/headers on StartPage.xaml.
It replace the older OpenSans font with ArtifaktElement in its Regular and Bold formats.
Headers are in ArtifaktElementBold 18px, other text is in ArtifaktElementRegular 16px.

It also slightly enlarges the Recent Files listbox, so that it comfortably displays 5 recent files (which are slightly larger now due to the font change). 

![MicrosoftTeams-image](https://user-images.githubusercontent.com/29973601/138086245-33179594-4b30-4cc9-831d-1fab2b9821d9.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
@Amoursol 