### PR TITLE
[DYN-4182] Can't undo removing nested group from parent group

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -212,6 +212,19 @@ namespace Dynamo.Graph.Workspaces
                     }
                     else if (model is AnnotationModel)
                     {
+                        // If the AnnotationModel is nested
+                        // we should record the modifications 
+                        // to the parent in this ActionGroup
+                        // to ensure that a single Undo will
+                        // revert everything.
+                        var parentGroup = this.Annotations
+                            .FirstOrDefault(x => x.ContainsModel(model));
+
+                        if (parentGroup != null)
+                        {
+                            undoRecorder.RecordModificationForUndo(parentGroup);
+                        }
+
                         undoRecorder.RecordDeletionForUndo(model);
                         RemoveAnnotation(model as AnnotationModel);
                     }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1691,9 +1691,14 @@ namespace Dynamo.Graph.Workspaces
         {
             ModelBase model = null;
             model = this.Nodes.FirstOrDefault(x => x.GUID == modelGuid);
+
             if (model == null) //Check if GUID is a Note instead.
             {
                 model = this.Notes.FirstOrDefault(x => x.GUID == modelGuid);
+            }
+            if (model == null)
+            {
+                model = this.Annotations.FirstOrDefault(x => x.GUID == modelGuid);
             }
 
             return model;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2122,7 +2122,10 @@ namespace Dynamo.Models
                 return;
 
             //Check for empty group
-            var annotations = Workspaces.SelectMany(ws => ws.Annotations);
+            var annotations = Workspaces
+                .SelectMany(ws => ws.Annotations)
+                .OrderBy(x => x.HasNestedGroups);
+
             foreach (var annotation in annotations)
             {
                 //record the annotation before the models in it are deleted.
@@ -2131,7 +2134,8 @@ namespace Dynamo.Models
                     //If there is only one model, then deleting that model should delete the group. In that case, do not record
                     //the group for modification. Until we have one model in a group, group should be recorded for modification
                     //otherwise, undo operation cannot get the group back.
-                    if (annotation.Nodes.Count() > 1 && annotation.Nodes.Where(x => x.GUID == model.GUID).Any())
+                    if (annotation.Nodes.Count() > 1 && 
+                        annotation.Nodes.Where(x => x.GUID == model.GUID).Any())
                     {
                         CurrentWorkspace.RecordGroupModelBeforeUngroup(annotation);
                     }

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -163,6 +163,7 @@ namespace Dynamo.Nodes
                 ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                    new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
                 ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
+                ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4182](https://jira.autodesk.com/browse/DYN-4182)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@QilongTang 

### FYIs

