### PR TITLE
Cherry Pick: Add internal visible for GenerativeDesign.Dynamo.PackAndGo

### DIFF
--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -39,6 +39,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("NodeDocumentationMarkdownGenerator")]
 [assembly: InternalsVisibleTo("LintingViewExtension")]
 [assembly: InternalsVisibleTo("GenerativeDesign.Dynamo.ViewExtension")]
+[assembly: InternalsVisibleTo("GenerativeDesign.Dynamo.PackAndGo")]
 [assembly: InternalsVisibleTo("DynamoPlayerExtension")]
 [assembly: InternalsVisibleTo("DSCPython")]
 [assembly: InternalsVisibleTo("DynamoPythonTests")]


### PR DESCRIPTION
### Purpose

(cherry picked from commit e6376686d06119b06e65ae4bfd6ecc6631224c71)

Cherry Pick https://github.com/DynamoDS/Dynamo/pull/12439

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

N/A Internal Visible Assembly for GenerativeDesign.Dynamo.PackAndGo


### Reviewers

@QilongTang 

