### PR TITLE
[DYN-4294] Start Page Bug Fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -722,7 +722,7 @@
         <!--Shortcuts Toolbar-->
         <Grid Grid.Row="1"
               Grid.Column="0"
-              Canvas.ZIndex="1"
+              Canvas.ZIndex="0"
               VerticalAlignment="Top"
               Grid.ColumnSpan="5"
               Name="shortcutsBarGrid">

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -20,7 +20,6 @@
             </ResourceDictionary.MergedDictionaries>
             <Style x:Key="SliderThumbStyle" TargetType="Thumb">
                 <Setter Property="Focusable" Value="false" />
-                <Setter Property="Cursor" Value="SizeWE" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Thumb">

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -24,7 +24,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Thumb">
-                            <Grid Name="ThumbGrid" IsHitTestVisible="True" Background="Transparent" Margin="-4,-8" Height="26" Width="12">
+                            <Grid>
                                 <Border
                                     Name="Thumb"
                                     Width="4"

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -20,10 +20,11 @@
             </ResourceDictionary.MergedDictionaries>
             <Style x:Key="SliderThumbStyle" TargetType="Thumb">
                 <Setter Property="Focusable" Value="false" />
+                <Setter Property="Cursor" Value="SizeWE" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Thumb">
-                            <Grid>
+                            <Grid Name="ThumbGrid" IsHitTestVisible="True" Background="Transparent" Margin="-4,-8" Height="26" Width="12">
                                 <Border
                                     Name="Thumb"
                                     Width="4"


### PR DESCRIPTION
### Purpose

This PR reponds to DYN-4294 by fixing a UI bug with the start page window whereby the menu icons were overlapping the GalleryView.

![image](https://user-images.githubusercontent.com/29973601/140304365-4049314d-9c0f-4f46-80a1-355ea16015f9.png)
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a UI bug with the getting started page.

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
