### PR TITLE
DYN-3836: [BASH] Buttons looks strange when not hovered

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2582,6 +2582,62 @@
         </Setter>
     </Style>
 
+    <Style x:Key="SolidButtonStyle" TargetType="Button">
+        <Setter Property="BorderBrush" Value="{StaticResource PreferencesWindowButtonColor}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Background" Value="{StaticResource PreferencesWindowButtonColor}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Margin" Value="15,0,0,0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Grid>
+                        <Border x:Name="mouseOverBorder"
+                                Margin="2"
+                                BorderThickness="2"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                Background="{TemplateBinding Background}"
+                                Visibility="Hidden"
+                                CornerRadius="2"/>
+                        <Border x:Name="mousePressedBorder"
+                                Margin="0"
+                                BorderThickness="4"
+                                Visibility="Hidden"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="4"/>
+                        <Border x:Name="border"
+                                Margin="4"
+                                Height="24px"
+                                Padding="8,0,8,0"
+                                BorderThickness="1"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="2">
+                            <TextBlock x:Name="textBlock"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       FontFamily="{StaticResource ArtifaktElementRegular}"
+                                       FontSize="14px"
+                                       Foreground="{TemplateBinding Foreground}"
+                                       Text="{TemplateBinding Content}" />
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Opacity" Value="0.9" />
+                            <Setter TargetName="mouseOverBorder" Property="Visibility " Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Opacity" Value="0.9" />
+                            <Setter TargetName="mousePressedBorder" Property="Visibility " Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="PopupButtonStyle" TargetType="Button">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="#4D4D4D" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2608,7 +2608,7 @@
                                 CornerRadius="4"/>
                         <Border x:Name="border"
                                 Margin="4"
-                                Height="24px"
+                                Height="36px"
                                 Padding="8,0,8,0"
                                 BorderThickness="1"
                                 BorderBrush="{TemplateBinding BorderBrush}"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -433,12 +433,10 @@
                                         </StackPanel>
                                     </Grid>
                                     <Button x:Name="ReloadCPython"
-                                                Style="{StaticResource FlatButtonStyle}" 
+                                                Style="{StaticResource SolidButtonStyle}" 
                                                 HorizontalAlignment="Left"                                             
-                                                Height="25"
-                                                MinWidth="100"
                                                 Grid.Row="0"
-                                                Margin="0,10,0,10"
+                                                Margin="0,10,0,0"
                                                 Click="ReloadCPython_Click"
                                                 Content="{x:Static p:Resources.ResetCPythonButtonText}"
                                                 ToolTip="{x:Static p:Resources.ResetCPythonButtonToolTip}">

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
@@ -126,15 +126,12 @@
         </Label>
         <Button x:Name="AddPaths"
                 HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Height="25"
-                MinWidth="55"
-                Margin="5,5,5,5"
+                Margin="0"
                 Content="{x:Static p:Resources.PackagePathAddPathButtonName}"
                 Command="{Binding Path=AddPathCommand}" 
                 ToolTip="{x:Static p:Resources.PackagePathViewToolTipPlus}">
             <Button.Style>
-                <Style BasedOn="{StaticResource FlatButtonStyle}" TargetType="{x:Type Button}">
+                <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
                     <Setter Property="IsEnabled" Value="True"/>
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding Path=PreferenceSettings.DisableCustomPackageLocations}" Value="True">


### PR DESCRIPTION
### Purpose

This pull request does:

* add a new solid button style for use in preferences.

![image](https://user-images.githubusercontent.com/7033002/142212496-087ef0d6-af01-4833-ac73-f5f66d71f3e2.png)

![image](https://user-images.githubusercontent.com/7033002/142212603-db7a44c2-5bbc-4505-870e-68e46b7af9cf.png)

I have followed the style we where pointed at but the buttons feels a little too large for me. What do you think? @Jingyi-Wen

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 
