### PR TITLE
[DYN-4270] Export As Image doesn't export Background 3D preview

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -166,6 +166,7 @@
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.ShortcutExportBackground3DPreview}"
                                   Command="{Binding ShowSaveImageDialogAndSaveResultCommand}"
+                                  CommandParameter="{x:Static p:Resources.ScreenShotFrom3DParameter}"
                                   ToolTip="{x:Static p:Resources.DynamoViewToolbarExport3DButtonTooltip}"
                                   Name="save3DImage">
                         </MenuItem>


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4270](https://jira.autodesk.com/browse/DYN-4270)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs
