### PR TITLE
Restore LoadCustomNodesAndPackages public API

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -256,14 +256,14 @@ namespace Dynamo.ViewModels
                 PreferenceSettings.CustomPackageFolders = newpaths;
                 if (packageLoader != null)
                 {
-                    packageLoader.LoadCustomNodesAndPackages(additionalPaths, PreferenceSettings, customNodeManager);
+                    packageLoader.LoadCustomNodesAndPackages(additionalPaths, customNodeManager);
                 }
             }
             // Load packages from paths enabled by disable-path toggles if they are not already loaded.
             if (packageLoader != null && packagePathsEnabled.Any())
             {
                 var newPaths = packagePathsEnabled.Except(additionalPaths);
-                packageLoader.LoadCustomNodesAndPackages(newPaths, PreferenceSettings, customNodeManager);
+                packageLoader.LoadCustomNodesAndPackages(newPaths, customNodeManager);
             }
             packagePathsEnabled.Clear();
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -256,14 +256,14 @@ namespace Dynamo.ViewModels
                 PreferenceSettings.CustomPackageFolders = newpaths;
                 if (packageLoader != null)
                 {
-                    packageLoader.LoadCustomNodesAndPackages(additionalPaths, customNodeManager);
+                    packageLoader.LoadNewCustomNodesAndPackages(additionalPaths, customNodeManager);
                 }
             }
             // Load packages from paths enabled by disable-path toggles if they are not already loaded.
             if (packageLoader != null && packagePathsEnabled.Any())
             {
                 var newPaths = packagePathsEnabled.Except(additionalPaths);
-                packageLoader.LoadCustomNodesAndPackages(newPaths, customNodeManager);
+                packageLoader.LoadNewCustomNodesAndPackages(newPaths, customNodeManager);
             }
             packagePathsEnabled.Clear();
         }

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -800,9 +800,7 @@
                                                VerticalAlignment="Center"
                                                Style="{StaticResource ToggleInfoStyle}">
                                             <Image.ToolTip>
-                                                <ToolTip Style="{StaticResource GenericToolTipLight}">
-                                                    <TextBlock Text="{x:Static p:Resources.DisableBuiltInPackageToggleInfo}" TextWrapping="Wrap" Width="300"/>
-                                                </ToolTip>
+                                                <ToolTip Content="{x:Static p:Resources.DisableBuiltInPackageToggleInfo}" Style="{StaticResource GenericToolTipLight}"/>
                                             </Image.ToolTip>
                                         </Image>
 
@@ -827,9 +825,7 @@
                                                VerticalAlignment="Center"
                                                Style="{StaticResource ToggleInfoStyle}">
                                             <Image.ToolTip>
-                                                <ToolTip Style="{StaticResource GenericToolTipLight}">
-                                                    <TextBlock Text="{x:Static p:Resources.DisableCustomPackageToggleInfo}" TextWrapping="Wrap" Width="300"/>
-                                                </ToolTip> 
+                                                <ToolTip Content="{x:Static p:Resources.DisableCustomPackageToggleInfo}" Style="{StaticResource GenericToolTipLight}"/>
                                             </Image.ToolTip>
                                         </Image>
                                     </StackPanel>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -800,7 +800,9 @@
                                                VerticalAlignment="Center"
                                                Style="{StaticResource ToggleInfoStyle}">
                                             <Image.ToolTip>
-                                                <ToolTip Content="{x:Static p:Resources.DisableBuiltInPackageToggleInfo}" Style="{StaticResource GenericToolTipLight}"/>
+                                                <ToolTip Style="{StaticResource GenericToolTipLight}">
+                                                    <TextBlock Text="{x:Static p:Resources.DisableBuiltInPackageToggleInfo}" TextWrapping="Wrap" Width="300"/>
+                                                </ToolTip>
                                             </Image.ToolTip>
                                         </Image>
 
@@ -825,7 +827,9 @@
                                                VerticalAlignment="Center"
                                                Style="{StaticResource ToggleInfoStyle}">
                                             <Image.ToolTip>
