### PR TITLE
Jira Bug Fix - [DYN 4161] - Creation of watch node using pin on connector should be undone in single step

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1211,17 +1211,23 @@ namespace Dynamo.ViewModels
 
 
         /// <summary>
-        /// Removes all connectorPinViewModels/ connectorPinModels. This occurs during 'dispose'
+        ///  Removes all connectorPinViewModels/ connectorPinModels. This occurs during 'dispose'
         /// operation as well as during the 'PlaceWatchNode', where all previous pins corresponding 
         /// to a connector are cleareed.
         /// </summary>
+        /// <param name="allDeletedModels"> This argument is used when placing a WatchNode from ConnectorAnchorViewModel. A reference
+        /// to all previous pins is required for undo/redo recorder.</param>
         internal void DiscardAllConnectorPinModels(List<ModelBase> allDeletedModels = null)
         {
             foreach (var pin in ConnectorPinViewCollection)
             {
                 workspaceViewModel.Pins.Remove(pin);
                 ConnectorModel.RemovePin(pin.Model);
-                allDeletedModels.Add(pin.Model);
+
+                if(allDeletedModels != null)
+                {
+                    allDeletedModels.Add(pin.Model);
+                }
                 pin.Model.Dispose();
                 pin.Dispose();
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -813,13 +813,13 @@ namespace Dynamo.ViewModels
         /// pins when a WatchNode is placed in the center of a connector.
         /// </summary>
         /// <param name="point"></param>
-        public void PinConnectorPlacementFromWatchNode(ConnectorModel[] connectors, int connectorWireIndex, Point point)
+        public void PinConnectorPlacementFromWatchNode(ConnectorModel[] connectors, int connectorWireIndex, Point point, List<ModelBase> createdModels)
         {
             var selectedConnector = connectors[connectorWireIndex];
 
             var connectorPinModel = new ConnectorPinModel(point.X, point.Y, Guid.NewGuid(), selectedConnector.GUID);
             selectedConnector.AddPin(connectorPinModel);
-            workspaceViewModel.Model.RecordCreatedModel(connectorPinModel);
+            createdModels.Add(connectorPinModel);
         }
 
         private void HandlerRedrawRequest(object sender, EventArgs e)
@@ -1215,12 +1215,13 @@ namespace Dynamo.ViewModels
         /// operation as well as during the 'PlaceWatchNode', where all previous pins corresponding 
         /// to a connector are cleareed.
         /// </summary>
-        internal void DiscardAllConnectorPinModels()
+        internal void DiscardAllConnectorPinModels(List<ModelBase> allDeletedModels = null)
         {
             foreach (var pin in ConnectorPinViewCollection)
             {
                 workspaceViewModel.Pins.Remove(pin);
                 ConnectorModel.RemovePin(pin.Model);
+                allDeletedModels.Add(pin.Model);
                 pin.Model.Dispose();
                 pin.Dispose();
             }

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -9,6 +9,10 @@ using CoreNodeModels;
 using Dynamo.UI.Commands;
 using System;
 using Dynamo.Graph.Connectors;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Graph;
+using Dynamo.Selection;
+using Dynamo.Graph.Annotations;
 
 namespace Dynamo.ViewModels
 {
@@ -214,9 +218,29 @@ namespace Dynamo.ViewModels
 
         private void PlaceWatchNodeCommandExecute(object param)
         {
+           //Collect previous pin locations
             var pinLocations = ViewModel.CollectPinLocations();
-            ViewModel.DiscardAllConnectorPinModels();
-            PlaceWatchNode(ViewModel.ConnectorModel, pinLocations);
+            List<ModelBase> AllDeletedModels = new List<ModelBase>();
+            ViewModel.DiscardAllConnectorPinModels(AllDeletedModels);
+            List<ModelBase> AllCreatedModels = PlaceWatchNode(ViewModel.ConnectorModel, pinLocations, AllDeletedModels);
+
+            RecordUndoModels(DynamoModel.CurrentWorkspace, AllCreatedModels, AllDeletedModels);
+        }
+
+        private void RecordUndoModels(WorkspaceModel workspace, List<ModelBase> undoItems, List<ModelBase> deletedItems)
+        {
+                var userActionDictionary = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
+                //Add models that were newly created
+                foreach (var undoItem in undoItems)
+                {
+                    userActionDictionary.Add(undoItem, UndoRedoRecorder.UserAction.Creation);
+                }
+                //Add models that were newly deleted
+                foreach (var deletedItem in deletedItems)
+                {
+                    userActionDictionary.Add(deletedItem, UndoRedoRecorder.UserAction.Deletion);
+                }
+                WorkspaceModel.RecordModelsForUndo(userActionDictionary, workspace.UndoRecorder);
         }
 
         /// <summary>
@@ -281,8 +305,10 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Places watch node at the midpoint of the connector
         /// </summary>
-        internal void PlaceWatchNode(ConnectorModel connector, IEnumerable<Point> connectorPinLocations)
+        internal List<ModelBase> PlaceWatchNode(ConnectorModel connector, IEnumerable<Point> connectorPinLocations, List<ModelBase> allDeletedModels)
         {
+            var createdModels = new List<ModelBase>();
+
             NodeModel startNode = ViewModel.ConnectorModel.Start.Owner;
             NodeModel endNode = ViewModel.ConnectorModel.End.Owner;
             this.Dispatcher.Invoke(() =>
@@ -291,8 +317,11 @@ namespace Dynamo.ViewModels
                 var nodeX = CurrentPosition.X - (watchNode.Width / 2);
                 var nodeY = CurrentPosition.Y - (watchNode.Height / 2);
                 DynamoModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, nodeX, nodeY, false, false));
-                WireNewNode(DynamoModel, startNode, endNode, watchNode, connector, connectorPinLocations);
+                createdModels.Add(watchNode);
+                WireNewNode(DynamoModel, startNode, endNode, watchNode, connector, connectorPinLocations, createdModels, allDeletedModels);
             });
+
+            return createdModels;
         }
 
         /// <summary>
@@ -308,7 +337,9 @@ namespace Dynamo.ViewModels
             NodeModel endNode, 
             NodeModel watchNodeModel,
             ConnectorModel connector,
-            IEnumerable<Point> connectorPinLocations)
+            IEnumerable<Point> connectorPinLocations,
+            List<ModelBase> allCreatedModels,
+            List<ModelBase> allDeletedModels)
         {
             (int startIndex, int endIndex) = GetPortIndex(connector);
 
@@ -320,37 +351,47 @@ namespace Dynamo.ViewModels
             dynamoModel.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNodeModel.GUID, 0, PortType.Output, DynamoModel.MakeConnectionCommand.Mode.Begin));
             dynamoModel.ExecuteCommand(new DynamoModel.MakeConnectionCommand(endNode.GUID, endIndex, PortType.Input, DynamoModel.MakeConnectionCommand.Mode.End));
 
