### PR TITLE
DYN-4309-StepCount-Bigger

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4175,4 +4175,9 @@
     </Style>
     <SolidColorBrush x:Key="RealTimeInfoWindowIconColor" Color="#38ABDF" />
     <SolidColorBrush x:Key="RealTimeInfoWindowBackgroundColor" Color="#535353" />
+    <Style x:Key="PopupStepCounterFontStyle"
+           TargetType="Label">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontFamily" Value="Artifakt Element" />
+    </Style>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -21,7 +21,6 @@
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         </ResourceDictionary>
-                
     </Popup.Resources>
 
     <Canvas Background="Transparent"
@@ -149,6 +148,7 @@
                             Style="{StaticResource CaretButtonStyle}">Back
                     </Button>
                     <Label Name="TourProgress"
+                           Style="{StaticResource PopupStepCounterFontStyle}"
                            Content="{Binding TourLabelProgress}"
                            HorizontalContentAlignment="Center"
                            VerticalContentAlignment="Center"


### PR DESCRIPTION
### Purpose

Fixing bug in the font size for Step 4 and 5 due that was bigger than previous steps, now all the steps will have the same font size as described in the figma design:
- FontSize "14" 
- FontFamily "Artifakt Element" 
I added a Style specifically for the Label located in the Step counter section in the Popup, so now the label in the Popup counter section will have the same FontSize and FontStyle.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing bug in the font size for Step 4 and 5 due that was bigger than previous steps,

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
