### PR TITLE
CherryPick Step8 Wrong Popup Location Bug (#12394)

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -73,6 +73,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         {
             GuideFlowEvents.GuidedTourNextStep -= GuideFlowEvents_GuidedTourNextStep;
             GuideFlowEvents.GuidedTourPrevStep -= GuideFlowEvents_GuidedTourPrevStep;
+            GuideFlowEvents.UpdatePopupLocation -= GuideFlowEvents_UpdatePopupLocation;
         }
 
         /// <summary>
@@ -82,6 +83,15 @@ namespace Dynamo.Wpf.UI.GuidedTour
         {
             GuideFlowEvents.GuidedTourNextStep += GuideFlowEvents_GuidedTourNextStep;
             GuideFlowEvents.GuidedTourPrevStep += GuideFlowEvents_GuidedTourPrevStep;
+            GuideFlowEvents.UpdatePopupLocation += GuideFlowEvents_UpdatePopupLocation;
+        }
+
+        /// <summary>
+        /// This event handler will be executed when the GuideFlowEvents.UpdatePopupLocation event is raised
+        /// </summary>
+        private void GuideFlowEvents_UpdatePopupLocation()
+        {
+            CurrentStep.UpdateLibraryPopupsLocation();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -4,6 +4,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
 {
     public delegate void GuidedTourNextEventHandler();
     public delegate void GuidedTourPrevEventHandler();
+    public delegate void UpdatePopupLocationEventHandler();
     public delegate void GuidedTourStartEventHandler(GuidedTourStateEventArgs args);
     public delegate void GuidedTourFinishEventHandler(GuidedTourStateEventArgs args);
 
@@ -49,6 +50,14 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 isAnyGuideActive = false;
                 GuidedTourFinish(new GuidedTourStateEventArgs(name));
             }
+        }
+
+        //Event that will be raised when we want to update the Popup location of the current step being executed
+        public static event UpdatePopupLocationEventHandler UpdatePopupLocation;
+        public static void OnUpdatePopupLocation()
+        {
+            if (GuidedTourFinish != null)
+                UpdatePopupLocation();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -128,6 +128,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         internal void UpdateGuideStepsLocation()
         {
+            //If there is no guide being executed then we shouldn't do anything
+            if (!GuideFlowEvents.IsAnyGuideActive) return;
+
             if (currentGuide != null)
             {
                 currentGuide.CurrentStep.UpdateLocation();

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -13,6 +13,7 @@ using static Dynamo.PackageManager.PackageManagerSearchViewModel;
 using static Dynamo.Wpf.UI.GuidedTour.Guide;
 using Dynamo.Wpf.Views.GuidedTour;
 using Dynamo.Utilities;
+using Newtonsoft.Json.Linq;
 
 namespace Dynamo.Wpf.UI.GuidedTour
 {
@@ -477,6 +478,43 @@ namespace Dynamo.Wpf.UI.GuidedTour
                     return;
                 dynamoView.CloseExtensionTab(closeButton, null);
             }
+        }
+
+        /// <summary>
+        /// This method will calculate the Popup location based in a item from the Library
+        /// </summary>
+        internal static void CalculateLibraryItemLocation(Step stepInfo, StepUIAutomation uiAutomationData, bool enableFunction, GuideFlow currentFlow)
+        {
+            CurrentExecutingStep = stepInfo;
+            if (uiAutomationData == null) return;
+            var jsFunctionName = uiAutomationData.JSFunctionName;
+            object[] jsParameters = new object[] { uiAutomationData.JSParameters[0] };
+            //Create the array for the paramateres that will be sent to the WebBrowser.InvokeScript Method
+            object[] parametersInvokeScript = new object[] { jsFunctionName, jsParameters };
+            //Execute the JS function with the provided parameters
+            var returnedObject = ResourceUtilities.ExecuteJSFunction(CurrentExecutingStep.MainWindow, CurrentExecutingStep.HostPopupInfo, parametersInvokeScript);
+            if (returnedObject == null) return;
+            //Due that the returned object is a json then we get the values from the json
+            JObject json = JObject.Parse(returnedObject.ToString());
+            double top = Convert.ToDouble(json["client"]["top"].ToString());
+            double bottom = Convert.ToDouble(json["client"]["bottom"].ToString());
+            //We calculate the Vertical location taking the average position "(top + bottom) / 2" and the height of the popup
+            double verticalPosition = (top + bottom) / 2 - CurrentExecutingStep.Height / 2;
+            CurrentExecutingStep.UpdatePopupVerticalPlacement(verticalPosition);
+        }
+
+        /// <summary>
+        /// This method will call a js function that will scroll down until the bottom of the page
+        /// </summary>
+        internal static void LibraryScrollToBottom(Step stepInfo, StepUIAutomation uiAutomationData, bool enableFunction, GuideFlow currentFlow)
+        {
+            CurrentExecutingStep = stepInfo;
+            if (uiAutomationData == null) return;
+            string jsFunctionName = uiAutomationData.JSFunctionName;
+            //Create the array for the paramateres that will be sent to the WebBrowser.InvokeScript Method
+            object[] parametersInvokeScript = new object[] { jsFunctionName, new object[] { } };
+            //Execute the JS function with the provided parameters
+            ResourceUtilities.ExecuteJSFunction(CurrentExecutingStep.MainWindow, CurrentExecutingStep.HostPopupInfo, parametersInvokeScript);
         }
     }
 }

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -10,10 +10,12 @@ using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 using System.Windows.Shapes;
 using Dynamo.Controls;
+using Dynamo.UI.Views;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Views.GuidedTour;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Dynamo.Wpf.UI.GuidedTour
 {
@@ -24,6 +26,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
     {
         #region Private Fields
         private static string WindowNamePopup = "PopupWindow";
+        private static string calculateLibraryFuncName = "CalculateLibraryItemLocation";
+        private static string libraryScrollToBottomFuncName = "LibraryScrollToBottom";
         #endregion
         #region Events
         //This event will be raised when a popup (Step) is closed by the user pressing the close button (PopupWindow.xaml).
@@ -221,6 +225,15 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //After UI Automation and calculate the target we need to highlight the element (otherwise probably won't exist)
             SetHighlightSection(true);
 
+            if (HostPopupInfo.WindowName != null  && HostPopupInfo.WindowName.Equals(nameof(LibraryView)))
+            {
+                var automationStep = (from automation in UIAutomation
+                                      where automation.Name.Equals(calculateLibraryFuncName)
+                                      select automation).FirstOrDefault();
+                GuidesValidationMethods.CalculateLibraryItemLocation(this, automationStep, true, Guide.GuideFlow.CURRENT);
+            }
+               
+
             stepUIPopup.IsOpen = true;
         }
 
@@ -366,7 +379,41 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 UpdatePopupLocationInvoke(stepUiPopupWindow?.webBrowserWindow);
             }
         }
