### PR TITLE
Creating pointer step 2 guided tour

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -118,7 +118,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         [JsonProperty("ExitGuide")]
         internal ExitGuide ExitGuide { get; set; }
 
-        public enum PointerDirection { TOP_RIGHT, TOP_LEFT, BOTTOM_RIGHT, BOTTOM_LEFT };
+        public enum PointerDirection { TOP_RIGHT, TOP_LEFT, BOTTOM_RIGHT, BOTTOM_LEFT, BOTTOM_DOWN };
 
         /// <summary>
         /// This will contains the 3 points needed for drawing the Tooltip pointer direction

--- a/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
@@ -11,8 +11,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
     public class Tooltip : Step
     {
         double PointerHeight = 30;
-        double PointerWidth = 10;
+        double PointerWidth = 15;
         double PointerDownWidth = 20;
+        double PointerDownHeight = 10;
         double PointerTooltipOverlap = 5;
         double PointerVerticalOffset;
         double PointerHorizontalOffset;
@@ -109,10 +110,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
             else if (direction == PointerDirection.BOTTOM_DOWN)
             {
                 pointX1 = PointerHorizontalOffset;
-                pointY1 = Height + PointerWidth;
+                pointY1 = Height + PointerDownHeight;
 
                 pointX2 = PointerDownWidth + PointerHorizontalOffset;
-                pointY2 = Height + PointerWidth;
+                pointY2 = Height + PointerDownHeight;
 
                 pointX3 = PointerDownWidth / 2 + PointerHorizontalOffset;
                 pointY3 = realHeight - PointerHeight;

--- a/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
@@ -11,9 +11,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
     public class Tooltip : Step
     {
         double PointerHeight = 30;
-        double PointerWidth = 15;
+        double PointerWidth = 10;
+        double PointerDownWidth = 20;
         double PointerTooltipOverlap = 5;
         double PointerVerticalOffset;
+        double PointerHorizontalOffset;
 
         /// <summary>
         /// The Tooltip constructor
@@ -29,6 +31,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
             //The offset represent the distance vertically from the top/bottom for showing the tooltip pointer (a triangle)
             PointerVerticalOffset = (Height / 8) + verticalTooltipOffset;
+            PointerHorizontalOffset = (Width / 8);
             DrawPointerDirection(direction);
         }
 
@@ -54,6 +57,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
             //Due that we are drawing the 2 direction pointers we need to add 20 to the current width (Width + PointerWidth*2 - PointerTooltipOverlap*2)
             double realWidth = Width + PointerWidth * 2 - PointerTooltipOverlap * 2;
+            double realHeight = Height + PointerHeight * 2 - PointerTooltipOverlap * 2;
 
             //For each Y coordinate we add the Vertical offset otherwise the pointer will be always at the top or the botton
             if (direction == PointerDirection.TOP_LEFT)
@@ -101,6 +105,17 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 pointX3 = realWidth;
                 pointY3 = Height - PointerHeight / 2 - PointerVerticalOffset;
+            }
+            else if (direction == PointerDirection.BOTTOM_DOWN)
+            {
+                pointX1 = PointerHorizontalOffset;
+                pointY1 = Height + PointerWidth;
+
+                pointX2 = PointerDownWidth + PointerHorizontalOffset;
+                pointY2 = Height + PointerWidth;
+
+                pointX3 = PointerDownWidth / 2 + PointerHorizontalOffset;
+                pointY3 = realHeight - PointerHeight;
             }
 
             TooltipPointerPoints = new PointCollection(new[] { new Point(pointX1, pointY1),

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -46,7 +46,7 @@
 				"Sequence": 2,
 				"Name": "run status",
 				"Type": "tooltip",
-				"TooltipPointerDirection": "bottom_left",
+				"TooltipPointerDirection": "bottom_down",
 				"Width": 480,
 				"Height": 260,
 				"StepContent": {
@@ -56,7 +56,7 @@
 				"HostPopupInfo": {
 					"PopupPlacement": "bottom",
 					"HostUIElementString": "bottomBarGrid",
-					"VerticalPopupOffset": 50,
+					"VerticalPopupOffset": 0,
 					"HorizontalPopupOffset": 320,
 					"CutOffRectArea": {
 						"WidthBoxDelta": 0,


### PR DESCRIPTION
### Purpose

This PR fixes the pointer of step 2 in the guided tour. 
The pointer of the tooltip should be pointing down.

![image](https://user-images.githubusercontent.com/89042471/141808276-01924f52-a111-4991-800c-7caf2241b4e4.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
