### PR TITLE
[DYN-4414] Adjust Input Slider 

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -282,16 +282,13 @@
 
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="30" />
-                <ColumnDefinition Width="60" />
+                <ColumnDefinition Width="120" />
                 <ColumnDefinition Width="150" MinWidth="150" />
             </Grid.ColumnDefinitions>
 
             <nodes1:DynamoTextBox
                 x:Name="ValTb"
                 Grid.Column="1"
-                Width="48"
-                MinWidth="48"
-                MaxWidth="48"
                 Height="34"
                 Margin="10,0,2,0"
                 Padding="4,6"
@@ -300,9 +297,14 @@
                 Background="{StaticResource MidGreyBrush}"
                 BorderBrush="#4A4A4A"
                 BorderThickness="1"
+                TextWrapping="NoWrap"
                 Foreground="{StaticResource PrimaryCharcoal100Brush}"
                 Opacity="1"
-                Text="{Binding ValueText, Mode=OneWay}" />
+                Text="{Binding ValueText, Mode=OneWay}">
+                <nodes1:DynamoTextBox.ToolTip>
+                    <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding RelativeSource={RelativeSource AncestorType=TextBox}, Path=Text}"/>
+                </nodes1:DynamoTextBox.ToolTip>
+            </nodes1:DynamoTextBox>
 
             <Slider
                 Name="slider"


### PR DESCRIPTION
### Purpose

Per https://jira.autodesk.com/browse/DYN-4414, This PR adjusts the width of the input slider on the `Integer Slider` and `Number Slider` nodes to display more values than at current. It also adds a ToolTip displaying the full number, should the input exceed the input's new width.

![frQhBvFzr6](https://user-images.githubusercontent.com/29973601/144828550-90aed0bc-5db6-4eee-b2fe-144303452f4e.gif)

Note: I believe there is a JIRA task for this, unsure of its number @Amoursol 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Increases width of the integer/number slider inputs.

### Reviewers

@QilongTang @Amoursol 

### FYIs

@SHKnudsen 
