### PR TITLE
[DYN-4144] Preview Icon Watch Node UI Bug Fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -520,7 +520,6 @@
 
         <Grid Name="PresentationGrid"
               Grid.Row="2"
-              Grid.RowSpan="2"
               Grid.Column="1"
               Margin="6,6,6,3"
               HorizontalAlignment="Left"


### PR DESCRIPTION
### Purpose

This PR fixes a UI bug whereby the watch node's content would overlap the node's bottom-row icons, such as the hidden eye glyph.

![image](https://user-images.githubusercontent.com/29973601/139907882-497b4586-60df-4dd0-b193-f8a20b8481bc.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Watch node UI bug fixed.


### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
