### PR TITLE
Adding enconded tag in the html files

### DIFF
--- a/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/installedPackage.html
+++ b/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/installedPackage.html
@@ -4,6 +4,7 @@
 <head>
 
     <meta http-equiv="x-ua-compatible" content="IE=11">
+    <meta charset="UTF-8">
 
     <style>
 

--- a/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/learnPackages.html
+++ b/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/learnPackages.html
@@ -4,6 +4,7 @@
 <head>
 
     <meta http-equiv="x-ua-compatible" content="IE=11">
+    <meta charset="UTF-8">
 
     <style>
 

--- a/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/nodePackage.html
+++ b/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/nodePackage.html
@@ -4,6 +4,7 @@
 <head>
 
     <meta http-equiv="x-ua-compatible" content="IE=11">
+    <meta charset="UTF-8">
 
     <style>
 

--- a/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/searchPackages.html
+++ b/src/DynamoCoreWpf/Views/GuidedTour/HtmlPages/searchPackages.html
@@ -4,6 +4,7 @@
 <head>
 
     <meta http-equiv="x-ua-compatible" content="IE=11">
+    <meta charset="UTF-8">
 
     <style>
 


### PR DESCRIPTION
### Purpose

This PR includes the <meta charset='UTF-8'> tag in the HTML related to the packages tour.

<img width="362" alt="de-DE" src="https://user-images.githubusercontent.com/89042471/145460677-585e7370-c571-4c93-b473-73df2c3a19e6.png">
<img width="371" alt="PT-BR" src="https://user-images.githubusercontent.com/89042471/145460685-91976ba8-fb34-4c7c-bb25-fa57f2096efe.png">
<img width="372" alt="zh-CN" src="https://user-images.githubusercontent.com/89042471/145460688-fbfe9702-b78c-4d1a-86e7-e705cfa83654.png">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
