### PR TITLE
DYN-4241-Step6-PackageDependencies

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -169,15 +169,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Autodesk sample.
-        /// </summary>
-        public static string AutodeskSamplePackage {
-            get {
-                return ResourceManager.GetString("AutodeskSamplePackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Autodesk Sign In.
         /// </summary>
         public static string AutodeskSignIn {
@@ -5096,7 +5087,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If you need other software or tools in order to use this package, they are listed under Dependencies. The interactive guide for Package Dependencies will tell you more..
+        ///   Looks up a localized string similar to \nIf you need other software or tools in order to use this package, they are listed under Dependencies..
         /// </summary>
         public static string PackagesGuideDependenciesText {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2922,11 +2922,8 @@ This package will be unloaded after the next Dynamo restart.</value>
   <data name="InfoBubbleInfo" xml:space="preserve">
     <value>Info</value>
   </data>
-  <data name="AutodeskSamplePackage" xml:space="preserve">
-    <value>Autodesk sample</value>
-  </data>
   <data name="PackagesGuideDependenciesText" xml:space="preserve">
-    <value>If you need other software or tools in order to use this package, they are listed under Dependencies. The interactive guide for Package Dependencies will tell you more.</value>
+    <value>\nIf you need other software or tools in order to use this package, they are listed under Dependencies.</value>
   </data>
   <data name="PackagesGuideDependenciesTitle" xml:space="preserve">
     <value>Package dependencies</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2903,9 +2903,6 @@ Delete the following packages: {2}?
   <data name="ShortcutExportWorkspace" xml:space="preserve">
     <value>Workspace</value>
   </data>
-  <data name="AutodeskSamplePackage" xml:space="preserve">
-    <value>Autodesk sample</value>
-  </data>
   <data name="PackagesGuideExitAcceptTerms" xml:space="preserve">
     <value>To continue the guide and install the sample package, you must accept the Terms of Service. \n\n **Click Continue.** Then in the terms, **click I Accept.** \n\n\n\n</value>
   </data>
@@ -2916,7 +2913,7 @@ Delete the following packages: {2}?
     <value>\nSearch results display summary information for each package: -author- -likes and downloads- -date of the most recent version- \n**Click View Details** to see more information about a package.</value>
   </data>
   <data name="PackagesGuideDependenciesText" xml:space="preserve">
-    <value>If you need other software or tools in order to use this package, they are listed under Dependencies. The interactive guide for Package Dependencies will tell you more.</value>
+    <value>\nIf you need other software or tools in order to use this package, they are listed under Dependencies.</value>
   </data>
   <data name="PackagesGuideDependenciesTitle" xml:space="preserve">
     <value>Package dependencies</value>

--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -95,15 +95,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 Step firstStep = GuideSteps.FirstOrDefault();
                 CurrentStep = firstStep;
 
-                //When the first step of the guide is a tooltip, then it need to have a background and a hole to highlight the element
-                if (firstStep.HostPopupInfo != null && 
-                    firstStep.StepType == Step.StepTypes.TOOLTIP)
-                {
-                    SetCutOffSectionSize(firstStep.HostPopupInfo);
-                    SetHighlightSectionColor(firstStep.HostPopupInfo);
-                }
-
-
                 firstStep.Show(GuideFlow.FORWARD);
             }
         }
@@ -230,19 +221,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                     SetLibraryViewVisible(resultStep.ShowLibrary);
                     CurrentStep = resultStep;
-
-                    if (resultStep.StepType != Step.StepTypes.WELCOME &&
-                       resultStep.StepType != Step.StepTypes.SURVEY
-                       && resultStep.HostPopupInfo != null)
-                    {
-                        SetCutOffSectionSize(CurrentStep.HostPopupInfo);
-                        SetHighlightSectionColor(CurrentStep.HostPopupInfo);
-                    }
-                    else
-                    {
-                        GuideBackgroundElement.ClearCutOffSection();
-                        GuideBackgroundElement.ClearHighlightSection();
-                    }
                 }
             }
         }
