### PR TITLE
DYN-4216 - Changing Trigger of GitHub action

### DIFF
--- a/.github/workflows/PR_merged.yaml
+++ b/.github/workflows/PR_merged.yaml
@@ -1,6 +1,6 @@
 ## Workflow for retrieve Release Notes section from PRs
 
-name: PR merged
+name: PR_merged
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/PR_merged.yaml
+++ b/.github/workflows/PR_merged.yaml
@@ -1,10 +1,10 @@
 ## Workflow for retrieve Release Notes section from PRs
 
-name: CI
+name: PR merged
 
 # Controls when the workflow will run
 on:
-   pull_request:
+   pull_request_target:
     branches: [master]
     types: [closed]
 


### PR DESCRIPTION
### Purpose

PR created for changing the trigger of github action from `pull_request` to `pull_request_target` to enable use secrets of repository when a PR is merged from a fork. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Enhancement for enabling a slack notification every time a PR is merged into master.

### Reviewers

@QilongTang @mjkkirschner 