-            PlacePinsOnWires(startNode, watchNodeModel, connector, connectorPinLocations);
+            PlacePinsOnWires(startNode, watchNodeModel, connector, connectorPinLocations, allCreatedModels, allDeletedModels);
         }
 
-        private void PlacePinsOnWires(NodeModel startNode, NodeModel watchNodeModel, ConnectorModel connector, IEnumerable<Point> connectorPinLocations)
+        private void PlacePinsOnWires(NodeModel startNode, 
+            NodeModel watchNodeModel, 
+            ConnectorModel connector, 
+            IEnumerable<Point> connectorPinLocations,
+            List<ModelBase> allCreatedModels,
+            List<ModelBase> allDeletedModels)
         {
-            if(connectorPinLocations.Count()<1)
-            {
-                return;
-            }
-
             // Collect ports & connectors of newly connected nodes
             // so that old pins (that need to remain) can be transferred over correctly.
-            PortModel startNodePort = startNode.OutPorts.FirstOrDefault(p=>p.GUID == connector.Start.GUID);
+            PortModel startNodePort = startNode.OutPorts.FirstOrDefault(p => p.GUID == connector.Start.GUID);
             PortModel watchNodePort = watchNodeModel.OutPorts[0];
             Graph.Connectors.ConnectorModel[] connectors = new Graph.Connectors.ConnectorModel[2];
 
-            connectors[0] = startNodePort.Connectors.FirstOrDefault(c=> c.End.Owner.GUID == watchNodeModel.GUID && c.GUID != connector.GUID);
-            connectors[1] = watchNodePort.Connectors.FirstOrDefault(c=> c.Start.Owner.GUID == watchNodeModel.GUID && c.GUID != connector.GUID);
-            if(connectors.Any(c=>c is null))
+            connectors[0] = startNodePort.Connectors.FirstOrDefault(c => c.End.Owner.GUID == watchNodeModel.GUID && c.GUID != connector.GUID);
+            connectors[1] = watchNodePort.Connectors.FirstOrDefault(c => c.Start.Owner.GUID == watchNodeModel.GUID && c.GUID != connector.GUID);
+
+            if (connectors.Any(c => c is null))
             {
                 return;
             }
+
+            allCreatedModels.AddRange(connectors);
+            allDeletedModels.Add(connector);
+
+            if (connectorPinLocations.Count()<1)
+            {
+                return;
+            }
+
             // Place each pin where required on the newly connected connectors.
             foreach (var connectorPinLocation in connectorPinLocations)
             {
                 int wireIndex = ConnectorSegmentIndex(CurrentPosition, connectorPinLocation);
-                ViewModel.PinConnectorPlacementFromWatchNode(connectors, wireIndex, connectorPinLocation);
+                ViewModel.PinConnectorPlacementFromWatchNode(connectors, wireIndex, connectorPinLocation, allCreatedModels);
             }
         }
 
