### PR TITLE
Issue - [DYN 4358] - Wire from collapsed nested group is hidden when collapsing/expanding parent group.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -841,6 +841,10 @@ namespace Dynamo.ViewModels
             {
                 if (viewModel is AnnotationViewModel annotationViewModel)
                 {
+                    if(annotationViewModel.Nodes.Any())
+                    {
+                        UpdateConnectorsAndPortsOnShowContents(annotationViewModel.Nodes);
+                    }
                     // If there is a group in this group
                     // we expand that and all of its content.
                     annotationViewModel.IsCollapsed = false;
@@ -850,7 +854,15 @@ namespace Dynamo.ViewModels
                 viewModel.IsCollapsed = false;
             }
 
-            foreach (var nodeModel in Nodes.OfType<NodeModel>())
+            UpdateConnectorsAndPortsOnShowContents(Nodes);
+            UpdateProxyPortsPosition();
+
+            Analytics.TrackEvent(Actions.Expanded, Categories.GroupOperations);
+        }
+
+        private void UpdateConnectorsAndPortsOnShowContents(IEnumerable<ModelBase> nodes)
+        {
+            foreach (var nodeModel in nodes.OfType<NodeModel>())
             {
                 var connectorGuids = nodeModel.AllConnectors
                     .Select(x => x.GUID);
@@ -865,10 +877,6 @@ namespace Dynamo.ViewModels
                 nodeModel.InPorts.ToList().ForEach(x => x.IsProxyPort = false);
                 nodeModel.OutPorts.ToList().ForEach(x => x.IsProxyPort = false);
             }
-
-            UpdateProxyPortsPosition();
-
-            Analytics.TrackEvent(Actions.Expanded, Categories.GroupOperations);
         }
 
         private void UpdateFontSize(object parameter)

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -9,6 +9,7 @@ using Dynamo.Models;
 using Dynamo.Selection;
 using Dynamo.Tests;
 using Dynamo.Utilities;
+using Dynamo.ViewModels;
 using NUnit.Framework;
 
 namespace DynamoCoreWpfTests
@@ -929,6 +930,62 @@ namespace DynamoCoreWpfTests
             // Assert
             CollectionAssert.AreNotEquivalent(groupNodesCollapsedStatusAfter, groupNodesCollapsedStatusBefore);
             Assert.That(groupNodesCollapsedStatusAfter.All(x => x == true));
+        }
+
+        /// <summary>
+        /// Expands parent group, child group is expanded already, so wire coming out of nested group node should be hidden == false.
+        /// </summary>
+        [Test]
+        public void NestedCollapsedGroupWiresDisplayCorrectlyWhenParentGroupExpands()
+        {
+            //Arrange
+            var outerGroupName = "OuterGroupCollapsed";
+            var innerGroupName = "InnerGroupExpanded";
+
+            OpenModel(@"core\annotationViewModelTests\groupsTestFile.dyn");
+            var outerGroup = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == outerGroupName);
+            var innerGroup = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == innerGroupName);
+
+            var innerGroupWiresBefore = innerGroup.Nodes.OfType<NodeModel>()
+              .SelectMany(x => x.OutPorts.SelectMany(c => c.Connectors));
+
+            // Act
+            outerGroup.IsExpanded = true;
+
+            var innerGroupWiresAfter = innerGroup.Nodes.OfType<NodeModel>()
+                .SelectMany(x => x.OutPorts.SelectMany(c => c.Connectors));
+
+            // Assert
+            CollectionAssert.AreEquivalent(innerGroupWiresBefore, innerGroupWiresAfter);
+            Assert.That(innerGroupWiresAfter.All(x => !x.IsHidden));
+        }
+
+        /// <summary>
+        /// Expands parent group, child group is collapsed, but wire coming out of proxy port for nested group should still be hidden == false.
+        /// </summary>
+        [Test]
+        public void NestedExpandedGroupWiresDisplayCorrectlyWhenParentGroupExpands()
+        {
+            //Arrange
+            var outerGroupName = "OuterGroupCollapsed2";
+            var innerGroupName = "InnerGroupCollapsed";
+
+            OpenModel(@"core\annotationViewModelTests\groupsTestFile.dyn");
+            var outerGroup = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == outerGroupName);
+            var innerGroup = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault(x => x.AnnotationText == innerGroupName);
+
+            var innerGroupWiresBefore = innerGroup.Nodes.OfType<NodeModel>()
+                .SelectMany(x => x.OutPorts.SelectMany(c => c.Connectors));
+
+            // Act
+            outerGroup.IsExpanded = true;
+
+            var innerGroupWiresAfter = innerGroup.Nodes.OfType<NodeModel>()
+                .SelectMany(x => x.OutPorts.SelectMany(c => c.Connectors));
+
+            // Assert
+            CollectionAssert.AreEquivalent(innerGroupWiresBefore, innerGroupWiresAfter);
+            Assert.That(innerGroupWiresAfter.All(x => !x.IsHidden));
         }
 
 

