### PR TITLE
DYN-4033-Validate-GetStartedControls

### DIFF
--- a/test/DynamoCoreWpfTests/GuidedTourTests.cs
+++ b/test/DynamoCoreWpfTests/GuidedTourTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Dynamo.Wpf.UI.GuidedTour;
 using NUnit.Framework;
 using SystemTestServices;
@@ -23,7 +24,7 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(File.Exists(GuidesManager.GuidesJsonFilePath), failMessageFile);
 
             //Creates the Guides Manager passing the Dynamo Window and ViewModel and validates that no exception is thrown
-            Assert.DoesNotThrow( () => testGuide = new GuidesManager(View._this, ViewModel));
+            Assert.DoesNotThrow( () => testGuide = new GuidesManager(View, ViewModel));
             
             //Initializes variables and reads json properties
             Assert.DoesNotThrow( () => testGuide.Initialize());
@@ -37,6 +38,42 @@ namespace DynamoCoreWpfTests
             foreach(var guide in testGuide.Guides)
             {
                 Assert.That(guide.GuideSteps.Count > 0, "No steps read from the JSON file"); 
+            }
+        }
+
+        /// <summary>
+        /// This test will validate that all the control names read from the json file for the GetStarted Guide exists in DynamoView
+        /// </summary>
+        [Test]
+        public void GetStartedGuide_ValidateControlNames()
+        {
+            //Initialize the GuideManager to null to later we can verify that it was created correctly
+            GuidesManager testGuide = null;
+
+            string failMessageFile = string.Format("The guides JSON file: {0} couldn't be located or doesn't exits", GuidesManager.GuidesJsonFilePath);
+            Assert.IsTrue(File.Exists(GuidesManager.GuidesJsonFilePath), failMessageFile);
+
+            //Creates the Guides Manager passing the Dynamo Window and ViewModel and validates that no exception is thrown
+            Assert.DoesNotThrow(() => testGuide = new GuidesManager(View, ViewModel));
+
+            //Initializes variables and reads json properties
+            Assert.DoesNotThrow(() => testGuide.Initialize());
+
+            //Find the Get Started guide in the list
+            var getStartedGuide = (from guide in testGuide.Guides 
+                                  where guide.Name.ToUpper().Equals("GET STARTED")
+                                  select guide).FirstOrDefault();
+
+            //Validate that the GetStarted guide exists
+            Assert.IsNotNull(getStartedGuide,"Get Started guide doesn't exists in the guides json file");
+
+            string elementNotFoundMessage = string.Empty;
+            foreach (var step in getStartedGuide.GuideSteps)
+            {
+                //Validate that for each Step, the HostUIElementString element exists in the Dynamo VisualTree
+                var childFound = Guide.FindChild(View, step.HostPopupInfo.HostUIElementString);
+                elementNotFoundMessage = string.Format("The UIElement: {0} was not found in the DynamoView VisualTree", step.HostPopupInfo.HostUIElementString);
+                Assert.IsNotNull(childFound, elementNotFoundMessage);
             }
         }
     }


### PR DESCRIPTION
### Purpose

I created a new unit test for validating that the names used in the json file for the GetStarted guide exists in the DynamoView VisualTree otherwise an error will be raised.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Unit Test for validating names in GetStarted guide.

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
