### PR TITLE
Align step 6 of the packages tour

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -491,10 +491,10 @@
 					"FormattedText": "PackagesGuideDependenciesText"
 				},
 				"HostPopupInfo": {
-					"PopupPlacement": "right",
+					"PopupPlacement": "left",
 					"DynamicHostWindow": true,
 					"HostUIElementString": "PackageDetailsWindow",
-					"VerticalPopupOffset": 400,
+					"VerticalPopupOffset": 0,
 					"HorizontalPopupOffset": 0,
 					"CutOffRectArea": {
 						"WindowElementNameString": "PackageDetailsWindow",


### PR DESCRIPTION
### Purpose

This PR fixes the alignment of step 6

![image](https://user-images.githubusercontent.com/89042471/144257589-d01cbf86-281d-4564-8825-14951052bd86.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
