### PR TITLE
Adjust the close button margin on preferences window.

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -132,15 +132,15 @@
                        HorizontalAlignment="Left" 
                        Width="459" />
             <StackPanel Grid.Column="1" 
-                        VerticalAlignment="Top"  
+                        VerticalAlignment="Top"
                         Orientation="Horizontal" 
                         HorizontalAlignment="Right">
-                <Button x:Name="CloseButton"  
-                        Style="{DynamicResource CloseButtonStyle}" 
-                        Click="CloseButton_Click" 
+                <Button x:Name="CloseButton"
+                        Style="{DynamicResource CloseButtonStyle}"
+                        Click="CloseButton_Click"
                         VerticalAlignment="Center"
                         KeyboardNavigation.IsTabStop="False"
-                        Margin="0,0,4,0"/>
+                        Margin="10,12,20,8"/>
             </StackPanel>
         </Grid>
 


### PR DESCRIPTION
### Purpose

This PR is to adjust the margin for the close button on preferences window.
Task: https://jira.autodesk.com/browse/DYN-4189

<img width="855" alt="Screen Shot 2021-11-04 at 6 11 35 AM" src="https://user-images.githubusercontent.com/43763136/140296010-aaa63f79-e553-41a8-b034-1d5d9edca426.png">

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhacement. **Mandatory section** 


### Reviewers

@QilongTang 
