### PR TITLE
[DYN-4287] + [DYN-4288] Publish Package Dialog: Fix Package Contents Display Bug

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2670,7 +2670,9 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Background" Value="#707070" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="#707070" />
                             <Setter TargetName="textBlock" Property="Opacity" Value="0.7" />
+                            <Setter Property="Cursor" Value="No" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageItemRootViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageItemRootViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace Dynamo.PackageManager.UI
@@ -16,11 +17,29 @@ namespace Dynamo.PackageManager.UI
         private ObservableCollection<PackageItemViewModel> _items = new ObservableCollection<PackageItemViewModel>();
         public override ObservableCollection<PackageItemViewModel> Items { get { return _items; } set { _items = value; } }
 
+        /// <summary>
+        /// The name of this item, regardless of which constructor was used.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// The file path of this item (if any), regardless of which constructor was used.
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// The target path of this item, regardless of which constructor was used.
+        /// </summary>
+        public string TargetPath { get; }
+
         public PackageItemRootViewModel(CustomNodeDefinition def)
         {
             this.Height = 32;
             this.DependencyType = DependencyType.CustomNode;
             this.Definition = def;
+            this.DisplayName = def.DisplayName;
+            this.FilePath = String.Empty;
+            this.TargetPath = String.Empty;
             this.BuildDependencies(new HashSet<object>());
         }
 
@@ -29,6 +48,9 @@ namespace Dynamo.PackageManager.UI
             this.Height = 32;
             this.DependencyType = DependencyType.Assembly;
             this.Assembly = assembly;
+            this.DisplayName = assembly.Name;
+            this.FilePath = assembly.Assembly.Location;
+            this.TargetPath = assembly.Assembly.Location;
             this.BuildDependencies(new HashSet<object>());
         }
 
@@ -37,9 +59,10 @@ namespace Dynamo.PackageManager.UI
             this.Height = 32;
             this.DependencyType = DependencyType.File;
             this.FileInfo = fileInfo;
+            this.DisplayName = fileInfo.Name;
+            this.FilePath = fileInfo.FullName;
+            this.TargetPath = fileInfo.FullName;
             this.BuildDependencies(new HashSet<object>());
         }
-
     }
-
 }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -706,15 +706,12 @@ namespace Dynamo.PackageManager
             RemoveItemCommand = new Dynamo.UI.Commands.DelegateCommand(RemoveItem);
             ToggleMoreCommand = new DelegateCommand(() => MoreExpanded = !MoreExpanded, () => true);
             Dependencies.CollectionChanged += DependenciesOnCollectionChanged;
-            PackageContents.CollectionChanged += PackageContentsOnCollectionChanged;
             Assemblies = new List<PackageAssembly>();
             PropertyChanged += ThisPropertyChanged;
             RefreshPackageContents();
             RefreshDependencyNames();
         }
 
-        private void PackageContentsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) => RefreshPackageContents();
-        
         private void DependenciesOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) => RefreshDependencyNames();
         
         private void RefreshDependencyNames()
@@ -729,12 +726,16 @@ namespace Dynamo.PackageManager
 
         private void RefreshPackageContents()
         {
-            PackageContents = CustomNodeDefinitions.Select(
-                    (def) => new PackageItemRootViewModel(def))
+            PackageContents.Clear();
+            
+            var itemsToAdd = CustomNodeDefinitions
+                .Select(def => new PackageItemRootViewModel(def))
                 .Concat(Assemblies.Select((pa) => new PackageItemRootViewModel(pa)))
                 .Concat(AdditionalFiles.Select((s) => new PackageItemRootViewModel(new FileInfo(s))))
                 .ToList()
                 .ToObservableCollection();
+
+            foreach (var item in itemsToAdd) PackageContents.Add(item);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -700,13 +700,13 @@
                                                 IsReadOnly="False"
                                                 IsThreeState="False" />
                         <DataGridTextColumn MinWidth="50"
-                                            Binding="{Binding Path=FileInfo.Name}"
+                                            Binding="{Binding Path=DisplayName, UpdateSourceTrigger=PropertyChanged}"
                                             Header="Name"
                                             HeaderStyle="{StaticResource DataGridColumnHeaderText}"
                                             IsReadOnly="True" />
                         <DataGridTextColumn Width="*"
                                             MinWidth="66"
-                                            Binding="{Binding Path=FileInfo.FullName}"
+                                            Binding="{Binding Path=FilePath, UpdateSourceTrigger=PropertyChanged}"
                                             Header="File Path"
                                             HeaderStyle="{StaticResource DataGridColumnHeaderText}"
                                             IsReadOnly="True" />
@@ -737,9 +737,9 @@
                                             </Button.Template>
                                         </Button>
                                         <TextBlock Margin="0,0,0,0"
-                                                   Text="{Binding Path=FileInfo.Directory}"
+                                                   Text="{Binding Path=TargetPath}"
                                                    TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding FileInfo.Directory}" />
+                                                   ToolTip="{Binding TargetPath}" />
                                     </DockPanel>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -157,7 +157,6 @@ namespace Dynamo.PackageManager
 
         private bool ExecuteTermsOfUseCall(bool queryAcceptanceStatus)
         {
-            return true;
             return FailFunc.TryExecute(() =>
             {
                 var request = new TermsOfUse(queryAcceptanceStatus);


### PR DESCRIPTION
### Purpose

This PR addresses JIRA bugs DYN-4287 and DYN-4288 by addressing the non-display of certain items in the publish package dialog's package contents grid.

![tiJd5c17Q9](https://user-images.githubusercontent.com/29973601/143431802-fb7c5778-5fd1-42eb-b8ff-b9a8eb5382e0.gif)

Note: I am unsure what the `Target Path` is meant to show users. This dialog does not give users the option to select an output directory (which is what I assumed the `Target Path` would show). For now, it simply mirrors the `File Path` value.

I am also unable to read the File Path of `.dyf` files from the `CustomNodeDefinition` object. However, if there's a way to do this, please let me know and I will update.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a bug in the publish package window.

### Reviewers

@QilongTang (please see notes above)

### FYIs
@Jingyi-Wen @Amoursol (please see notes above)
@SHKnudsen 
