### PR TITLE
Cherry-pick: Report loading of blocked assemblies to user and exclude cases from impacting MTBF results

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -621,6 +621,11 @@ namespace Dynamo.Engine
                     ImportProcedure(library, globalFunction);
                 }
             }
+            catch (DynamoServices.AssemblyBlockedException e)
+            {
+                // This exception is caught upstream after displaying a failed load library warning to the user.
+                throw e;
+            }
             catch (Exception e)
             {
                 OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, e.Message,
@@ -631,7 +636,6 @@ namespace Dynamo.Engine
             {
                 importedLibraries.Add(library);
             }
-
             return true;
         }
 

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -269,6 +269,26 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///
+        ///This assembly is likely blocked. Try restarting Dynamo after unblocking this assembly and all other core assemblies that might be blocked. If you are running a downloaded DynamoSandbox build that is extracted from a .zip file, try using 7zip to extract the Dynamo binaries and try again..
+        /// </summary>
+        public static string CoreLibraryLoadFailureForBlockedAssembly {
+            get {
+                return ResourceManager.GetString("CoreLibraryLoadFailureForBlockedAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Core library load failure.
+        /// </summary>
+        public static string CoreLibraryLoadFailureMessageBoxTitle {
+            get {
+                return ResourceManager.GetString("CoreLibraryLoadFailureMessageBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not compress file.  Is the file in use?.
         /// </summary>
         public static string CouldNotCompressFile {
@@ -945,6 +965,26 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///
+        ///This assembly is likely blocked. Try importing it again after unblocking the assembly..
+        /// </summary>
+        public static string LibraryLoadFailureForBlockedAssembly {
+            get {
+                return ResourceManager.GetString("LibraryLoadFailureForBlockedAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Library load failure.
+        /// </summary>
+        public static string LibraryLoadFailureMessageBoxTitle {
+            get {
+                return ResourceManager.GetString("LibraryLoadFailureMessageBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find library path: {0}..
         /// </summary>
         public static string LibraryPathCannotBeFound {
@@ -1250,6 +1290,17 @@ namespace Dynamo.Properties {
         public static string PackageEmpty {
             get {
                 return ResourceManager.GetString("PackageEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///
+        ///This package likely contains an assembly that is blocked. You will need to load the package again after unblocking the assembly. Restart Dynamo to reload the package..
+        /// </summary>
+        public static string PackageLoadFailureForBlockedAssembly {
+            get {
+                return ResourceManager.GetString("PackageLoadFailureForBlockedAssembly", resourceCulture);
             }
         }
         

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -810,4 +810,25 @@ This package has not been loaded because another conflicting package was loaded 
   <data name="NodeUnhandledMsg" xml:space="preserve">
     <value>Unhandled 'DummyNode.NodeNature' value: {0}</value>
   </data>
+  <data name="CoreLibraryLoadFailureForBlockedAssembly" xml:space="preserve">
+    <value>{0}
+
+This assembly is likely blocked. Try restarting Dynamo after unblocking this assembly and all other core assemblies that might be blocked. If you are running a downloaded DynamoSandbox build that is extracted from a .zip file, try using 7zip to extract the Dynamo binaries and try again.</value>
+  </data>
+  <data name="LibraryLoadFailureForBlockedAssembly" xml:space="preserve">
+    <value>{0}
+
+This assembly is likely blocked. Try importing it again after unblocking the assembly.</value>
+  </data>
+  <data name="PackageLoadFailureForBlockedAssembly" xml:space="preserve">
+    <value>{0}
+
+This package likely contains an assembly that is blocked. You will need to load the package again after unblocking the assembly. Restart Dynamo to reload the package.</value>
+  </data>
+  <data name="CoreLibraryLoadFailureMessageBoxTitle" xml:space="preserve">
+    <value>Core library load failure</value>
+  </data>
+  <data name="LibraryLoadFailureMessageBoxTitle" xml:space="preserve">
+    <value>Library load failure</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -813,4 +813,25 @@ This package has not been loaded because another conflicting package was loaded 
   <data name="NodeUnhandledMsg" xml:space="preserve">
     <value>Unhandled 'DummyNode.NodeNature' value: {0}</value>
   </data>
+  <data name="CoreLibraryLoadFailureForBlockedAssembly" xml:space="preserve">
+    <value>{0}
+
+This assembly is likely blocked. Try restarting Dynamo after unblocking this assembly and all other core assemblies that might be blocked. If you are running a downloaded DynamoSandbox build that is extracted from a .zip file, try using 7zip to extract the Dynamo binaries and try again.</value>
+  </data>
+  <data name="LibraryLoadFailureForBlockedAssembly" xml:space="preserve">
+    <value>{0}
+
+This assembly is likely blocked. Try importing it again after unblocking the assembly.</value>
+  </data>
+  <data name="PackageLoadFailureForBlockedAssembly" xml:space="preserve">
+    <value>{0}
+
+This package likely contains an assembly that is blocked. You will need to load the package again after unblocking the assembly. Restart Dynamo to reload the package.</value>
+  </data>
+  <data name="CoreLibraryLoadFailureMessageBoxTitle" xml:space="preserve">
+    <value>Core library load failure</value>
+  </data>
+  <data name="LibraryLoadFailureMessageBoxTitle" xml:space="preserve">
+    <value>Library load failure</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -639,7 +639,7 @@ namespace Dynamo.ViewModels
 
         public static DynamoViewModel Start(StartConfiguration startConfiguration = new StartConfiguration())
         {
-            if(startConfiguration.DynamoModel == null) 
+            if (startConfiguration.DynamoModel == null) 
                 startConfiguration.DynamoModel = DynamoModel.Start();
 
             if(startConfiguration.WatchHandler == null)
@@ -856,6 +856,8 @@ namespace Dynamo.ViewModels
             model.RequestBugReport += ReportABug;
             model.RequestDownloadDynamo += DownloadDynamo;
             model.Preview3DOutage += Disable3DPreview;
+
+            DynamoServices.LoadLibraryEvents.LoadLibraryFailure += LoadLibraryEvents_LoadLibraryFailure;
         }
 
         private void UnsubscribeModelUiEvents()
@@ -863,6 +865,8 @@ namespace Dynamo.ViewModels
             model.RequestBugReport -= ReportABug;
             model.RequestDownloadDynamo -= DownloadDynamo;
             model.Preview3DOutage -= Disable3DPreview;
+
+            DynamoServices.LoadLibraryEvents.LoadLibraryFailure -= LoadLibraryEvents_LoadLibraryFailure;
         }
 
         private void SubscribeModelCleaningUpEvent()
@@ -2593,6 +2597,11 @@ namespace Dynamo.ViewModels
             return true;
         }
 
+        private static void LoadLibraryEvents_LoadLibraryFailure(string failureMessage, string messageBoxTitle)
+        {
+            Wpf.Utilities.MessageBoxService.Show(failureMessage, messageBoxTitle, MessageBoxButton.OK, MessageBoxImage.Exclamation);
+        }
+
         public void ImportLibrary(object parameter)
         {
             string[] fileFilter = {string.Format(Resources.FileDialogLibraryFiles, "*.dll; *.ds" ), string.Format(Resources.FileDialogAssemblyFiles, "*.dll"), 
@@ -2629,7 +2638,14 @@ namespace Dynamo.ViewModels
                 }
                 catch(LibraryLoadFailedException ex)
                 {
-                    System.Windows.MessageBox.Show(String.Format(ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Warning));
+                    Wpf.Utilities.MessageBoxService.Show(
+                        ex.Message, Properties.Resources.LibraryLoadFailureMessageBoxTitle, MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                }
+                catch(DynamoServices.AssemblyBlockedException ex)
+                {
+                    var failureMessage = string.Format(Properties.Resources.LibraryLoadFailureForBlockedAssembly, ex.Message);
+                    Wpf.Utilities.MessageBoxService.Show(
+                        failureMessage, Properties.Resources.LibraryLoadFailureMessageBoxTitle, MessageBoxButton.OK, MessageBoxImage.Exclamation);
                 }
             }
         }

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -76,7 +76,15 @@ namespace DynamoSandbox
                 Dynamo.Applications.StartupUtils.ASMPreloadFailure -= ASMPreloadFailureHandler;
 
             }
+            catch(DynamoServices.AssemblyBlockedException e)
+            {
+                var failureMessage = string.Format(Dynamo.Properties.Resources.CoreLibraryLoadFailureForBlockedAssembly, e.Message);
+                Dynamo.Wpf.Utilities.MessageBoxService.Show(
+                    failureMessage, Dynamo.Properties.Resources.CoreLibraryLoadFailureMessageBoxTitle, MessageBoxButton.OK, MessageBoxImage.Error);
 
+                Debug.WriteLine(e.Message);
+                Debug.WriteLine(e.StackTrace);
+            }
             catch (Exception e)
             {
                 try

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1188,17 +1188,18 @@ namespace ProtoFFI
                     //This probably wasn't a .NET dll
                     System.Diagnostics.Debug.WriteLine(exception.Message);
                     System.Diagnostics.Debug.WriteLine(exception.StackTrace);
-                    throw new System.Exception(string.Format("Dynamo can only import .NET DLLs. Failed to load library: {0}.", name));
+                    throw new Exception(string.Format("Dynamo can only import .NET DLLs. Failed to load library: {0}.", name));
                 }
-
-                catch (System.Exception exception)
+                catch(DynamoServices.AssemblyBlockedException exception)
                 {
-                    // If the exception is having HRESULT of 0x80131515, then perhaps we need to instruct the user to "unblock" the downloaded DLL. Please seee the following link for details:
-                    // http://blogs.msdn.com/b/brada/archive/2009/12/11/visual-studio-project-sample-loading-error-assembly-could-not-be-loaded-and-will-be-ignored-could-not-load-file-or-assembly-or-one-of-its-dependencies-operation-is-not-supported-exception-from-hresult-0x80131515.aspx
-                    // 
+                    // this exception is caught upstream after displaying a failed load library warning to the user.
+                    throw exception;
+                }
+                catch (Exception exception)
+                {
                     System.Diagnostics.Debug.WriteLine(exception.Message);
                     System.Diagnostics.Debug.WriteLine(exception.StackTrace);
-                    throw new System.Exception(string.Format("Fail to load library: {0}.", name));
+                    throw new Exception(string.Format("Fail to load library: {0}.", name));
                 }
             }
 

--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -34,7 +34,18 @@ namespace ProtoFFI
             System.Diagnostics.Debug.Write("Trying to load assembly: " + name);
             if (System.IO.File.Exists(name))
             {
-                return Assembly.LoadFrom(name);
+                try
+                {
+                    return Assembly.LoadFrom(name);
+                }
+                catch(System.IO.FileLoadException e)
+                {
+                    // If the exception is having HRESULT of 0x80131515, then we need to instruct the user to "unblock" the downloaded DLL.
+                    if (e.HResult == unchecked((int)0x80131515))
+                    {
+                        throw new DynamoServices.AssemblyBlockedException(e.Message);
+                    }
+                }
             }
             throw new System.IO.FileNotFoundException();
         }

--- a/src/Engine/ProtoCore/FFI/FFIHandler.cs
+++ b/src/Engine/ProtoCore/FFI/FFIHandler.cs
@@ -157,7 +157,12 @@ namespace ProtoFFI
                 {
                     Modules.Add(moduleFileName, helpers[FFILanguage.CSharp].getModule(dllModuleName));
                 }
-                catch
+                catch (DynamoServices.AssemblyBlockedException exception)
+                {
+                    // this exception is caught upstream after displaying a failed load library warning to the user.
+                    throw exception;
+                }
+                catch (Exception)
                 {
                     //try loading c++
                     try
@@ -176,8 +181,5 @@ namespace ProtoFFI
         }
     }
 
-    //public class PYthonFFIHandler
-    //{
-    //}
 }
 

--- a/src/Engine/ProtoCore/FFI/ImportModuleHandler.cs
+++ b/src/Engine/ProtoCore/FFI/ImportModuleHandler.cs
@@ -78,9 +78,9 @@ namespace ProtoFFI
                 return node;
             }
 
-            ProtoCore.AST.AssociativeAST.CodeBlockNode codeNode = null;
+            CodeBlockNode codeNode = null;
             if (importedNode == null)
-                codeNode = new ProtoCore.AST.AssociativeAST.CodeBlockNode();
+                codeNode = new CodeBlockNode();
             else
                 codeNode = importedNode.CodeNode;
 
@@ -88,9 +88,14 @@ namespace ProtoFFI
             {
                 codeNode = ImportCodeBlock(modulePathFileName, typeName, alias, codeNode);
             }
-            catch (System.Exception ex)
+            catch (DynamoServices.AssemblyBlockedException ex)
             {
-                if (ex is System.Reflection.ReflectionTypeLoadException)
+                // this exception is caught upstream after displaying a failed load library warning to the user.
+                throw ex;
+            }
+            catch (Exception ex)
+            {
+                if (ex is ReflectionTypeLoadException)
                 {
                     StringBuilder sb = new StringBuilder();
                     var typeLoadException = ex as ReflectionTypeLoadException;
@@ -247,7 +252,12 @@ namespace ProtoFFI
                 {
                     dllModule = DLLFFIHandler.GetModule(importModuleName);
                 }
-                catch
+                catch (DynamoServices.AssemblyBlockedException ex)
+                {
+                    // this exception is caught upstream after displaying a failed load library warning to the user.
+                    throw ex;
+                }
+                catch (Exception)
                 {
                     _coreObj.LogSemanticError(string.Format(Resources.FailedToImport, importModuleName), _coreObj.CurrentDSFileName, curLine, curCol);
                 }

--- a/src/NodeServices/MessageEvents.cs
+++ b/src/NodeServices/MessageEvents.cs
@@ -22,7 +22,18 @@ namespace DynamoServices
             if (LogWarningMessage != null)
                 LogWarningMessage(new LogWarningMessageEventArgs(message));
         }
+    }
 
+    internal static class LoadLibraryEvents
+    {
+        /// <summary>
+        /// Raised when loading of a library fails. A failure message is passed as a parameter.
+        /// </summary>
+        internal static event Action<string, string> LoadLibraryFailure;
 
+        internal static void OnLoadLibraryFailure(string failureMessage, string messageBoxTitle)
+        {
+            LoadLibraryFailure?.Invoke(failureMessage, messageBoxTitle);
+        }
     }
 }

--- a/src/NodeServices/Properties/AssemblyInfo.cs
+++ b/src/NodeServices/Properties/AssemblyInfo.cs
@@ -31,3 +31,5 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamoPythonTests")]
 [assembly: InternalsVisibleTo("IronPythonTests")]
 [assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
+[assembly: InternalsVisibleTo("DynamoPackages")]
+[assembly: InternalsVisibleTo("DynamoSandbox")]

--- a/src/NodeServices/Validity.cs
+++ b/src/NodeServices/Validity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using System.IO;
 
 namespace DynamoServices
 {
@@ -48,4 +49,14 @@ namespace DynamoServices
         }
     }
 
+    /// <summary>
+    /// Represents FileLoadException having HRESULT value of 0x80131515. 
+    /// Throw this when we need to instruct the user to "unblock" the downloaded assembly.
+    /// </summary>
+    internal class AssemblyBlockedException : FileLoadException
+    {
+        public AssemblyBlockedException(string message) : base(message)
+        {
+        }
+    }
 }


### PR DESCRIPTION
 Cherry-pick: #12357

* show message box to user if there are any blocked assemblies that prevent startup

* catch file load exception at top level and skip reporting to analytics

* cleanup

* cleanup

* show same msg box for importing blocked assemblies without crashing Dynamo

* cleanup

* rethrow explicit load library exception for blocked assembly and handle at top level

* cleanup

* cleanup

* add code comments

* edit user facing message

* use new message box style, add message box for package loading of blocked assemblies

* add comment

* add new exception type

* add code comments