### PR TITLE
DYN-4276-Step8-BugFix2

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -74,6 +74,15 @@ namespace Dynamo.Wpf.UI.GuidedTour
             GuideFlowEvents.GuidedTourNextStep -= GuideFlowEvents_GuidedTourNextStep;
             GuideFlowEvents.GuidedTourPrevStep -= GuideFlowEvents_GuidedTourPrevStep;
             GuideFlowEvents.UpdatePopupLocation -= GuideFlowEvents_UpdatePopupLocation;
+            GuideFlowEvents.UpdateLibraryInteractions -= GuideFlowEvents_UpdateLibraryInteractions;
+        }
+
+        /// <summary>
+        /// This method handler will be executed when a package is installed in the LibraryView so the Popup over the library will be updated
+        /// </summary>
+        private void GuideFlowEvents_UpdateLibraryInteractions()
+        {
+            CurrentStep.UpdateLibraryInteractions();
         }
 
         /// <summary>
@@ -84,6 +93,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             GuideFlowEvents.GuidedTourNextStep += GuideFlowEvents_GuidedTourNextStep;
             GuideFlowEvents.GuidedTourPrevStep += GuideFlowEvents_GuidedTourPrevStep;
             GuideFlowEvents.UpdatePopupLocation += GuideFlowEvents_UpdatePopupLocation;
+            GuideFlowEvents.UpdateLibraryInteractions += GuideFlowEvents_UpdateLibraryInteractions;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -5,6 +5,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
     public delegate void GuidedTourNextEventHandler();
     public delegate void GuidedTourPrevEventHandler();
     public delegate void UpdatePopupLocationEventHandler();
+    public delegate void UpdateLibraryInteractionsEventHandler();
     public delegate void GuidedTourStartEventHandler(GuidedTourStateEventArgs args);
     public delegate void GuidedTourFinishEventHandler(GuidedTourStateEventArgs args);
 
@@ -56,14 +57,22 @@ namespace Dynamo.Wpf.UI.GuidedTour
         public static event UpdatePopupLocationEventHandler UpdatePopupLocation;
         public static void OnUpdatePopupLocation()
         {
-            if (GuidedTourFinish != null)
+            if (UpdatePopupLocation != null)
                 UpdatePopupLocation();
+        }
+
+        //Event that will be raised when we want to update the Library interactions of Popups like event subscriptions and highlighted elements
+        public static event UpdateLibraryInteractionsEventHandler UpdateLibraryInteractions;
+        public static void OnUpdateLibraryInteractions()
+        { 
+            if (UpdateLibraryInteractions != null)
+                UpdateLibraryInteractions();
         }
 
         /// <summary>
         /// This property will returm if the a guide is being executed or not. 
         /// </summary>
-        internal static bool IsAnyGuideActive
+        public static bool IsAnyGuideActive
         {
             get { return isAnyGuideActive; }
             private set { isAnyGuideActive = value; }

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -29,6 +29,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private static readonly string NextButton = "NextButton";
         private static string calculateLibraryFuncName = "CalculateLibraryItemLocation";
         private static string libraryScrollToBottomFuncName = "LibraryScrollToBottom";
+        private static string subscribePackageClickedFuncName = "subscribePackageClickedEvent";
         #endregion
         #region Events
         //This event will be raised when a popup (Step) is closed by the user pressing the close button (PopupWindow.xaml).
@@ -233,6 +234,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                                       select automation).FirstOrDefault();
                 GuidesValidationMethods.CalculateLibraryItemLocation(this, automationStep, true, Guide.GuideFlow.CURRENT);
             }
+   
 
             stepUIPopup.IsOpen = true;
 
@@ -407,6 +409,20 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 if (automationCalculateStep == null) return;
                 GuidesValidationMethods.CalculateLibraryItemLocation(this, automationCalculateStep, true, Guide.GuideFlow.CURRENT);
             }
+        }
+
+        /// <summary>
+        /// This method will update the interactions of the Popup with the Library like the highligthed items or the event subscriptions
+        /// </summary>
+        internal void UpdateLibraryInteractions()
+        {
+            var automationSubscribePackage = (from automation in UIAutomation
+                                              where automation.JSFunctionName.Equals(subscribePackageClickedFuncName)
+                                              select automation).FirstOrDefault();
+            if (automationSubscribePackage == null) return;
+            ExecuteUIAutomationStep(automationSubscribePackage, true, Guide.GuideFlow.FORWARD);
+
+            SetHighlightSection(true);
         }
 
       

--- a/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
@@ -426,7 +426,13 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
             dynamoWindow.Dispatcher.BeginInvoke(new Action(() =>
             {
                 CloseTooltip(closeImmediately);
-            }));
+                //The packages installed are shown at this moment then we need to update the Popup location and the interactions with the Library
+                if (GuideFlowEvents.IsAnyGuideActive)
+                {
+                    GuideFlowEvents.OnUpdatePopupLocation();
+                    GuideFlowEvents.OnUpdateLibraryInteractions();
+                }                  
+            }));         
         }
 
         private FloatingLibraryTooltipPopup CreateTooltipControl()


### PR DESCRIPTION
### Purpose

When the sample package is installed for the first time the Step8 Popup was in the wrong location then I did a change to that then the package is installed the Popup location and interactions are updated.
For implementing this I added a new event called OnUpdateLibraryInteractions() and also added a method that will be subscribing the package click event and putting the Highlight over the Library.
The IsAnyGuideActive property needs to be public due that will be using in a different assembly.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing Step8 location when the sample package is installed for the first time.

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