-                                                <ToolTip Content="{x:Static p:Resources.DisableCustomPackageToggleInfo}" Style="{StaticResource GenericToolTipLight}"/>
+                                                <ToolTip Style="{StaticResource GenericToolTipLight}">
+                                                    <TextBlock Text="{x:Static p:Resources.DisableCustomPackageToggleInfo}" TextWrapping="Wrap" Width="300"/>
+                                                </ToolTip> 
                                             </Image.ToolTip>
                                         </Image>
                                     </StackPanel>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -379,12 +379,11 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Helper function to load new custom nodes and packages.
         /// </summary>
+        /// <param name="newPaths">New package paths to load custom nodes and packages from.</param>
         /// <param name="preferences">Can be a temporary local preferences object.</param>
         /// <param name="customNodeManager"></param>
-        /// <param name="newPaths">New package paths to load custom nodes and packages from.</param>
-        /// <param name="packageDirectoriesToScan">Scan new paths if this is null.</param>
-        private void LoadCustomNodesAndPackagesHelper(IPreferences preferences, 
-            CustomNodeManager customNodeManager, IEnumerable<string> newPaths, IEnumerable<string> packageDirectoriesToScan = null)
+        private void LoadCustomNodesAndPackagesHelper(IEnumerable<string> newPaths, IPreferences preferences, 
+            CustomNodeManager customNodeManager)
         {
             foreach (var path in preferences.CustomPackageFolders)
             {
@@ -394,8 +393,7 @@ namespace Dynamo.PackageManager
 
                 customNodeManager.AddUninitializedCustomNodesInPath(dir, false, false);
             }
-            var paths = packageDirectoriesToScan ?? newPaths;
-            foreach (var path in paths)
+            foreach (var path in newPaths)
             {
                 if (DynamoModel.IsDisabledPath(path, preferences))
                 {
@@ -449,7 +447,7 @@ namespace Dynamo.PackageManager
                     packageDirsToScan.Add(packageDirectory);
                 }
             }
-            LoadCustomNodesAndPackagesHelper(preferences, customNodeManager, newPaths, packageDirsToScan);
+            LoadCustomNodesAndPackagesHelper(packageDirsToScan, preferences, customNodeManager);
 
         }
 
@@ -467,7 +465,7 @@ namespace Dynamo.PackageManager
         public void LoadCustomNodesAndPackages(LoadPackageParams loadPackageParams, CustomNodeManager customNodeManager)
         {
             var preferences = loadPackageParams.Preferences;
-            LoadCustomNodesAndPackagesHelper(preferences, customNodeManager, preferences.CustomPackageFolders);
+            LoadCustomNodesAndPackagesHelper(preferences.CustomPackageFolders, preferences, customNodeManager);
         }
 
         private void ScanAllPackageDirectories(IPreferences preferences)

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -422,9 +422,11 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// If only custom nodes and packages from temporary custom paths, need to be loaded,
-        /// initialize a local PreferenceSettings object and add the temporary path(s) to its CustomPackageFolders property,
-        /// then initialize LoadPackageParams with this PreferenceSettings and use as input to this method.
+        /// To load custom nodes and packages from temporary custom paths,
+        /// initialize a local PreferenceSettings object and add the paths to its CustomPackageFolders property,
+        /// then initialize LoadPackageParams with this preferences object and use as input to this method.
+        /// To load from custom paths that need to be persisted to the preferences, 
+        /// initialize a LoadPackageParams from an existing preferences object.
         /// </summary>
         /// <param name="loadPackageParams">LoadPackageParams initialized with local PreferenceSettings object containing custom package path.</param>
         /// <param name="customNodeManager"></param>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -379,10 +379,10 @@ namespace Dynamo.PackageManager
         /// This method is called when custom nodes and packages need to be reloaded if there are new package paths.
         /// </summary>
         /// <param name="newPaths"></param>
-        /// <param name="preferences"></param>
         /// <param name="customNodeManager"></param>
