### PR TITLE
Restyle Watch / Preview Bubble

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3088,7 +3088,7 @@ namespace Dynamo.Controls
             {
                 return "Transparent";
             }
-            return "#aaaaaa";
+            return "#DCDCDC";
         }
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
@@ -10,6 +10,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -20,7 +21,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="15" />
         </Grid.ColumnDefinitions>
-        <TextBlock Name="Label" Foreground="#DCDCDC" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}" />
+        <TextBlock Name="Label" Foreground="{StaticResource PrimaryCharcoal200}" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}" />
 
         <TextBlock Name="Items" Grid.Column="2" Margin="0,3,0,7" Foreground="{StaticResource PrimaryCharcoal200Brush}"
                    FontFamily="{StaticResource SourceCodePro}"

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
@@ -21,7 +21,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="15" />
         </Grid.ColumnDefinitions>
-        <TextBlock Name="Label" Foreground="{StaticResource PrimaryCharcoal200}" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}" />
+        <TextBlock Name="Label" Foreground="{StaticResource PrimaryCharcoal200Brush}" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}" />
 
         <TextBlock Name="Items" Grid.Column="2" Margin="0,3,0,7" Foreground="{StaticResource PrimaryCharcoal200Brush}"
                    FontFamily="{StaticResource SourceCodePro}"

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
@@ -9,6 +9,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -19,11 +20,12 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="15" />
         </Grid.ColumnDefinitions>
-        <TextBlock Name="Label" Grid.Column="0" Margin="5,5,0,5" FontFamily="Consolas" Text="{Binding Path=NodeLabel}" />
+        <TextBlock Name="Label" Foreground="#DCDCDC" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}" />
 
-        <TextBlock Name="Items" Grid.Column="2" Margin="0,3,0,7" Foreground="Gray" FontStyle="Italic"
+        <TextBlock Name="Items" Grid.Column="2" Margin="0,3,0,7" Foreground="{StaticResource PrimaryCharcoal200Brush}"
+                   FontFamily="{StaticResource SourceCodePro}"
                    Visibility="{Binding ShowNumberOfItems, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-            {<Run Foreground="DarkRed" Text="{Binding NumberOfItems}" />}
+            {<Run Foreground="#F48686" Text="{Binding NumberOfItems}" />}
         </TextBlock>
 
         <Image x:Name="ExpandIcon" Grid.Column="3" VerticalAlignment="Bottom" Height="6" Width="6" Margin="0,5,5,5"

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -20,6 +20,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
                 <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
 
@@ -72,8 +73,9 @@
                     <MenuItem Header="{x:Static p:Resources.ContextMenuCopy}" Click="OnCopyToClipboardClick"/>
                 </ContextMenu>
             </Grid.ContextMenu>
-            <Border Background="White"
-                    BorderThickness="1"
+            <Border Background="{StaticResource DarkerGreyBrush}"
+                    CornerRadius="2"
+                    BorderThickness="0"
                     BorderBrush="{StaticResource BubblePreviewBorderColor}" />
             <!--bubbleTools is a pin icon which expands large preview bubble on mouse hover -->
             <Border Name="bubbleTools"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -61,17 +61,22 @@
                         <ControlTemplate TargetType="ToggleButton">
                             <Grid Width="17"
                                   Height="13"
-                                  Background="White">
+                                  Background="Transparent">
                                 <Path x:Name="ExpandPath"
-                                      Margin="2,2,0,0"
+                                      Margin="0,2,-1,0"
                                       HorizontalAlignment="Right"
                                       VerticalAlignment="Center"
-                                      Data="M 4 0 L 8 4 L 4 8 Z"
-                                      Fill="#0e67b1" />
+                                      Data="M0,0 L4.5,4.5 L9,0"
+                                      Stroke="#6AC0E7"
+                                      Fill="Transparent"
+                                      StrokeEndLineCap="Round"
+                                      StrokeStartLineCap="Round"
+                                      StrokeLineJoin="Round"
+                                      StrokeThickness="2"/>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="ExpandPath" Property="Data" Value="M 0 4 L 8 4 L 4 8 Z" />
+                                    <Setter TargetName="ExpandPath" Property="Data" Value="M-8,0 -4,4 L-8,8" />
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -164,7 +169,7 @@
                                                HorizontalAlignment="Center"
                                                Fill="Black"
                                                SnapsToDevicePixels="true"
-                                               Stroke="Gray" />
+                                               Stroke="#959595" />
 
                                     <!--  Draw Ellipse at the bottom of each vertical line  -->
 
@@ -174,9 +179,9 @@
                                              Margin="8,0,0,0"
                                              HorizontalAlignment="Center"
                                              VerticalAlignment="Bottom"
-                                             Fill="Gray"
+                                             Fill="#959595"
                                              SnapsToDevicePixels="True"
-                                             Stroke="Gray" />
+                                             Stroke="#959595" />
 
                                 </Grid>
 