@@ -270,63 +248,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private void GuideFlowEvents_GuidedTourNextStep(GuidedTourMovementEventArgs args)
         {
             NextStep(args.StepSequence);
-        }
-
-        /// <summary>
-        /// This method will set the highlight rectangle color if there is any configured in the json file
-        /// </summary>
-        /// <param name="highlightColor">This parameter represents the color in hexadecimal</param>
-        private void SetHighlightSectionColor(HostControlInfo hostControlInfo)
-        {
-            if (hostControlInfo.HighlightRectArea != null)
-            {
-                //If is not empty means that the HighlightRectArea.WindowElementNameString doesn't belong to the DynamoView then another way for hightlighting the element will be applied
-                if (!string.IsNullOrEmpty(hostControlInfo.HighlightRectArea.WindowName)) return;
-
-                string highlightColor = hostControlInfo.HighlightRectArea.HighlightColor;
-
-                //This section will get the X,Y coordinates of the HostUIElement based in the Ancestor UI Element so we can put the highlight rectangle
-                Point relativePoint = hostControlInfo.HostUIElement.TransformToAncestor(MainWindow)
-                                  .Transform(new Point(0, 0));
-
-                var holeWidth = hostControlInfo.HostUIElement.DesiredSize.Width + hostControlInfo.HighlightRectArea.WidthBoxDelta;
-                var holeHeight = hostControlInfo.HostUIElement.DesiredSize.Height + hostControlInfo.HighlightRectArea.HeightBoxDelta;
-
-                GuideBackgroundElement.HighlightBackgroundArea.SetHighlighRectSize(relativePoint.Y, relativePoint.X, holeWidth, holeHeight);
-
-                if (string.IsNullOrEmpty(highlightColor))
-                {
-                    GuideBackgroundElement.GuideHighlightRectangle.Stroke = Brushes.Transparent;
-                }
-                else
-                {
-                    var converter = new BrushConverter();
-                    var brush = (Brush)converter.ConvertFromString(highlightColor);
-                    GuideBackgroundElement.GuideHighlightRectangle.Stroke = brush;
-                }
-            }
-        }
-
-        /// <summary>
-        /// This method will update the CutOff rectangle size everytime that the step change
-        /// </summary>
-        /// <param name="hostElement">Element for size and position reference</param>
-        private void SetCutOffSectionSize(HostControlInfo hostControlInfo)
-        {
-            if (hostControlInfo.CutOffRectArea != null)
-            {
-                Point relativePoint = hostControlInfo.HostUIElement.TransformToAncestor(MainWindow)
-                              .Transform(new Point(0, 0));
-
-               
-                var holeWidth = hostControlInfo.HostUIElement.DesiredSize.Width + hostControlInfo.CutOffRectArea.WidthBoxDelta;
-                var holeHeight = hostControlInfo.HostUIElement.DesiredSize.Height + hostControlInfo.CutOffRectArea.HeightBoxDelta;
-
-                if (GuideBackgroundElement.CutOffBackgroundArea != null)
-                {
-                    GuideBackgroundElement.CutOffBackgroundArea.CutOffRect = new Rect(relativePoint.X, relativePoint.Y, holeWidth, holeHeight);
-                }
-            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -4,11 +4,13 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.PackageManager;
 using Dynamo.PackageManager.UI;
 using Dynamo.PackageManager.ViewModels;
 using Dynamo.ViewModels;
+using static Dynamo.PackageManager.PackageManagerSearchViewModel;
 using static Dynamo.Wpf.UI.GuidedTour.Guide;
 using Res = Dynamo.Wpf.Properties.Resources;
 
@@ -25,6 +27,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         internal static GuidesManager CurrentExecutingGuidesManager;
         
         private static ExitGuide exitGuide;
+        private const string AutodeskSamplePackage = "Autodesk sample";
 
         //This method will return a bool that describes if the Terms Of Service was accepted or not.
         internal static bool AcceptedTermsOfUse(DynamoViewModel dynViewModel)
@@ -89,7 +92,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         /// <param name="element">The element to subscribe the method I.E: Button</param>
         /// <param name="eventname">The event name that will be subscribed I.E: Click</param>
-        /// <param name="methodname">The method that will listen the event I.E: AcceptButton_Click</param>
+        /// <param name="methodname">The method that will listen the event I.E: AcceptButton_Click
+        /// The method need to have Access Modifier internal and return void 
+        /// </param>
         /// <param name="addEvent">A flag that will check if it's to subscribe or unsubscribe</param>
         internal static void ManageEventHandler(object element, string eventname, string methodname, bool addEvent = true)
         {
@@ -152,39 +157,120 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if(enableFunction)
             {
                 //We need to check if the PackageManager search is already open if that is the case we don't need to open it again
-                if (ownedWindow == null)
-                {
+                if (ownedWindow != null) return;
                     stepInfo.DynamoViewModelStep.ShowPackageManagerSearch(null);
-                    PackageManagerSearchView packageManager = Guide.FindWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window) as PackageManagerSearchView;
-                    if (packageManager == null)
-                        return;
-                    PackageManagerSearchViewModel packageManagerViewModel = packageManager.DataContext as PackageManagerSearchViewModel;
-                    if (packageManagerViewModel == null)
-                        return;
-                    //Put the name of the Package to be searched in the SearchTextBox
-                    packageManagerViewModel.SearchText = Res.AutodeskSamplePackage;
-                    //Execute the Search
-                    packageManagerViewModel.RefreshAndSearchAsync();
-                }             
+
+                PackageManagerSearchView packageManager = Guide.FindWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window) as PackageManagerSearchView;
+                if (packageManager == null)
+                    return;
+                PackageManagerSearchViewModel packageManagerViewModel = packageManager.DataContext as PackageManagerSearchViewModel;
+                if (packageManagerViewModel == null)
+                    return;
+
+                //Due that we need to search the Autodesk Sample package after the inicial search is completed 
+                //we need to subscribe to the PropertyChanged event so we will know when the SearchState property is equal to Results (meaning that got results)
+                packageManagerViewModel.PropertyChanged += PackageManagerViewModel_PropertyChanged;          
             }
             else
             {
-                if (ownedWindow == null) return;
+
+                PackageManagerSearchView packageManager = Guide.FindWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window) as PackageManagerSearchView;
+                if (packageManager == null)
+                    return;
+                PackageManagerSearchViewModel packageManagerViewModel = packageManager.DataContext as PackageManagerSearchViewModel;
+                if (packageManagerViewModel == null)
+                    return;
 
                 //Depending of the SetUp done in the Guides Json we will make the Clean Up or not, for example there are several Steps that use the PackageManagerSearchView then we won't close it
 
                 //The Guide is moving to FORWARD and the ExecuteCleanUpForward = false, then we don't need to close the PackageManagerSearchView
                 if (uiAutomationData.ExecuteCleanUpForward && currentFlow == GuideFlow.FORWARD)
-                    ownedWindow.Close();
+                {
+                    ClosePackageManager(packageManager);
+                }                  
 
                 //The Guide is moving to FORWARD and the ExecuteCleanUpForward = false, then we don't need to close the PackageManagerSearchView
                 if (uiAutomationData.ExecuteCleanUpBackward && currentFlow == GuideFlow.BACKWARD)
-                    ownedWindow.Close();
+                {
+                    ClosePackageManager(packageManager);
+                }
 
                 //The currentFlow = GuideFlow.CURRENT when exiting the Guide
                 if (currentFlow == GuideFlow.CURRENT)
-                    ownedWindow.Close();
+                {
+                    ClosePackageManager(packageManager);
+                }
             }