-        private static (int StartIndex, int EndIndex) GetPortIndex(ConnectorModel connector)
+        private (int StartIndex, int EndIndex) GetPortIndex(ConnectorModel connector)
         {
             return (connector.Start.Index, connector.End.Index);
         }

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -11,8 +11,6 @@ using System;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Graph;
-using Dynamo.Selection;
-using Dynamo.Graph.Annotations;
 
 namespace Dynamo.ViewModels
 {

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -3,16 +3,7 @@ using Dynamo.Selection;
 using NUnit.Framework;
 using static Dynamo.Models.DynamoModel;
 using Dynamo.Utilities;
-using System.IO;
-using System.Collections.Generic;
-using Dynamo.Configuration;
-using Dynamo.Models;
-using System.Reflection;
-using DynamoShapeManager;
-using TestServices;
 using Dynamo.ViewModels;
-using Dynamo.Controls;
-using Dynamo.Graph.Connectors;
 using System;
 
 namespace DynamoCoreWpfTests
@@ -31,7 +22,7 @@ namespace DynamoCoreWpfTests
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            // Default collapse state should be false when opening legacy graph
+            //Default collapse state should be false when opening legacy graph
             Assert.AreEqual(connectorViewModel.IsHidden, false);
         }
 
@@ -47,17 +38,17 @@ namespace DynamoCoreWpfTests
 
             int initialConnectorCount = connectorViewModel.ConnectorPinViewCollection.Count;
 
-            ///hard-coded position (1) on wire
+            //hard-coded position (1) on wire
             connectorViewModel.PanelX = 292.66666;
             connectorViewModel.PanelY = 278;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Pin command
+            //Pin command
             connectorViewModel.PinConnectorCommand.Execute(null);
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialConnectorCount + 1);
 
-            ///hard-coded position (2) on wire
+            //hard-coded position (2) on wire
             connectorViewModel.PanelX = 419.33333;
             connectorViewModel.PanelY = 347.33333;
 
@@ -75,17 +66,17 @@ namespace DynamoCoreWpfTests
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            ///hard-coded position (1) on wire
+            //hard-coded position (1) on wire
             connectorViewModel.PanelX = 292.66666;
             connectorViewModel.PanelY = 278;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Pin command
+            //Pin command
             connectorViewModel.PinConnectorCommand.Execute(null);
             int connectorCountAfterAddingOne = connectorViewModel.ConnectorPinViewCollection.Count;
 
-            ///Request remove pin
+            //Request remove pin
             var firstPin = connectorViewModel.ConnectorPinViewCollection.First();
             firstPin.OnRequestRemove(firstPin, System.EventArgs.Empty);
 
@@ -103,7 +94,7 @@ namespace DynamoCoreWpfTests
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
             connectorViewModel.SelectConnectedCommand.Execute(null);
-            ///Should result in 2 selected nodes.
+            //Should result in 2 selected nodes.
             Assert.AreEqual(DynamoSelection.Instance.Selection.Count, initialSelectedCount + 2);
         }
 
@@ -117,7 +108,7 @@ namespace DynamoCoreWpfTests
             int initialConnectorCount = this.ViewModel.CurrentSpaceViewModel.Connectors.Count;
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
             connectorViewModel.BreakConnectionCommand.Execute(null);
-            ///This should result in no connectors existing anymore.
+            //This should result in no connectors existing anymore.
             Assert.AreEqual(this.ViewModel.CurrentSpaceViewModel.Connectors.Count, initialConnectorCount - 1);
         }
 
@@ -132,7 +123,7 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
             bool initialVisibility = connectorViewModel.IsHidden;
-            ///Toggles hide (visibility == off)
+            //Toggles hide (visibility == off)
             connectorViewModel.HideConnectorCommand.Execute(null);
             Assert.AreEqual(connectorViewModel.IsHidden, !initialVisibility);
         }
