### PR TITLE
Make the node autocompletion window UI consistent with rest of Dynamo.

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -57,7 +57,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-                <Border Background="{StaticResource WorkspaceBackgroundBrush}"
+                <Border Background="{StaticResource ExtensionBackgroundColor}"
                     Padding="0"
                     CornerRadius="8,8,0,0">
                 <Grid>

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -57,7 +57,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <Border Background="{StaticResource autocompletionWindow}"
+                <Border Background="{StaticResource WorkspaceBackgroundBrush}"
                     Padding="0"
                     CornerRadius="8,8,0,0">
                 <Grid>
@@ -75,8 +75,7 @@
                                TextAlignment="Center"
                                FontSize="14">
                         </TextBlock>
-                        <Button Name="InfoButton" Click="OnMoreInfoClicked" Margin="50,7,5,7" BorderThickness="0"  Background="{StaticResource autocompletionWindow}">
-                        <Image Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Center">
+                        <Image Width="14" Height="14" MouseDown="OnMoreInfoClicked" Margin="40,5,10,5" HorizontalAlignment="Right" VerticalAlignment="Center">
                             <Image.Style>
                                 <Style TargetType="{x:Type Image}">
                                     <Style.Triggers>
@@ -84,15 +83,13 @@
                                             <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/whiteinfotab.png" />
                                         </Trigger>
                                         <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/whiteinfotab.png" />
+                                            <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/info_2.png" />
                                         </Trigger>
                                     </Style.Triggers>
                                 </Style>
                             </Image.Style>
                         </Image>
-                        </Button>
-                        <Button Name="CloseButton" Margin="0,7,5,7" Height="14" Width="14" BorderThickness="0" Click="CloseAutocompletionWindow" Background="{StaticResource autocompletionWindow}">
-                                <Image Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Center">
+                        <Image Width="14" Height="14" Margin="0,5,10,5" MouseDown="CloseAutocompletionWindow" HorizontalAlignment="Right" VerticalAlignment="Center">
                                 <Image.Style>
                                     <Style TargetType="{x:Type Image}">
                                         <Style.Triggers>
@@ -100,13 +97,12 @@
                                                 <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/whiteclosetab.png" />
                                             </Trigger>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/whiteclosetab.png" />
+                                                <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/close_blue.png" />
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>
                                 </Image.Style>
-                            </Image>
-                        </Button>
+                        </Image>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -197,7 +193,6 @@
                                                     Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
                                    HorizontalAlignment="Center"
                                    Height="18"
-                                   Margin="6,2,0,0"
                                    Text="{x:Static resx:Resources.AutocompleteSearchTextBlockText}" />
 
                     </StackPanel>


### PR DESCRIPTION
### Purpose

This PR is to match the Node Autocompletion window styling with other Dynamo controls.

![nodeautocomplete](https://user-images.githubusercontent.com/43763136/145303154-5078c933-c37e-4471-8a37-ee31f959d24c.gif)

The things I changed:
1) Close image and more-info image control to be consistent with rest of dynamo and removed the button around the image that shows a blue square border.
2) Background of header to match the Extension background as header background was same as the main content background.
3) Adjust the margin for search text box to align centrally.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@Amoursol @QilongTang 
