### PR TITLE
Update Default Connector Visibility When Deserializing Xml DYN

### DIFF
--- a/src/DynamoCore/Graph/NodeGraph.cs
+++ b/src/DynamoCore/Graph/NodeGraph.cs
@@ -92,7 +92,7 @@ namespace Dynamo.Graph
             int endIndex = helper.ReadInteger("end_index");
             bool isHidden = helper.HasAttribute(nameof(ConnectorModel.IsHidden)) ?
                 helper.ReadBoolean(nameof(ConnectorModel.IsHidden)) :
-                true;
+                false;
 
             //find the elements to connect
             NodeModel start;

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -13,12 +13,26 @@ namespace DynamoCoreWpfTests
 
         #region Regular Connector Tests
         /// <summary>
-        /// Check to see a pin can be added to a connector
+        /// Check to see a connector is visible after pre 2.13 graph open
         /// </summary>
         [Test]
         public void ConnectorVisibilityForLegacyGraphTest()
         {
             Open(@"UI/ConnectorPinTests.dyn");
+
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
+
+            //Default collapse state should be false when opening legacy graph
+            Assert.AreEqual(connectorViewModel.IsHidden, false);
+        }
+
+        /// <summary>
+        /// Check to see a connector is visible after xml graph open
+        /// </summary>
+        [Test]
+        public void ConnectorVisibilityForLegacyXMLGraphTest()
+        {
+            Open(@"UI/UI_visual_test.dyn");
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -5,6 +5,8 @@ using static Dynamo.Models.DynamoModel;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using System;
+using System.Xml;
+using System.IO;
 
 namespace DynamoCoreWpfTests
 {
@@ -13,7 +15,7 @@ namespace DynamoCoreWpfTests
 
         #region Regular Connector Tests
         /// <summary>
-        /// Check to see a connector is visible after pre 2.13 graph open
+        /// Check to see if a connector is visible after pre 2.13 graph open
         /// </summary>
         [Test]
         public void ConnectorVisibilityForLegacyGraphTest()
@@ -22,7 +24,7 @@ namespace DynamoCoreWpfTests
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            //Default collapse state should be false when opening legacy graph
+            //Default IsHidden state should be false when opening legacy graph
             Assert.AreEqual(connectorViewModel.IsHidden, false);
         }
 
@@ -32,11 +34,16 @@ namespace DynamoCoreWpfTests
         [Test]
         public void ConnectorVisibilityForLegacyXMLGraphTest()
         {
-            Open(@"UI/UI_visual_test.dyn");
+            var filePath = @"UI/UI_visual_test.dyn";
+            string openPath = Path.Combine(GetTestDirectory(ExecutingDirectory), filePath);
+            // Assert xml graph open
+            Assert.IsTrue(DynamoUtilities.PathHelper.isValidXML(openPath, out _, out _));
+
+            Open(filePath);
 
             var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
 
-            //Default collapse state should be false when opening legacy graph
+            //Default IsHidden state should be false when opening legacy graph
             Assert.AreEqual(connectorViewModel.IsHidden, false);
         }
 


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Update default connector visibility when deserializing XML. Unit test added. Previous unit test only covers a legacy Json file.

Here is the diff when opening basic sample 1 from Dynamo 2.13.

Before:
![image](https://user-images.githubusercontent.com/3942418/142895099-9222bd9f-e436-4f8f-9166-f1abdfaa9a30.png)

After:
![image](https://user-images.githubusercontent.com/3942418/142895269-3b0e391e-6c40-4602-b33e-9b19a2f3106d.png)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes




### Reviewers

@DynamoDS/dynamo 

### FYIs

@Amoursol 
