### PR TITLE
Add localization strings for Graph Properties and Graph Status View Extensions

### DIFF
--- a/src/GraphMetadataViewExtension/GraphMetadataView.xaml
+++ b/src/GraphMetadataViewExtension/GraphMetadataView.xaml
@@ -7,6 +7,7 @@
              xmlns:controls="clr-namespace:Dynamo.GraphMetadata.Controls"
              xmlns:fa="http://schemas.fontawesome.io/icons/"
              xmlns:converters="clr-namespace:Dynamo.GraphMetadata.Converters"
+             xmlns:properties="clr-namespace:Dynamo.GraphMetadata.Properties"
              xmlns:vr="clr-namespace:Dynamo.GraphMetadata.ValidationRules"
              xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
              mc:Ignorable="d" 
@@ -140,25 +141,25 @@
         <StackPanel Orientation="Vertical"
                     Grid.Row="0" KeyDown="StackPanel_KeyDown">
 
-            <HeaderedContentControl Header="Description">
+            <HeaderedContentControl Header="{x:Static properties:Resources.GraphMetaData_Description}">
                 <TextBox Text="{Binding GraphDescription, Mode=TwoWay, FallbackValue='Graph Description'}"
                          Style="{StaticResource TextBoxStyle}"
                          TextWrapping="WrapWithOverflow" />
             </HeaderedContentControl>
 
-            <HeaderedContentControl Header="Image">
+            <HeaderedContentControl Header="{x:Static properties:Resources.GraphMetaData_Image}">
                 <controls:ImageSelector MaxHeight="150"
                                         MinHeight="100"
                                         Image="{Binding Thumbnail, Mode=TwoWay}"/>
             </HeaderedContentControl>
 
-            <HeaderedContentControl Header="Author Name">
+            <HeaderedContentControl Header="{x:Static properties:Resources.GraphMetaData_AuthorName}">
                 <TextBox Text="{Binding GraphAuthor, Mode=TwoWay}"
                          Style="{StaticResource TextBoxStyle}"
                          TextWrapping="WrapWithOverflow"/>
             </HeaderedContentControl>
 
-            <HeaderedContentControl Header="Learn more URL">
+            <HeaderedContentControl Header="{x:Static properties:Resources.GraphMetaData_LearnMoreURL}">
                 <TextBox Validation.ErrorTemplate="{StaticResource ResourceKey=textboxErrorTemplate}"
                          Name="UriTextBox"
                          TextWrapping="WrapWithOverflow"
@@ -211,7 +212,7 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <HeaderedContentControl Grid.Row="0" Grid.Column="0" Header="Graph Type">
+            <HeaderedContentControl Grid.Row="0" Grid.Column="0" Header="{x:Static properties:Resources.GraphMetaData_GraphType}">
                 <TextBlock Text="{Binding CurrentLinter.Name, Mode=OneWay, FallbackValue='Current Linter'}" />
             </HeaderedContentControl>
             <Button Grid.Row="0"
@@ -244,7 +245,7 @@
                     <ColumnDefinition Width="20" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Grid.Column="0"
-                           Text="Custom Properties"
+                           Text="{x:Static properties:Resources.GraphMetaData_CustomProperties}"
                            Style="{StaticResource headerStyle}" />
                 <Button Grid.Column="1"
                         Command="{Binding AddCustomPropertyCommand}">

--- a/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
@@ -216,7 +216,7 @@ namespace Dynamo.GraphMetadata
 
         private void AddCustomPropertyExecute(object obj)
         {
-            var propName = $"Custom Property {CustomProperties.Count + 1}";
+            var propName = Properties.Resources.CustomPropertyControl_CustomPropertyDefault + " " + (CustomProperties.Count + 1);
             AddCustomProperty(propName, string.Empty);
         }
 

