### PR TITLE
DYN-4111: Installed packages view is cut off and some packages cannot be viewed

### DIFF
--- a/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
@@ -68,7 +68,7 @@
         <ScrollViewer Grid.Row="1"  
             VerticalScrollBarVisibility="Auto" 
             Background="{StaticResource PreferencesWindowBackgroundColor}" 
-            MaxHeight="290">
+            MaxHeight="246">
             <ItemsControl Name="SearchResultsListBox"
                               ItemsSource="{Binding Path=LocalPackages}"
                               HorizontalContentAlignment="Stretch"


### PR DESCRIPTION
### Purpose

This pull request does:

* adjust the max size for the package list

Dialog after fix:

![DYN-4111-Fixed](https://user-images.githubusercontent.com/7033002/140167834-e4d9fda9-dda5-4de8-8079-c102d631b618.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhacement. **Mandatory section** 
