### PR TITLE
Serialize Copyright info while publishing a package

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -74,8 +74,8 @@ limitations under the License.
     <Reference Include="Analytics.NET.Google">
       <HintPath>..\..\extern\Analytics.NET\Analytics.NET.Google.dll</HintPath>
     </Reference>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/DynamoCore/packages.config
+++ b/src/DynamoCore/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="DynamoVisualProgramming.LibG_227_0_0" version="2.13.0.6926" targetFramework="net48" developmentDependency="true" />
   <package id="DynamoVisualProgramming.LibG_228_0_0" version="2.13.0.6925" targetFramework="net48" developmentDependency="true" />
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
 </packages>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -47,9 +47,9 @@
     <Reference Include="FontAwesome.WPF, Version=4.7.0.37774, Culture=neutral, PublicKeyToken=0758b07a11a4f466, processorArchitecture=MSIL">
       <HintPath>..\packages\FontAwesome.WPF.4.7.0.9\lib\net40\FontAwesome.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+      <HintPath>..\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
     </Reference>
     <Reference Include="HelixToolkit, Version=2.17.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
       <HintPath>..\packages\HelixToolkit.2.17.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -793,6 +793,8 @@ namespace Dynamo.PackageManager
             this.Assemblies = new List<PackageAssembly>();
             this.SelectedHosts = new List<String>();
             this.SelectedHostsString = string.Empty;
+            this.copyrightHolder = "";
+            this.copyrightYear = "";
         }
 
         private void ClearPackageContents()
@@ -841,7 +843,9 @@ namespace Dynamo.PackageManager
                 SiteUrl = l.SiteUrl ?? "",
                 Package = l,
                 License = l.License,
-                SelectedHosts = l.HostDependencies as List<string>
+                SelectedHosts = l.HostDependencies as List<string>,
+                CopyrightHolder = l.CopyrightHolder,
+                CopyrightYear = l.CopyrightYear
             };
 
             // add additional files
@@ -1570,7 +1574,9 @@ namespace Dynamo.PackageManager
                 Package.Keywords = KeywordList;
                 Package.License = License;
                 Package.SiteUrl = SiteUrl;
-                Package.RepositoryUrl = RepositoryUrl;                
+                Package.RepositoryUrl = RepositoryUrl;
+                Package.CopyrightHolder = CopyrightHolder;
+                Package.CopyrightYear = CopyrightYear;
 
                 AppendPackageContents();
 
@@ -1579,13 +1585,13 @@ namespace Dynamo.PackageManager
 
                 Package.HostDependencies = Enumerable.Empty<string>();
                 Package.HostDependencies = SelectedHosts;
-                foreach (var py in GetPythonDependency()) 
+                foreach (string py in GetPythonDependency()) 
                 {
                     if (!Package.HostDependencies.Contains(py)) 
                     {
                         Package.HostDependencies = Package.HostDependencies.Concat(new[] { py });
                     }
-                }                                
+                }
 
                 var files = GetAllFiles().ToList();
                 var pmExtension = dynamoViewModel.Model.GetPackageManagerExtension();

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -771,17 +771,17 @@ namespace Dynamo.PackageManager
         private void ClearAllEntries()
         {
             // this function clears all the entries of the publish package dialog
-            this.Name = "";
-            this.RepositoryUrl = "";
-            this.SiteUrl = "";
-            this.License = "";
-            this.Keywords = "";
-            this.Description = "";
-            this.Group = "";
+            this.Name = string.Empty;
+            this.RepositoryUrl = string.Empty;
+            this.SiteUrl = string.Empty;
+            this.License = string.Empty;
+            this.Keywords = string.Empty;
+            this.Description = string.Empty;
+            this.Group = string.Empty;
             this.MajorVersion = "0";
             this.MinorVersion = "0";
             this.BuildVersion = "0";
-            this.ErrorString = "";
+            this.ErrorString = string.Empty;
             this.Uploading = false;
             this.UploadHandle = null;
             this.IsNewVersion = false;
@@ -793,8 +793,8 @@ namespace Dynamo.PackageManager
             this.Assemblies = new List<PackageAssembly>();
             this.SelectedHosts = new List<String>();
             this.SelectedHostsString = string.Empty;
-            this.copyrightHolder = "";
-            this.copyrightYear = "";
+            this.copyrightHolder = string.Empty;
+            this.copyrightYear = string.Empty;
         }
 
         private void ClearPackageContents()

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -620,7 +620,7 @@
                             <TextBlock Name="copyrightHolderSubLabel"
                                        Style="{StaticResource SubLabelStyle}"
                                        Text="{x:Static p:Resources.PublishPackageViewCopyrightHolderSubLabel}" />
-                            <TextBox Name="copyrightHolderInput"
+                            <TextBox Name="CopyrightHolder"
                                      Style="{StaticResource InputStyle}"
                                      Text="{Binding CopyrightHolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      Tag="{x:Static p:Resources.PublishPackageViewCopyrightHolderWatermark}" />
@@ -632,7 +632,7 @@
                             <TextBlock Name="copyrightYearSubLabel"
                                        Style="{StaticResource SubLabelStyle}"
                                        Text="{x:Static p:Resources.PublishPackageViewCopyrightYearSubLabel}" />
-                            <TextBox Name="copyrightYearInput"
+                            <TextBox Name="CopyrightYear"
                                      Margin="0,0,0,-20"
                                      Style="{StaticResource InputStyle}"
                                      Text="{Binding CopyrightYear, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/src/DynamoCoreWpf/packages.config