--- a/src/GraphMetadataViewExtension/Properties/Resources.Designer.cs
+++ b/src/GraphMetadataViewExtension/Properties/Resources.Designer.cs
@@ -61,6 +61,69 @@ namespace Dynamo.GraphMetadata.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Custom Property.
+        /// </summary>
+        public static string CustomPropertyControl_CustomPropertyDefault {
+            get {
+                return ResourceManager.GetString("CustomPropertyControl_CustomPropertyDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Author Name.
+        /// </summary>
+        public static string GraphMetaData_AuthorName {
+            get {
+                return ResourceManager.GetString("GraphMetaData_AuthorName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom Properties.
+        /// </summary>
+        public static string GraphMetaData_CustomProperties {
+            get {
+                return ResourceManager.GetString("GraphMetaData_CustomProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        public static string GraphMetaData_Description {
+            get {
+                return ResourceManager.GetString("GraphMetaData_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graph Type.
+        /// </summary>
+        public static string GraphMetaData_GraphType {
+            get {
+                return ResourceManager.GetString("GraphMetaData_GraphType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image.
+        /// </summary>
+        public static string GraphMetaData_Image {
+            get {
+                return ResourceManager.GetString("GraphMetaData_Image", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Learn More URL.
+        /// </summary>
+        public static string GraphMetaData_LearnMoreURL {
+            get {
+                return ResourceManager.GetString("GraphMetaData_LearnMoreURL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Drag and Drop or Select image.
         /// </summary>
         public static string ImageSelector_Message_DefaultFeedback {

--- a/src/GraphMetadataViewExtension/Properties/Resources.en-US.resx
+++ b/src/GraphMetadataViewExtension/Properties/Resources.en-US.resx
@@ -117,6 +117,28 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CustomPropertyControl_CustomPropertyDefault" xml:space="preserve">
+    <value>Custom Property</value>
+  </data>
+  <data name="GraphMetaData_AuthorName" xml:space="preserve">
+    <value>Author Name</value>
+  </data>
+  <data name="GraphMetaData_CustomProperties" xml:space="preserve">
+    <value>Custom Properties</value>
+  </data>
+  <data name="GraphMetaData_Description" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="GraphMetaData_GraphType" xml:space="preserve">
+    <value>Graph Type</value>
+    <comment>Same label as found in LintingViewExtension</comment>
+  </data>
+  <data name="GraphMetaData_Image" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="GraphMetaData_LearnMoreURL" xml:space="preserve">
+    <value>Learn More URL</value>
+  </data>
   <data name="ImageSelector_Message_DefaultFeedback" xml:space="preserve">
     <value>Drag and Drop or Select image</value>
   </data>

--- a/src/GraphMetadataViewExtension/Properties/Resources.resx
+++ b/src/GraphMetadataViewExtension/Properties/Resources.resx
@@ -117,6 +117,28 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CustomPropertyControl_CustomPropertyDefault" xml:space="preserve">
+    <value>Custom Property</value>
+  </data>
+  <data name="GraphMetaData_AuthorName" xml:space="preserve">
+    <value>Author Name</value>
+  </data>
+  <data name="GraphMetaData_CustomProperties" xml:space="preserve">
+    <value>Custom Properties</value>
+  </data>
+  <data name="GraphMetaData_Description" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="GraphMetaData_GraphType" xml:space="preserve">
+    <value>Graph Type</value>
+    <comment>Same label as found in LintingViewExtension</comment>
+  </data>
+  <data name="GraphMetaData_Image" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="GraphMetaData_LearnMoreURL" xml:space="preserve">
+    <value>Learn More URL</value>
+  </data>
   <data name="ImageSelector_Message_DefaultFeedback" xml:space="preserve">
     <value>Drag and Drop or Select image</value>
   </data>

--- a/src/LintingViewExtension/LinterView.xaml
+++ b/src/LintingViewExtension/LinterView.xaml
@@ -139,7 +139,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <HeaderedContentControl Header="Graph Type"
+        <HeaderedContentControl Header="{x:Static props:Resources.GraphType}"
                                 HeaderTemplate="{StaticResource HeaderItemControlHeaderTemplate}"
                                 Margin="16 10">
             <Grid>
@@ -191,7 +191,7 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Expander Grid.Row="0"
-                          Header="Node Issues"
+                          Header="{x:Static props:Resources.NodeIssues}"
                           HeaderTemplate="{StaticResource HeaderItemControlHeaderTemplate}"
                           IsExpanded="True"
                           Template="{StaticResource issueExpander}"
@@ -205,7 +205,7 @@
                 </Expander>
 
                 <Expander Grid.Row="1"
-                          Header="Graph Issues"
+                          Header="{x:Static props:Resources.GraphIssues}"
                           HeaderTemplate="{StaticResource HeaderItemControlHeaderTemplate}"
                           IsExpanded="True"
                           Template="{StaticResource issueExpander}">

--- a/src/LintingViewExtension/Properties/Resources.Designer.cs
+++ b/src/LintingViewExtension/Properties/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Dynamo.LintingViewExtension.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Graph Issues.
+        /// </summary>
+        public static string GraphIssues {
+            get {
+                return ResourceManager.GetString("GraphIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graph Type.
+        /// </summary>
+        public static string GraphType {
+            get {
+                return ResourceManager.GetString("GraphType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to What is a Graph Type?.
         /// </summary>
         public static string GraphTypeHelpTooltip {
@@ -75,6 +93,15 @@ namespace Dynamo.LintingViewExtension.Properties {
         public static string MenuItemText {
             get {
                 return ResourceManager.GetString("MenuItemText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Node Issues.
+        /// </summary>
+        public static string NodeIssues {
+            get {
+                return ResourceManager.GetString("NodeIssues", resourceCulture);
             }
         }
         

--- a/src/LintingViewExtension/Properties/Resources.en-US.resx
+++ b/src/LintingViewExtension/Properties/Resources.en-US.resx
@@ -117,11 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="GraphIssues" xml:space="preserve">
+    <value>Graph Issues</value>
+  </data>
+  <data name="GraphType" xml:space="preserve">
+    <value>Graph Type</value>
+  </data>
   <data name="GraphTypeHelpTooltip" xml:space="preserve">
     <value>What is a Graph Type?</value>
   </data>
   <data name="MenuItemText" xml:space="preserve">
     <value>Show Graph _Status</value>
+  </data>
+  <data name="NodeIssues" xml:space="preserve">
+    <value>Node Issues</value>
   </data>
   <data name="NoneLinterDescriptorName" xml:space="preserve">
     <value>None</value>

--- a/src/LintingViewExtension/Properties/Resources.resx
+++ b/src/LintingViewExtension/Properties/Resources.resx
@@ -117,11 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="GraphIssues" xml:space="preserve">
+    <value>Graph Issues</value>
+  </data>
+  <data name="GraphType" xml:space="preserve">
+    <value>Graph Type</value>
+  </data>
   <data name="GraphTypeHelpTooltip" xml:space="preserve">
     <value>What is a Graph Type?</value>
   </data>
   <data name="MenuItemText" xml:space="preserve">
     <value>Show Graph _Status</value>
+  </data>
+  <data name="NodeIssues" xml:space="preserve">
+    <value>Node Issues</value>
   </data>
   <data name="NoneLinterDescriptorName" xml:space="preserve">
     <value>None</value>


### PR DESCRIPTION
### Purpose

Add Missing localized string resources for Graph Properties and Graph Status View Extensions 

https://jira.autodesk.com/browse/DYN-3876
https://jira.autodesk.com/browse/DYN-3877

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Localized Resource strings added for Graph Properties and Graph Status View Extension 

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@nate-peters 
