### PR TITLE
Fix step 2 popup position when window is moved

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -54,7 +54,7 @@
 					"FormattedText": "GetStartedGuideRunStatusBarText"
 				},
 				"HostPopupInfo": {
-					"PopupPlacement": "bottom",
+					"PopupPlacement": "top",
 					"HostUIElementString": "bottomBarGrid",
 					"VerticalPopupOffset": 0,
 					"HorizontalPopupOffset": 320,


### PR DESCRIPTION
### Purpose

This PR fixes the popup of step 2 when the window is moved 

![image](https://user-images.githubusercontent.com/89042471/142637694-2c3e4267-056e-4207-8a66-0f1d800529c0.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 