### PR TITLE
Fix group layout bug

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -155,6 +155,15 @@ namespace Dynamo.Graph.Workspaces
 
             foreach (NoteModel note in workspace.Notes)
             {
+                // If the note is pinned to a node we dont want to
+                // modify its posistion as it is tied to the node.
+                if (note.PinnedNode != null)
+                {
+                    var graphNode = combinedGraph.FindNode(note.PinnedNode.GUID);
+                    graphNode.LinkNote(note, note.Width, note.Height);
+                    continue;
+                }
+
                 AnnotationModel group = workspace.Annotations.Where(
                     g => g.Nodes.Contains(note)).ToList().FirstOrDefault();
 
@@ -471,6 +480,7 @@ namespace Dynamo.Graph.Workspaces
 
                     foreach (NoteModel note in n.LinkedNotes)
                     {
+                        if (note.PinnedNode != null) continue;
                         if (note.IsSelected || DynamoSelection.Instance.Selection.Count == 0)
                         {
                             note.X += deltaX;
@@ -500,6 +510,7 @@ namespace Dynamo.Graph.Workspaces
                     double noteOffset = -n.NotesHeight;
                     foreach (NoteModel note in n.LinkedNotes)
                     {
+                        if (note.PinnedNode != null) continue;
                         if (note.IsSelected || DynamoSelection.Instance.Selection.Count == 0)
                         {
                             note.X = node.X;
@@ -558,6 +569,7 @@ namespace Dynamo.Graph.Workspaces
                     double noteOffset = -n.NotesHeight;
                     foreach (NoteModel note in n.LinkedNotes)
                     {
+                        if (note.PinnedNode != null) continue;
                         if (note.IsSelected || DynamoSelection.Instance.Selection.Count == 0)
                         {
                             note.X = node.X;

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -153,14 +153,18 @@ namespace Dynamo.Graph.Workspaces
                 }
             }
 
-            foreach (NoteModel note in workspace.Notes)
+            var sortedNotes = workspace.Notes.OrderBy(x => x.PinnedNode is null);
+            foreach (NoteModel note in sortedNotes)
             {
                 // If the note is pinned to a node we dont want to
                 // modify its posistion as it is tied to the node.
                 if (note.PinnedNode != null)
                 {
+                    // We add this note to the LinkedNotes on the 
+                    // pinned node. 
                     var graphNode = combinedGraph.FindNode(note.PinnedNode.GUID);
-                    graphNode.LinkNote(note, note.Width, note.Height);
+                    var height = note.PinnedNode.Rect.Top - note.Rect.Top;
+                    graphNode.LinkNote(note, note.Width, height);
                     continue;
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -185,6 +185,7 @@ namespace Dynamo.ViewModels
         public void UpdateSizeFromView(double w, double h)
         {
             this._model.SetSize(w,h);
+            MoveNoteAbovePinnedNode();
         }
 
         private bool CanSelect(object parameter)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -318,6 +318,7 @@ namespace Dynamo.Nodes
         {
             if (ViewModel != null)
             {
+                DynamoSelection.Instance.ClearSelection();
                 ViewModel.SelectAll();
                 ViewModel.WorkspaceViewModel.DynamoViewModel.GraphAutoLayoutCommand.Execute(null);
             }

--- a/test/DynamoCoreWpfTests/GraphLayoutTests.cs
+++ b/test/DynamoCoreWpfTests/GraphLayoutTests.cs
@@ -361,6 +361,7 @@ namespace Dynamo.Tests
         {
             OpenModel(GetDynPath("GraphLayoutComplex.dyn"));
             IEnumerable<NodeModel> nodes = ViewModel.CurrentSpace.Nodes;
+            nodes.ToList().ForEach(node => node.ReportPosition());
             var subgraphs = ViewModel.CurrentSpace.DoGraphAutoLayout();
 
             Assert.AreEqual(ViewModel.CurrentSpace.Nodes.Count(), 82);


### PR DESCRIPTION
### Purpose

This PR fixes a bug that was happening when using `Cleanup node layout` on groups that contained notes that were pinned to a node. See [Slack thread](https://autodesk.slack.com/archives/CPJ5UQW0Z/p1638981530093700)

new behaviour:
![groupLayoutBugFix](https://user-images.githubusercontent.com/13732445/145264975-223da889-c32f-415d-ae22-d741bef88ecc.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix bug with `Cleanup node layout` on groups that contained notes that were pinned to a node. See [Slack thread](https://autodesk.slack.com/archives/CPJ5UQW0Z/p1638981530093700)


### Reviewers

@QilongTang 

### FYIs

@Amoursol 
