### PR TITLE
Fix the connectors and ports, when the group is collapsed.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -153,6 +153,7 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
+        private Point2D center = new Point2D();
         /// <summary>
         /// Center is used by connected connectors to update their shape
         /// The "center" of a port is derived from the type of port and
@@ -164,27 +165,40 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-                double halfHeight = Height * 0.5;
-
-                double offset = Owner.GetPortVerticalOffset(this);
-                double y = Owner.Y + NodeModel.HeaderHeight + halfHeight + offset + 9;
-
-                switch (PortType)
+                // If it is a proxy port, return the center as it is already set in the Annotion Model.
+                if (IsProxyPort)
                 {
-                    case PortType.Input:
-                        return new Point2D(Owner.X, y);
-                    case PortType.Output:
-                        if (Owner is CodeBlockNodeModel)
-                        {
-                            // Special case because code block outputs are smaller than regular outputs.
-                            // This ensures the output port of the first code block output aligns with
-                            // the first input port of any node.
-                            return new Point2D(Owner.X + Owner.Width, y + 9);
-                        }
-                        return new Point2D(Owner.X + Owner.Width, y);
+                    return center;
                 }
+                // If it is a node port, calculate the center based on that node position.
+                else 
+                {
+                    double halfHeight = Height * 0.5;
 
-                return new Point2D();
+                    double offset = Owner.GetPortVerticalOffset(this);
+                    double y = Owner.Y + NodeModel.HeaderHeight + halfHeight + offset + 9;
+
+                    switch (PortType)
+                    {
+                        case PortType.Input:
+                            return new Point2D(Owner.X, y);
+                        case PortType.Output:
+                            if (Owner is CodeBlockNodeModel)
+                            {
+                                // Special case because code block outputs are smaller than regular outputs.
+                                // This ensures the output port of the first code block output aligns with
+                                // the first input port of any node.
+                                return new Point2D(Owner.X + Owner.Width, y + 9);
+                            }
+                            return new Point2D(Owner.X + Owner.Width, y);
+                    }
+
+                    return new Point2D();
+                }
+            }
+            internal set 
+            {
+                center = value;
             }
         }
 
@@ -309,8 +323,11 @@ namespace Dynamo.Graph.Nodes
                 return Connectors.Any() || (UsingDefaultValue && DefaultValue != null);
             }
         }
+
         #endregion
-        
+
+        internal bool IsProxyPort { get; set; } = false;
+
         [JsonConstructor]
         internal PortModel(string name, string toolTip)
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -831,7 +831,7 @@ namespace Dynamo.ViewModels
 
                 connectorViewModels.ForEach(x => x.IsCollapsed = false);
 
-                // Set IsProxyPort back to false when the group is collapsed.
+                // Set IsProxyPort back to false when the group is expanded.
                 nodeModel.InPorts.ToList().ForEach(x => x.IsProxyPort = false);
                 nodeModel.OutPorts.ToList().ForEach(x => x.IsProxyPort = false);
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -649,7 +649,7 @@ namespace Dynamo.ViewModels
                 );
         }
 
-        private double GetPortVerticalOffset(PortModel portModel)
+        private double GetPortVerticalOffset(PortModel portModel, int proxyPortIndex)
         {
             // vertical offset accounts for the port margins
             double verticalOffset = 20;
@@ -662,14 +662,14 @@ namespace Dynamo.ViewModels
             // calculate the vertical offset for the port index.
             int portVerticalMidPoint = 17;
             double portHeight = portModel.Height;
-            return verticalOffset + (index * portHeight) + portVerticalMidPoint;
+            return verticalOffset + (proxyPortIndex * portHeight) + portVerticalMidPoint;
         }
 
-        private Point2D CalculatePortPosition(PortModel portModel)
+        private Point2D CalculatePortPosition(PortModel portModel, int proxyPortIndex)
         {
             double groupHeaderHeight = Height - ModelAreaRect.Height;
 
-            double offset = GetPortVerticalOffset(portModel);
+            double offset = GetPortVerticalOffset(portModel, proxyPortIndex);
             double y = Top + groupHeaderHeight + offset;
 
             switch (portModel.PortType)
@@ -695,8 +695,8 @@ namespace Dynamo.ViewModels
                 var model = groupPortModels.ElementAt(i);
                 newPortViewModels.Add(originalPortViewModels[i].CreateProxyPortViewModel(model));
 
-                // calculate new position for the proxy inports
-                model.Center = CalculatePortPosition(model);
+                // calculate new position for the proxy inports.
+                model.Center = CalculatePortPosition(model, i);
                 model.Owner.ReportPosition();
             } 
 
@@ -717,7 +717,7 @@ namespace Dynamo.ViewModels
                 newPortViewModels.Add(originalPortViewModels[i].CreateProxyPortViewModel(model));
 
                 // calculate new position for the proxy outports
-                model.Center = CalculatePortPosition(model);
+                model.Center = CalculatePortPosition(model, i);
                 model.Owner.ReportPosition();
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -144,6 +144,7 @@ namespace Dynamo.ViewModels
 
         internal override PortViewModel CreateProxyPortViewModel(PortModel portModel)
         {
+            portModel.IsProxyPort = true;
             return new InPortViewModel(node, portModel);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -131,6 +131,7 @@ namespace Dynamo.ViewModels
 
         internal override PortViewModel CreateProxyPortViewModel(PortModel portModel)
         {
+            portModel.IsProxyPort = true;
             return new OutPortViewModel(node, portModel);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -265,8 +265,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-        internal bool IsProxyPort { get; set; } = false;
-
         #endregion
 
         #region events
@@ -297,7 +295,8 @@ namespace Dynamo.ViewModels
 
         internal virtual PortViewModel CreateProxyPortViewModel(PortModel portModel)
         {
-            return new PortViewModel(node, portModel){IsProxyPort = true};
+            portModel.IsProxyPort = true;
+            return new PortViewModel(node, portModel);
         }
 
         /// <summary>
@@ -472,12 +471,12 @@ namespace Dynamo.ViewModels
             DynamoViewModel dynamoViewModel = node.DynamoViewModel;
             // If user trying to trigger Node AutoComplete from proxy ports, display notification
             // telling user it is not available that way
-            if (IsProxyPort)
+            if (port.IsProxyPort)
             {
                 dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Wpf.Properties.Resources.NodeAutoCompleteNotAvailableForCollapsedGroups);
             }
             // If the feature is enabled from Dynamo experiment setting and if user interaction is not on proxy ports.
-            return dynamoViewModel.EnableNodeAutoComplete && !(IsProxyPort);
+            return dynamoViewModel.EnableNodeAutoComplete && !port.IsProxyPort;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -705,7 +705,7 @@
                               HorizontalContentAlignment="Left"
                               Style="{StaticResource InOutPortControlStyle}"
                               ItemsSource="{Binding Path=InPorts}"
-                              Margin="0,10">
+                              Margin="-25,10">
                 </ItemsControl>
 
                 <!--OUTPUT PORTS-->


### PR DESCRIPTION
### Purpose

This PR is to fix the issue related to connectors and ports when the group is collapsed. 

Task: https://jira.autodesk.com/browse/DYN-3983

![group collapsing](https://user-images.githubusercontent.com/43763136/139962866-a484f652-1893-420a-a032-8ccad2827e65.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhacement. **Mandatory section** 


### Reviewers

@QilongTang @SHKnudsen 

