### PR TITLE
[DYN-XXXX] Update Periodic Run TextBox

### DIFF
--- a/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
+++ b/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
@@ -175,7 +175,7 @@
                 Text="{Binding RunPeriod, Converter={StaticResource RunPeriodConverter}, Mode=TwoWay}"
                 Visibility="{Binding RunPeriodInputVisibility}">
                 <TextBox.ToolTip>
-                    <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding RelativeSource={RelativeSource AncestorType= TextBox}, Path=Text}"></ToolTip>
+                    <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding RelativeSource={RelativeSource AncestorType= TextBox}, Path=Text}"/>
                 </TextBox.ToolTip>
             </TextBox>
 

--- a/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
+++ b/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
@@ -162,15 +162,22 @@
 
             <TextBox
                 Name="RunPeriodTextBox"
-                Width="80"
+                MinWidth="80"
+                MaxWidth="120"
                 Margin="2.5,0,0,0"
+                Padding="3,0,10,0"
                 VerticalContentAlignment="Center"
                 FontSize="14px"
                 Foreground="{StaticResource DynamoStandardLabelTextBrush}"
                 KeyDown="UIElement_OnKeyDown"
+                TextWrapping="NoWrap"
                 Style="{DynamicResource ResourceKey=SDarkTextBox}"
                 Text="{Binding RunPeriod, Converter={StaticResource RunPeriodConverter}, Mode=TwoWay}"
-                Visibility="{Binding RunPeriodInputVisibility}" />
+                Visibility="{Binding RunPeriodInputVisibility}">
+                <TextBox.ToolTip>
+                    <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding RelativeSource={RelativeSource AncestorType= TextBox}, Path=Text}"></ToolTip>
+                </TextBox.ToolTip>
+            </TextBox>
 
             <CheckBox
                 Name="debugCheckBox"


### PR DESCRIPTION
### Purpose

This PR responds to JIRA Task [DYN-XXXX] (@Amoursol for number) by making the periodic run TextBox able to slightly adjust its width to respond to longer inputs. This appears to have no affect on the UI for other Run Types. It also adds a ToolTip so that the user can see extra-long numbers if they are truncated. 

![Mz5RA2hsKQ](https://user-images.githubusercontent.com/29973601/144840710-aa1a2196-a0b8-45c6-9a5d-a3f5c279da2d.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Updates the Periodic Run Type UI


### Reviewers

@QilongTang @Amoursol 

### FYIs

@SHKnudsen 
