### PR TITLE
Reduce Main Menu Item Height

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -28,7 +28,7 @@
             </ResourceDictionary>
         </Border.Resources>
 
-        <Border Margin="11 0 0 0"
+        <Border Margin="11 4 0 0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Center">
             <Grid Name="ShortcutToolbarGrid">

--- a/src/DynamoCoreWpf/UI/Themes/Modern/MenuStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/MenuStyleDictionary.xaml
@@ -26,7 +26,7 @@
             <!--  TopLevelHeader  -->
             <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="MenuItem">
                 <Border Name="Border"
-                        Height="45px"
+                        Height="35px"
                         Padding="17,0"
                         Background="#3C3C3C">
                     <Grid>
@@ -36,6 +36,7 @@
                         </Grid.ColumnDefinitions>
                         <ContentPresenter Name="Content"
                                           Grid.Column="0"
+                                          Margin="0,3,0,0"
                                           VerticalAlignment="Center"
                                           ContentSource="Header"
                                           RecognizesAccessKey="True"
@@ -43,6 +44,7 @@
                                           TextBlock.FontSize="14px" />
                         <Path Name="DownArrow"
                               Grid.Column="1"
+                              Margin="0,3,0,0"
                               Width="10px"
                               Height="10px"
                               HorizontalAlignment="Right"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -184,7 +184,7 @@
           PreviewMouseLeftButtonUp="Window_PreviewMouseLeftButtonUp">
 
         <Grid.RowDefinitions>
-            <RowDefinition Height="45px" />
+            <RowDefinition Height="37px" />
             <RowDefinition Height="40px" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />


### PR DESCRIPTION
### Purpose

This PR slightly reduces the height of items in Dynamo's main menu.

![HOVPktA2GR](https://user-images.githubusercontent.com/29973601/145252160-8907b038-a7a0-4e3b-92e1-07e5d410d281.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Refines main menu item height.

### Reviewers

@QilongTang 
@Amoursol 

### FYIs

@SHKnudsen 