### PR TITLE
Publish Package View Binding Style Fix

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.13.0.2733")]
+[assembly: AssemblyVersion("2.13.0.3066")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.13.0.2733")]
+[assembly: AssemblyFileVersion("2.13.0.3066")]

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -222,7 +222,7 @@
                 Grid.RowSpan="4"
                 Background="{StaticResource DarkMidGreyBrush}"
                 CornerRadius="4"
-                MouseDown="PreferencesPanel_MouseDown">
+                MouseDown="PackageManagerSearchView_MouseDown">
             <DockPanel HorizontalAlignment="Stretch">
                 <Button x:Name="closeButton"
                         Margin="25,20"

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -131,7 +131,7 @@ namespace Dynamo.PackageManager.UI
             }
         }
 
-        private void PreferencesPanel_MouseDown(object sender, MouseButtonEventArgs e)
+        private void PackageManagerSearchView_MouseDown(object sender, MouseButtonEventArgs e)
         {
             //Drag functionality when the TitleBar is clicked with the left button and dragged to another place
             if (e.ChangedButton == MouseButton.Left)

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -5,7 +5,9 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
-        xmlns:ui="clr-namespace:Dynamo.UI"
+        xmlns:ui="clr-namespace:Dynamo.UI" 
+        xmlns:packagemanager="clr-namespace:Dynamo.PackageManager"
+        d:DataContext="{d:DesignInstance Type=packagemanager:PublishPackageViewModel}"
         Name="PublishInfoControl"
         Width="900"
         Height="710"
@@ -504,7 +506,7 @@
                 Grid.Column="0"
                 Background="{StaticResource DarkMidGreyBrush}"
                 CornerRadius="4"
-                MouseDown="PreferencesPanel_MouseDown">
+                MouseDown="PublishPackageView_MouseDown">
             <DockPanel HorizontalAlignment="Stretch">
 
                 <!--  Close Button  -->
@@ -558,7 +560,9 @@
                                ToolTip="{x:Static p:Resources.PublishPackageViewPackageNameTooltip}" />
                     <TextBox Name="packageNameInput"
                              Style="{StaticResource InputStyle}"
-                             Tag="{x:Static p:Resources.PublishPackageViewPackageNameWatermark}" />
+                             Tag="{x:Static p:Resources.PublishPackageViewPackageNameWatermark}"
+                             IsEnabled ="{Binding Path=CanEditName}"
+                             Text="{Binding Path=Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                     <!--  Description  -->
                     <TextBlock Name="descriptionLabel"
@@ -568,7 +572,8 @@
                     <TextBox Name="descriptionInput"
                              MinHeight="81px"
                              Style="{StaticResource InputStyle}"
-                             Tag="{x:Static p:Resources.PublishPackageViewPackageDescription}" />
+                             Tag="{x:Static p:Resources.PublishPackageViewPackageDescription}"
+                             Text="{Binding Path=Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                     <!--  Version  -->
                     <TextBlock Name="versionLabel"
@@ -580,17 +585,20 @@
                                  Margin="0,0,6,0"
                                  MaxLength="4"
                                  Style="{StaticResource InputStyle}"
-                                 Tag="{x:Static p:Resources.PublishPackageVersionMajorWatermark}" />
+                                 Tag="{x:Static p:Resources.PublishPackageVersionMajorWatermark}"
+                                 Text="{Binding Path=MajorVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         <TextBox Name="versionMinorInput"
                                  Margin="0,0,6,0"
                                  MaxLength="4"
                                  Style="{StaticResource InputStyle}"
-                                 Tag="{x:Static p:Resources.PublishPackageVersionMinorWatermark}" />
+                                 Tag="{x:Static p:Resources.PublishPackageVersionMinorWatermark}"
+                                 Text="{Binding Path=MinorVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                         <TextBox Name="versionBuildInput"
                                  Margin="0,0,6,0"
                                  MaxLength="4"
                                  Style="{StaticResource InputStyle}"
-                                 Tag="{x:Static p:Resources.PublishPackageVersionBuildWatermark}" />
+                                 Tag="{x:Static p:Resources.PublishPackageVersionBuildWatermark}"
+                                 Text="{Binding Path=BuildVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                     </StackPanel>
 
                     <!--  External Dependency  -->
@@ -803,7 +811,7 @@
                                                 IsReadOnly="False"
                                                 IsThreeState="False" />
                         <DataGridTextColumn MinWidth="50"
-                                            Binding="{Binding Path=Name}"
+                                            Binding="{Binding Path=FileInfo.Name}"
                                             Header="Name"
                                             HeaderStyle="{StaticResource DataGridColumnHeaderText}"
                                             IsReadOnly="True" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -13,6 +13,7 @@
         Height="710"
         MinWidth="630"
         MinHeight="500"
+        DataContext="{Binding PublishPackageViewModel, RelativeSource={RelativeSource Self}}"
         ResizeMode="CanResizeWithGrip"
         Visibility="Visible"
         WindowStartupLocation="CenterOwner"
@@ -90,7 +91,6 @@
                 <Setter Property="Margin" Value="0,0,0,5" />
             </Style>
             <Style x:Key="InputStyle" TargetType="TextBox">
-                <Setter Property="OverridesDefaultStyle" Value="True" />
                 <Setter Property="Margin" Value="0,0,0,12" />
                 <Setter Property="MinWidth" Value="62px" />
                 <Setter Property="Cursor" Value="IBeam" />
@@ -107,8 +107,8 @@
                                          FontSize="12px"
                                          Foreground="#DFDFDF"
                                          MaxLength="{TemplateBinding MaxLength}"
+                                         Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Text, UpdateSourceTrigger=PropertyChanged}"
                                          Tag="{TemplateBinding Tag}"
-                                         Text="{TemplateBinding Text}"
                                          TextWrapping="Wrap" />
                                 <TextBlock x:Name="WatermarkLabel"
                                            Padding="13,13,10,8"
@@ -868,9 +868,9 @@
                         <TextBlock Style="{StaticResource LabelStyle}" Text="{x:Static p:Resources.PublishPackageViewMarkdownFilesDirectory}" />
                         <Image Width="16px"
                                Height="16px"
-                               DockPanel.Dock="Left"
-                               VerticalAlignment="Top"
                                Margin="5,0,0,0"
+                               VerticalAlignment="Top"
+                               DockPanel.Dock="Left"
                                Source="/DynamoCoreWpf;component/UI/Images/info-grey.png" />
                         <Button Command="{Binding Path=ClearMarkdownDirectoryCommand}"
                                 Content="{x:Static p:Resources.PublishPackageViewResetMarkdownDirectoryButton}"

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
@@ -18,7 +18,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Internal reference of PublishPackageViewModel
         /// </summary>
-        private PublishPackageViewModel PublishPackageViewModel { get; }
+        public PublishPackageViewModel PublishPackageViewModel { get; }
 
         public PublishPackageView(PublishPackageViewModel publishPackageViewModel)
         {

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
@@ -112,7 +112,7 @@ namespace Dynamo.PackageManager
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void PreferencesPanel_MouseDown(object sender, MouseButtonEventArgs e)
+        private void PublishPackageView_MouseDown(object sender, MouseButtonEventArgs e)
         {
             // Drag functionality when the TitleBar is clicked with the left button and dragged to another place
             if (e.ChangedButton == MouseButton.Left)


### PR DESCRIPTION
### Purpose

This PR sets the DataContext on the PublishPackageView and adjusts the InputStyle to bind correctly to its targets.
Aaron, please let me know if this is the preferred way to get these changes over to you!

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a data binding bug in the publish package dialog.

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