@@ -214,10 +219,10 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ScrollViewer}">
-                            <Grid x:Name="Grid" Background="{TemplateBinding Background}">
+                            <Grid x:Name="Grid" Background="Transparent">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="12" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="*" />
@@ -239,6 +244,9 @@
                                 <ScrollBar x:Name="PART_VerticalScrollBar"
                                            Grid.Row="0"
                                            Grid.Column="1"
+                                           Background="Transparent"
+                                           HorizontalAlignment="Left"
+                                           Margin="-4,6,0,6"
                                            AutomationProperties.AutomationId="VerticalScrollBar"
                                            Cursor="Arrow"
                                            Maximum="{TemplateBinding ScrollableHeight}"
@@ -249,6 +257,8 @@
                                 <ScrollBar x:Name="PART_HorizontalScrollBar"
                                            Grid.Row="1"
                                            Grid.Column="0"
+                                           Grid.ColumnSpan="2"
+                                           Background="#3C3C3C"
                                            Margin="0,-6,0,-5"
                                            AutomationProperties.AutomationId="HorizontalScrollBar"
                                            Cursor="Arrow"
@@ -273,11 +283,13 @@
         </Grid.RowDefinitions>
 
         <TreeView Name="treeView1"
-                  Background="White"
-                  BorderBrush="{x:Null}"
+                  Background="#3C3C3C"
+                  BorderBrush="#DCDCDC"
+                  BorderThickness="0,0,0,1"
+                  Margin="0,5,0,0"
                   ItemContainerStyle="{StaticResource WatchTreeViewItem}"
                   ItemsSource="{Binding Children}"
-                  Opacity=".5"
+                  Opacity="1"
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Recycling">
 
@@ -320,16 +332,28 @@
                                    Padding="0,0,0,-1"
                                    VerticalAlignment="Center"
                                    Background="{Binding Path=IsCollection, Converter={StaticResource ListIndexBackgroundConverter}}"
-                                   FontFamily="Consolas"
+                                   FontFamily="{StaticResource SourceCodePro}"
                                    FontStyle="Italic"
                                    LineHeight="12"
                                    LineStackingStrategy="BlockLineHeight"
                                    Text="{Binding Path=ViewPath}"
-                                   Visibility="{Binding Path=ViewPath, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
+                                   Visibility="{Binding Path=ViewPath, Converter={StaticResource EmptyStringToCollapsedConverter}}">
+                            <TextBlock.Style>
+                                <Style TargetType="{x:Type TextBlock}">
+                                    <Setter Property="Foreground" Value="#DCDCDC"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=Children.Count}" Value="0">
+                                            <Setter Property="Foreground" Value="#4D4D4D" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                         <TextBlock Width="Auto"
                                    Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
                                    VerticalAlignment="Center"
-                                   FontFamily="Consolas"
+                                   Foreground="#DCDCDC"
+                                   FontFamily="{StaticResource SourceCodePro}"
                                    Text="{Binding Path=NodeLabel}"
                                    Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
                         <Button Margin="10,2,2,2"
@@ -347,8 +371,9 @@
 
         <Border Grid.Row="1"
                 HorizontalAlignment="Stretch"
-                BorderBrush="#d4d4d4"
-                BorderThickness="1">
+                BorderBrush="#D3D3D3"
+                CornerRadius="0,0,3,3"
+                BorderThickness="0,0,0,0">
 
             <Grid Name="ListLevelsDisplay" Grid.Row="1">
                 <Grid.ColumnDefinitions>
@@ -357,8 +382,8 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition Height="27" />
+                    
                 </Grid.RowDefinitions>
 
                 <!--  Shows counts of all items in List  -->
@@ -366,19 +391,20 @@
                 <TextBlock Name="ListItems"
                            Grid.Row="0"
                            Grid.Column="2"
-                           Margin="0,3,0,7"
-                           FontStyle="Italic"
-                           Foreground="Gray"
+                           Margin="0,0,13,2"
+                           FontFamily="{StaticResource SourceCodePro}"
+                           Foreground="#D3D3D3"
+                           VerticalAlignment="Center"
                            Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                    {<Run Foreground="DarkRed" Text="{Binding NumberOfItems}" />
-                    }</TextBlock>
+                    {<Run Foreground="#F48686" Text="{Binding NumberOfItems}" />}</TextBlock>
 
                 <!--  Shows list@level labels in List  -->
 
                 <ListView Name="listLevelsView"
                           Grid.Row="0"
                           Grid.Column="0"
-                          Margin="6,3,0,7"
+                          Margin="13,0,0,3"
+                          VerticalAlignment="Center"
                           Background="Transparent"
                           BorderThickness="0"
                           Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
@@ -391,7 +417,7 @@
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="{x:Type ListViewItem}">
-                                        <ContentPresenter />
+                                        <ContentPresenter TextBlock.FontSize="10px" TextBlock.Foreground="#D3D3D3" />
                                     </ControlTemplate>
                                 </Setter.Value>
                             </Setter>
