### PR TITLE
Dyn 4422 step7 guide crash

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.14.0.3326")]
+[assembly: AssemblyVersion("2.14.0.3410")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.14.0.3326")]
+[assembly: AssemblyFileVersion("2.14.0.3410")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.14.0.3410")]
+[assembly: AssemblyVersion("2.14.0.3326")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.14.0.3410")]
+[assembly: AssemblyFileVersion("2.14.0.3326")]

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -28,7 +28,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         internal static GuidesManager CurrentExecutingGuidesManager;
         
         private static ExitGuide exitGuide;
-        private const string AutodeskSamplePackage = "Sample View Extension";
+        private const string AutodeskSamplePackage = "Dynamo Samples";
         private static PackageManagerSearchViewModel viewModel;
         private static PackageDownloadHandle packageDownloadHandle;
 
@@ -117,8 +117,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
             }
             else
             {
-                //Tries to close the TermsOfUseView or the PackageManagerSearchView if they were opened previously
-                Guide.CloseWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window);
+                //Tries to close the TermsOfUseView or the PackageManagerSearchView if they were opened previously (just if the flow if FORWARD from Step6 to Step7)
+                if (uiAutomationData.ExecuteCleanUpForward && currentFlow == GuideFlow.FORWARD)
+                    Guide.CloseWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window);
             }
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -708,7 +708,7 @@
 						"HighlightColor": "#EF9362",
 						"UIElementTypeString": "WebBrowser",
 						"UIElementGridContainer": "sidebarGrid",
-						"WindowElementNameString": "Autodesk Sample",
+						"WindowElementNameString": "SampleLibraryUI",
 						"WindowName": "LibraryView"
 					}
 				},
@@ -720,7 +720,7 @@
 						"Name": "SubscribeNextButtonClickEvent",
 						"Action": "execute",
 						"JSFunctionName": "collapseExpandPackage",
-						"JSParameters": [ "Autodesk Sample" ],
+						"JSParameters": [ "SampleLibraryUI" ],
 						"AutomaticHandlers": [
 							{
 								"HandlerElement": "NextButton",
@@ -742,7 +742,7 @@
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "subscribePackageClickedEvent",
-						"JSParameters": [ "Autodesk Sample" ],
+						"JSParameters": [ "SampleLibraryUI" ],
 						"Action": "execute"
 					},
 					{
@@ -750,7 +750,7 @@
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "getDocumentClientRect",
-						"JSParameters": [ "Autodesk Sample" ],
+						"JSParameters": [ "SampleLibraryUI" ],
 						"Action": "execute"
 					},
 					{
@@ -766,7 +766,7 @@
 						"ControlType": "function",
 						"Name": "CalculateLibraryItemLocation",
 						"JSFunctionName": "getDocumentClientRect",
-						"JSParameters": [ "Autodesk Sample" ],
+						"JSParameters": [ "SampleLibraryUI" ],
 						"Action": "execute"
 					}
 				]


### PR DESCRIPTION
### Purpose

Packages Guide crashing when coming from Step7 to Step6 (no sample package installed).
The crash was happening when coming from Step7 to Step6 and the sample package was not installed, it was happening because Step6 is expecting the PackageSearch window opened but when going from Step7 to Step6 it was closed, then Step6 was disappearing (Popup.PlacementTarget doesn't exist).
Then this fix is preventing to close the PackageSearch window when coming from Step7 to Step6 so the Step6 will be appearing right.
Also I included the changes related to the new package name uploaded "Dynamo Samples" and one of the contents "SampleLibraryUI" .

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Packages Guide crashing when coming from Step7 to Step6 (no sample package installed).

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