+++ b/src/DynamoCoreWpf/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-<package id="DynamoVisualProgramming.LibG_228_0_0" version="2.13.0.6925" targetFramework="net48" developmentDependency="true" />  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="DynamoVisualProgramming.LibG_228_0_0" version="2.13.0.6925" targetFramework="net48" developmentDependency="true" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
 </packages>

--- a/src/DynamoPackages/DynamoPackages.csproj
+++ b/src/DynamoPackages/DynamoPackages.csproj
@@ -39,8 +39,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -181,6 +181,12 @@ namespace Dynamo.PackageManager
         /// </summary>
         public IEnumerable<string> HostDependencies { get { return hostDependencies; } set { hostDependencies = value; RaisePropertyChanged("HostDependencies"); } }
 
+        private string copyrightHolder = "";
+        public string CopyrightHolder { get { return copyrightHolder; } set { copyrightHolder = value; RaisePropertyChanged("CopyrightHolder"); } }
+
+        private string copyrightYear = "";
+        public string CopyrightYear { get { return copyrightYear; } set { copyrightYear = value; RaisePropertyChanged("CopyrightYear"); } }
+
         internal bool BuiltInPackage
         {
             get { return RootDirectory.StartsWith(PathManager.BuiltinPackagesDirectory); }
@@ -283,6 +289,8 @@ namespace Dynamo.PackageManager
                     SiteUrl = body.site_url,
                     RepositoryUrl = body.repository_url,
                     HostDependencies = body.host_dependencies,
+                    CopyrightHolder = body.copyright_holder,
+                    CopyrightYear = body.copyright_year,
                     Header = body
                 };
                 

--- a/src/DynamoPackages/PackageUploadBuilder.cs
+++ b/src/DynamoPackages/PackageUploadBuilder.cs
@@ -53,7 +53,7 @@ namespace Dynamo.PackageManager
             return new PackageUploadRequestBody(package.Name, package.VersionName, package.Description, package.Keywords, package.License, package.Contents, PackageManagerClient.PackageEngineName,
                                                          version, engineMetadata, package.Group, package.Dependencies,
                                                          package.SiteUrl, package.RepositoryUrl, package.ContainsBinaries, 
-                                                         package.NodeLibraries.Select(x => x.FullName), package.HostDependencies);
+                                                         package.NodeLibraries.Select(x => x.FullName), package.HostDependencies, package.CopyrightHolder, package.CopyrightYear);
         }
 
 

--- a/src/DynamoPackages/packages.config
+++ b/src/DynamoPackages/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
 </packages>

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">

--- a/src/PackageDetailsViewExtension/packages.config
+++ b/src/PackageDetailsViewExtension/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
 </packages>

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -37,8 +37,8 @@
     <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Magick.NET-Q8-AnyCPU, Version=7.24.1.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">

--- a/src/Tools/NodeDocumentationMarkdownGenerator/packages.config
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="CommandLineParser" version="2.8.0" targetFramework="net48" />
   <package id="DynamoVisualProgramming.LibG_228_0_0" version="2.13.0.6925" targetFramework="net48" developmentDependency="true" />
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Magick.NET.Core" version="7.0.1" targetFramework="net48" />
   <package id="Magick.NET-Q8-AnyCPU" version="7.24.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -45,8 +45,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\extern\Analytics.NET\Analytics.NET.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Diagnostics.Runtime, Version=2.0.4.26801, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/DynamoCoreTests/packages.config
+++ b/test/DynamoCoreTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -47,8 +47,8 @@
       <Private>True</Private>
       <HintPath>..\..\src\packages\Cyotek.Drawing.BitmapFont.2.0.0\lib\net48\Cyotek.Drawing.BitmapFont.dll</HintPath>
     </Reference>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
     </Reference>
     <Reference Include="HelixToolkit, Version=2.17.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
       <HintPath>..\..\src\packages\HelixToolkit.2.17.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>

--- a/test/DynamoCoreWpfTests/packages.config
+++ b/test/DynamoCoreWpfTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AvalonEdit" version="4.3.1.9430" targetFramework="net48" />
   <package id="Cyotek.Drawing.BitmapFont" version="2.0.0" targetFramework="net48" />
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="HelixToolkit" version="2.17.0" targetFramework="net48" />
   <package id="HelixToolkit.Wpf" version="2.17.0" targetFramework="net48" />
   <package id="HelixToolkit.Wpf.SharpDX" version="2.17.0" targetFramework="net48" />

--- a/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
+++ b/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Greg, Version=2.1.7972.24350, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\src\packages\Greg.2.1.7972.24350\lib\net48\Greg.dll</HintPath>
+    <Reference Include="Greg, Version=2.1.8012.24290, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\src\packages\Greg.2.1.8012.24290\lib\net48\Greg.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\..\src\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>

--- a/test/Libraries/PackageManagerTests/packages.config
+++ b/test/Libraries/PackageManagerTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Greg" version="2.1.7972.24350" targetFramework="net48" />
+  <package id="Greg" version="2.1.8012.24290" targetFramework="net48" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
   <package id="NUnit" version="2.6.3" targetFramework="net48" />


### PR DESCRIPTION
### Purpose

Add `Copyright Holder` and `Copyright Year` to package serialization file
Update `Greg` to `2.1.8012.24290`

![pub2](https://user-images.githubusercontent.com/32665108/145272469-20540183-a8fa-4259-82cb-5319e1e26a78.gif)

Snapshot of Package file (`pkg.json`)

![Screen Shot 2021-12-08 at 2 37 16 PM](https://user-images.githubusercontent.com/32665108/145272828-5c4b478b-34bb-40a7-9e8f-395681823788.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated



### Reviewers

@DynamoDS/dynamo 
