### PR TITLE
Remove margin for Run Button

### DIFF
--- a/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
+++ b/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
@@ -38,7 +38,6 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate>
-
                             <Border x:Name="container"
                                     Background="Transparent"
                                     BorderBrush="#FF23A597"
@@ -46,9 +45,7 @@
                                     BorderThickness="1">
                                 <Grid x:Name="inner"
                                       Background="#FF23A597">
-
                                     <TextBlock x:Name="text"
-                                               Margin="10,10,10,10"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center"
                                                FontSize="14px"


### PR DESCRIPTION
### Purpose

This PR fixes a small bug where the content of the Run Button would be slightly cut off when pressed

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
