### PR TITLE
[DYN-4424] Adjust InPort Context Menu Accessibility

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -505,10 +505,11 @@ namespace Dynamo.ViewModels
 
         private void NodePortContextMenu(object obj)
         {
-            // If this port does not display a Chevron button to open the context menu, then
-            // using right-click to open the context menu should also do nothing.
+            // If this port does not display a Chevron button to open the context menu and it doesn't
+            // have a default value then using right-click to open the context menu should also do nothing.
             if (obj is InPortViewModel inPortViewModel &&
-                inPortViewModel.UseLevelVisibility == Visibility.Collapsed) return;
+                inPortViewModel.UseLevelVisibility == Visibility.Collapsed &&
+                !inPortViewModel.DefaultValueEnabled) return;
             
             var wsViewModel = node.WorkspaceViewModel;
             

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -505,6 +505,11 @@ namespace Dynamo.ViewModels
 
         private void NodePortContextMenu(object obj)
         {
+            // If this port does not display a Chevron button to open the context menu, then
+            // using right-click to open the context menu should also do nothing.
+            if (obj is InPortViewModel inPortViewModel &&
+                inPortViewModel.UseLevelVisibility == Visibility.Collapsed) return;
+            
             var wsViewModel = node.WorkspaceViewModel;
             
             wsViewModel.CancelActiveState();


### PR DESCRIPTION
### Purpose

Per https://jira.autodesk.com/browse/DYN-4424, This PR responds to JIRA Ticket [DYN-XXXX] by restricting access to the InPort context menu to only those ports which are displaying the `UseLevels` chevron button. This equates to the `UseLevelsVisibility` property on the InPortViewModel. 
Access to context menus on output ports has not been adjusted. 

![eQ3fIfUEZi](https://user-images.githubusercontent.com/29973601/144831392-87c05233-c0cb-436c-852d-39f1aef4f3b5.gif)

Note: What was the JIRA ticket number for this? @Amoursol 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Restricts access to the InPort context menu.

### Reviewers

@QilongTang @Amoursol 

### FYIs

@SHKnudsen 
