### PR TITLE
Connector ZIndex modified to be under that of nested node/group ports.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -808,7 +808,7 @@ namespace Dynamo.ViewModels
 
                 viewModel.IsCollapsed = true;
                 if (viewModel is NodeViewModel nodeViewModel)
-                    nodeViewModel.NodeInCollapsedGroup = true;
+                    nodeViewModel.IsNodeInCollapsedGroup = true;
             }
 
             if (!collapseConnectors) return;

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -807,6 +807,8 @@ namespace Dynamo.ViewModels
                 }
 
                 viewModel.IsCollapsed = true;
+                if (viewModel is NodeViewModel nodeViewModel)
+                    nodeViewModel.NodeInCollapsedGroup = true;
             }
 
             if (!collapseConnectors) return;

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -363,6 +363,9 @@ namespace Dynamo.ViewModels
 
         private int SetZIndex()
         {
+            if (isConnecting)
+                return (int)zIndex;
+
             var firstNode = this.Nodevm;
             var lastNode = this.NodeEnd;
 
@@ -476,7 +479,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return workspaceViewModel.Nodes.FirstOrDefault(x => x.NodeLogic.GUID == model.Start.Owner.GUID);
+                return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.Start.Owner.GUID);
             }
         }
 
@@ -484,7 +487,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return workspaceViewModel.Nodes.FirstOrDefault(x => x.NodeLogic.GUID == model.End.Owner.GUID);
+                return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.End.Owner.GUID);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -349,8 +349,7 @@ namespace Dynamo.ViewModels
         {
             get 
             {
-                zIndex = SetZIndex();
-                return zIndex;
+                return SetZIndex();
             }
 
             protected set

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -388,11 +388,11 @@ namespace Dynamo.ViewModels
         }
         private bool OneConnectingNodeInCollapsedGroup(NodeViewModel firstNode, NodeViewModel lastNode)
         {
-            return firstNode.NodeInCollapsedGroup || lastNode.NodeInCollapsedGroup;
+            return firstNode.IsNodeInCollapsedGroup || lastNode.IsNodeInCollapsedGroup;
         }
         private bool ConnectingNodesBothInCollapsedGroup(NodeViewModel firstNode, NodeViewModel lastNode)
         {
-            return firstNode.NodeInCollapsedGroup && lastNode.NodeInCollapsedGroup;
+            return firstNode.IsNodeInCollapsedGroup && lastNode.IsNodeInCollapsedGroup;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -59,7 +59,7 @@ namespace Dynamo.ViewModels
         private bool isexplictFrozen;
         private bool canToggleFrozen = true;
         private bool isRenamed = false;
-        private bool nodeInCollapsedGroup = false;
+        private bool isNodeInCollapsedGroup = false;
         #endregion
 
         #region public members
@@ -665,13 +665,13 @@ namespace Dynamo.ViewModels
         /// Used as a flag to indicate to associated connectors what ZIndex to be drawn at.
         /// </summary>
         [JsonIgnore]
-        public bool NodeInCollapsedGroup
+        public bool IsNodeInCollapsedGroup
         {
-            get => nodeInCollapsedGroup;
+            get => isNodeInCollapsedGroup;
             set
             {
-                nodeInCollapsedGroup = value;
-                RaisePropertyChanged(nameof(NodeInCollapsedGroup));
+                isNodeInCollapsedGroup = value;
+                RaisePropertyChanged(nameof(IsNodeInCollapsedGroup));
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -664,6 +664,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Used as a flag to indicate to associated connectors what ZIndex to be drawn at.
         /// </summary>
+        [JsonIgnore]
         public bool NodeInCollapsedGroup
         {
             get => nodeInCollapsedGroup;

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -59,6 +59,7 @@ namespace Dynamo.ViewModels
         private bool isexplictFrozen;
         private bool canToggleFrozen = true;
         private bool isRenamed = false;
+        private bool nodeInCollapsedGroup = false;
         #endregion
 
         #region public members
@@ -658,6 +659,18 @@ namespace Dynamo.ViewModels
                 if (ErrorBubble == null) return;
                 ErrorBubble.IsCollapsed = value;
                 RaisePropertyChanged(nameof(NodeWarningBarVisible));
+            }
+        }
+        /// <summary>
+        /// Used as a flag to indicate to associated connectors what ZIndex to be drawn at.
+        /// </summary>
+        public bool NodeInCollapsedGroup
+        {
+            get => nodeInCollapsedGroup;
+            set
+            {
+                nodeInCollapsedGroup = value;
+                RaisePropertyChanged(nameof(NodeInCollapsedGroup));
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR ensures the ZIndex of a connector (ellipses are tightly coupled w/ connectors and at the same ZIndex) is always lower than that of a port/ node. So it adds logic to check if one of the nodes associated with connectors (but not both, as that means the connector is fully inside of a group) are in a collapsed group, if so, it drops the ZIndex to be lower than that of the group's.

The only thing that isn't great about this fixed behaviour is that it requires the connector that connects to a group input/output node to be rendered below the group boundary. The alternative would be to decouple the ellipse from the connector xaml, or to add additional flags to that xaml to render individual ellipses at separate ZIndeces based on their respective node's state.

_Previous:_
![ConnectorEllipse-Previous](https://user-images.githubusercontent.com/24754290/145587339-8bbb326a-44da-4ec3-a12d-50691e4125b8.gif)

_Fixed:_
![ConnectorEllipse-Fixed](https://user-images.githubusercontent.com/24754290/145587352-e41bffba-3e20-4270-928a-860f719e6dc3.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
@Amoursol 
