### PR TITLE
DYN-4356 Cherrypick

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -221,6 +221,12 @@ namespace Dynamo.Views
                         {
                             popup.Child.Visibility = Visibility.Hidden;
                             if (!(PortContextMenu.DataContext is PortViewModel portViewModel)) return;
+
+                            if (portViewModel is OutPortViewModel outPortViewModel)
+                            {
+                                outPortViewModel.RefreshHideWiresState();
+                            }
+
                             portViewModel.SetupPortContextMenuPlacement(popup);
                         }
                     }


### PR DESCRIPTION
### Purpose

Cherrypick https://github.com/DynamoDS/Dynamo/pull/12372 to RC2.13

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Bug fix for hide / show wire context menu state not working properly for nodes with multiple outports

### Reviewers

@QilongTang 

### FYIs

@Amoursol @mjkkirschner 