### PR TITLE
Adding meta tag in header by code

### DIFF
--- a/src/DynamoCoreWpf/Views/GuidedTour/WebBrowserWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/WebBrowserWindow.xaml.cs
@@ -29,6 +29,8 @@ namespace Dynamo.Wpf.Views.GuidedTour
         private const string mainFontStylePath = "Dynamo.Wpf.Views.GuidedTour.HtmlPages.Resources.ArtifaktElement-Regular.woff";
         //Assembly path to the Resources folder
         private const string resourcesPath = "Dynamo.Wpf.Views.GuidedTour.HtmlPages.Resources";
+        //Enconding to be defined in the page
+        private const string encondingTag = "<meta charset='UTF-8'>";
 
         public WebBrowserWindow(PopupWindowViewModel viewModel, HostControlInfo hInfo)
         {
@@ -61,8 +63,14 @@ namespace Dynamo.Wpf.Views.GuidedTour
 
             bodyHtmlPage = LoadResouces(bodyHtmlPage, htmlPage.Resources);
             bodyHtmlPage = LoadResourceAndReplaceByKey(bodyHtmlPage, "#fontStyle", mainFontStylePath);
+            bodyHtmlPage = SetEnconding(bodyHtmlPage);
 
             webBrowser.NavigateToString(bodyHtmlPage);
+        }
+
+        private string SetEnconding(string bodyHtmlPage)
+        {
+            return bodyHtmlPage.Replace("<head>", "<head>"+ encondingTag);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This PR includes the `<meta charset='UTF-8'>` tag in the HTML related to the packages tour.

<img width="362" alt="de-DE" src="https://user-images.githubusercontent.com/89042471/145408611-1d13cb0b-aea1-4bde-ab26-203b5fb25a58.png">
<img width="371" alt="PT-BR" src="https://user-images.githubusercontent.com/89042471/145408617-d8fc994c-fffe-4876-8d96-3b7fe38c6a59.png">
<img width="372" alt="zh-CN" src="https://user-images.githubusercontent.com/89042471/145408619-95c8a11d-c7ac-4537-bd89-0d14a279b8a2.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