@@ -407,13 +433,13 @@
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock FontFamily="Consolas" FontSize="9">
-                                    <Run Foreground="Gray">@</Run>
+                                <TextBlock FontFamily="{StaticResource SourceCodePro}" FontSize="10">
+                                    <Run Foreground="#D3D3D3">@</Run>
                                 </TextBlock>
                                 <TextBlock Name="indivListLevel"
-                                           FontFamily="Consolas"
-                                           FontSize="9">
-                                    L<Run Foreground="Black" Text="{Binding Path=.}" />
+                                           FontFamily="{StaticResource SourceCodePro}"
+                                           FontSize="10">
+                                    L<Run Foreground="#D3D3D3" Text="{Binding Path=.}" />
                                 </TextBlock>
                             </StackPanel>
                         </DataTemplate>
@@ -423,8 +449,9 @@
                 <Thumb Name="resizeThumb"
                        Grid.Row="1"
                        Grid.Column="2"
-                       Margin="3"
+                       Margin="3,3,3,3"
                        HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
                        Cursor="SizeNWSE"
                        DragDelta="ThumbResizeThumbOnDragDeltaHandler"
                        Visibility="Hidden">

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -284,7 +284,7 @@
 
         <TreeView Name="treeView1"
                   Background="#3C3C3C"
-                  BorderBrush="#DCDCDC"
+                  BorderBrush="{StaticResource PrimaryCharcoal200Brush}"
                   BorderThickness="0,0,0,1"
                   Margin="0,5,0,0"
                   ItemContainerStyle="{StaticResource WatchTreeViewItem}"
@@ -340,7 +340,7 @@
                                    Visibility="{Binding Path=ViewPath, Converter={StaticResource EmptyStringToCollapsedConverter}}">
                             <TextBlock.Style>
                                 <Style TargetType="{x:Type TextBlock}">
-                                    <Setter Property="Foreground" Value="#DCDCDC"/>
+                                    <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding Path=Children.Count}" Value="0">
                                             <Setter Property="Foreground" Value="#4D4D4D" />
@@ -352,7 +352,7 @@
                         <TextBlock Width="Auto"
                                    Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
                                    VerticalAlignment="Center"
-                                   Foreground="#DCDCDC"
+                                   Foreground="{StaticResource PrimaryCharcoal200Brush}"
                                    FontFamily="{StaticResource SourceCodePro}"
                                    Text="{Binding Path=NodeLabel}"
                                    Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
@@ -377,8 +377,8 @@
         <Border Grid.Row="1"
                 HorizontalAlignment="Stretch"
                 BorderBrush="#D3D3D3"
-                CornerRadius="0,0,3,3"
-                BorderThickness="0,0,0,0">
+                CornerRadius="0,0,2,2"
+                BorderThickness="0">
 
             <Grid Name="ListLevelsDisplay" Grid.Row="1">
                 <Grid.ColumnDefinitions>
@@ -454,7 +454,7 @@
                 <Thumb Name="resizeThumb"
                        Grid.Row="1"
                        Grid.Column="2"
-                       Margin="3,3,3,3"
+                       Margin="3"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Center"
                        Cursor="SizeNWSE"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -67,7 +67,7 @@
                                       HorizontalAlignment="Right"
                                       VerticalAlignment="Center"
                                       Data="M0,0 L4.5,4.5 L9,0"
-                                      Stroke="#6AC0E7"
+                                      Stroke="{StaticResource Blue300Brush}"
                                       Fill="Transparent"
                                       StrokeEndLineCap="Round"
                                       StrokeStartLineCap="Round"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -367,6 +367,11 @@
                     </VirtualizingStackPanel>
                 </HierarchicalDataTemplate>
             </TreeView.ItemTemplate>
+
+            <TreeView.Resources>
+                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"
+                                 Color="{StaticResource Blue300}" />
+            </TreeView.Resources>
         </TreeView>
 
         <Border Grid.Row="1"

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Media;
 using System.Windows.Threading;
 using CoreNodeModels;
 using Dynamo.Configuration;
@@ -39,6 +40,8 @@ namespace CoreNodeModelsWpf.Nodes
             this.syncContext = new DispatcherSynchronizationContext(nodeView.Dispatcher);
 
             var watchTree = new WatchTree();
+            watchTree.BorderThickness = new Thickness(1, 1, 1, 1);
+            watchTree.BorderBrush = new SolidColorBrush(Color.FromRgb(161, 161, 161));
 
             watchTree.SetWatchNodeProperties();
 


### PR DESCRIPTION
### Purpose

This PR restyles the `Watch` node, `PreviewControl` and `PreviewCompact` views to align with the visual refresh.

![TzNZvA4XKF](https://user-images.githubusercontent.com/29973601/145081432-a6540083-4b2a-43b4-948a-07d0b5c2e8d6.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Restyles the watch node and preview bubbles.

### Reviewers

@QilongTang @Amoursol 

### FYIs

@SHKnudsen 
