### PR TITLE
[DYN-4326] Menu Item Font Size Reduction

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/MenuStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/MenuStyleDictionary.xaml
@@ -40,7 +40,7 @@
                                           ContentSource="Header"
                                           RecognizesAccessKey="True"
                                           TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
-                                          TextBlock.FontSize="16px" />
+                                          TextBlock.FontSize="14px" />
                         <Path Name="DownArrow"
                               Grid.Column="1"
                               Width="10px"
@@ -109,7 +109,7 @@
                                           ContentSource="Header"
                                           RecognizesAccessKey="True"
                                           TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
-                                          TextBlock.FontSize="16px"
+                                          TextBlock.FontSize="14px"
                                           TextBlock.Foreground="#AFAFAF" />
                     </Grid>
                 </Border>
@@ -161,7 +161,7 @@
                                           ContentSource="Header"
                                           RecognizesAccessKey="True"
                                           TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
-                                          TextBlock.FontSize="16px" />
+                                          TextBlock.FontSize="14px" />
                         <TextBlock x:Name="InputGestureText"
                                    Grid.Column="2"
                                    Margin="0,2,2,2"
@@ -246,7 +246,7 @@
                                           VerticalAlignment="Center"
                                           ContentSource="Icon"
                                           TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
-                                          TextBlock.FontSize="16px" />
+                                          TextBlock.FontSize="14px" />
                         <Border Name="CheckMarkBackground"
                                 Grid.Column="0"
                                 HorizontalAlignment="Stretch"
@@ -268,7 +268,7 @@
                                           ContentSource="Header"
                                           RecognizesAccessKey="True"
                                           TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
-                                          TextBlock.FontSize="16px" />
+                                          TextBlock.FontSize="14px" />
                         <TextBlock x:Name="InputGestureText"
                                    Grid.Column="2"
                                    Margin="5,0,0,2"
@@ -332,7 +332,7 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
-        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Margin" Value="0,0,0,0" />
         <Setter Property="Template">

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -248,7 +248,7 @@
                                             </Grid.ColumnDefinitions>
                                             <ContentPresenter Name="HeaderHost"
                                                               Grid.Column="0"
-                                                              TextBlock.FontSize="16px"
+                                                              TextBlock.FontSize="14px"
                                                               TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
                                                               TextBlock.Foreground="{StaticResource NormalForegroundBrush}"
                                                               Margin="5,0,0,0"


### PR DESCRIPTION

### Purpose
This PR respond to ticket DYN-4326, reduces main menu font size to 14px 

![image](https://user-images.githubusercontent.com/80236301/143014355-5b00007e-2adf-490d-8ef6-9ac35af5ef7c.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated

### Release Notes

Make menu font size change


### Reviewers

@QilongTang 



### FYIs

@OliverEGreen @SHKnudsen 