-        
+
+        /// <summary>
+        /// Update the Location of Popups only when they are located over the Library (HostPopupInfo.WindowName = LibraryView)
+        /// </summary>
+        public void UpdateLibraryPopupsLocation()
+        {
+            if (HostPopupInfo.WindowName != null && HostPopupInfo.WindowName.Equals(nameof(LibraryView)))
+            {
+                var automationScrollDownStep = (from automation in UIAutomation
+                                      where automation.Name.Equals(libraryScrollToBottomFuncName)
+                                      select automation).FirstOrDefault();
+                if (automationScrollDownStep == null) return;
+                GuidesValidationMethods.LibraryScrollToBottom(this, automationScrollDownStep, true, Guide.GuideFlow.CURRENT);
+
+                var automationCalculateStep = (from automation in UIAutomation
+                                      where automation.Name.Equals(calculateLibraryFuncName)
+                                      select automation).FirstOrDefault();
+                if (automationCalculateStep == null) return;
+                GuidesValidationMethods.CalculateLibraryItemLocation(this, automationCalculateStep, true, Guide.GuideFlow.CURRENT);
+            }
+        }
+
+      
+
+        /// <summary>
+        /// This method will update the Popup vertical location
+        /// </summary>
+        /// <param name="verticalPosition"></param>
+        internal void UpdatePopupVerticalPlacement(double verticalPosition)
+        {
+            stepUIPopup.VerticalOffset = verticalPosition + HostPopupInfo.VerticalPopupOffSet;
+            UpdatePopupLocationInvoke(stepUIPopup);
+        }
+
+
         private void UpdatePopupLocationInvoke(Popup popUp)
         {
             if(popUp != null && popUp.IsOpen)

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -616,7 +616,7 @@
 				"Type": "tooltip",
 				"TooltipPointerDirection": "bottom_left",
 				"Width": 480,
-				"Height": 230,
+				"Height": 250,
 				"ShowLibrary": true,
 				"StepContent": {
 					"Title": "PackagesGuideNavigatePackagesTitle",
@@ -626,7 +626,7 @@
 					"PopupPlacement": "right",
 					"HostUIElementString": "sidebarGrid",
 					"WindowName": "LibraryView",
-					"VerticalPopupOffset": 600,
+					"VerticalPopupOffset": -70,
 					"HorizontalPopupOffset": -30,
 					"HighlightRectArea": {
 						"HighlightColor": "#EF9362",
@@ -666,6 +666,30 @@
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "subscribePackageClickedEvent",
+						"JSParameters": [ "Autodesk Sample" ],
+						"Action": "execute"
+					},
+					{
+						"Sequence": 4,
+						"ControlType": "JSFunction",
+						"Name": "InvokeJSFunction",
+						"JSFunctionName": "getDocumentClientRect",
+						"JSParameters": [ "Autodesk Sample" ],
+						"Action": "execute"
+					},
+					{
+						"Sequence": 5,
+						"ControlType": "function",
+						"Name": "LibraryScrollToBottom",
+						"JSFunctionName": "scrollToBottom",
+						"JSParameters": [],
+						"Action": "execute"
+					},
+					{
+						"Sequence": 6,
+						"ControlType": "function",
+						"Name": "CalculateLibraryItemLocation",
+						"JSFunctionName": "getDocumentClientRect",
 						"JSParameters": [ "Autodesk Sample" ],
 						"Action": "execute"
 					}

--- a/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
@@ -284,14 +284,15 @@ namespace Dynamo.Utilities
         /// <param name="MainWindow">MainWindow in which the LibraryView is located</param>
         /// <param name="popupInfo">Popup Information about the Step </param>
         /// <param name="parametersInvokeScript">Parameters for the WebBrowser.InvokeScript() function</param>
-        internal static void ExecuteJSFunction(UIElement MainWindow, HostControlInfo popupInfo, object[] parametersInvokeScript)
+        internal static object ExecuteJSFunction(UIElement MainWindow, HostControlInfo popupInfo, object[] parametersInvokeScript)
         {
             const string webBrowserString = "Browser";
             const string invokeScriptFunction = "InvokeScript";
+            object resultJSHTML = null;
 
             //Try to find the grid that contains the LibraryView
             var sidebarGrid = (MainWindow as Window).FindName(popupInfo.HostUIElementString) as Grid;
-            if (sidebarGrid == null) return;
+            if (sidebarGrid == null) return null;
 
             //We need to iterate every child in the grid due that we need to apply reflection to get the Type and find the LibraryView (a reference to LibraryViewExtensionMSWebBrowser cannot be added).
             foreach (var child in sidebarGrid.Children)
@@ -302,16 +303,17 @@ namespace Dynamo.Utilities
                     var libraryView = child as UserControl;
                     //get the WebBrowser instance inside the LibraryView
                     var browser = libraryView.FindName(webBrowserString);
-                    if (browser == null) return;
+                    if (browser == null) return null;
 
                     Type typeBrowser = browser.GetType();
                     //Due that there are 2 methods with the same name "InvokeScript", then we need to get the one with 2 parameters
                     MethodInfo methodInvokeScriptInfo = typeBrowser.GetMethods().Single(m => m.Name == invokeScriptFunction && m.GetParameters().Length == 2);
                     //Invoke the JS method located in library.html
-                    var resultHTML = methodInvokeScriptInfo.Invoke(browser, parametersInvokeScript);
+                    resultJSHTML = methodInvokeScriptInfo.Invoke(browser, parametersInvokeScript);
                     break;
                 }
             }
+            return resultJSHTML;
         }
     }
 }

