### PR TITLE
Adjust proxy positions when opening a collapsed group.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -723,7 +723,7 @@ namespace Dynamo.ViewModels
             return newPortViewModels;
         }
 
-        private void UpdateProxyPortsPosition()
+        internal void UpdateProxyPortsPosition()
         {
             var groupInports = GetGroupInPorts();
 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -78,6 +78,8 @@ namespace Dynamo.Nodes
                     SetTextMaxWidth();
                     SetTextHeight();
                 }
+
+                ViewModel.UpdateProxyPortsPosition();
             }
         }
 


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-4313

This PR is to adjust the proxy ports location when a workspace with collapsed group is opened. 

![adjust proxy position on opening collapsed group](https://user-images.githubusercontent.com/43763136/142234664-0c8fb4b0-299b-4978-9164-0f130df60568.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@QilongTang 