-        public void LoadCustomNodesAndPackages(IEnumerable<string> newPaths, IPreferences preferences, CustomNodeManager customNodeManager)
+        public void LoadCustomNodesAndPackages(IEnumerable<string> newPaths, CustomNodeManager customNodeManager)
         {
+            var preferences = (pathManager as PathManager).Preferences;
             foreach (var path in preferences.CustomPackageFolders)
             {
                 // Append the definitions subdirectory for custom nodes.

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -757,7 +757,7 @@ namespace DynamoCoreWpfTests
 
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences, currentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(newPaths, currentDynamoModel.CustomNodeManager);
             Assert.AreEqual(4, loader.LocalPackages.Count());
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -757,7 +757,7 @@ namespace DynamoCoreWpfTests
 
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, currentDynamoModel.CustomNodeManager);
+            loader.LoadNewCustomNodesAndPackages(newPaths, currentDynamoModel.CustomNodeManager);
             Assert.AreEqual(4, loader.LocalPackages.Count());
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1004,10 +1004,11 @@ namespace DynamoCoreWpfTests
         [Test]
         public void NewCustomNodeSaveAndLoadPt2()
         {
-            this.ViewModel.Model.PreferenceSettings.CustomPackageFolders = new List<string>() { Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad") };
+            var newPaths = new List<string> { Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad") };
+            ViewModel.Model.PreferenceSettings.CustomPackageFolders = newPaths;
 
             var loader = ViewModel.Model.GetPackageManagerExtension().PackageLoader;
-            loader.LoadNewCustomNodesAndPackages(new List<string>(), ViewModel.Model.CustomNodeManager);
+            loader.LoadNewCustomNodesAndPackages(newPaths, ViewModel.Model.CustomNodeManager);
             // This unit test is a follow-up of NewCustomNodeSaveAndLoadPt1 test to make sure the newly created
             // custom node will be loaded once DynamoCore restarted
             var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1006,19 +1006,19 @@ namespace DynamoCoreWpfTests
         {
             this.ViewModel.Model.PreferenceSettings.CustomPackageFolders = new List<string>() { Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad") };
 
-            var loader = this.ViewModel.Model.GetPackageManagerExtension().PackageLoader;
-            loader.LoadCustomNodesAndPackages(new List<string>(), ViewModel.Model.PreferenceSettings, this.ViewModel.Model.CustomNodeManager);
+            var loader = ViewModel.Model.GetPackageManagerExtension().PackageLoader;
+            loader.LoadCustomNodesAndPackages(new List<string>(), ViewModel.Model.CustomNodeManager);
             // This unit test is a follow-up of NewCustomNodeSaveAndLoadPt1 test to make sure the newly created
             // custom node will be loaded once DynamoCore restarted
             var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");
             var functionnode =
-                this.ViewModel.Model.CustomNodeManager.CreateCustomNodeInstance(funcguid, "testnode", true);
+                ViewModel.Model.CustomNodeManager.CreateCustomNodeInstance(funcguid, "testnode", true);
             Assert.IsTrue(functionnode.IsCustomFunction);
             Assert.IsFalse(functionnode.IsInErrorState);
             Assert.AreEqual(functionnode.OutPorts.Count, 2);
 
-            this.ViewModel.CurrentSpace.AddAndRegisterNode(functionnode);
-            var nodeingraph = this.ViewModel.CurrentSpace.Nodes.FirstOrDefault();
+            ViewModel.CurrentSpace.AddAndRegisterNode(functionnode);
+            var nodeingraph = ViewModel.CurrentSpace.Nodes.FirstOrDefault();
             Assert.NotNull(nodeingraph);
             Assert.IsTrue(nodeingraph.State == ElementState.Active);
             //remove custom node from definitions folder

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1007,7 +1007,7 @@ namespace DynamoCoreWpfTests
             this.ViewModel.Model.PreferenceSettings.CustomPackageFolders = new List<string>() { Path.Combine(Path.GetTempPath(), "NewCustomNodeSaveAndLoad") };
 
             var loader = ViewModel.Model.GetPackageManagerExtension().PackageLoader;
-            loader.LoadCustomNodesAndPackages(new List<string>(), ViewModel.Model.CustomNodeManager);
+            loader.LoadNewCustomNodesAndPackages(new List<string>(), ViewModel.Model.CustomNodeManager);
             // This unit test is a follow-up of NewCustomNodeSaveAndLoadPt1 test to make sure the newly created
             // custom node will be loaded once DynamoCore restarted
             var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -12,7 +12,6 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Search.SearchElements;
-using Dynamo.Models;
 using Moq;
 using NUnit.Framework;
 using Dynamo.Interfaces;
@@ -119,11 +118,13 @@ namespace Dynamo.PackageManager.Tests
         [Test]
         public void PackageDoesNotReloadOnAbsenceOfNewPackagePath()
         {
-            var pathManager = new Mock<Dynamo.Interfaces.IPathManager>();
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory });
+            var pathManager = new PathManager(new PathManagerParams { });
 
-            var loader = new PackageLoader(pathManager.Object);
+            var settings = new PreferenceSettings();
+            settings.CustomPackageFolders = new List<string> { PackagesDirectory };
+            pathManager.Preferences = settings;
+
+            var loader = new PackageLoader(pathManager);
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
@@ -134,10 +135,9 @@ namespace Dynamo.PackageManager.Tests
             Action<IEnumerable<Assembly>> pkgsLoadedDelegate = (x) => { packagesLoaded = true; };
             loader.PackagesLoaded += pkgsLoadedDelegate;
 
-            CurrentDynamoModel.PreferenceSettings.CustomPackageFolders = new List<string>();
             var loadPackageParams = new LoadPackageParams
             {
-                Preferences = CurrentDynamoModel.PreferenceSettings,
+                Preferences = settings,
                 
             };
             loader.LoadAll(loadPackageParams);
@@ -149,7 +149,7 @@ namespace Dynamo.PackageManager.Tests
 
             packagesLoaded = false;
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(new List<string>(), loadPackageParams.Preferences, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(new List<string>(), CurrentDynamoModel.CustomNodeManager);
             Assert.AreEqual(19, loader.LocalPackages.Count());
 
             // Assert packages are not reloaded if there are no new package paths.
@@ -165,12 +165,14 @@ namespace Dynamo.PackageManager.Tests
 
         [Test]
         public void NoPackageNodeDuplicatesOnAddingNewPackagePath()
-        { 
-            var pathManager = new Mock<Dynamo.Interfaces.IPathManager>();
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory });
+        {
+            var pathManager = new PathManager(new PathManagerParams { });
 
-            var loader = new PackageLoader(pathManager.Object);
+            var settings = new PreferenceSettings();
+            settings.CustomPackageFolders = new List<string> { PackagesDirectory };
+            pathManager.Preferences = settings;
+
+            var loader = new PackageLoader(pathManager);
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
@@ -180,10 +182,9 @@ namespace Dynamo.PackageManager.Tests
             Action<IEnumerable<Assembly>> pkgsLoadedDelegate = (x) => { packagesLoaded = true; };
             loader.PackagesLoaded += pkgsLoadedDelegate;
 
-            CurrentDynamoModel.PreferenceSettings.CustomPackageFolders = new List<string>();
             var loadPackageParams = new LoadPackageParams
             {
-                Preferences = CurrentDynamoModel.PreferenceSettings,
+                Preferences =settings,
             };
             loader.LoadAll(loadPackageParams);
             Assert.AreEqual(19, loader.LocalPackages.Count());
@@ -193,11 +194,10 @@ namespace Dynamo.PackageManager.Tests
             Assert.IsTrue(entries.Count(x => x.FullName == "Package.Package.Package.Hello") == 1);
 
             packagesLoaded = false;
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory, BuiltInPackagesTestDir });
+            settings.CustomPackageFolders = new List<string> { PackagesDirectory, BuiltInPackagesTestDir };
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(newPaths, CurrentDynamoModel.CustomNodeManager);
             Assert.AreEqual(20, loader.LocalPackages.Count());
 
             // Assert packages are reloaded if there are new package paths.
@@ -216,30 +216,30 @@ namespace Dynamo.PackageManager.Tests
         {
             PathManager.BuiltinPackagesDirectory = BuiltInPackagesTestDir;
 
-            var pathManager = new Mock<Dynamo.Interfaces.IPathManager>();
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectorySigned });
+            var pathManager = new PathManager(new PathManagerParams { });
 
-            var loader = new PackageLoader(pathManager.Object);
+            var settings = new PreferenceSettings();
+            settings.CustomPackageFolders = new List<string> { PackagesDirectorySigned };
+            pathManager.Preferences = settings;
+
+            var loader = new PackageLoader(pathManager);
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
 
             loader.PackagesLoaded += libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
 
-            CurrentDynamoModel.PreferenceSettings.CustomPackageFolders = new List<string>();
             var loadPackageParams = new LoadPackageParams
             {
-                Preferences = CurrentDynamoModel.PreferenceSettings,
+                Preferences = settings
             };
             loader.LoadAll(loadPackageParams);
             Assert.AreEqual(3, loader.LocalPackages.Count());
             Assert.IsTrue(loader.LocalPackages.Count(x => x.Name == "SignedPackage") == 1);
 
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory, BuiltInPackagesTestDir });
+            settings.CustomPackageFolders = new List<string> { PackagesDirectory, BuiltInPackagesTestDir };
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, loadPackageParams.Preferences, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadCustomNodesAndPackages(newPaths, CurrentDynamoModel.CustomNodeManager);
             Assert.AreEqual(4, loader.LocalPackages.Count());
 
             Assert.IsTrue(loader.LocalPackages.Count(x => x.Name == "SignedPackage") == 2);

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -149,7 +149,7 @@ namespace Dynamo.PackageManager.Tests
 
             packagesLoaded = false;
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(new List<string>(), CurrentDynamoModel.CustomNodeManager);
+            loader.LoadNewCustomNodesAndPackages(new List<string>(), CurrentDynamoModel.CustomNodeManager);
             Assert.AreEqual(19, loader.LocalPackages.Count());
 
             // Assert packages are not reloaded if there are no new package paths.
@@ -197,7 +197,7 @@ namespace Dynamo.PackageManager.Tests
             settings.CustomPackageFolders = new List<string> { PackagesDirectory, BuiltInPackagesTestDir };
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadNewCustomNodesAndPackages(newPaths, CurrentDynamoModel.CustomNodeManager);
             Assert.AreEqual(20, loader.LocalPackages.Count());
 
             // Assert packages are reloaded if there are new package paths.
@@ -239,7 +239,7 @@ namespace Dynamo.PackageManager.Tests
             settings.CustomPackageFolders = new List<string> { PackagesDirectory, BuiltInPackagesTestDir };
             var newPaths = new List<string> { Path.Combine(TestDirectory, "builtinpackages testdir") };
             // This function is called upon addition of new package paths in the UI.
-            loader.LoadCustomNodesAndPackages(newPaths, CurrentDynamoModel.CustomNodeManager);
+            loader.LoadNewCustomNodesAndPackages(newPaths, CurrentDynamoModel.CustomNodeManager);
             Assert.AreEqual(4, loader.LocalPackages.Count());
 
             Assert.IsTrue(loader.LocalPackages.Count(x => x.Name == "SignedPackage") == 2);


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose
[Needs to be cherry-picked to 2.13]
- Restore previously obsoleted `LoadCustomNodesAndPackages` method to allow external devs to load packages from temporary custom paths.
- Update signature of internal `PackageLoader.LoadCustomNodesAndPackages` method. Previously the method took preference settings as input as well as used the `pathManager `member of the `PackageLoader`. Since the `pathManager` has its own reference of `PreferenceSettings`, the one belonging to the `pathManager `could be different from that that is independently passed to the `LoadCustomNodesAndPackages `method. I'm therefore removing the preference settings input and making use of the settings object that is referenced by `pathManager `itself.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
