### PR TITLE
fixing icons css style

### DIFF
--- a/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/searchPackages.html
+++ b/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/searchPackages.html
@@ -20,18 +20,20 @@
             height: auto;
         }
 
-        .filterIcon {
-            background: url(data:image/png;base64,#filterIcon);
+        span {
             height: 1rem;
             width: 1rem;
             display: inline-block;
         }
 
+        .filterIcon {
+            background: url(data:image/png;base64,#filterIcon);
+            background-size: cover;
+        }
+
         .sortIcon {
             background: url(data:image/png;base64,#sortIcon);
-            height: 1rem;
-            width: 1rem;
-            display: inline-block;
+            background-size: cover;
         }
 
         body {


### PR DESCRIPTION
### Purpose

This PR fixes the icons cut off in the HTML modal of step 4 as discussed [in this task](https://jira.autodesk.com/browse/DYN-4239?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix icons cut off

![image](https://user-images.githubusercontent.com/89042471/140793790-fce35460-b984-4752-be88-b964b692c88d.png)


### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 