### PR TITLE
DYN-4142-GetStarted-Localization

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -60,6 +60,10 @@ namespace Dynamo.Controls
     {
         public const string BackgroundPreviewName = "BackgroundPreview";
 
+        //The "Packages" and "Get Started" strings needs to be hardcoded due that are hardcoded in the json file (no need localization)
+        private static string GetStartedGuideName = "Get Started";
+        private static string PackagesGuideName = "Packages";
+
         private const int navigationInterval = 100;
         // This is used to determine whether ESC key is being held down
         private bool IsEscKeyPressed = false;
@@ -2342,8 +2346,7 @@ namespace Dynamo.Controls
             //We pass the root UIElement to the GuidesManager so we can found other child UIElements
             try
             {
-                //The "Get Started" string needs to be hardcoded due that is hardcoded in the json file (no need localization)
-                dynamoViewModel.MainGuideManager.LaunchTour("Get Started");
+                dynamoViewModel.MainGuideManager.LaunchTour(GetStartedGuideName);
             }
             catch (Exception ex)
             {
@@ -2361,8 +2364,7 @@ namespace Dynamo.Controls
         {
             try
             {
-                //The "Packages" string needs to be hardcoded due that is hardcoded in the json file (no need localization)
-                dynamoViewModel.MainGuideManager.LaunchTour("Packages");
+                dynamoViewModel.MainGuideManager.LaunchTour(PackagesGuideName);
             }
             catch (Exception)
             {


### PR DESCRIPTION
### Purpose

The Guides were not starting when using a different language due that we were passing to the MainGuideManager.LaunchTour() method a resource string parameter that was translated previously, then the Guide was not found when searching by Guide.Name.
For fixing the issue we need to use a hardcoded string with the same value than the Guide.Name in the json file (the resources cannot be deleted due that are used in other places) .

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
