### PR TITLE
DYN-4398-GetStartedButton-Localization

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7201,6 +7201,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start Tour.
+        /// </summary>
+        public static string StartTourButtonText {
+            get {
+                return ResourceManager.GetString("StartTourButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit....
         /// </summary>
         public static string StringInputNodeEditMenu {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3028,4 +3028,7 @@ To install the latest version of a package, click Install. \n
   <data name="WorkspaceTabTooltipHeaderUnsaved" xml:space="preserve">
     <value>Unsaved</value>
   </data>
+  <data name="StartTourButtonText" xml:space="preserve">
+    <value>Start Tour</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3009,4 +3009,7 @@ To install the latest version of a package, click Install. \n
   <data name="WorkspaceTabTooltipHeaderUnsaved" xml:space="preserve">
     <value>Unsaved</value>
   </data>
+  <data name="StartTourButtonText" xml:space="preserve">
+    <value>Start Tour</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:Dynamo.Wpf.Views.GuidedTour"
         xmlns:localui="clr-namespace:Dynamo.Wpf.UI.GuidedTour"
         xmlns:ui="clr-namespace:Dynamo.UI"
+        xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
         mc:Ignorable="d"
         PopupAnimation="Fade"
         AllowsTransparency="True"
@@ -172,9 +173,9 @@
                         Visibility="{Binding ShowPopupButton, Converter={StaticResource BooleanToVisibilityConverter}}"
                         Style="{StaticResource PoupButtonStyle}"
                         Grid.Column="3"                      
-                        Margin="0,0,10,0"                      
+                        Margin="0,0,10,0"              
+                        Content="{x:Static p:Resources.StartTourButtonText}"
                         Click="StartTourButton_Click" >
-                    Start Tour
                 </Button>
             </Grid>
         </Grid>


### PR DESCRIPTION
### Purpose

Hard-Coded string in the GetStarted button name,
Instead of having the hard-coded string in the xaml GetStarted Button I move it to a resource so it can be translated to the desired language.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Hard-Coded string in the GetStarted button name,

### Reviewers

@QilongTang 

### FYIs
