### PR TITLE
[DYN-4425] Set Workspace Tab Minimum Width

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1026,6 +1026,8 @@
                         <Style TargetType="{x:Type TabItem}">
                             <Setter Property="MaxWidth"
                                     Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
+                            <Setter Property="MinWidth"
+                                    Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
                             <Setter Property="Width">
                                 <Setter.Value>
                                     <MultiBinding Converter="{StaticResource TabSizeConverter}">

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -758,7 +758,7 @@
                                                     </Grid.ColumnDefinitions>
                                                     <ScrollViewer Grid.Column="0"
                                                                   Margin="0,0,0,0"
-                                                                  HorizontalScrollBarVisibility="Hidden"
+                                                                  HorizontalScrollBarVisibility="Auto"
                                                                   VerticalScrollBarVisibility="Disabled">
                                                         <TabPanel x:Name="HeaderPanel"
                                                                   IsItemsHost="True"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -757,7 +757,7 @@
                                                         <ColumnDefinition Width="Auto" />
                                                     </Grid.ColumnDefinitions>
                                                     <ScrollViewer Grid.Column="0"
-                                                                  Margin="0,0,0,0"
+                                                                  Margin="0,0,150,0"
                                                                   HorizontalScrollBarVisibility="Auto"
                                                                   VerticalScrollBarVisibility="Disabled">
                                                         <TabPanel x:Name="HeaderPanel"


### PR DESCRIPTION
### Purpose

This PR responds to JIRA Ticket [DYN-4425](https://jira.autodesk.com/browse/DYN-4425), by setting a minimum width value for new workspace tabs. 

![0Ph2Eetdi7](https://user-images.githubusercontent.com/29973601/144855864-b7bb336a-fac0-435e-beba-fab5647ab1cc.gif)

Note: I wasn't able to reproduce the issue, given the steps described. However, by setting a minimum width for tabs (same as maximum width: 225, from the config file) I believe the issue should be resolved. 

I also realised that our current UI might not be built to handle multiple (e.g. 50) tabs open at once, so I set the `HorizontalScrollBarVisibility` to `Auto`. Here's what this looks like: 

![bcTwwU108Y](https://user-images.githubusercontent.com/29973601/144858024-d19bfd17-56d4-4d67-88db-54e1b3ec872d.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Sets a minimum width for workspace tab items.
Updates the workspace tab to handle many tabs at once.

### Reviewers

@QilongTang @Amoursol 

### FYIs

@SHKnudsen 
