### PR TITLE
[DYN-4260] Increase Slider Grip Area

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -20,10 +20,11 @@
             </ResourceDictionary.MergedDictionaries>
             <Style x:Key="SliderThumbStyle" TargetType="Thumb">
                 <Setter Property="Focusable" Value="false" />
+                <Setter Property="Cursor" Value="SizeWE" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Thumb">
-                            <Grid>
+                            <Grid Name="ThumbGrid" IsHitTestVisible="True" Background="Transparent" Margin="-4,-8" Height="26" Width="12">
                                 <Border
                                     Name="Thumb"
                                     Width="4"


### PR DESCRIPTION
### Purpose

This PR responds to DYN-4260 by slightly increasing the size of the Integer Slider + Number Slider's thumb grip area (shown briefly in red).

![GpOPtCzvN0](https://user-images.githubusercontent.com/29973601/140299246-d625aa8a-d36d-4f50-b354-ceb93cca485a.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Increases the size of the integer/number slider node's grip area for better UX.

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
