### PR TITLE
Adjust hight of the step 3

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -70,7 +70,7 @@
 				"Type": "tooltip",
 				"TooltipPointerDirection": "top_left",
 				"Width": 480,
-				"Height": 230,
+				"Height": 245,
 				"StepContent": {
 					"Title": "GetStartedGuideToolbarTitle",
 					"FormattedText": "GetStartedGuideToolbarText"

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -97,7 +97,7 @@
 				"Type": "tooltip",
 				"TooltipPointerDirection": "top_left",
 				"Width": 480,
-				"Height": 190,
+				"Height": 205,
 				"StepContent": {
 					"Title": "GetStartedGuidePreferencesTitle",
 					"FormattedText": "GetStartedGuidePreferencesText"


### PR DESCRIPTION
### Purpose

This PR increases the height of step 3 on the guided tour

![image](https://user-images.githubusercontent.com/89042471/141479393-453a4b93-dc86-4a71-a1b5-c72f6d9d9e29.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
