### PR TITLE
Shortcuts Bar Bug Fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -722,7 +722,7 @@
         <!--Shortcuts Toolbar-->
         <Grid Grid.Row="1"
               Grid.Column="0"
-              Canvas.ZIndex="0"
+              Canvas.ZIndex="1"
               VerticalAlignment="Top"
               Grid.ColumnSpan="5"
               Name="shortcutsBarGrid">
@@ -1777,6 +1777,7 @@
         <!--Gallery or What's new-->
         <Grid Name="galleryBackground"
               Visibility="Hidden"
+              Canvas.ZIndex="2"
               MouseLeftButtonDown="OnGalleryBackgroundMouseClick">
             <Grid.Background>
                 <SolidColorBrush Color="Black" Opacity="0.8"/>


### PR DESCRIPTION
### Purpose

This PR fixes a bug where the shortcuts bar buttons aren't pressable (due to ZIndex issues). 
This is a result of me 'fixing' the start window (`GalleryView.xaml`) ZIndex issues here: #12246

Instead, I've undone the value set in #12246 and have instead incremented the ZIndex of the galleryBackground Grid. 
Looks fine visually:

![image](https://user-images.githubusercontent.com/29973601/141085931-ffcd7f1a-951a-46ec-a08c-cdaaa7d759a7.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixed a UI bug on the shortcuts toolbar.

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
