### PR TITLE
[DYN-4157] Node to code for group leaves behind a vertical line

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -176,4 +176,5 @@
         TrueBrush="{StaticResource PinnedIconForegroundColor}" />
     <controls:NestedGroupsLabelConverter x:Key="NestedGroupsLabelConverter" />
     <controls:CollectionHasMoreThanNItemsToBoolConverter x:Key="CollectionHasMoreThanNItemsToBoolConverter" />
+    <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -347,6 +347,7 @@
                 CornerRadius="{StaticResource ExpanderCornerRadius}"
                 IsHitTestVisible="False"
                 Canvas.ZIndex="41"
+                Visibility="{Binding Nodes, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}"
                 Margin="-1">
             <Border.BorderBrush>
                 <SolidColorBrush Color="{Binding Background}" />


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4182](https://jira.autodesk.com/browse/DYN-4182)

![N2CBug](https://user-images.githubusercontent.com/13732445/140727144-d9b64c65-da66-495f-9c31-512575d7e1ab.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@QilongTang 

### FYIs

