### PR TITLE
DYN-4216: Adding Release notes section on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,11 @@ Check these if you believe they are true
 - [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
 - [ ] This PR modifies some build requirements and the readme is updated
 
+### Release Notes
+
+(FILL ME IN) Brief description of the fix / enhacement.
+
+
 ### Reviewers
 
 (FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Check these if you believe they are true
 
 ### Release Notes
 
-(FILL ME IN) Brief description of the fix / enhacement.
+(FILL ME IN) Brief description of the fix / enhacement. **Mandatory section** 
 
 
 ### Reviewers


### PR DESCRIPTION
### Purpose

PR created for add a Release Notes section on the Pull Request template. This section will help to the team to retrieve information and will be use as a entry for Release Notes wiki page.

### Declarations
Minor change on the PR template

### Reviewers

@QilongTang 

