### PR TITLE
Raise width property + unsubscribe groups removed using CTRL+Z

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -496,6 +496,7 @@ namespace Dynamo.ViewModels
             annotationModel = model;           
             this.WorkspaceViewModel = workspaceViewModel;
             model.PropertyChanged += model_PropertyChanged;
+            model.RemovedFromGroup += OnModelRemovedFromGroup;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
 
             //https://jira.autodesk.com/browse/QNTM-3770
@@ -888,6 +889,7 @@ namespace Dynamo.ViewModels
                 case nameof(AnnotationModel.ModelAreaHeight):
                     RaisePropertyChanged(nameof(ModelAreaHeight));
                     RaisePropertyChanged(nameof(ModelAreaRect));
+                    RaisePropertyChanged(nameof(Width));
                     break;
                 case nameof(AnnotationModel.Position):
                     RaisePropertyChanged(nameof(ModelAreaRect));
@@ -895,6 +897,11 @@ namespace Dynamo.ViewModels
                     break;
 
             }
+        }
+
+        private void OnModelRemovedFromGroup(object sender, EventArgs e)
+        {
+            RaisePropertyChanged(nameof(ZIndex));
         }
 
         private void UpdateAllGroupedGroups()
@@ -1000,6 +1007,7 @@ namespace Dynamo.ViewModels
         public override void Dispose()
         {
             annotationModel.PropertyChanged -= model_PropertyChanged;
+            annotationModel.RemovedFromGroup -= OnModelRemovedFromGroup;
             DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;
             base.Dispose();
         }


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4221](https://jira.autodesk.com/browse/DYN-4221)
We weren't unsubscribing PropertyChanged when groups were removed from the group by CTRL+Z which was causing Dynamo to crash because of a StackOverflow exception. There was also a weird bug with how the group was displayed after a nested group was removed by CTRL+Z, this was because the `Width` property was not raised as changed in this case causing the UI to not know about it.

![GroupBugFix](https://user-images.githubusercontent.com/13732445/139682562-998f1693-31ef-4903-bbb8-9e51f9017acf.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
