### PR TITLE
DYN-4168-GuideBackground-Split-Fix

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/MenuStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/MenuStyleDictionary.xaml
@@ -250,7 +250,7 @@
                              TargetType="MenuItem">
                 <Border Name="Border"
                         Height="25" Background="Transparent">
-                    <Grid>
+                    <Grid Name="SubmenuItemGrid">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="15"/>
                             <ColumnDefinition Width="*"
@@ -259,35 +259,6 @@
                                               SharedSizeGroup="Shortcut" />
                             <ColumnDefinition Width="10" />
                         </Grid.ColumnDefinitions>
-                        <!--This rectangle will be used by the Guided tours when we need to highlight a SubMenuItem (due that shown a Popup we cannot use the normal highlight rectangle-->
-                        <Rectangle x:Name="HighlightRectangle"
-                                   Grid.Column="0"
-                                   Grid.ColumnSpan="2"
-                                   Stroke="Transparent"
-                                   Visibility="Collapsed"
-                                   Width="Auto"
-                                   Fill="Transparent"
-                                   StrokeThickness="2">
-                            <Rectangle.Effect>
-                                <BlurEffect Radius="1.0"
-                                            KernelType="Box"/>
-                            </Rectangle.Effect>
-                            <!--When the Rectangle is Loaded we will be showing a glow increasing a decreasing using the BlurEffect--> 
-                            <Rectangle.Triggers>
-                                <EventTrigger RoutedEvent="Rectangle.Loaded">
-                                    <BeginStoryboard>
-                                        <Storyboard>
-                                            <DoubleAnimation Storyboard.TargetName="HighlightRectangle"
-                                                             Storyboard.TargetProperty="(Effect).Radius"
-                                                             From="0.0" To="4.0" 
-                                                             Duration="0:0:1" 
-                                                             AutoReverse="True" 
-                                                             RepeatBehavior="Forever" />
-                                        </Storyboard>
-                                    </BeginStoryboard>
-                                </EventTrigger>
-                            </Rectangle.Triggers>
-                        </Rectangle>
                         <ContentPresenter Name="Icon"
                                           Grid.Column="0"
                                           Margin="6,0,6,0"


### PR DESCRIPTION
### Purpose

Due that I added a Rectangle in the MenuStyleDictionary.xaml for the Sub MenuItems then we had possibility of decreasing the Performance because all the MenuItems will have this Rectangle, then I did a change for removing the Rectangle from the MenuItems template and add it just when a specific Step is shown and remove it when the Step is hidden or when exiting the guide (this will happen just for the Step 2 from the Packages guide).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
