### PR TITLE
Fix default package search filter results.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -796,6 +796,8 @@ namespace Dynamo.PackageManager
                 this.AddToSearchResults(result);
             }
 
+            this.Sort();
+
             SearchState = HasNoResults ? PackageSearchState.NoResults : PackageSearchState.Results;
         }
 
@@ -895,7 +897,13 @@ namespace Dynamo.PackageManager
                         PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
                         CanInstallPackage(x.Name), isEnabledForInstall)))
                     .ToList();
+
                 Sort(list, this.SortingKey);
+
+                if (SortingDirection == PackageSortingDirection.Descending)
+                {
+                    list.Reverse();
+                }
             }
 
             foreach (var x in list)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -427,7 +427,7 @@ namespace Dynamo.PackageManager
         }
         
         /// <summary>
-        /// Sort the search results
+        /// Sort the search results in the view based on the sorting key and sorting direction.
         /// </summary>
         public void Sort()
         {


### PR DESCRIPTION
### Purpose

This PR is to sort the default package search results in descending order, by default.

<img width="888" alt="Screen Shot 2021-11-29 at 11 29 50 AM" src="https://user-images.githubusercontent.com/43763136/143907184-d9ad0d6b-44b2-4c0d-88aa-1aa3a805578f.png">

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix default package search filter results.


### Reviewers
@QilongTang 
