### PR TITLE
AGD-2323 : add more control over custom package load options

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -256,14 +256,14 @@ namespace Dynamo.ViewModels
                 PreferenceSettings.CustomPackageFolders = newpaths;
                 if (packageLoader != null)
                 {
-                    packageLoader.LoadCustomNodesAndPackages(additionalPaths, PreferenceSettings, customNodeManager);
+                    packageLoader.LoadCustomNodesAndPackages(additionalPaths, PreferenceSettings.CustomPackageFolders, customNodeManager, PreferenceSettings.PackageDirectoriesToUninstall);
                 }
             }
             // Load packages from paths enabled by disable-path toggles if they are not already loaded.
             if (packageLoader != null && packagePathsEnabled.Any())
             {
                 var newPaths = packagePathsEnabled.Except(additionalPaths);
-                packageLoader.LoadCustomNodesAndPackages(newPaths, PreferenceSettings, customNodeManager);
+                packageLoader.LoadCustomNodesAndPackages(newPaths, PreferenceSettings.CustomPackageFolders, customNodeManager, PreferenceSettings.PackageDirectoriesToUninstall);
             }
             packagePathsEnabled.Clear();
         }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -376,13 +376,13 @@ namespace Dynamo.PackageManager
         /// <param name="packagePaths"></param>
         /// <param name="nodePaths"></param>
         /// <param name="customNodeManager"></param>
-        /// <param name="uninstallPackageDir">
+        /// <param name="uninstallPackageDirs">
         /// After the next Dynamo restart, the package will be in an unloaded state (if it is a built-in package) or 
-        /// deleted from package locations if it's path is among uninstallPackeDir.
+        /// deleted from package locations if it's path is among uninstallPackeDirs.
         /// </param>
         /// <param name="checkPathInPathManager">Load new packages only if their path is accounted for in path manager</param>
         public void LoadCustomNodesAndPackages(IEnumerable<string> packagePaths, IEnumerable<string> nodePaths, 
-            CustomNodeManager customNodeManager, IEnumerable<string> uninstallPackageDir = null, bool checkPathInPathManager = true)
+            CustomNodeManager customNodeManager, IEnumerable<string> uninstallPackageDirs = null, bool checkPathInPathManager = true)
         {
             foreach (var path in nodePaths)
             {
@@ -405,7 +405,7 @@ namespace Dynamo.PackageManager
                     }
                 }
 
-                ScanPackageDirectories(packageDirectory, uninstallPackageDir);
+                ScanPackageDirectories(packageDirectory, uninstallPackageDirs);
             }
 
             if (pathManager != null)

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -376,6 +376,11 @@ namespace Dynamo.PackageManager
         /// <param name="packagePaths"></param>
         /// <param name="nodePaths"></param>
         /// <param name="customNodeManager"></param>
+        /// <param name="uninstallPackageDir">
+        /// After the next Dynamo restart, the package will be in an unloaded state (if it is a built-in package) or 
+        /// deleted from package locations if it's path is among uninstallPackeDir.
+        /// </param>
+        /// <param name="checkPathInPathManager">Load new packages only if their path is accounted for in path manager</param>
         public void LoadCustomNodesAndPackages(IEnumerable<string> packagePaths, IEnumerable<string> nodePaths, 
             CustomNodeManager customNodeManager, IEnumerable<string> uninstallPackageDir = null, bool checkPathInPathManager = true)
         {

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -682,7 +682,8 @@ namespace DynamoCoreWpfTests
 
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences, currentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences.CustomPackageFolders, 
+                currentDynamoModel.CustomNodeManager, loadPackageParams.Preferences.PackageDirectoriesToUninstall);
             Assert.AreEqual(4, loader.LocalPackages.Count());
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1007,7 +1007,8 @@ namespace DynamoCoreWpfTests
             this.ViewModel.Model.PreferenceSettings.CustomPackageFolders = new List<string>() { Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad") };
 
             var loader = this.ViewModel.Model.GetPackageManagerExtension().PackageLoader;
-            loader.LoadCustomNodesAndPackages(new List<string>(), ViewModel.Model.PreferenceSettings, this.ViewModel.Model.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(new List<string>(), ViewModel.Model.PreferenceSettings.CustomPackageFolders, 
+                this.ViewModel.Model.CustomNodeManager, ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall);
             // This unit test is a follow-up of NewCustomNodeSaveAndLoadPt1 test to make sure the newly created
             // custom node will be loaded once DynamoCore restarted
             var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -149,7 +149,8 @@ namespace Dynamo.PackageManager.Tests
 
             packagesLoaded = false;
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(new List<string>(), loadPackageParams.Preferences, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(new List<string>(), loadPackageParams.Preferences.CustomPackageFolders, 
+                CurrentDynamoModel.CustomNodeManager, loadPackageParams.Preferences.PackageDirectoriesToUninstall);
             Assert.AreEqual(19, loader.LocalPackages.Count());
 
             // Assert packages are not reloaded if there are no new package paths.
@@ -197,7 +198,8 @@ namespace Dynamo.PackageManager.Tests
                 () => new List<string> { PackagesDirectory, BuiltInPackagesTestDir });
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences.CustomPackageFolders, 
+                CurrentDynamoModel.CustomNodeManager, loadPackageParams.Preferences.PackageDirectoriesToUninstall);
             Assert.AreEqual(20, loader.LocalPackages.Count());
 
             // Assert packages are reloaded if there are new package paths.
@@ -239,7 +241,8 @@ namespace Dynamo.PackageManager.Tests
                 () => new List<string> { PackagesDirectory, BuiltInPackagesTestDir });
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences.CustomPackageFolders, 
+                CurrentDynamoModel.CustomNodeManager, loadPackageParams.Preferences.PackageDirectoriesToUninstall);
             Assert.AreEqual(4, loader.LocalPackages.Count());
 
             Assert.IsTrue(loader.LocalPackages.Count(x => x.Name == "SignedPackage") == 2);


### PR DESCRIPTION
### Purpose
Add more control and clarity over custom package load options.

### Declarations
Sometimes we want to be able to load packages from specific locations that don't necessarily have an entry in the pathManager. In the previous form of this utility, we had to temporarily manipulate pathManger to allow our packages to load.
On the same note, we also don't want to create a temporary Preferences instance or modify the existing one.


Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers
@mjkkirschner @aparajit-pratap @saintentropy 

