### PR TITLE
Set default filters for package search

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -412,7 +412,7 @@ namespace Dynamo.PackageManager
             ClearDownloadToastNotificationCommand = new DelegateCommand<object>(ClearDownloadToastNotification);
             SearchText = string.Empty;
             SortingKey = PackageSortingKey.LastUpdate;
-            SortingDirection = PackageSortingDirection.Ascending;
+            SortingDirection = PackageSortingDirection.Descending;
             HostFilter = new List<FilterEntry>();
             SelectedHosts = new List<string>();
         }
@@ -430,7 +430,7 @@ namespace Dynamo.PackageManager
         /// Sort the search results
         /// </summary>
         public void Sort()
-        {
+        { 
             var list = this.SearchResults.AsEnumerable().ToList();
             Sort(list, this.SortingKey);
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -430,7 +430,7 @@ namespace Dynamo.PackageManager
         /// Sort the search results
         /// </summary>
         public void Sort()
-        { 
+        {
             var list = this.SearchResults.AsEnumerable().ToList();
             Sort(list, this.SortingKey);
 


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-4338

This will set the default filters for package search to "Most Recent Update" in "Descending" order.

<img width="757" alt="Screen Shot 2021-11-24 at 8 12 06 AM" src="https://user-images.githubusercontent.com/43763136/143244799-ec375b03-fc97-43a2-9fcc-427e7a10fac6.png">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Set default filters for package search results as "Most Recent Update" in "Descending" order.

### Reviewers

@QilongTang @zeusongit 

