### PR TITLE
[DYN-4245] + [DYN-4244] Package Details Extension Install Button Bug Fixes

### DIFF
--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -278,7 +278,7 @@
                                                                 Command="{Binding ElementName=PackageDetailsWindow, Path=DataContext.TryInstallPackageVersionCommand}"
                                                                 CommandParameter="{Binding PackageVersionNumber}"
                                                                 Content="{Binding CanInstall, Converter={StaticResource InstalledButtonTextConverter}}"
-                                                                IsEnabled="{Binding IsInstalled, Converter={StaticResource InverseBooleanConverter}}">
+                                                                IsEnabled="{Binding CanInstall}">
                                                             <Button.Template>
                                                                 <ControlTemplate TargetType="{x:Type Button}">
                                                                     <Border Name="ButtonBorder"

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
@@ -50,6 +50,7 @@ namespace Dynamo.PackageDetails
         
         public override void Dispose()
         {
+            PackageDetailsViewModel?.Dispose();
             ViewLoadedParamsReference.ViewExtensionOpenRequestWithParameter -= OnViewExtensionOpenWithParameterRequest;
         }
 

--- a/src/PackageDetailsViewExtension/PackageDetailsViewModel.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewModel.cs
@@ -22,7 +22,7 @@ namespace Dynamo.PackageDetails
         #region Public Properties
         
         /// <summary>
-        /// Stores a  collection of the PackageDetailItems.
+        /// Stores a collection of PackageDetailItems.
         /// </summary>
         public List<PackageDetailItem> PackageDetailItems
         {
@@ -121,7 +121,6 @@ namespace Dynamo.PackageDetails
             PackageInfo packageInfo = new PackageInfo(PackageName, Version.Parse(versionName));
             
             this.PackageDetailsViewExtension.PackageManagerClientViewModel.DownloadAndInstallPackage(packageInfo);
-            RefreshPackageDetailItemInstalledStatus(versionName);
         }
 
         /// <summary>
@@ -188,7 +187,7 @@ namespace Dynamo.PackageDetails
                 (
                     packageManagerSearchElement.Name,
                     x,
-                    DetectWhetherCanInstall(packageLoader, x.version)
+                    DetectWhetherCanInstall(packageLoader, x.version, PackageName)
                 )).ToList();
 
             PackageName = packageManagerSearchElement.Name;
@@ -201,15 +200,29 @@ namespace Dynamo.PackageDetails
             PackageDetailsViewExtension = packageDetailsViewExtension;
             License = packageManagerSearchElement.Header.license;
 
+            packageLoader.PackageAdded += PackageLoaderOnPackageAdded;
+
             OpenDependencyDetailsCommand = new DelegateCommand(OpenDependencyDetails);
             TryInstallPackageVersionCommand = new DelegateCommand(TryInstallPackageVersion);
+        }
+
+        private void PackageLoaderOnPackageAdded(Package obj)
+        {
+            DetectWhetherCanInstall
+            (
+                PackageDetailsViewExtension.PackageManagerExtension.PackageLoader,
+                obj.Header.version,
+                obj.Header.name
+            );
+
+            RefreshPackageDetailItemInstalledStatus(obj.Header.version);
         }
 
         /// <summary>
         /// Detects whether the user can install a particular package at a particular version.
         /// Checks whether this is already installed using the PackageLoader.
         /// </summary>
-        private bool DetectWhetherCanInstall(PackageLoader packageLoader, string packageVersion)
+        private bool DetectWhetherCanInstall(PackageLoader packageLoader, string packageVersion, string packageName)
         {
             // In order for CanInstall to be false, both the name and installed package version must match
             // what is found in the PackageLoader.LocalPackages which are designated as 'Loaded'.
@@ -218,8 +231,7 @@ namespace Dynamo.PackageDetails
 
             List<Package> sameNamePackages = packageLoader
                 .LocalPackages
-                .Where(x => x.Name == PackageName)
-                .Where(x => x.LoadState.State == PackageLoadState.StateTypes.Loaded)
+                .Where(x => x.Name == packageName)
                 .ToList();
 
             if (sameNamePackages.Count < 1) return true;

--- a/src/PackageDetailsViewExtension/PackageDetailsViewModel.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewModel.cs
@@ -240,5 +240,13 @@ namespace Dynamo.PackageDetails
                 .Select(x => x.VersionName)
                 .Contains(packageVersion);
         }
+
+        /// <summary>
+        /// Called when the extension is disposed, unsubscribes from events.
+        /// </summary>
+        internal void Dispose()
+        {
+            PackageDetailsViewExtension.PackageManagerExtension.PackageLoader.PackageAdded -= PackageLoaderOnPackageAdded;
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR fixes two bugs on JIRA (stemming from the same issue, hence the single PR):

[DYN-4245] Install button in Package Details View Extension remains active after installation
[DYN-4244] Wrong installation status in Package Details View Extension

![T3cASVo4vA](https://user-images.githubusercontent.com/29973601/139701991-374582f7-4b00-45cd-94f3-8b406acc886b.gif)
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a bug in the package details view extension, whereby the Install button next to a specific package version was not updating its UI correctly.

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
