### PR TITLE
Updating NodeAutocomplete Font Color

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -70,7 +70,7 @@
                                TextWrapping="Wrap"
                                Padding="4"
                                Margin="80,1.75,0,0"
-                               Foreground="{StaticResource autocompletionWindowFont}"
+                               Foreground="{StaticResource AutocompletionWindowFontColor}"
                                Background="Transparent"
                                TextAlignment="Center"
                                FontSize="14">
@@ -197,13 +197,13 @@
                                                     Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
                                    HorizontalAlignment="Center"
                                    Height="18"
-                                   Margin="2,2,0,0"
+                                   Margin="6,2,0,0"
                                    Text="{x:Static resx:Resources.AutocompleteSearchTextBlockText}" />
 
                     </StackPanel>
 
                     <TextBox Name="SearchTextBox"
-                             Foreground="{StaticResource SearchBoxBackgroundColor}"
+                             Foreground="{StaticResource AutocompletionWindowFontColor}"
                              Background="Transparent"
                              BorderThickness="0"
                              FontSize="12"
@@ -213,7 +213,7 @@
                              Text="{Binding Path=SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                              MinWidth="200"
                              CaretBrush="{StaticResource CommonSidebarTextColor}"
-                             Margin="20,0,0,0"
+                             Margin="15,0,0,0"
                              TextChanged="OnSearchTextBoxTextChanged" />
                 </Grid>
             </Border>

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -70,7 +70,8 @@
                                TextWrapping="Wrap"
                                Padding="4"
                                Margin="80,1.75,0,0"
-                               Foreground="{StaticResource SearchTextBoxBackground}"
+                               Foreground="{StaticResource autocompletionWindowFont}"
+                               Background="Transparent"
                                TextAlignment="Center"
                                FontSize="14">
                         </TextBlock>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -91,7 +91,7 @@
 
     <!-- Node Autocomplete -->
     <SolidColorBrush x:Key="autocompletionWindow" Color="#535353" />
-    <SolidColorBrush x:Key="autocompletionWindowFont" Color="#F5F5F5" />
+    <SolidColorBrush x:Key="AutocompletionWindowFontColor" Color="#F5F5F5" />
 
     <!--  Update Manager  -->
     <SolidColorBrush x:Key="UpdateManagerUpdateAvailableBrush" Color="OrangeRed" />


### PR DESCRIPTION
### Purpose

As per https://jira.autodesk.com/browse/DYN-4372, font updated to white for visibility purposes and to match UI buttons next to it.

![image](https://user-images.githubusercontent.com/12857357/143274021-8da4e561-4e0f-4a74-a4b6-f5aa6effc0ff.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Font color updated on Node Autocomplete dialog


### Reviewers

@DynamoDS/dynamo 

### FYIs


