### PR TITLE
Updating the default marker on Ports

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -81,14 +81,14 @@
                        IsHitTestVisible="False"
                        SnapsToDevicePixels="True" />
 
-            <!--  A circular marker indicating that the port has a default value  -->
+            <!--  A rectangular marker indicating that the port has a default value  -->
             <Border x:Name="PortDefaultValueMarker"
                     Grid.Column="0"
-                    Width="5"
-                    Height="12"
+                    Width="4"
+                    Height="27px"
+                    Margin="0,0,1,0"
                     HorizontalAlignment="Right"
                     Background="{StaticResource Blue300Brush}"
-                    CornerRadius="6,0,0,6"
                     Visibility="{Binding PortDefaultValueMarkerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <!--  The name of this port  -->


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

As per https://jira.autodesk.com/browse/DYN-4388, this PR updates the default marker on ports from a blue half-circle, to a blue vertical rectangle that mimics the pattern language of the honored/dishonored ports to increase clarity and remove confusing connotations from the connection with wires. Smaller pixel size speaks of visual hierarchy with port dis/honored states. 

![image](https://user-images.githubusercontent.com/12857357/143240539-fa5ef158-c554-49a4-acc1-3390317eba82.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Updated default port indicator from half-circle to rectangle. 

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Jingyi-Wen 
