### PR TITLE
DYN-3998: GLOB: Truncated "Add Paths" in "Package Manager" - UI layout issue

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4610,7 +4610,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Paths.
+        ///   Looks up a localized string similar to Add Path.
         /// </summary>
         public static string PackagePathAddPathButtonName {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2415,7 +2415,7 @@ Uninstall the following packages: {0}?</value>
     <value>Package Manager</value>
   </data>
   <data name="PackagePathAddPathButtonName" xml:space="preserve">
-    <value>Add Paths</value>
+    <value>Add Path</value>
   </data>
   <data name="PackagePathPreferencesTitle" xml:space="preserve">
     <value>Package/Library Search Paths</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2613,7 +2613,7 @@ Uninstall the following packages: {0}?</value>
     <value>Package Manager</value>
   </data>
   <data name="PackagePathAddPathButtonName" xml:space="preserve">
-    <value>Add Paths</value>
+    <value>Add Path</value>
   </data>
   <data name="PackagePathPreferencesTitle" xml:space="preserve">
     <value>Package/Library Search Paths</value>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
@@ -118,34 +118,32 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <StackPanel Orientation="Vertical" Margin="0,6,0,0">
-        <DockPanel>
-            <Label  Style="{StaticResource PreferenceTitleLabelStyle}"  
-                    Content="{x:Static p:Resources.PackagePathPreferencesTitle}" 
-                                            Padding="5,5,5,5"
-                                            VerticalAlignment="Center"
-                                            HorizontalAlignment="Left">
-            </Label>
-            <Button x:Name="AddPaths"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
-                    Width="100"
-                    Height="25"
-                    Margin="0,0,0,0"
-                    Content="{x:Static p:Resources.PackagePathAddPathButtonName}"
-                    Command="{Binding Path=AddPathCommand}" 
-                    ToolTip="{x:Static p:Resources.PackagePathViewToolTipPlus}">
-                <Button.Style>
-                    <Style BasedOn="{StaticResource FlatButtonStyle}" TargetType="{x:Type Button}">
-                        <Setter Property="IsEnabled" Value="True"/>
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=PreferenceSettings.DisableCustomPackageLocations}" Value="True">
-                                <Setter Property="IsEnabled" Value="False" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
-        </DockPanel>
+        <Label  Style="{StaticResource PreferenceTitleLabelStyle}"  
+                Content="{x:Static p:Resources.PackagePathPreferencesTitle}" 
+                                        Padding="5,5,5,5"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Left">
+        </Label>
+        <Button x:Name="AddPaths"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Height="25"
+                MinWidth="67"
+                Margin="5,5,5,5"
+                Content="{x:Static p:Resources.PackagePathAddPathButtonName}"
+                Command="{Binding Path=AddPathCommand}" 
+                ToolTip="{x:Static p:Resources.PackagePathViewToolTipPlus}">
+            <Button.Style>
+                <Style BasedOn="{StaticResource FlatButtonStyle}" TargetType="{x:Type Button}">
+                    <Setter Property="IsEnabled" Value="True"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Path=PreferenceSettings.DisableCustomPackageLocations}" Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Button.Style>
+        </Button>
         <ItemsControl
             Background="{StaticResource PreferencesWindowVisualSettingsBackground}"
             ItemsSource="{Binding RootLocations}"

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
@@ -128,7 +128,7 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Height="25"
-                MinWidth="67"
+                MinWidth="55"
                 Margin="5,5,5,5"
                 Content="{x:Static p:Resources.PackagePathAddPathButtonName}"
                 Command="{Binding Path=AddPathCommand}" 


### PR DESCRIPTION
### Purpose

This pull request does:

* move add path button to its own row.
* change `Add Paths` to `Add Path`.

New ENU dialog:
![image](https://user-images.githubusercontent.com/7033002/140783244-037f949f-8543-4523-b3df-82b3df59ba1e.png)

Testing with FRA string:
![FRA-New-test](https://user-images.githubusercontent.com/7033002/140083144-77d32f8f-01eb-4f8e-8c6d-75cd81afd852.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhacement. **Mandatory section** 

