### PR TITLE
Removing extra space in Click

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5207,6 +5207,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package installations are typically quick, depending on their size and other factors. \n\n**Click Install** to install the latest version of the sample Autodesk package and proceed with this guide..
+        /// </summary>
+        public static string PackagesGuideInstallAPackageText {
+            get {
+                return ResourceManager.GetString("PackagesGuideInstallAPackageText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package installations are typically quick, depending on their size and other factors. \n
         ///To install the latest version of a package, click Install. \n
         ///%./UI/Images/alert.png% The sample Autodesk package is already installed on your computer..

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2348,12 +2348,12 @@ Uninstall the following packages: {0}?</value>
     <value>Requires relaunch of Dynamo</value>
     <comment>Preferences | Features | Python | Requires relaunch of Dynamo</comment>
   </data>
-    <data name="MessagePackageDepsInBuiltinPackages" xml:space="preserve">
+  <data name="MessagePackageDepsInBuiltinPackages" xml:space="preserve">
     <value>{0} has dependencies that conflict with the following built-in package(s): {1}. Dependency conflicts could cause unintended behavior to occur.
     
 Do you wish to continue trying to install {0}?</value>
   </data>
-    <data name="MessageSamePackageDiffVersInBuiltinPackages" xml:space="preserve">
+  <data name="MessageSamePackageDiffVersInBuiltinPackages" xml:space="preserve">
     <value>{0} cannot be installed as it conflicts with a different version of the built-in package, {1}, which is already installed.
     
 You can try disabling loading packages from built-in package paths, or unload the conflicting package, then restart {2} and download {0} again.</value>
@@ -2365,10 +2365,10 @@ You can try disabling loading packages from built-in package paths, or unload th
     <value>The same version of {0} is already installed and does not need to be installed again.</value>
   </data>
   <data name="MessageSamePackageDiffVersInLocalPackages" xml:space="preserve">
-        <value>Package {0} cannot be installed as it conflicts with a different version, {1}, which is already installed. 
+    <value>Package {0} cannot be installed as it conflicts with a different version, {1}, which is already installed. 
         
 Do you wish to restart {2} to first uninstall {1}, then download {0} again?</value>
-    </data>
+  </data>
   <data name="PreferencesViewVisualSettingsGeoScaling" xml:space="preserve">
     <value>Geometry Scaling</value>
     <comment>Expander Header Name</comment>
@@ -2953,7 +2953,7 @@ This package will be unloaded after the next Dynamo restart.</value>
     <value>Save</value>
   </data>
   <data name="PackagesGuideInstallAPackageText" xml:space="preserve">
-    <value>Package installations are typically quick, depending on their size and other factors. \n\n **Click Install** to install the latest version of the sample Autodesk package and proceed with this guide.</value>
+    <value>Package installations are typically quick, depending on their size and other factors. \n\n**Click Install** to install the latest version of the sample Autodesk package and proceed with this guide.</value>
   </data>
   <data name="PackagesGuideInstallAPackageTitle" xml:space="preserve">
     <value>Install a package</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2563,10 +2563,10 @@ You can try disabling loading packages from built-in package paths, or unload th
     <value>The same version of {0} is already installed and does not need to be installed again.</value>
   </data>
   <data name="MessageSamePackageDiffVersInLocalPackages" xml:space="preserve">
-        <value>Package {0} cannot be installed as it conflicts with a different version, {1}, which is already installed. 
+    <value>Package {0} cannot be installed as it conflicts with a different version, {1}, which is already installed. 
         
 Do you wish to restart {2} to first uninstall {1}, then download {0} again?</value>
-    </data>
+  </data>
   <data name="PreferencesViewVisualSettingsGeoScaling" xml:space="preserve">
     <value>Geometry Scaling</value>
     <comment>Expander Header Name</comment>
@@ -2955,5 +2955,8 @@ To install the latest version of a package, click Install. \n
   </data>
   <data name="PackageContextMenuDeletePackageCustomNodesInUseTooltip" xml:space="preserve">
     <value>This package contains custom nodes that are in use. These custom nodes need to be deleted or the graph needs to be closed before the package can be deleted.</value>
+  </data>
+  <data name="PackagesGuideInstallAPackageText" xml:space="preserve">
+    <value>Package installations are typically quick, depending on their size and other factors. \n\n**Click Install** to install the latest version of the sample Autodesk package and proceed with this guide.</value>
   </data>
 </root>


### PR DESCRIPTION
### Purpose

This PR fixes the extra space in Step 7 of the packages tour
Card related: [DYN-4381](https://jira.autodesk.com/browse/DYN-4381)
![image](https://user-images.githubusercontent.com/89042471/143598203-446dd505-953b-4980-a178-ff2b76d740a5.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