--- a/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
@@ -134,6 +134,10 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 {
                     controller.MoveToNextStep();
                 }
+                else if (funcName == "ResizedEvent")
+                {
+                    controller.UpdatePopupLocation();
+                }
             }
             catch (Exception e)
             {
@@ -395,6 +399,7 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
             if (browser != null)
             {
                 browser.InvalidateVisual();
+                UpdatePopupLocation();
             }
         }
 
@@ -568,6 +573,12 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
         internal void MoveToNextStep()
         {
             GuideFlowEvents.OnGuidedTourNext();
+        }
+
+        //This method will be called when the Library was resized and the current Popup location needs to be updated
+        internal void UpdatePopupLocation()
+        {
+            GuideFlowEvents.OnUpdatePopupLocation();
         }
 
         /// <summary>

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -104,7 +104,7 @@
 
 </head>
 
-<body>
+<body onresize="bodyResizeEvent()">
     <!-- Placeholders must exist before all other scripts that try to access them -->
     <div class="OuterMostContainer" id="libraryContainerPlaceholder"></div>
     <!-- The main library view component -->
@@ -367,6 +367,37 @@
             }          
         }
 
+        //get information about the current position of a specific div element, if the WebBrowser is resized the values will change
+        function getDocumentClientRect(divElement) {
+            var targetDiv = findPackageDiv(divElement);
+            if (targetDiv == null) return;
+            var rect = targetDiv.parentNode.getBoundingClientRect();
+            var clientRectDiv = {
+                "width": rect.width,
+                "height": rect.height,
+                "top": rect.top,
+                "bottom": rect.bottom
+            }
+            var documentSize = {
+                "width": document.body.clientWidth,
+                "height": document.body.clientHeight
+            }
+            var locationInfo = {
+                "document": documentSize,
+                "client": clientRectDiv
+            }     
+            return JSON.stringify(locationInfo);
+        }
+
+        //scroll down until the bottom of the page so the AddOns always be visible
+        function scrollToBottom() {
+            window.scrollTo(0, document.body.scrollHeight);
+        }
+
+        //This method will be executed when the WebBrowser change its size, so we can update the Popup vertical location that is over the library
+        function bodyResizeEvent() {
+            window.external.notify(JSON.stringify({ "func": "ResizedEvent", "data": "" }));
+        }
     </script>
 
 </body>


### PR DESCRIPTION
### Purpose

CherryPick Step8 Wrong Popup Location Bug PR:https://github.com/DynamoDS/Dynamo/pull/12394

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

CherryPick Step8 Wrong Popup Location Bug 

### Reviewers

@QilongTang 

