### PR TITLE
[DYN-4207] Package Install Toast Notification UI Bug Fix

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -901,6 +901,10 @@
                                 Background="#4E4E4E"
                                 CornerRadius="3">
                             <Grid Height="40">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="23" />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
@@ -910,6 +914,8 @@
                                 <!--  Download Icon  -->
                                 <Image Name="downloadCompletedIcon"
                                        Grid.Column="0"
+                                       Grid.Row="0"
+                                       Grid.RowSpan="2"
                                        Width="16"
                                        Height="16"
                                        VerticalAlignment="Center"
@@ -917,6 +923,8 @@
                                        Visibility="Collapsed" />
                                 <Image Name="downloadingIcon"
                                        Grid.Column="0"
+                                       Grid.Row="0"
+                                       Grid.RowSpan="2"
                                        Width="16"
                                        Height="16"
                                        VerticalAlignment="Center"
@@ -942,42 +950,54 @@
                                         </EventTrigger>
                                     </Image.Triggers>
                                 </Image>
+
+                                <!--  Package Name  -->
                                 <TextBlock Name="name"
+                                           Grid.Row="0"
                                            Grid.Column="1"
-                                           Margin="5,0,0,0"
-                                           Padding="5"
-                                           VerticalAlignment="Top"
+                                           Margin="10,0,0,0"
+                                           VerticalAlignment="Bottom"
                                            FontFamily="{StaticResource ArtifaktElementRegular}"
                                            FontSize="14"
                                            Foreground="#F5F5F5"
                                            Text="{Binding Path=Name}"
                                            TextTrimming="CharacterEllipsis" />
+                                
+                                <!--  Error Message  -->
                                 <TextBlock Name="error"
+                                           Grid.Row="1"
                                            Grid.Column="1"
-                                           Margin="5,0,0,0"
-                                           Padding="5"
-                                           VerticalAlignment="Bottom"
+                                           Margin="10,0,0,0"
+                                           VerticalAlignment="Top"
                                            FontSize="10"
                                            Foreground="White"
                                            Text="{Binding Path=ErrorString}"
                                            TextTrimming="CharacterEllipsis" />
+                                
+                                <!--  Download State  -->
                                 <TextBlock Name="downloadState"
+                                           Grid.Row="0"
                                            Grid.Column="2"
-                                           Padding="5"
-                                           VerticalAlignment="Top"
+                                           Margin="0,0,0,2"
+                                           VerticalAlignment="Bottom"
+                                           HorizontalAlignment="Left"
                                            FontFamily="{StaticResource ArtifaktElementRegular}"
                                            FontSize="10"
                                            Foreground="#F5F5F5"
                                            Text="{Binding Path=DownloadState, Converter={StaticResource PackageDownloadStateToStringConverter}}" />
+
+                                <!--  Version  -->
                                 <TextBlock Name="version"
+                                           Grid.Row="1"
                                            Grid.Column="2"
-                                           Padding="5"
-                                           VerticalAlignment="Bottom"
+                                           VerticalAlignment="Top"
                                            FontFamily="{StaticResource ArtifaktElementRegular}"
                                            FontSize="10"
                                            Foreground="#F5F5F5"
                                            Text="{Binding Path=VersionName}" />
                                 <Button Name="closeDownloadToastButton"
+                                        Grid.Row="0"
+                                        Grid.RowSpan="2"
                                         Grid.Column="3"
                                         Width="16"
                                         Height="16"


### PR DESCRIPTION
### Purpose

This PR responds to JIRA ticket DYN-4207 by attempting to fix a UI bug reported by @mjkkirschner in the package download toast notification.

Note: I have been unable to reproduce this bug, however I have adjusted the layout grid so that elements can no longer overlap. Hopefully, this should stop the UI bug from happening again. 

![UG6mGf53lR](https://user-images.githubusercontent.com/29973601/143439124-36a53f1b-0da2-454c-add7-4145cd2ae495.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a UI bug when downloading packages. 

### Reviewers

@QilongTang 
@mjkkirschner 

### FYIs

@Amoursol 
@SHKnudsen 
