### PR TITLE
[DYN-4331] Ungrouping a collapsed group hides it

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1229,6 +1229,20 @@ namespace Dynamo.ViewModels
             //Check for multiple groups - Delete the group and not the nodes.
             foreach (var group in DynamoSelection.Instance.Selection.OfType<AnnotationModel>().ToList())
             {
+                if (!group.IsExpanded)
+                {
+                    // If the group is not expanded we expanded
+                    // and show the group content before deleting 
+                    // the group.
+                    var viewModel = this.CurrentSpaceViewModel.Annotations
+                        .FirstOrDefault(x => x.AnnotationModel == group);
+
+                    if (viewModel is null) continue;
+
+                    viewModel.IsExpanded = true;
+                    viewModel.ShowGroupContents();
+                }
+
                 var command = new DynamoModel.DeleteModelCommand(group.GUID);
                 this.ExecuteCommand(command);
             }            

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -1056,6 +1056,35 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(addNodeViewModel.AddToGroupCommand.CanExecute(null));
         }
 
+        [Test]
+        public void CollapsedGroupsUnhidesContentBeforeBeingUngrouped()
+        {
+            // Arrange
+            var groupName = "CollapsedGroup";
+
+            OpenModel(@"core\annotationViewModelTests\groupsTestFile.dyn");
+            var groupViewModel = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == groupName);
+            var groupModel = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault(x => x.GUID == groupViewModel.AnnotationModel.GUID);
+
+            var groupIsExpandedBefore = groupViewModel.IsExpanded;
+            var collapsedStateBefore = groupViewModel.ViewModelBases
+                .Select(x => x.IsCollapsed)
+                .ToList();
+
+            // Act
+            DynamoSelection.Instance.Selection.Clear();
+            DynamoSelection.Instance.Selection.Add(groupModel);
+
+            ViewModel.UngroupAnnotationCommand.Execute(null);
+
+            var collapsedStateAfter = groupViewModel.ViewModelBases.Select(x => x.IsCollapsed);
+
+            // Assert
+            Assert.IsFalse(groupIsExpandedBefore);
+            Assert.That(collapsedStateBefore.All(x => x is true));
+            Assert.That(collapsedStateAfter.All(x => x is false));
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4331](https://jira.autodesk.com/browse/DYN-4331)

![ungroupBug](https://user-images.githubusercontent.com/13732445/143473894-c2986b80-31a7-4df6-a1e9-234b7f963c5f.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
