### PR TITLE
Set the focus on the guided-tour popup window when the current step is loaded.

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -26,6 +26,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
     {
         #region Private Fields
         private static string WindowNamePopup = "PopupWindow";
+        private static readonly string NextButton = "NextButton";
         private static string calculateLibraryFuncName = "CalculateLibraryItemLocation";
         private static string libraryScrollToBottomFuncName = "LibraryScrollToBottom";
         #endregion
@@ -236,7 +237,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
             stepUIPopup.IsOpen = true;
 
-            var nextButton = stepUIPopup.FindName("NextButton") as Button;
+            var nextButton = stepUIPopup.FindName(NextButton) as Button;
             if (nextButton != null) 
             {
                 nextButton.Focus();

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -235,6 +235,12 @@ namespace Dynamo.Wpf.UI.GuidedTour
                
 
             stepUIPopup.IsOpen = true;
+
+            var nextButton = stepUIPopup.FindName("NextButton") as Button;
+            if (nextButton != null) 
+            {
+                nextButton.Focus();
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -237,10 +237,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
             stepUIPopup.IsOpen = true;
 
-            var nextButton = stepUIPopup.FindName(NextButton) as Button;
-            if (nextButton != null) 
+            if (Guide.FindChild((this.StepUIPopup as PopupWindow).mainPopupGrid, NextButton) is Button nextbuttonFound)
             {
-                nextButton.Focus();
+                nextbuttonFound.Focus();
             }
         }
 


### PR DESCRIPTION
### Purpose

This is just to set the focus on the popup window element so that keyboard events can be handled smoothly. This was missed as a part of this PR: https://github.com/DynamoDS/Dynamo/pull/12400. So creating a new one and will cherry-pick it too.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Improvement to https://github.com/DynamoDS/Dynamo/pull/12400

### Reviewers
@QilongTang @RobertGlobant20 

