### PR TITLE
Fixes Context Menu UI Bug

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2610,7 +2610,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ContextMenu}">
                     <Border x:Name="Border"
-                            Background="{StaticResource NodeContextMenuBackground}"
+                            Background="{TemplateBinding Background}"
                             BorderThickness="0px">
                         <StackPanel Margin="0,10"
                                     ClipToBounds="True"

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
@@ -22,6 +22,7 @@
             <Button.ContextMenu>
             <ContextMenu Name="MainContextMenu"
                          Style="{StaticResource ContextMenuStyle}"
+                         Background="#666666"
                          MouseLeave="OnMouseLeaveContextMenu"
                          ContextMenuClosing="OnContextMenuClosing">
                 <MenuItem x:Name="BreakItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderBreakConnections}" 

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -21,7 +21,7 @@
 
     <Canvas Left="{Binding Left, Mode=TwoWay}" Top="{Binding Top, Mode=TwoWay}">
         <Canvas.ContextMenu>
-            <ContextMenu Style="{StaticResource ContextMenuStyle}">
+            <ContextMenu Style="{StaticResource ContextMenuStyle}" Background="{StaticResource NodeContextMenuBackground}">
                     <MenuItem Header="{x:Static props:Resources.ConnectorContextMenuHeaderUnpinConnector}" Command="{Binding UnpinConnectorCommand}"/>
                 </ContextMenu>
             </Canvas.ContextMenu>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -49,6 +49,7 @@
         <Grid.ContextMenu>
             <ContextMenu Name="MainContextMenu"
                          x:FieldModifier="public"
+                         Background="{StaticResource NodeContextMenuBackground}"
                          Closed="MainContextMenu_OnClosed"
                          Style="{StaticResource ContextMenuStyle}">
                 <ContextMenu.Resources>


### PR DESCRIPTION
### Purpose

My previous PR to update the ContextMenuStyle led to a UI bug in the PackageManagerSearchView Filter/Sort context menus, which looks like this:

![image](https://user-images.githubusercontent.com/29973601/138251166-d353d801-683f-4707-a9ba-d4ee964ab58c.png)

This PR switches the ContextMenuStyle's Background property to use a TemplateBinding, meaning the value for the context menu background is set locally. This means we can use the same style resource to handle ContextMenus which are designed to have different background colours. I have manually updated the background to the appropriate value wherever ContextMenuStyle is used (nodes, connectors, PackageManagerSearchView).

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