@@ -147,10 +138,10 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
             bool initialVisibility = connectorViewModel.IsHidden;
-            ///Toggles hide (visibility == off)
+            //Toggles hide (visibility == off)
             connectorViewModel.HideConnectorCommand.Execute(null);
             Assert.AreEqual(connectorViewModel.IsHidden, !initialVisibility);
-            ///Toggles hide on/off (visibility == on)
+            //Toggles hide on/off (visibility == on)
             connectorViewModel.HideConnectorCommand.Execute(null);
             Assert.AreEqual(connectorViewModel.IsHidden, initialVisibility);
         }
@@ -166,13 +157,13 @@ namespace DynamoCoreWpfTests
             int initialNodeCount = this.ViewModel.CurrentSpaceViewModel.Nodes.Count;
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Place watch node
+            //Place watch node
             connectorViewModel.ConnectorAnchorViewModel.PlaceWatchNodeCommand.Execute(null);
-            ///Two connectors should result when you place a new (watch) node in between.
+            //Two connectors should result when you place a new (watch) node in between.
             Assert.AreEqual(this.ViewModel.CurrentSpaceViewModel.Connectors.Count, initialConnectorCount + 1);
-            ///Three nodes should be the total number of nodes after this operation.
+            //Three nodes should be the total number of nodes after this operation.
             Assert.AreEqual(this.ViewModel.CurrentSpaceViewModel.Nodes.Count, initialNodeCount + 1);
         }
 
@@ -202,9 +193,9 @@ namespace DynamoCoreWpfTests
             connectorViewModel.PanelX = 435;
             connectorViewModel.PanelY = 394;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Place watch node
+            //Place watch node
             connectorViewModel.ConnectorAnchorViewModel.PlaceWatchNodeCommand.Execute(null);
 
             //get new connectors if they are connected to correct nodes/ports
@@ -254,9 +245,9 @@ namespace DynamoCoreWpfTests
             connectorViewModel.PanelX = 600.6666;
             connectorViewModel.PanelY = 265.3333;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Place watch node
+            //Place watch node
             connectorViewModel.ConnectorAnchorViewModel.PlaceWatchNodeCommand.Execute(null);
 
             int newPinCount = this.ViewModel.CurrentSpaceViewModel.Pins.Count;
@@ -287,20 +278,20 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            ///hard-coded position (1) on wire
+            //hard-coded position (1) on wire
             connectorViewModel.PanelX = 292.66666;
             connectorViewModel.PanelY = 278;
 
             int initialPinCount = connectorViewModel.ConnectorPinViewCollection.Count;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Pin command
+            //Pin command
             connectorViewModel.PinConnectorCommand.Execute(null);
-            ///Should be 1 more than the original count
+            //Should be 1 more than the original count
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialPinCount + 1);
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
-            ///Should be the original count
+            //Should be the original count
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialPinCount);
         }
         /// <summary>
@@ -312,24 +303,24 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            ///hard-coded position (1) on wire
+            //hard-coded position (1) on wire
             connectorViewModel.PanelX = 292.66666;
             connectorViewModel.PanelY = 278;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Pin command
+            //Pin command
             connectorViewModel.PinConnectorCommand.Execute(null);
             int initialPinsAfterOneAdded = connectorViewModel.ConnectorPinViewCollection.Count;
 
-            ///Request remove pin
+            //Request remove pin
             var firstPin = connectorViewModel.ConnectorPinViewCollection.First();
             firstPin.OnRequestRemove(firstPin, System.EventArgs.Empty);
-            ///Pin count should be zero
+            //Pin count should be zero
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialPinsAfterOneAdded - 1);
-            ///Undo 'unpin' pin
+            //Undo 'unpin' pin
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
-            ///Pin count should be one
+            //Pin count should be one
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialPinsAfterOneAdded);
         }
         /// <summary>
@@ -341,24 +332,24 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            ///hard-coded position (1) on wire
+            //hard-coded position (1) on wire
             connectorViewModel.PanelX = 292.66666;
             connectorViewModel.PanelY = 278;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Pin command
+            //Pin command
             connectorViewModel.PinConnectorCommand.Execute(null);
             int initialPinsAfterOneAdded = connectorViewModel.ConnectorPinViewCollection.Count;
 
-            ///Request delete pin
+            //Request delete pin
             var firstPin = connectorViewModel.ConnectorPinViewCollection.First();
             Model.ExecuteCommand(new DeleteModelCommand(firstPin.Model.GUID));