+        }
+
+        /// <summary>
+        /// This method will find the PackageManagerSearch window and then close it
+        /// </summary>
+        /// <param name="packageManager"></param>
+        private static void ClosePackageManager(PackageManagerSearchView packageManager)
+        {
+            PackageManagerSearchViewModel packageManagerViewModel = packageManager.DataContext as PackageManagerSearchViewModel;
+            if (packageManagerViewModel == null)
+                return;
+            packageManagerViewModel.PropertyChanged -= PackageManagerViewModel_PropertyChanged;
+            packageManager.Close();
+        }
+
+        /// <summary>
+        /// This method is subscribed to the PropertyChanged event so we will be notified when the SearchState changed
+        /// </summary>
+        /// <param name="sender">PackageManagerSearchViewModel</param>
+        /// <param name="e">PropertyChanged</param>
+        private static void PackageManagerViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            PackageManagerSearchViewModel packageManagerViewModel = sender as PackageManagerSearchViewModel;
+            if (packageManagerViewModel == null) return;
+            if (e.PropertyName == nameof(packageManagerViewModel.SearchState))
+            {
+                //Let wait until the initial Package Search is completed and we got results then we will search the Autodesk Sample package
+                if (packageManagerViewModel.SearchState == PackageSearchState.Results)
+                {
+                    //Put the name of the Package to be searched in the SearchTextBox
+                    packageManagerViewModel.SearchText = AutodeskSamplePackage;
+
+                    //Unsubscribe from the PropertyChanged event otherwise it will enter everytime the SearchTextBox is updated
+                    packageManagerViewModel.PropertyChanged -= PackageManagerViewModel_PropertyChanged;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// This method will subcribe the menu "Packages->Search for a Package" MenuItem to the Next event so when is pressed we will moved to the next Step
+        /// </summary>
+        /// <param name="stepInfo">Information about the Step</param>
+        /// <param name="uiAutomationData">Information about UI Automation that is being executed</param>
+        /// <param name="enableFunction">Variable used to know if we are executing the automation or undoing changes</param>
+        /// <param name="currentFlow">Current Guide Flow</param>
+        internal static void SubscribeSearchForPackagesOption(Step stepInfo, StepUIAutomation uiAutomationData, bool enableFunction, GuideFlow currentFlow)
+        {
+            CurrentExecutingStep = stepInfo;
+
+            //We try to find the WindowElementNameString (in this case the MenuItem) in the DynamoView VisualTree
+            var foundUIElement = Guide.FindChild(CurrentExecutingStep.MainWindow, CurrentExecutingStep.HostPopupInfo.HighlightRectArea.WindowElementNameString) as MenuItem;
+            if (foundUIElement == null)
+                return;
+            if (enableFunction)
+                //Executed then Showing the Step
+                foundUIElement.Click += SearchForPackage_Click;
+            else
+                //Just executed when exiting the Guide or when passing to the next Step
+                foundUIElement.Click -= SearchForPackage_Click;
+        }
+
+        /// <summary>
+        /// When the "Search for a Package" MenuItem is clicked this method will be executed moving to the next Step
+        /// </summary>
+        /// <param name="sender">MenuItem</param>
+        /// <param name="e"></param>
+        internal static void SearchForPackage_Click(object sender, RoutedEventArgs e)
+        {
+            CurrentExecutingGuide.NextStep(CurrentExecutingStep.Sequence);
         }
 
         /// <summary>
@@ -235,16 +321,16 @@ namespace Dynamo.Wpf.UI.GuidedTour
         {
             const string packageDetailsName = "Package Details";
             const string closeButtonName = "CloseButton";
-            const string packageDetailsWindowName = "PackageDetailsWindow";
+            const string packageSearchWindowName = "PackageSearch";
 
             CurrentExecutingStep = stepInfo;
             var stepMainWindow = stepInfo.MainWindow as Window;          
-            var packageDetailsWindow = Guide.FindChild(stepMainWindow, packageDetailsWindowName) as UserControl;
+            var packageDetailsWindow = Guide.FindChild(stepMainWindow, stepInfo.HostPopupInfo.HostUIElementString) as UserControl;
 
             if (enableFunction)
             {
                 //This section will open the Package Details Sidebar
-                PackageManagerSearchView packageManager = Guide.FindWindowOwned(stepInfo.HostPopupInfo.WindowName, stepMainWindow) as PackageManagerSearchView;
+                PackageManagerSearchView packageManager = Guide.FindWindowOwned(packageSearchWindowName, stepMainWindow) as PackageManagerSearchView;
                 if (packageManager == null)
                     return;
                 PackageManagerSearchViewModel packageManagerViewModel = packageManager.DataContext as PackageManagerSearchViewModel;
@@ -259,10 +345,15 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 if (packageDetailsWindow == null)
                     packageManagerViewModel.ViewPackageDetailsCommand.Execute(packageManagerSearchElementViewModel.Model);
+
+                //The PackageDetails sidebar is using events when is being shown then we need to execute those events before setting the Popup.PlacementTarget.
+                //otherwise the sidebar will not be present (and we don't have host for the Popup) and the Popup will be located out of the Dynamo window
+                CurrentExecutingStep.MainWindow.Dispatcher.Invoke(DispatcherPriority.Background,new Action(delegate { }));
             }
             else
             {
-                //This section will close the Package Details Sidebar (just in case is still opened)
+                //This section will close the Package Details Sidebar (just in case is still opened), 
+                //due that the sidebar (UserControl) is inserted inside a TabItem the only way to close is by using the method dynamoView.CloseExtensionTab
                 var dynamoView = (stepMainWindow as DynamoView);
                 if (packageDetailsWindow == null)
                     return;
@@ -270,6 +361,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 TabItem tabitem = dynamoView.ExtensionTabItems.OfType<TabItem>().SingleOrDefault(n => n.Header.ToString() == packageDetailsName);
                 if (tabitem == null)
                     return;
+                //Get the Close button from the PackageDetailsView
                 Button closeButton = Guide.FindChild(tabitem, closeButtonName) as Button;
                 if (closeButton == null)
                     return;

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -167,7 +167,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 if (packageManagerViewModel == null)
                     return;
 
-                //Due that we need to search the Autodesk Sample package after the inicial search is completed 
+                //Due that we need to search the Autodesk Sample package after the initial search is completed 
                 //we need to subscribe to the PropertyChanged event so we will know when the SearchState property is equal to Results (meaning that got results)
                 packageManagerViewModel.PropertyChanged += PackageManagerViewModel_PropertyChanged;          
             }

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -264,7 +264,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This method will update the CutOff rectangle size everytime that the step change
         /// </summary>
-        /// <param name="bVisible">It will say it the CutOff Area will be disabled or enable</param>
+        /// <param name="bVisible">It will say if the CutOff Area will be disabled or enabled</param>
         private void SetCutOffSectionSize(bool bVisible)
         {
             if (HostPopupInfo.CutOffRectArea == null)
@@ -296,7 +296,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This method will set the highlight rectangle color if there is any configured in the json file
         /// </summary>
-        /// <param name="bVisible">It will say it the Highlight Area will be disabled or enable</param>
+        /// <param name="bVisible">It will say if the Highlight Area will be disabled or enabled</param>
         private void SetHighlightSection(bool bVisible)
         {
             if (HostPopupInfo.HighlightRectArea == null)

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -200,13 +200,16 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 ExecutePreValidation();
             }
 
-            stepUIPopup.IsOpen = true;
-
             //After the UI Automation is done we need to calculate the Target (if is not in DynamoView)
             CalculateTargetHost();
 
+            //After the Popup.PlacementTarget was recalculated (or calculated) then we proceed to put the cut off section
+            SetCutOffSectionSize(true);
+
             //After UI Automation and calculate the target we need to highlight the element (otherwise probably won't exist)
-            HighlightWindowElement(true);
+            SetHighlightSection(true);
+
+            stepUIPopup.IsOpen = true;
         }
 
         /// <summary>
@@ -216,9 +219,12 @@ namespace Dynamo.Wpf.UI.GuidedTour
         {
             stepUIPopup.IsOpen = false;
 
-            //First we undo the highlight over the element (otherwise probably won't exist)
-            HighlightWindowElement(false);
-      
+            //Disable the HightlightArea functionality
+            SetHighlightSection(false);
+
+            //We need to remove the cutoff section from the Overlay for the current Step (it will be set again for the next Step)
+            SetCutOffSectionSize(false);
+
             //Disable the current action automation that is executed for the Current Step (if there is one)
             if (UIAutomation != null)
             {
@@ -246,6 +252,92 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 stepUIPopup.PlacementTarget = ownedWindow;
                 UpdateLocation();
             }
+            //This case will be used for UIElements that are in the Dynamo VisualTree but they are shown until there is a user interaction (like the SideBar cases)
+            var hostUIElement = Guide.FindChild(MainWindow, HostPopupInfo.HostUIElementString);
+            if (hostUIElement == null)
+                return;
+            HostPopupInfo.HostUIElement = hostUIElement;
+            stepUIPopup.PlacementTarget = hostUIElement;
+            UpdateLocation();
+        }
+
+        /// <summary>
+        /// This method will update the CutOff rectangle size everytime that the step change
+        /// </summary>
+        /// <param name="bVisible">It will say it the CutOff Area will be disabled or enable</param>
+        private void SetCutOffSectionSize(bool bVisible)
+        {
+            if (HostPopupInfo.CutOffRectArea == null)
+                return;
+            if(bVisible)
+            {
+                //This will validate that HostPopupInfo.HostUIElement is in the MainWindow VisualTree otherwise the TransformToAncestor() will crash
+                var foundUIElement = Guide.FindChild(MainWindow, HostPopupInfo.HostUIElementString);
+                if (foundUIElement == null)
+                    return;
+
+                Point relativePoint = HostPopupInfo.HostUIElement.TransformToAncestor(MainWindow)
+                              .Transform(new Point(0, 0));
+
+                var holeWidth = HostPopupInfo.HostUIElement.DesiredSize.Width + HostPopupInfo.CutOffRectArea.WidthBoxDelta;
+                var holeHeight = HostPopupInfo.HostUIElement.DesiredSize.Height + HostPopupInfo.CutOffRectArea.HeightBoxDelta;
+
+                if (StepGuideBackground.CutOffBackgroundArea != null)
+                {
+                    StepGuideBackground.CutOffBackgroundArea.CutOffRect = new Rect(relativePoint.X, relativePoint.Y, holeWidth, holeHeight);
+                }
+            }
+            else
+            {
+                StepGuideBackground.ClearCutOffSection();
+            }
+        }
+
+        /// <summary>
+        /// This method will set the highlight rectangle color if there is any configured in the json file
+        /// </summary>
+        /// <param name="bVisible">It will say it the Highlight Area will be disabled or enable</param>
+        private void SetHighlightSection(bool bVisible)
+        {
+            if (HostPopupInfo.HighlightRectArea == null)
+                return;
+            if (bVisible)
+            {
+                if (!string.IsNullOrEmpty(HostPopupInfo.HighlightRectArea.UIElementTypeString))
+                    HighlightWindowElement(bVisible);
+                else
+                {
+                    //If is not empty means that the HighlightRectArea.WindowElementNameString doesn't belong to the DynamoView then another way for hightlighting the element will be applied
+                    if (!string.IsNullOrEmpty(HostPopupInfo.HighlightRectArea.WindowName)) return;
+
+                    string highlightColor = HostPopupInfo.HighlightRectArea.HighlightColor;
+
+                    //This section will get the X,Y coordinates of the HostUIElement based in the Ancestor UI Element so we can put the highlight rectangle
+                    Point relativePoint = HostPopupInfo.HostUIElement.TransformToAncestor(MainWindow)
+                                      .Transform(new Point(0, 0));
+
+                    var holeWidth = HostPopupInfo.HostUIElement.DesiredSize.Width + HostPopupInfo.HighlightRectArea.WidthBoxDelta;
+                    var holeHeight = HostPopupInfo.HostUIElement.DesiredSize.Height + HostPopupInfo.HighlightRectArea.HeightBoxDelta;
+
+                    StepGuideBackground.HighlightBackgroundArea.SetHighlighRectSize(relativePoint.Y, relativePoint.X, holeWidth, holeHeight);
+
+                    if (string.IsNullOrEmpty(highlightColor))
+                    {
+                        StepGuideBackground.GuideHighlightRectangle.Stroke = Brushes.Transparent;
+                    }
+                    else
+                    {
+                        var converter = new BrushConverter();
+                        var brush = (Brush)converter.ConvertFromString(highlightColor);
+                        StepGuideBackground.GuideHighlightRectangle.Stroke = brush;
+                    }
+                }          
+            }
+            else
+            {
+                HighlightWindowElement(bVisible);
+                StepGuideBackground.ClearHighlightSection();
+            }             
         }
 
 
@@ -254,6 +346,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         public void UpdateLocation()
         {
+            SetCutOffSectionSize(true);
             UpdatePopupLocationInvoke(stepUIPopup);
             if(stepUIPopup is PopupWindow)
             {

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -222,7 +222,16 @@
 						"WidthBoxDelta": 0,
 						"HeightBoxDelta": 3
 					}
-				}
+				},
+				"UIAutomation": [
+					{
+						"Sequence": 1,
+						"ControlType": "button",
+						"WindowName": "PopupWindow",
+						"Name": "BackButton",
+						"Action": "disable"
+					}
+				]
 			},
 			{
 				"Sequence": 2,
@@ -259,6 +268,20 @@
 						"ControlType": "MenuItem",
 						"Name": "PackageManagerMenu",
 						"Action": "open"
+					},
+					{
+						"Sequence": 2,
+						"ControlType": "function",
+						"Name": "SubscribeSearchForPackagesOption",
+						"Action": "execute",
+						"UpdatePlacementTarget": true,
+						"AutomaticHandlers": [
+							{
+								"HandlerElement": "showPMSearch",
+								"HandlerElementEvent": "Click",
+								"ExecuteMethod": "SearchForPackage_Click"
+							}
+						]
 					}
 				]
 			},
