### PR TITLE
Fixing title from exit modal

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5114,7 +5114,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do you want to continue the guide?.
+        ///   Looks up a localized string similar to Do you want to exit the guide?.
         /// </summary>
         public static string PackagesGuideExitTitle {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2917,7 +2917,7 @@ This package will be unloaded after the next Dynamo restart.</value>
     <value>To continue the guide and install the sample package, you must accept the Terms of Service. \n\n **Click Continue.** Then in the terms, **click I Accept.** \n\n\n\n</value>
   </data>
   <data name="PackagesGuideExitTitle" xml:space="preserve">
-    <value>Do you want to continue the guide?</value>
+    <value>Do you want to exit the guide?</value>
   </data>
   <data name="InfoBubbleInfo" xml:space="preserve">
     <value>Info</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1530,16 +1530,16 @@ If the toggle is off custom packages that are not already loaded will load once 
     <value>0</value>
   </data>
   <data name="PublishPackageVersionMinorWatermark" xml:space="preserve">
-  <value>0</value>
+    <value>0</value>
   </data>
   <data name="PublishPackageVersionBuildWatermark" xml:space="preserve">
-  <value>1</value>
+    <value>1</value>
   </data>
   <data name="PublishPackageGroupWatermark" xml:space="preserve">
-  <value>Group</value>
+    <value>Group</value>
   </data>
   <data name="PublishPackageKeywordsWatermark" xml:space="preserve">
-  <value>Keywords</value>
+    <value>Keywords</value>
   </data>
   <data name="PublishPackageViewPublish" xml:space="preserve">
     <value>Publish a Package</value>
@@ -2910,6 +2910,6 @@ Delete the following packages: {2}?
     <value>To continue the guide and install the sample package, you must accept the Terms of Service. \n\n **Click Continue.** Then in the terms, **click I Accept.** \n\n\n\n</value>
   </data>
   <data name="PackagesGuideExitTitle" xml:space="preserve">
-    <value>Do you want to continue the guide?</value>
+    <value>Do you want to exit the guide?</value>
   </data>
 </root>


### PR DESCRIPTION
### Purpose

Related to this [discussion](https://jira.autodesk.com/browse/DYN-4264?focusedCommentId=8196121&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8196121), this fixes the title of the exit modal

![image](https://user-images.githubusercontent.com/89042471/140089020-3e9abc25-af98-4ebe-b1ef-fff57e5e5fd1.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhacement. **Mandatory section** 


### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
