### PR TITLE
Fix nested proxy port bug

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -741,7 +741,6 @@ namespace Dynamo.ViewModels
                     .SelectMany(x => x.Nodes.OfType<NodeModel>())
                     .Concat(Nodes.OfType<NodeModel>());
 
-
                 // If any of the nested groups are collapsed
                 // we need to update the posistion of the 
                 // prox ports on it.

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -736,25 +736,24 @@ namespace Dynamo.ViewModels
             IEnumerable<NodeModel> nestedNodes = null;
             if (annotationModel.HasNestedGroups)
             {
-                if (!IsExpanded)
-                {
-                    nestedNodes = Nodes
-                        .OfType<AnnotationModel>()
-                        .SelectMany(x => x.Nodes.OfType<NodeModel>())
-                        .Concat(Nodes.OfType<NodeModel>());
-                }
+                nestedNodes = Nodes
+                    .OfType<AnnotationModel>()
+                    .SelectMany(x => x.Nodes.OfType<NodeModel>())
+                    .Concat(Nodes.OfType<NodeModel>());
+
 
                 // If any of the nested groups are collapsed
                 // we need to update the posistion of the 
                 // prox ports on it.
-                ViewModelBases
-                    .OfType<AnnotationViewModel>()
-                    .Where(x => !x.IsExpanded)
-                    .ToList()
-                    .ForEach(x => x.UpdateProxyPortsPosition());
+                foreach (var nestedGroup in ViewModelBases.OfType<AnnotationViewModel>().Where(x => !x.IsExpanded))
+                {
+                    nestedGroup.SetGroupInputPorts();
+                    nestedGroup.SetGroupOutPorts();
+                    nestedGroup.UpdateProxyPortsPosition();
+                }
             }
 
-            var groupInports = GetGroupInPorts(nestedNodes);
+            var groupInports = GetGroupInPorts(IsExpanded ? null : nestedNodes);
 
             for (int i = 0; i < groupInports.Count(); i++)
             {
@@ -765,7 +764,7 @@ namespace Dynamo.ViewModels
                 model.Owner.ReportPosition();
             }
 
-            var groupOutports = GetGroupOutPorts(nestedNodes);
+            var groupOutports = GetGroupOutPorts(IsExpanded ? null : nestedNodes);
 
             for (int i = 0; i < groupOutports.Count(); i++)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -736,10 +736,22 @@ namespace Dynamo.ViewModels
             IEnumerable<NodeModel> nestedNodes = null;
             if (annotationModel.HasNestedGroups)
             {
-                nestedNodes = Nodes
-                    .OfType<AnnotationModel>()
-                    .SelectMany(x => x.Nodes.OfType<NodeModel>())
-                    .Concat(Nodes.OfType<NodeModel>());
+                if (!IsExpanded)
+                {
+                    nestedNodes = Nodes
+                        .OfType<AnnotationModel>()
+                        .SelectMany(x => x.Nodes.OfType<NodeModel>())
+                        .Concat(Nodes.OfType<NodeModel>());
+                }
+
+                // If any of the nested groups are collapsed
+                // we need to update the posistion of the 
+                // prox ports on it.
+                ViewModelBases
+                    .OfType<AnnotationViewModel>()
+                    .Where(x => !x.IsExpanded)
+                    .ToList()
+                    .ForEach(x => x.UpdateProxyPortsPosition());
             }
 
             var groupInports = GetGroupInPorts(nestedNodes);
@@ -753,7 +765,7 @@ namespace Dynamo.ViewModels
                 model.Owner.ReportPosition();
             }
 
-            var groupOutports = GetGroupOutPorts();
+            var groupOutports = GetGroupOutPorts(nestedNodes);
 
             for (int i = 0; i < groupOutports.Count(); i++)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -743,7 +743,7 @@ namespace Dynamo.ViewModels
 
                 // If any of the nested groups are collapsed
                 // we need to update the posistion of the 
-                // prox ports on it.
+                // proxy ports on it.
                 foreach (var nestedGroup in ViewModelBases.OfType<AnnotationViewModel>().Where(x => !x.IsExpanded))
                 {
                     nestedGroup.SetGroupInputPorts();


### PR DESCRIPTION
### Purpose

This PR fixes a small bug where nested groups proxy ports where not calculated correctly when expanding the parent group

See https://jira.autodesk.com/browse/DYN-4358

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix proxy port location bug on nested groups

### Reviewers

@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
