### PR TITLE
Node Autocomplete Style Updates

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -37,7 +37,15 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid PreviewKeyDown="OnInCanvasSearchKeyDown">
+    <Grid>
+        <Border Margin="0"
+                BorderBrush="{StaticResource WorkspaceBackgroundHomeBrush}"
+                BorderThickness="1"
+                CornerRadius="7,7,0,0"
+                Panel.ZIndex="1"
+                IsHitTestVisible="False" />
+
+        <Grid PreviewKeyDown="OnInCanvasSearchKeyDown">
         <Grid.RowDefinitions>
             <RowDefinition Height="30" />
             <RowDefinition Height="*" />
@@ -50,7 +58,8 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Border Background="{StaticResource autocompletionWindow}"
-                    Padding="0">
+                    Padding="0"
+                    CornerRadius="8,8,0,0">
                 <Grid>
                     <StackPanel Name="AutoCompletionHeader"
                                 Grid.ColumnSpan="1"
@@ -60,7 +69,7 @@
                         <TextBlock Text="{x:Static resx:Resources.Autocomplete}"
                                TextWrapping="Wrap"
                                Padding="4"
-                               Margin="80,0,0,0"
+                               Margin="80,1.75,0,0"
                                Foreground="{StaticResource SearchTextBoxBackground}"
                                TextAlignment="Center"
                                FontSize="14">
@@ -187,7 +196,7 @@
                                                     Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
                                    HorizontalAlignment="Center"
                                    Height="18"
-                                   Margin="2,0,0,0"
+                                   Margin="2,2,0,0"
                                    Text="{x:Static resx:Resources.AutocompleteSearchTextBlockText}" />
 
                     </StackPanel>
@@ -209,5 +218,6 @@
             </Border>
         </Grid>
 
+    </Grid>
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -54,6 +54,7 @@
     <SolidColorBrush x:Key="WorkspaceTabHeaderInactiveTextBrush" Color="#777777" />
     <SolidColorBrush x:Key="WorkspaceBackgroundHomeBrush" Color="{StaticResource WorkspaceBackgroundHome}" />
     <SolidColorBrush x:Key="WorkspaceBackgroundCustomBrush" Color="{StaticResource WorkspaceBackgroundCustom}" />
+    <SolidColorBrush x:Key="WorkspaceBackGroundHomeBrush" Color="{StaticResource WorkspaceBackgroundHome}" />
 
     <SolidColorBrush x:Key="WorkspaceTabBorderSelectedTrue" Color="#353535" />
     <SolidColorBrush x:Key="WorkspaceTabBorderSelectedFalse" Color="#232323" />
@@ -76,7 +77,9 @@
     <!--  Node colors in selected state  -->
     <SolidColorBrush x:Key="outerBorderSelection" Color="#4192d9" />
 
-    <SolidColorBrush x:Key="autocompletionWindow" Color="#4192d9" />
+    <!-- Node Autocomplete -->
+    <SolidColorBrush x:Key="autocompletionWindow" Color="#535353" />
+    <SolidColorBrush x:Key="autocompletionWindowFont" Color="#F5F5F5" />
 
     <!--  Update Manager  -->
     <SolidColorBrush x:Key="UpdateManagerUpdateAvailableBrush" Color="OrangeRed" />

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -617,7 +617,7 @@
                 Grid.RowSpan="4"
                 Grid.ColumnSpan="3"
                 Margin="-1"
-                BorderBrush="#F9F9F9"
+                BorderBrush="{StaticResource WorkspaceBackgroundHomeBrush}"
                 BorderThickness="1"
                 Canvas.ZIndex="5"
                 CornerRadius="8,8,0,0"


### PR DESCRIPTION
Updates to the Style of Node Autocomplete to match the new Dynamo Visual Refresh.

Existing State in Dynamo 2.12:
![image](https://user-images.githubusercontent.com/12857357/138317261-de319d09-322d-42b9-9e23-df662355e36b.png)

New proposed state for Dynamo 2.13:
![image](https://user-images.githubusercontent.com/12857357/138317523-0b1463ef-67a2-4f51-8a11-75d926be7bf6.png)


Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

The purpose of this PR is to update the Node Autocomplete window to match the new Visual Refresh styling, by doing the following:

- Changing the background color of the header to match the new Node Header
- Ensuring the header text "Autocomplete" is correctly centered
- Ensuring the Search text "Search Autocomplete Results" is correctly centered
- Adding in a 1px border that matches the background color
- Introducing a new brush style that matches the background color so that future changes will propagate

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner - Can you please have a look at let me know if anything needs changing? 

### FYIs

@QilongTang
@jasonstratton 
@Jingyi-Wen 
