### PR TITLE
Fix Slider Node ToolTip Bug

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -302,7 +302,7 @@
                 Opacity="1"
                 Text="{Binding ValueText, Mode=OneWay}">
                 <nodes1:DynamoTextBox.ToolTip>
-                    <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding RelativeSource={RelativeSource AncestorType=TextBox}, Path=Text}"/>
+                    <ToolTip Style="{StaticResource GenericToolTipLight}" Content="{Binding ValueText, UpdateSourceTrigger=PropertyChanged}"/>
                 </nodes1:DynamoTextBox.ToolTip>
             </nodes1:DynamoTextBox>
 


### PR DESCRIPTION
### Purpose

This PR fixes a bug found with the ToolTip in the double/number slider nodes. 

![V7H6DKA7YJ](https://user-images.githubusercontent.com/29973601/145374219-f1d3d799-3c6f-43d3-9e6a-f11e8a4a8f89.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes a UI bug with the double/number slider nodes' input box ToolTip.


### Reviewers

@QilongTang 

### FYIs

@Amoursol 