### PR TITLE
Open View Extension From DynamoCoreWpf in localized environment correctly

### DIFF
--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -237,7 +237,7 @@ namespace Dynamo.Wpf.Extensions
 
         /// <summary>
         /// Event raised when a component inside Dynamo raises a request to open a view extension
-        /// while being passed a parameter object.
+        /// providing extension name or GUID while being passed a parameter object.
         /// </summary>
         public event Action<string, object> ViewExtensionOpenRequestWithParameter
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
@@ -191,9 +191,9 @@ namespace Dynamo.ViewModels
         /// Event raised when there's a request to open the view extension in the side panel.
         /// </summary>
         internal event Action<string, object> ViewExtensionOpenWithParameterRequest;
-        internal void OnViewExtensionOpenWithParameterRequest(string extensionName, object obj)
+        internal void OnViewExtensionOpenWithParameterRequest(string extensionIdentification, object obj)
         {
-            ViewExtensionOpenWithParameterRequest?.Invoke(extensionName, obj);
+            ViewExtensionOpenWithParameterRequest?.Invoke(extensionIdentification, obj);
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -521,7 +521,7 @@ namespace Dynamo.PackageManager
 
             PackageManagerClientViewModel
                 .DynamoViewModel
-                .OnViewExtensionOpenWithParameterRequest("Package Details", packageManagerSearchElement);
+                .OnViewExtensionOpenWithParameterRequest("C71CA1B9-BF9F-425A-A12C-53DF56770406", packageManagerSearchElement);
         }
 
         /// <summary>

--- a/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
@@ -24,9 +24,7 @@ namespace Dynamo.GraphMetadata
 
         public override void Loaded(ViewLoadedParams viewLoadedParams)
         {
-            if (viewLoadedParams == null) throw new ArgumentNullException(nameof(viewLoadedParams));
-
-            this.viewLoadedParamsReference = viewLoadedParams;
+            this.viewLoadedParamsReference = viewLoadedParams ?? throw new ArgumentNullException(nameof(viewLoadedParams));
             this.viewModel = new GraphMetadataViewModel(viewLoadedParams, this);
             this.graphMetadataView = new GraphMetadataView();
             graphMetadataView.DataContext = viewModel;

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
@@ -32,9 +32,15 @@ namespace Dynamo.PackageDetails
             PackageManagerClientViewModel = dynamoViewModel.PackageManagerClientViewModel;
         }
 
-        internal void OnViewExtensionOpenWithParameterRequest(string extensionName, object obj)
+        internal void OnViewExtensionOpenWithParameterRequest(string extensionIdentification, object obj)
         {
-            if (extensionName != Name || !(obj is PackageManagerSearchElement pmSearchElement)) return;
+            // If the target view extension is not the current one, skip
+            if (!System.Guid.TryParse(extensionIdentification, out _) ||
+                !extensionIdentification.Equals(Name) ||
+                !(obj is PackageManagerSearchElement pmSearchElement))
+            {
+                return;
+            }
             OpenPackageDetails(pmSearchElement);
         }
         

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
@@ -34,14 +34,18 @@ namespace Dynamo.PackageDetails
 
         internal void OnViewExtensionOpenWithParameterRequest(string extensionIdentification, object obj)
         {
-            // If the target view extension is not the current one, skip
-            if (!System.Guid.TryParse(extensionIdentification, out _) ||
-                !extensionIdentification.Equals(Name) ||
-                !(obj is PackageManagerSearchElement pmSearchElement))
+            // If param type does not match return
+            if (!(obj is PackageManagerSearchElement pmSearchElement)) return;
+
+            // Make sure the target view extension is the current one
+            // Either view extension Guid match or name match
+            // String comparison of Guid is simplified check, if desired, we can update to use Guid check
+            if (UniqueId.ToString().Equals(extensionIdentification) ||
+                extensionIdentification.Equals(Name))
             {
-                return;
+                OpenPackageDetails(pmSearchElement);
             }
-            OpenPackageDetails(pmSearchElement);
+            return;
         }
         
         internal void OpenPackageDetails(PackageManagerSearchElement packageManagerSearchElement)


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-4402, we are facing a challenge to open target view extension from DynamoCoreWpf with or without additional param. The current way is to pass the view extension name so we are specific but the view extension name will get localized if it is from our team. With this factor, this is not a reliable way to open view extension I believe.

Potential solution:
1. Define target view extension name also in DynamoCoreWpf and use that instead of hard coded name, given they will be localized, it will work as before
2. Modify the API description to indicate support of both view extension Guid and name. Since Guid is not localized, it is more reliable in my opinion. But the current code is still not in desired states, we should maybe expose view extension manager in our API so API caller can pick, etc. It's nasty currently because the calling code is in another view extension..

I belive the Lint view extension share the same problem, not sure if you guys tested in a localized environment.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Open View Extension From DynamoCoreWpf in localized environment correctly


### Reviewers

@DynamoDS/dynamo 

### FYIs

@saintentropy 
