### PR TITLE
DYN 4216 - Enable GitHub action for compare releases

### DIFF
--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -1,0 +1,24 @@
+# This is a basic workflow to help you get started with Actions
+
+name: create-release
+  on:
+    workflow_dispatch:
+  
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # To use this repository's private action, you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Generate changelog
+        id: changelog
+        uses: metcalfc/changelog-generator@v1.0.0
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+          head-ref: 'v2.12.0'
+          base-ref: 'v2.11.1'
+
+      - name: Get the changelog
+        run: echo "${{ steps.changelog.outputs.changelog }}"

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -1,9 +1,17 @@
 # This is a basic workflow to help you get started with Actions
 
 name: create-release
-  on:
-    workflow_dispatch:
-  
+on: 
+  workflow_dispatch:
+    inputs:
+      head-ref:
+        description: Head version
+        default: v1.0.0
+        required: true
+      base-ref:
+        description: Base Version
+        default: v1.0.0
+        required: true
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -17,8 +25,8 @@ jobs:
         uses: metcalfc/changelog-generator@v1.0.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
-          head-ref: 'v2.12.0'
-          base-ref: 'v2.11.1'
+          head-ref: ${{ github.event.inputs.head-ref }}
+          base-ref: ${{ github.event.inputs.base-ref }}
 
       - name: Get the changelog
         run: echo "${{ steps.changelog.outputs.changelog }}"


### PR DESCRIPTION
### Purpose

DYN 4216 - We are adding this github action for compare releases in order to facilitate the creation of Release Notes wiki page. This workflow will be executed on-demand.


### Release Notes

Enhancement for comparing releases and create Change Log that will help the Release Notes wiki page.


### Reviewers

@QilongTang 
