### PR TITLE
Fix the guided tour crash while setting the focus.

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -233,13 +233,15 @@ namespace Dynamo.Wpf.UI.GuidedTour
                                       select automation).FirstOrDefault();
                 GuidesValidationMethods.CalculateLibraryItemLocation(this, automationStep, true, Guide.GuideFlow.CURRENT);
             }
-               
 
             stepUIPopup.IsOpen = true;
 
-            if (Guide.FindChild((this.StepUIPopup as PopupWindow).mainPopupGrid, NextButton) is Button nextbuttonFound)
+            if (this.StepUIPopup is PopupWindow popupWindow)
             {
-                nextbuttonFound.Focus();
+                if (Guide.FindChild((popupWindow).mainPopupGrid, NextButton) is Button nextbuttonFound)
+                {
+                    nextbuttonFound.Focus();
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR fixes a crash to the guided tour. The crash was introduced after https://github.com/DynamoDS/Dynamo/pull/12416 was merged. We need to check if the StepUIPopup is a PopupWindow before setting the focus on next button.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix the crash that is being caused by https://github.com/DynamoDS/Dynamo/pull/12416.


### Reviewers
@QilongTang 

