### PR TITLE
Remove Target Path From Publish Package Dialog

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -6328,6 +6328,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File Path.
+        /// </summary>
+        public static string PublishPackageViewFilePath {
+            get {
+                return ResourceManager.GetString("PublishPackageViewFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to License (optional).
         /// </summary>
         public static string PublishPackageViewLicense {
@@ -6369,6 +6378,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PublishPackageViewMarkdownFilesDirectoryToolTip {
             get {
                 return ResourceManager.GetString("PublishPackageViewMarkdownFilesDirectoryToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Node Library.
+        /// </summary>
+        public static string PublishPackageViewNodeLibrary {
+            get {
+                return ResourceManager.GetString("PublishPackageViewNodeLibrary", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3016,4 +3016,10 @@ To install the latest version of a package, click Install. \n
   <data name="PackagesGuidePackagesNodeTitle" xml:space="preserve">
     <value>Use package nodes</value>
   </data>
+  <data name="PublishPackageViewFilePath" xml:space="preserve">
+    <value>File Path</value>
+  </data>
+  <data name="PublishPackageViewNodeLibrary" xml:space="preserve">
+    <value>Node Library</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1540,6 +1540,9 @@ If the toggle is off custom packages that are not already loaded will load once 
   <data name="PublishPackageViewPackageName" xml:space="preserve">
     <value>Name</value>
   </data>
+  <data name="PublishPackageViewFilePath" xml:space="preserve">
+    <value>File Path</value>
+  </data>
   <data name="PublishPackageViewPackageVersion" xml:space="preserve">
     <value>Version (Major Minor Build)</value>
   </data>
@@ -1585,6 +1588,9 @@ If the toggle is off custom packages that are not already loaded will load once 
   </data>
   <data name="PublishPackageViewRemoveItemToolTip" xml:space="preserve">
     <value>Removes this item from the package contents list.</value>
+  </data>
+  <data name="PublishPackageViewNodeLibrary" xml:space="preserve">
+    <value>Node Library</value>
   </data>
   <data name="ShowClassicNodeLibrary" xml:space="preserve">
     <value>Show Classic Node Library</value>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageItemRootViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageItemRootViewModel.cs
@@ -26,12 +26,7 @@ namespace Dynamo.PackageManager.UI
         /// The file path of this item (if any), regardless of which constructor was used.
         /// </summary>
         public string FilePath { get; }
-
-        /// <summary>
-        /// The target path of this item, regardless of which constructor was used.
-        /// </summary>
-        public string TargetPath { get; }
-
+        
         public PackageItemRootViewModel(CustomNodeDefinition def)
         {
             this.Height = 32;
@@ -39,7 +34,6 @@ namespace Dynamo.PackageManager.UI
             this.Definition = def;
             this.DisplayName = def.DisplayName;
             this.FilePath = String.Empty;
-            this.TargetPath = String.Empty;
             this.BuildDependencies(new HashSet<object>());
         }
 
@@ -50,7 +44,6 @@ namespace Dynamo.PackageManager.UI
             this.Assembly = assembly;
             this.DisplayName = assembly.Name;
             this.FilePath = assembly.Assembly.Location;
-            this.TargetPath = assembly.Assembly.Location;
             this.BuildDependencies(new HashSet<object>());
         }
 
@@ -61,7 +54,6 @@ namespace Dynamo.PackageManager.UI
             this.FileInfo = fileInfo;
             this.DisplayName = fileInfo.Name;
             this.FilePath = fileInfo.FullName;
-            this.TargetPath = fileInfo.FullName;
             this.BuildDependencies(new HashSet<object>());
         }
     }

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -695,23 +695,18 @@
                                                 MaxWidth="85"
                                                 Binding="{Binding Path=IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                 ElementStyle="{StaticResource CheckBoxStyle}"
-                                                Header="Node Library"
+                                                Header="{x:Static p:Resources.PublishPackageViewNodeLibrary}"
                                                 HeaderStyle="{StaticResource DataGridColumnHeaderText}"
                                                 IsReadOnly="False"
                                                 IsThreeState="False" />
                         <DataGridTextColumn MinWidth="50"
                                             Binding="{Binding Path=DisplayName, UpdateSourceTrigger=PropertyChanged}"
-                                            Header="Name"
-                                            HeaderStyle="{StaticResource DataGridColumnHeaderText}"
-                                            IsReadOnly="True" />
-                        <DataGridTextColumn Width="*"
-                                            MinWidth="66"
-                                            Binding="{Binding Path=FilePath, UpdateSourceTrigger=PropertyChanged}"
-                                            Header="File Path"
+                                            Header="{x:Static p:Resources.PublishPackageViewPackageName}"
                                             HeaderStyle="{StaticResource DataGridColumnHeaderText}"
                                             IsReadOnly="True" />
                         <DataGridTemplateColumn MinWidth="90"
-                                                Header="Target Path"
+                                                Width="*"
+                                                Header="{x:Static p:Resources.PublishPackageViewFilePath}"
                                                 HeaderStyle="{StaticResource DataGridColumnHeaderLast}"
                                                 IsReadOnly="True">
                             <DataGridTemplateColumn.CellTemplate>
@@ -737,9 +732,9 @@
                                             </Button.Template>
                                         </Button>
                                         <TextBlock Margin="0,0,0,0"
-                                                   Text="{Binding Path=TargetPath}"
+                                                   Text="{Binding Path=FilePath, UpdateSourceTrigger=PropertyChanged}"
                                                    TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding TargetPath}" />
+                                                   ToolTip="{Binding Path=FilePath, UpdateSourceTrigger=PropertyChanged}" />
                                     </DockPanel>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
### Purpose

Cherrypicked from: #12422. This PR removes the Target Path column in the `PublishPackageView` and its associate properties in the `PackageItemRootViewModel`.

![SbA58DVHmV](https://user-images.githubusercontent.com/29973601/145204927-a5297afd-0e66-4c0d-b8eb-1b3a799b2b34.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Removes a redundant column from the Publish Package dialog.


### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@Amoursol
@SHKnudsen 
