### PR TITLE
Fix Warnings UnDismissal Bug

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -84,31 +84,6 @@ namespace Dynamo.Controls
         }
     }
 
-    public class AlertsLengthTruncater : IValueConverter
-    {
-        // The value for this variable is highly depending on default width for the alert submenu item
-        private const int MaxChars = 32;
-
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            var result = new ObservableCollection<string>();
-            foreach (var alert in value as ObservableCollection<string>)
-            {
-                if (alert != null && alert.Length > MaxChars)
-                {
-                    var trimIndex = alert.LastIndexOf('\n', MaxChars - 5);
-                    result.Add(alert.Remove(trimIndex > 0 ? trimIndex : MaxChars - 5) + "...");
-                }
-            }
-            return result;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return null;
-        }
-    }
-
     public class PrettyDateConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
@@ -352,7 +352,6 @@ namespace Dynamo.Wpf.Utilities
                 {
                     Source = NodeViewModel,
                     Path = new PropertyPath(nameof(NodeViewModel.DismissedAlerts)),
-                    Converter = new AlertsLengthTruncater(),
                     UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
                 }
             );

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -87,7 +87,14 @@
                                                               DockPanel.Dock="Left"
                                                               RecognizesAccessKey="True"
                                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                              TextBlock.Foreground="{StaticResource NodeContextMenuForeground}" />
+                                                              TextBlock.Foreground="{StaticResource NodeContextMenuForeground}">
+                                                <ContentPresenter.Resources>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="MaxWidth" Value="200"></Setter>
+                                                        <Setter Property="TextTrimming" Value="CharacterEllipsis"></Setter>
+                                                    </Style>
+                                                </ContentPresenter.Resources>
+                                            </ContentPresenter>
                                             <Border x:Name="dismissedAlertsBadge"
                                                     Height="15"
                                                     MinWidth="15"


### PR DESCRIPTION
### Purpose

This PR fixes a recent bug where node warnings can no longer be dismissed.
It introduces a local style-based change to maintain ellipses for longer MenuItems, while removing the `AlertsLengthTruncater`.

![Gtolhg3u9x](https://user-images.githubusercontent.com/29973601/142204284-c078b19f-1878-4067-8444-0a6212e1e8f4.gif)
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a bug with un-dismissing node warnings.

### Reviewers

@QilongTang 

### FYIs

@SHKnudsen 