-            ///Pin count should be zero
+            //Pin count should be zero
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialPinsAfterOneAdded - 1);
-            ///Undo delete pin
+            //Undo delete pin
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
-            ///Pin count should be one
+            //Pin count should be one
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, initialPinsAfterOneAdded);
         }
         /// <summary>
@@ -370,53 +361,78 @@ namespace DynamoCoreWpfTests
             Open(@"UI/ConnectorPinTests.dyn");
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            ///hard-coded position on wire
+            //hard-coded position on wire
             connectorViewModel.PanelX = 292.66666;
             connectorViewModel.PanelY = 278;
 
-            ///deltas to move by
+            //deltas to move by
             double xMove = 250;
             double yMove = 150;
 
-            ///Action triggered when hovering over a connector
+            //Action triggered when hovering over a connector
             connectorViewModel.FlipOnConnectorAnchor();
-            ///Pin command
+            //Pin command
             connectorViewModel.PinConnectorCommand.Execute(null);
             Assert.AreEqual(connectorViewModel.ConnectorPinViewCollection.Count, 1);
 
-            /// add connectorpin to selection
+            // add connectorpin to selection
             var connectorPin = connectorViewModel.ConnectorModel.ConnectorPinModels.First();
             DynamoSelection.Instance.Selection.Add(connectorPin);
 
-            ///initial x, y position of pin
+            //initial x, y position of pin
             double initialX = connectorPin.CenterX;
             double initialY = connectorPin.CenterY;
 
             var point = new Point2D(initialX, initialY);
             var operation = DragSelectionCommand.Operation.BeginDrag;
-            ///'begin drag' command defined
+            //'begin drag' command defined
             var command = new DragSelectionCommand(point, operation);
-            ///execute 'begin drag'
+            //execute 'begin drag'
             Model.ExecuteCommand(command);
 
             operation = DragSelectionCommand.Operation.EndDrag;
             point.X += xMove;
             point.Y += yMove;
-            ///'end drag' command defined
+            //'end drag' command defined
             command = new DragSelectionCommand(point, operation);
-            ///execute 'end drag'
+            //execute 'end drag'
             Model.ExecuteCommand(command);
 
-            ///assert initial position and end position is NOT the same
+            //assert initial position and end position is NOT the same
             Assert.AreNotEqual(initialX, connectorPin.CenterX);
             Assert.AreNotEqual(initialY, connectorPin.CenterY);
 
-            ///undo drag
+            //undo drag
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
 
-            ///assert that after undo initial position and end position IS the same
+            //assert that after undo initial position and end position IS the same
             Assert.AreEqual(initialX, connectorPin.CenterX);
             Assert.AreEqual(initialY, connectorPin.CenterY);
+        }
+
+        [Test]
+        public void CanUndoPlaceWatchNode()
+        {
+            Open(@"UI/WatchNodePlacement.dyn");
+            int initialConnectorCount = this.ViewModel.CurrentSpaceViewModel.Connectors.Count;
+
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.FirstOrDefault(c => c.ConnectorModel.GUID == Guid.Parse("f49e39e1-4eb0-47da-9dbe-bbf0badddc71"));
+            //mimic correct mouse placement over this connector
+            connectorViewModel.PanelX = 435;
+            connectorViewModel.PanelY = 394;
+
+            //Action triggered when hovering over a connector
+            connectorViewModel.FlipOnConnectorAnchor();
+            //Place watch node
+            connectorViewModel.ConnectorAnchorViewModel.PlaceWatchNodeCommand.Execute(null);
+            //asserts an additional connector exists
+            int partialConnectorCount = this.ViewModel.CurrentSpaceViewModel.Connectors.Count;
+            Assert.AreEqual(initialConnectorCount+1, partialConnectorCount);
+            //Undo watch node placement
+            Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
+            //assert after one undo action we are back at the original connector count
+            int finalConnectorCount = this.ViewModel.CurrentSpaceViewModel.Connectors.Count;
+            Assert.AreEqual(initialConnectorCount, finalConnectorCount);
         }
         #endregion
     }


### PR DESCRIPTION
### Description

This PR:

- Fixes: _Creation of watch node using pin on connector should be undone in single step_
- Adds a unit test (`CanUndoPlaceWatchNode`) to guard correctness of watch node placement undo/redo.

![WatchNodePlacement-UndoFix](https://user-images.githubusercontent.com/24754290/140323828-c2e454a2-a8f6-4881-9187-b5b7748c4ace.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
@Amoursol 