@@ -470,23 +493,18 @@
 				"HostPopupInfo": {
 					"PopupPlacement": "right",
 					"DynamicHostWindow": true,
-					"WindowName": "PackageSearch",
 					"HostUIElementString": "PackageDetailsWindow",
-					"VerticalPopupOffset": 50,
-					"HorizontalPopupOffset": 0
+					"VerticalPopupOffset": 400,
+					"HorizontalPopupOffset": 0,
+					"CutOffRectArea": {
+						"WindowElementNameString": "PackageDetailsWindow",
+						"WidthBoxDelta": 0,
+						"HeightBoxDelta": 3
+					}
 				},
 				"UIAutomation": [
 					{
 						"Sequence": 1,
-						"ControlType": "function",
-						"Name": "ExecutePackageSearch",
-						"ExecuteCleanUpForward": false,
-						"ExecuteCleanUpBackward": false,
-						"Action": "execute",
-						"UpdatePlacementTarget": true
-					},
-					{
-						"Sequence": 2,
 						"ControlType": "function",
 						"Name": "ExecuteViewDetailsSideBar",
 						"ExecuteCleanUpForward": false,


### PR DESCRIPTION
### Purpose

I added the Step 6 to the packages guide, the automation needed for opening the PackageDetaiils and adding support for showing the PackageDetails User Control over the dark overlay.
Basically I did the next changes:

- The highlight and cutoff functionality was moved from the Guide class to the Step class, so it will be executed on Step.Show(), Step.Hide() or when exiting the Guide.
- I modified resources for the Package Details popup and remove the resource for the "Autodesk Sample Package" due that it shouldn't be localized.
- I added some code to subscribe the "Search for a Package" menuitem Click event to the NextStep method (bug reported by Sol).
- I added a method that will be executing the search in the PackageSearch window after the initial search is completed so the message "Please wait.." is shown.
- I disable the Back button in the Step1 due that was closing all the Steps and leaving the dark overlay.
- Finally I added some methods for closing the PackageSearch window

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Adding the Step 6 (package dependencies) to the Packages Guide


### Reviewers

@QilongTang 

### FYIs

@filipeotero 
