### PR TITLE
DYN-4343: Bump version number in master to 2.14

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.13.0.3197")]
+[assembly: AssemblyVersion("2.14.0.3326")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.13.0.3197")]
+[assembly: AssemblyFileVersion("2.14.0.3326")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -68,7 +68,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("<#= this.MajorVersion #>.<#= this.MinorVersion #>.<#= this.BuildNumber #>.<#= this.RevisionNumber #>")]
 <#+
 int MajorVersion = 2;
-int MinorVersion = 13;
+int MinorVersion = 14;
 int BuildNumber = 0;
 // The datetime baseline we choose using this algorithm will affect build number and all nuget packages uploaded
 // Please only change when major or minor version got incremented

--- a/tools/autobuild/build.json
+++ b/tools/autobuild/build.json
@@ -1,9 +1,9 @@
 {
   "product_id": "DYN",
-  "release_id": "2.13.0",
+  "release_id": "2.14.0",
   "master_id": "Win64",
-  "build_id": "2.13.0",
-  "name": "2.13.0",
+  "build_id": "2.14.0",
+  "name": "2.14.0",
   "build_milestone": "FCS",
   "description":"Build"
 }

--- a/tools/autobuild/master.json
+++ b/tools/autobuild/master.json
@@ -1,11 +1,11 @@
 {
   "product_id": "DYN",
-  "release_id": "2.13.0",
-  "name": "DynamoCore2.13.0 Win64",
+  "release_id": "2.14.0",
+  "name": "DynamoCore2.14.0 Win64",
   "master_id": "Win64",
   "language_pk": 1,
   "language_code_pk": 3,
   "master_platform_pk": 2,
   "master_type_pk": 1,
-  "description":"DynamoCore2.13.0"
+  "description":"DynamoCore2.14.0"
 }

--- a/tools/autobuild/release.json
+++ b/tools/autobuild/release.json
@@ -1,8 +1,8 @@
 {
   "product_id": "DYN",
-  "release_id": "2.13.0",
-  "name": "DynamoCore2.13.0",
-  "marketing_release_name": "DynamoCore2.13.0",
-  "description":"DynamoCore2.13.0",
-  "code_name": "DynamoCore2.13.0"
+  "release_id": "2.14.0",
+  "name": "DynamoCore2.14.0",
+  "marketing_release_name": "DynamoCore2.14.0",
+  "description":"DynamoCore2.14.0",
+  "code_name": "DynamoCore2.14.0"
 }


### PR DESCRIPTION
### Purpose

Bump version number in master to 2.14.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

