### PR TITLE
Legal Text updates

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4366,7 +4366,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to LICENSE:.
+        ///   Looks up a localized string similar to LICENSE OF LATEST PACKAGE.
         /// </summary>
         public static string PackageDetailsLicense {
             get {
@@ -6141,7 +6141,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If blank, the package will be licensed under .
+        ///   Looks up a localized string similar to Applies to the latest package version. If blank, the package will be licensed under.
         /// </summary>
         public static string PublishPackageViewLicenseSubLabel {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2730,7 +2730,7 @@ This package will be unloaded after the next Dynamo restart.</value>
     <value>Keywords</value>
   </data>
   <data name="PublishPackageViewLicenseSubLabel" xml:space="preserve">
-    <value>If blank, the package will be licensed under </value>
+    <value>Applies to the latest package version. If blank, the package will be licensed under </value>
   </data>
   <data name="PublishPackageViewLicenseWatermark" xml:space="preserve">
     <value>License</value>
@@ -2818,7 +2818,7 @@ This package will be unloaded after the next Dynamo restart.</value>
     <comment>Header in the PackageDetailsViewExtension.</comment>
   </data>
   <data name="PackageDetailsLicense" xml:space="preserve">
-    <value>LICENSE:</value>
+    <value>LICENSE OF LATEST PACKAGE</value>
     <comment>Header in the PackageDetailsViewExtension.</comment>
   </data>
   <data name="PackageDetailsVersionsAndPackageRequirements" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1246,7 +1246,7 @@ You will get a chance to save your work.</value>
     <comment>Header in the PackageDetailsViewExtension.</comment>
   </data>
   <data name="PackageDetailsLicense" xml:space="preserve">
-    <value>LICENSE:</value>
+    <value>LICENSE OF LATEST PACKAGE</value>
     <comment>Header in the PackageDetailsViewExtension.</comment>
   </data>
   <data name="PackageDetailsVersionsAndPackageRequirements" xml:space="preserve">
@@ -1474,7 +1474,7 @@ If the toggle is off custom packages that are not already loaded will load once 
     <value>License (optional)</value>
   </data>
   <data name="PublishPackageViewLicenseSubLabel" xml:space="preserve">
-    <value>If blank, the package will be licensed under </value>
+    <value>Applies to the latest package version. If blank, the package will be licensed under</value>
   </data>
   <data name="PublishPackageViewLicenseWatermark" xml:space="preserve">
     <value>License</value>

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -714,7 +714,8 @@
                             <TextBlock Name="licenseLabel"
                                        Style="{StaticResource LabelStyle}"
                                        Text="{x:Static p:Resources.PublishPackageViewLicense}" />
-                            <TextBlock Name="licenseSubLabel" Style="{StaticResource SubLabelStyle}">
+                            <TextBlock Name="licenseSubLabel" Style="{StaticResource SubLabelStyle}"
+                                       TextWrapping="Wrap">
                                 <Run Text="{x:Static p:Resources.PublishPackageViewLicenseSubLabel}" />
                                 <Hyperlink Cursor="Hand"
                                            NavigateUri="https://opensource.org/licenses/MIT"

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -23,7 +23,7 @@
             <controls:InverseBooleanConverter x:Key="InverseBooleanConverter" />
             <controls:PrettyDateConverter x:Key="PrettyDateConverter" />
             <Style x:Key="LabelStyle" TargetType="TextBlock">
-                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementBold}" />
                 <Setter Property="FontWeight" Value="Bold" />
                 <Setter Property="FontSize" Value="14px" />
                 <Setter Property="MinWidth" Value="200px" />
@@ -227,13 +227,13 @@
                            Text="{Binding PackageDescription}" />
 
                 <!--  License  -->
-                <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation ="Vertical">
                     <TextBlock Name="LicenseTitle"
                                MinWidth="0"
                                Style="{StaticResource LabelStyle}"
                                Text="{x:Static p:Resources.PackageDetailsLicense}" />
                     <TextBlock Name="LicenseBody"
-                               Margin="5,0,0,20"
+                               Margin="0,0,0,20"
                                FontSize="14px"
                                Style="{StaticResource BodyTextStyle}"
                                Text="{Binding License}" />


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Text updated for both the Package Manager Authoring and Consumption workflows after conversation with Legal.

Changes:

- Package Manager - Authoring license text updated, wrapping enabled.
- Package Manager - Consumer Details Extension license text updated, changed to vertical stack panel to enable license underneath the header, and added bold to all headers.

![LegalTextChanges_DynamoUI](https://user-images.githubusercontent.com/12857357/140823416-b66602d0-910a-40b8-8e82-c135422d806c.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Updated license text to better represent the license situation on packages on both Package creation and consumption.


### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 