--- a/test/core/annotationViewModelTests/groupsTestFile.dyn
+++ b/test/core/annotationViewModelTests/groupsTestFile.dyn
@@ -544,6 +544,282 @@
       ],
       "Replication": "Disabled",
       "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "718830a434ea4332a4297bf83d2a6dd8",
+      "Inputs": [
+        {
+          "Id": "6b921960ba9f4805be1bba4ff0687bbd",
+          "Name": "centerPoint",
+          "Description": "Center point of circle\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f5e33601522a4bcf8c8c365f2bb9814f",
+          "Name": "radius",
+          "Description": "Radius\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "24ec7f8846bc4e659cb71d049b2ef27e",
+          "Name": "Circle",
+          "Description": "Circle created with center point and radius",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "04aba113a75141acb85f2e7f1c50f6b1",
+      "Inputs": [
+        {
+          "Id": "057c3c09f5934685bd03e061ff9a6fc3",
+          "Name": "centerPoint",
+          "Description": "Center point of circle\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d27f7c994c974d7d8654e10381a24ec7",
+          "Name": "radius",
+          "Description": "Radius\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3d1864b0ab2c4615993fa3a45f18deac",
+          "Name": "Circle",
+          "Description": "Circle created with center point and radius",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "data;",
+      "Id": "1ad5ed75d1b947d48a9e2e984ea7cbe1",
+      "Inputs": [
+        {
+          "Id": "ddbdfc5a5c8748d1bb9a2d5dd928db5e",
+          "Name": "data",
+          "Description": "data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "165828ebce0548558fa7c3532baab347",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "data;",
+      "Id": "215c30d17230412f88d09d0c8a25b732",
+      "Inputs": [
+        {
+          "Id": "afa00844884d4312bf070c881929f46d",
+          "Name": "data",
+          "Description": "data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "18f007c621f84ce0a2567f10882653a0",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "data;",
+      "Id": "552e316c27af44b393e69b09e87b6ab5",
+      "Inputs": [
+        {
+          "Id": "c69c24df317647898db8b73a952637c8",
+          "Name": "data",
+          "Description": "data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9bc6fc5e9ef041b4ac82f5622d6198b1",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "4444abc7afb649a4b6dda3bd7c7095c9",
+      "Inputs": [
+        {
+          "Id": "7975ba8454a741809518b82591874589",
+          "Name": "centerPoint",
+          "Description": "Center point of circle\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "60f7688958a34baf9377cca5d3659432",
+          "Name": "radius",
+          "Description": "Radius\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "826d01837d0442c4b9b5e3986202c02c",
+          "Name": "Circle",
+          "Description": "Circle created with center point and radius",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "c9eef7bc31aa45a38f268c84628ae183",
+      "Inputs": [
+        {
+          "Id": "8d5cfef37c734e5ead99b7694ebd677b",
+          "Name": "centerPoint",
+          "Description": "Center point of circle\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "143b757ce82d4aa59f004b345e43efc5",
+          "Name": "radius",
+          "Description": "Radius\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "2c75a91957474dc9b81e43c1a453db5a",
+          "Name": "Circle",
+          "Description": "Circle created with center point and radius",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "data;",
+      "Id": "372bc90f795f471f8c06debb10cf3987",
+      "Inputs": [
+        {
+          "Id": "685c220c28dd4d1aa8206fdc8913fb8b",
+          "Name": "data",
+          "Description": "data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "39d69bd897924e729c5bed48da1dd8ec",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
     }
   ],
   "Connectors": [
@@ -551,61 +827,85 @@
       "Start": "1ec879353ffe4c89b958beef800ff8f0",
       "End": "23d3c316183b4bed9b9b1ea806b5b80a",
       "Id": "392464856868484eba83cfd0a68d33c3",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "66767072e46545b49aacf30b5fe09ff9",
       "End": "47329c4f8b524d2983ceadbcce335104",
       "Id": "ea557fe9a8984162be32954b7adaf442",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "49f6249777514261b00ad52849e9dbab",
       "End": "78a380fd4a464e0fa277df227e1add74",
       "Id": "78840d5e24964f71965bf9b48b393e2b",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "cd55abcfc7334ed0b7d45b1de3d47b37",
       "End": "c9df894df2da4e4d8adf09d01848df83",
       "Id": "d9c813f40729448b8775ba4aeaaa071c",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "72d156b2824946cb9742d155f670e4e1",
       "End": "2861368e4f074af490f010c57e58c879",
       "Id": "212315b25bb44ce6ab94686183071d77",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "72d156b2824946cb9742d155f670e4e1",
       "End": "48403b80bc69414e808cabae9cc0bcfd",
       "Id": "bbc9d5dcc9c54b05a590135ee04d8685",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "50417e00bd1c4d9891599a37bcff391a",
       "End": "6f929e17d4404e30a5e38dbf23910d0d",
       "Id": "9ad3d9c203de49c9baa13aca2a75df67",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "baadd530104c448287cdea91c3db2850",
       "End": "81ba0b87cd564a47ad3656fc16b135e4",
       "Id": "b21bd761b0244ff6af953d8c8a18cb67",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "100b389bc9564ee483a721b0bca97342",
       "End": "6704d22af2ff424ab10a009a6875b28b",
       "Id": "4b7cb708a19148feaa7cc63be6711bf4",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
     },
     {
       "Start": "7872b35b1e01440bbf5b2bfa5092988d",
       "End": "48d52e734c9049878d217514b5eaf12e",
       "Id": "17318da5dd194962a7b751344001f14b",
-      "IsCollapsed": "False"
+      "IsHidden": "False"
+    },
+    {
+      "Start": "24ec7f8846bc4e659cb71d049b2ef27e",
+      "End": "ddbdfc5a5c8748d1bb9a2d5dd928db5e",
+      "Id": "692c11b64d1040c392a235324f735ac9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "3d1864b0ab2c4615993fa3a45f18deac",
+      "End": "afa00844884d4312bf070c881929f46d",
+      "Id": "42a8b8f275b545ada29a88b6475453f5",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "826d01837d0442c4b9b5e3986202c02c",
+      "End": "685c220c28dd4d1aa8206fdc8913fb8b",
+      "Id": "09d031dc3ffa4c959e4e221d8063c3de",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2c75a91957474dc9b81e43c1a453db5a",
+      "End": "c69c24df317647898db8b73a952637c8",
+      "Id": "547e3ea7fa024cf9b260fd22330c719b",
+      "IsHidden": "False"
     }
   ],
   "Dependencies": [],
@@ -633,7 +933,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.13.0.2693",
+      "Version": "2.13.0.3346",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -652,14 +952,15 @@
     "ConnectorPins": [
       {
         "Left": 368.21708173297861,
-        "Top": 2232.6963790506429,
+        "Top": 2202.6966790506435,
+        "IsHidden": false,
         "ConnectorGuid": "17318da5-dd19-4962-a7b7-51344001f14b"
       }
     ],
     "NodeViews": [
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "20d4ed50fa3244408aa401356cf29614",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -668,8 +969,8 @@
         "Y": 292.0
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "dcd595f0655347418fd28bc6747289ab",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -678,8 +979,8 @@
         "Y": 297.0
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "4e929260e6d64452bb6d33a4742164dd",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -688,8 +989,8 @@
         "Y": 510.35150805245615
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "dbb1c03101da49ef8eed8abbc0c5744e",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -698,8 +999,8 @@
         "Y": 516.35150805245621
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "62e057ea66584360886ca5a75557beb2",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -708,8 +1009,8 @@
         "Y": 723.310353761023
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "ebb5a1eccc864bc4bfcd4e5c84ed8ba9",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -718,8 +1019,8 @@
         "Y": 825.14289426720336
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "eabd40dd4a344814891be6d5693e0d02",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -728,8 +1029,8 @@
         "Y": 825.14289426720336
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "1c7b783b69a34f5cafadeaadda4ce24b",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -738,8 +1039,8 @@
         "Y": 715.73087078149433
       },
       {
-        "Name": "List Create",
         "ShowGeometry": true,
+        "Name": "List Create",
         "Id": "20e10367e1a4483c9f9c9e15019a5237",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -748,8 +1049,8 @@
         "Y": 925.38644752439416
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "1ffbaf75bf12424b8f6f55fdcea208dc",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -758,8 +1059,8 @@
         "Y": 1177.5616440215917
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "3a8039e80d984ae19f1a4dfd08a49289",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -768,8 +1069,8 @@
         "Y": 1181.0853867450789
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "64d897c190f243c69b8c0dbd31a91406",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -778,8 +1079,8 @@
         "Y": 1388.4374678788438
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "1dab3860fa534ab9b3a6b46772bc8e08",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -788,8 +1089,8 @@
         "Y": 1388.811115085796
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "41b081b0992a4b819e6ad4e21621d7b1",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -798,8 +1099,8 @@
         "Y": 1189.0864406921821
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "b66aa988e2c14953ba8b161b0f748e1d",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -808,8 +1109,8 @@
         "Y": 1735.9676605763452
       },
       {
-        "Name": "Code Block",
         "ShowGeometry": true,
+        "Name": "Code Block",
         "Id": "bb8e7e6e3daf42f19b24b34fd2b6429a",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -818,8 +1119,8 @@
         "Y": 1742.6828879588616
       },
       {
-        "Name": "PinNode1",
         "ShowGeometry": true,
+        "Name": "PinNode1",
         "Id": "0fa88a0f76bf484c8f24d0c98f2001cb",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -828,14 +1129,94 @@
         "Y": 2028.0
       },
       {
-        "Name": "PinNode2",
         "ShowGeometry": true,
+        "Name": "PinNode2",
         "Id": "db79855ec8da41f59d5bd442d2c0bdc6",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
         "X": 483.49280771890994,
         "Y": 2027.8375359168431
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Circle.ByCenterPointRadius",
+        "Id": "718830a434ea4332a4297bf83d2a6dd8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 932.37367776446126,
+        "Y": 2077.8043552020749
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Circle.ByCenterPointRadius",
+        "Id": "04aba113a75141acb85f2e7f1c50f6b1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1030.9682193163105,
+        "Y": 2334.6598334862274
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "1ad5ed75d1b947d48a9e2e984ea7cbe1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1568.310718536286,
+        "Y": 2142.129131953664
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "215c30d17230412f88d09d0c8a25b732",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1578.7046712258984,
+        "Y": 2378.5119756047675
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "552e316c27af44b393e69b09e87b6ab5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2343.9271215450044,
+        "Y": 1980.6820492352663
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Circle.ByCenterPointRadius",
+        "Id": "4444abc7afb649a4b6dda3bd7c7095c9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1711.4473256440424,
+        "Y": 1663.3529917600015
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Circle.ByCenterPointRadius",
+        "Id": "c9eef7bc31aa45a38f268c84628ae183",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1787.8799510991264,
+        "Y": 1947.9108651651015
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "372bc90f795f471f8c06debb10cf3987",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2334.9182886114427,
+        "Y": 1740.143846316013
       }
     ],
     "Annotations": [
@@ -853,8 +1234,8 @@
         "HasNestedGroups": false,
         "Left": 187.33333333333326,
         "Top": 218.66666666666666,
-        "Width": 656.0,
-        "Height": 214.66666666666666,
+        "Width": 655.33333333333337,
+        "Height": 210.66666666666666,
         "FontSize": 36.0,
         "InitialTop": 292.0,
         "InitialHeight": 150.0,
@@ -876,7 +1257,7 @@
         "Left": 185.0,
         "Top": 437.01817471912284,
         "Width": 425.0,
-        "Height": 215.66666666666674,
+        "Height": 211.66666666666674,
         "FontSize": 36.0,
         "InitialTop": 510.35150805245615,
         "InitialHeight": 151.00000000000006,
@@ -901,7 +1282,7 @@
         "Left": 188.16669442413149,
         "Top": 642.397537448161,
         "Width": 703.74548060428992,
-        "Height": 482.65557674289983,
+        "Height": 478.65557674289983,
         "FontSize": 36.0,
         "InitialTop": 715.73087078149433,
         "InitialHeight": 354.65557674289971,
@@ -922,8 +1303,8 @@
         "HasNestedGroups": false,
         "Left": 283.38819583319059,
         "Top": 1315.1041345455105,
-        "Width": 541.1509233736366,
-        "Height": 210.04031387361874,
+        "Width": 540.48425670696986,
+        "Height": 206.04031387361874,
         "FontSize": 36.0,
         "InitialTop": 1388.4374678788438,
         "InitialHeight": 145.37364720695223,
@@ -944,11 +1325,53 @@
         "HasNestedGroups": false,
         "Left": 185.06467884730887,
         "Top": 1672.634327243012,
-        "Width": 465.02899200447985,
-        "Height": 150.0,
+        "Width": 544.36232533781322,
+        "Height": 160.0,
         "FontSize": 36.0,
         "InitialTop": 1735.9676605763452,
         "InitialHeight": 151.71522738251633,
+        "TextblockHeight": 53.333333333333336,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "5be2f19f51d44158af8bc63a823927f7",
+        "Title": "InnerGroupExpanded",
+        "DescriptionText": "<Double click here to edit group description>",
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [
+          "04aba113a75141acb85f2e7f1c50f6b1"
+        ],
+        "HasNestedGroups": false,
+        "Left": 1020.9682193163105,
+        "Top": 2261.3265001528939,
+        "Width": 357.32666666666671,
+        "Height": 234.33333333333348,
+        "FontSize": 36.0,
+        "InitialTop": 2334.6598334862274,
+        "InitialHeight": 145.0,
+        "TextblockHeight": 63.333333333333336,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "995c0b6aa35b428095c3116a77ce35aa",
+        "Title": "InnerGroupCollapsed",
+        "DescriptionText": "<Double click here to edit group description>",
+        "IsExpanded": false,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [
+          "c9eef7bc31aa45a38f268c84628ae183"
+        ],
+        "HasNestedGroups": false,
+        "Left": 1777.8799510991264,
+        "Top": 1884.5775318317683,
+        "Width": 357.12,
+        "Height": 194.66666666666669,
+        "FontSize": 36.0,
+        "InitialTop": 1947.9108651651015,
+        "InitialHeight": 145.0,
         "TextblockHeight": 53.333333333333336,
         "Background": "#FFC1D676"
       },
@@ -967,8 +1390,8 @@
         "HasNestedGroups": true,
         "Left": 185.70075726305083,
         "Top": 1104.2283106882585,
-        "Width": 648.83836194377636,
-        "Height": 435.91613773087079,
+        "Width": 648.17169527710962,
+        "Height": 431.91613773087079,
         "FontSize": 36.0,
         "InitialTop": 1177.5616440215917,
         "InitialHeight": 371.24947106420427,
@@ -976,24 +1399,46 @@
         "Background": "#FFC1D676"
       },
       {
-        "Id": "a87c3469dc5d4475849e85ccd5fbae78",
-        "Title": "CollapsedGroup",
+        "Id": "6cf8e7773a4346589a4f8105a8eb0be6",
+        "Title": "OuterGroupCollapsed",
         "DescriptionText": "<Double click here to edit group description>",
         "IsExpanded": false,
         "WidthAdjustment": 0.0,
         "HeightAdjustment": 0.0,
         "Nodes": [
-          "b66aa988e2c14953ba8b161b0f748e1d",
-          "bb8e7e6e3daf42f19b24b34fd2b6429a"
+          "718830a434ea4332a4297bf83d2a6dd8",
+          "5be2f19f51d44158af8bc63a823927f7"
         ],
-        "HasNestedGroups": false,
-        "Left": 185.06467884730887,
-        "Top": 1672.634327243012,
-        "Width": 544.36232533781322,
-        "Height": 150.0,
+        "HasNestedGroups": true,
+        "Left": 922.37367776446126,
+        "Top": 2014.4710218687417,
+        "Width": 465.92120821851586,
+        "Height": 194.66666666666669,
         "FontSize": 36.0,
-        "InitialTop": 1735.9676605763452,
-        "InitialHeight": 173.04856071584959,
+        "InitialTop": 2077.8043552020749,
+        "InitialHeight": 444.55787340510597,
+        "TextblockHeight": 53.333333333333336,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "f627cf3f6a8d46e78d7cc5e64eaee87d",
+        "Title": "OuterGroupCollapsed2",
+        "DescriptionText": "<Double click here to edit group description>",
+        "IsExpanded": false,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [
+          "4444abc7afb649a4b6dda3bd7c7095c9",
+          "995c0b6aa35b428095c3116a77ce35aa"
+        ],
+        "HasNestedGroups": true,
+        "Left": 1701.4473256440424,
+        "Top": 1600.0196584266682,
+        "Width": 443.55262545508413,
+        "Height": 194.66666666666669,
+        "FontSize": 36.0,
+        "InitialTop": 1663.3529917600015,
+        "InitialHeight": 444.55787340509983,
         "TextblockHeight": 53.333333333333336,
         "Background": "#FFC1D676"
       },
@@ -1017,8 +1462,8 @@
         "Background": "#FFC1D676"
       }
     ],
-    "X": 284.7662528512343,
-    "Y": -2058.3224230670721,
-    "Zoom": 1.1994243414922043
+    "X": -310.77067861648328,
+    "Y": -655.28924627146876,
+    "Zoom": 0.48130615692678169
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the visibility of the wire of a collapsed nested group when parent group is collapsed/expanded.

_Fixed behaviour:_
![Issue-Fix-GroupShow-WireOfCollapsedGroup](https://user-images.githubusercontent.com/24754290/144018274-f05b8997-7ba9-4797-9644-733ee13c5174.gif)

_Previous behaviour:_
![nested_group_wire](https://user-images.githubusercontent.com/24754290/144018236-253a82b5-61c4-4b96-9708-ef3fc27c34fd.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
@Amoursol 
