### PR TITLE
Update Workspace TabItems with Ellipses

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml
@@ -39,7 +39,7 @@
             BorderThickness="0,0,0,5"
             BorderBrush="#ADE4DE">
             <Grid Margin="10" Width="212">
-                <TextBlock Margin="10,3,0,-2"
+                <TextBlock Margin="3,2,0,-2"
                            FontSize="16px"
                            FontFamily="{StaticResource ArtifaktElementRegular}"
                            Text="{x:Static p:Resources.StartPageStart}"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1103,7 +1103,8 @@
                                                 CornerRadius="0,0,0,0">
                                             <Border.ToolTip>
                                                 <uictrls:DynamoToolTip AttachmentSide="Bottom" Style="{DynamicResource ResourceKey=SLightToolTip}">
-                                                    <StackPanel Margin="5">
+                                                    <StackPanel Margin="5" MaxWidth="250">
+                                                        <TextBlock x:Name="FileName" Margin="0,0,0,5"  Text="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" TextWrapping="Wrap"/>
                                                         <TextBlock x:Name="topMessage"
                                                                    FontFamily="{StaticResource ArtifaktElementBold}"
                                                                    FontSize="11px"
@@ -1232,119 +1233,107 @@
 
                     <TabControl.ItemTemplate>
                         <DataTemplate>
-                            <Grid Height="35">
+                            <Grid Height="35" Margin="12,0,5,0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="*"/>
                                     <RowDefinition Height="5" />
                                 </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <StackPanel Orientation="Horizontal"
-                                            Margin="15,10,0,0"
-                                            VerticalAlignment="Center">
-                                    <Ellipse Name="UnsavedChangesIcon" Margin="0,0,7,0"  Height="9" Width="9" Fill="#FAA21B" VerticalAlignment="Center">
-                                        <Ellipse.Style>
-                                            <Style TargetType="Ellipse">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding HasUnsavedChanges}"
+                                <Ellipse Name="UnsavedChangesIcon"
+                                         Grid.Column="0"
+                                         Margin="0,5,5,0"
+                                         Height="9"
+                                         Width="9"
+                                         Fill="#FAA21B"
+                                         VerticalAlignment="Center">
+                                    <Ellipse.Style>
+                                        <Style TargetType="Ellipse">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding HasUnsavedChanges}"
                                                                  Value="True">
-                                                        <Setter Property="Visibility"
+                                                    <Setter Property="Visibility"
                                                                 Value="Visible" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding HasUnsavedChanges}"
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding HasUnsavedChanges}"
                                                                  Value="False">
-                                                        <Setter Property="Visibility"
+                                                    <Setter Property="Visibility"
                                                                 Value="Collapsed" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Ellipse.Style>
-                                    </Ellipse>
-                                    <Rectangle Width="16" Height="16" Margin="0,0,7,0" VerticalAlignment="Center">
-                                        <Rectangle.Fill>
-                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/custom-node.png"/>
-                                        </Rectangle.Fill>
-                                        <Rectangle.Style>
-                                            <Style TargetType="Rectangle">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsHomeSpace}" Value="False">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding IsHomeSpace}" Value="True">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Rectangle.Style>
-                                    </Rectangle>
-                                    <TextBlock Name="WorkspaceName"
-                                               Padding="0,0,0,0"
-                                               HorizontalAlignment="Stretch"
-                                               VerticalAlignment="Center"
-                                               FontSize="16px"
-                                               FontFamily="{StaticResource ArtifaktElementRegular}"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}"
-                                                                 Value="True">
-                                                        <Setter Property="Foreground"
-                                                                Value="{StaticResource WorkspaceTabHeaderActiveTextBrush}"></Setter>
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}"
-                                                                 Value="False">
-                                                        <Setter Property="Foreground"
-                                                                Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}"></Setter>
-                                                    </DataTrigger>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
-                                                                       Value="{x:Type workspaces:HomeWorkspaceModel}" />
-                                                            <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
-                                                                       Value="Unsaved" />
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Text"
-                                                                Value="Home" />
-                                                    </MultiDataTrigger>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
-                                                                       Value="{x:Type workspaces:HomeWorkspaceModel}" />
-                                                            <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
-                                                                       Value="Saved" />
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Text"
-                                                                Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
-                                                    </MultiDataTrigger>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
-                                                                       Value="{x:Type workspaces:CustomNodeWorkspaceModel}" />
-                                                            <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
-                                                                       Value="Unsaved" />
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Text"
-                                                                Value="{Binding Name}" />
-                                                    </MultiDataTrigger>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
-                                                                       Value="{x:Type workspaces:CustomNodeWorkspaceModel}" />
-                                                            <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
-                                                                       Value="Saved" />
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Text"
-                                                                Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
-                                                    </MultiDataTrigger>
-
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                </StackPanel>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Ellipse.Style>
+                                </Ellipse>
+                                <Rectangle Grid.Column="1" Width="16" Height="16" Margin="0,5,7,0" VerticalAlignment="Center">
+                                    <Rectangle.Fill>
+                                        <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/custom-node.png"/>
+                                    </Rectangle.Fill>
+                                    <Rectangle.Style>
+                                        <Style TargetType="Rectangle">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsHomeSpace}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding IsHomeSpace}" Value="True">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Rectangle.Style>
+                                </Rectangle>
+                                <TextBlock Name="WorkspaceName"
+                                           Grid.Column="2"
+                                           Margin="0,7,0,0"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Center"
+                                           FontSize="16px"
+                                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                                           TextTrimming="CharacterEllipsis">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}" Value="True">
+                                                    <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}" Value="False">
+                                                    <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}" />
+                                                </DataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:HomeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Unsaved" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="Home" />
+                                                </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:HomeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Saved" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:CustomNodeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Unsaved" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="{Binding Name}" />
+                                                </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:CustomNodeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Saved" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </Grid>
                         </DataTemplate>
 


### PR DESCRIPTION
### Purpose

This PR updates the workspace TabItems to truncate with ellipses when they grow beyond a certain length. 
The full filename can now be found in a ToolTip.

![eTn1UWdL2J](https://user-images.githubusercontent.com/29973601/139723012-47e2d5e7-8597-435d-8d78-a5e7e3556df9.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Updates the workspace TabItems to truncate with ellipses when they grow beyond a certain length. 

### Reviewers

@QilongTang 
@Amoursol 

### FYIs

@SHKnudsen 
