### PR TITLE
DYN-4461 Warning Bar color persists warning or error state after resolution if the node is set preview off

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1015,7 +1015,6 @@ namespace Dynamo.ViewModels
                     break;
                 case "State":
                     RaisePropertyChanged("State");
-                    RaisePropertyChanged(nameof(NodeWarningBarVisible));
                     WarningBarColor = GetWarningColor();
                     break;
                 case "ArgumentLacing":
@@ -1027,7 +1026,6 @@ namespace Dynamo.ViewModels
                     break;
                 case "IsVisible":
                     RaisePropertyChanged("IsVisible");
-                    RaisePropertyChanged(nameof(NodeWarningBarVisible));
                     WarningBarColor = GetWarningColor();
                     break;
                 case "Width":
@@ -1067,6 +1065,21 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Respond to property changes on the error bubble.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        void ErroBubble_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(ErrorBubble.DoesNodeDisplayMessages):
+                    WarningBarColor = GetWarningColor();
+                    break;
+            }
+        }
+
+        /// <summary>
         /// Updates the width of the node's Warning/Error bubbles, in case the width of the node changes.
         /// </summary>
         private void UpdateErrorBubbleWidth()
@@ -1087,6 +1100,7 @@ namespace Dynamo.ViewModels
             ErrorBubble.NodeInfoToDisplay.CollectionChanged += UpdateOverlays;
             ErrorBubble.NodeWarningsToDisplay.CollectionChanged += UpdateOverlays;
             ErrorBubble.NodeErrorsToDisplay.CollectionChanged += UpdateOverlays;
+            ErrorBubble.PropertyChanged += ErroBubble_PropertyChanged;
             
             if (DynamoViewModel.UIDispatcher != null)
             {
@@ -1129,6 +1143,12 @@ namespace Dynamo.ViewModels
 
             if (NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning)
             {
+                //Handle the case where the user has dismissed the warning and no warnings are showing.
+                if (ErrorBubble != null && !ErrorBubble.DoesNodeDisplayMessages)
+                {
+                    return noPreviewColor;
+                }
+
                 return warningColor;
             }
 
@@ -1154,6 +1174,7 @@ namespace Dynamo.ViewModels
             ErrorBubble.NodeInfoToDisplay.CollectionChanged -= UpdateOverlays;
             ErrorBubble.NodeWarningsToDisplay.CollectionChanged -= UpdateOverlays;
             ErrorBubble.NodeErrorsToDisplay.CollectionChanged -= UpdateOverlays;
+            ErrorBubble.PropertyChanged -= ErroBubble_PropertyChanged;
 
             ErrorBubble.Dispose();
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1106,6 +1106,14 @@ namespace Dynamo.ViewModels
             ErrorBubble.DismissedMessages.CollectionChanged += DismissedNodeMessages_CollectionChanged;
         }
 
+        // These colors are duplicated from the DynamoColorsAndBrushesDictionary as it is not assumed that the xaml will be loaded before setting the color
+        // SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeErrorColor"];
+        private static SolidColorBrush errorColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#EB5555"));
+        // SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeWarningColor"];
+        private static SolidColorBrush warningColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#FAA21B"));
+        // SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodePreviewColor"];
+        private static SolidColorBrush noPreviewColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#BBBBBB"));
+
         /// <summary>
         /// Sets the color of the warning bar, which informs the user that the node is in
         /// either an error or a warning state.
@@ -1116,15 +1124,15 @@ namespace Dynamo.ViewModels
         {
             if (nodeLogic.IsInErrorState)
             {
-                return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeErrorColor"];
+                return errorColor;
             }
 
             if (NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning)
             {
-                return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeWarningColor"];
+                return warningColor;
             }
 
-            return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodePreviewColor"];
+            return noPreviewColor;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -377,8 +377,11 @@ namespace Dynamo.ViewModels
             get => warningBarColor;
             internal set
             {
-                warningBarColor = value;
-                RaisePropertyChanged(nameof(WarningBarColor));
+                if (warningBarColor != value)
+                {
+                    warningBarColor = value;
+                    RaisePropertyChanged(nameof(WarningBarColor));
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1074,7 +1074,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        void ErroBubble_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        void ErrorBubble_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -1106,7 +1106,7 @@ namespace Dynamo.ViewModels
             ErrorBubble.NodeInfoToDisplay.CollectionChanged += UpdateOverlays;
             ErrorBubble.NodeWarningsToDisplay.CollectionChanged += UpdateOverlays;
             ErrorBubble.NodeErrorsToDisplay.CollectionChanged += UpdateOverlays;
-            ErrorBubble.PropertyChanged += ErroBubble_PropertyChanged;
+            ErrorBubble.PropertyChanged += ErrorBubble_PropertyChanged;
             
             if (DynamoViewModel.UIDispatcher != null)
             {
@@ -1180,7 +1180,7 @@ namespace Dynamo.ViewModels
             ErrorBubble.NodeInfoToDisplay.CollectionChanged -= UpdateOverlays;
             ErrorBubble.NodeWarningsToDisplay.CollectionChanged -= UpdateOverlays;
             ErrorBubble.NodeErrorsToDisplay.CollectionChanged -= UpdateOverlays;
-            ErrorBubble.PropertyChanged -= ErroBubble_PropertyChanged;
+            ErrorBubble.PropertyChanged -= ErrorBubble_PropertyChanged;
 
             ErrorBubble.Dispose();
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1016,6 +1016,7 @@ namespace Dynamo.ViewModels
                 case "State":
                     RaisePropertyChanged("State");
                     WarningBarColor = GetWarningColor();
+                    RaisePropertyChanged(nameof(NodeWarningBarVisible));
                     break;
                 case "ArgumentLacing":
                     RaisePropertyChanged("ArgumentLacing");
@@ -1027,6 +1028,7 @@ namespace Dynamo.ViewModels
                 case "IsVisible":
                     RaisePropertyChanged("IsVisible");
                     WarningBarColor = GetWarningColor();
+                    RaisePropertyChanged(nameof(NodeWarningBarVisible));
                     break;
                 case "Width":
                     RaisePropertyChanged("Width");
@@ -1075,6 +1077,7 @@ namespace Dynamo.ViewModels
             {
                 case nameof(ErrorBubble.DoesNodeDisplayMessages):
                     WarningBarColor = GetWarningColor();
+                    RaisePropertyChanged(nameof(NodeWarningBarVisible));
                     break;
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1015,6 +1015,8 @@ namespace Dynamo.ViewModels
                     break;
                 case "State":
                     RaisePropertyChanged("State");
+                    RaisePropertyChanged(nameof(NodeWarningBarVisible));
+                    WarningBarColor = GetWarningColor();
                     break;
                 case "ArgumentLacing":
                     RaisePropertyChanged("ArgumentLacing");
@@ -1026,8 +1028,7 @@ namespace Dynamo.ViewModels
                 case "IsVisible":
                     RaisePropertyChanged("IsVisible");
                     RaisePropertyChanged(nameof(NodeWarningBarVisible));
-                    if (ErrorBubble != null) return;
-                    WarningBarColor = GetWarningColor(InfoBubbleViewModel.Style.None);
+                    WarningBarColor = GetWarningColor();
                     break;
                 case "Width":
                     RaisePropertyChanged("Width");
@@ -1111,30 +1112,21 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="style"></param>
         /// <returns></returns>
-        internal SolidColorBrush GetWarningColor(InfoBubbleViewModel.Style style)
+        internal SolidColorBrush GetWarningColor()
         {
-            switch (style)
+            if (nodeLogic.IsInErrorState)
             {
-                case InfoBubbleViewModel.Style.None:
-                    if (IsVisible == false)
-                    {
-                        return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodePreviewColor"];
-                    }
-                    break;
-                case InfoBubbleViewModel.Style.Warning:
-                case InfoBubbleViewModel.Style.WarningCondensed:
-                    return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeWarningColor"];
-                case InfoBubbleViewModel.Style.Error:
-                case InfoBubbleViewModel.Style.ErrorCondensed:
-                    return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeErrorColor"];
-                case InfoBubbleViewModel.Style.Info:
-                    return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeInfoColor"];
+                return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeErrorColor"];
             }
 
-            return null;
+            if (NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning)
+            {
+                return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeWarningColor"];
+            }
+
+            return (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodePreviewColor"];
         }
 
-        
         /// <summary>
         /// Disposes the ErrorBubble when it's no longer needed.
         /// </summary>
@@ -1190,13 +1182,13 @@ namespace Dynamo.ViewModels
                 DynamoViewModel.UIDispatcher.Invoke(() =>
                 {
                     ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
-                    WarningBarColor = GetWarningColor(ErrorBubble.InfoBubbleStyle);
+                    WarningBarColor = GetWarningColor();
                 });
             }
             else
             {
                 ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
-                WarningBarColor = GetWarningColor(ErrorBubble.InfoBubbleStyle);
+                WarningBarColor = GetWarningColor();
             }
             
             ErrorBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Pinned);

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -541,12 +541,12 @@
                 Grid.RowSpan="4"
                 Grid.ColumnSpan="3"
                 Margin="-8"
-                Background="{Binding NodeOverlayColor, UpdateSourceTrigger=PropertyChanged}"
+                Background="{StaticResource NodeFrozenOverlayColor}"
                 Canvas.ZIndex="7"
                 CornerRadius="8,8,0,0"
                 IsHitTestVisible="False"
                 Opacity="0.5"
-                Visibility="{Binding Path=NodeOverlayVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                Visibility="{Binding Path=IsFrozen, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
 
         <!--  Displays when the node is selected  -->
         <Border Name="selectionBorder"

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -385,24 +385,31 @@ namespace DynamoCoreWpfTests
         public void WarningColorReflectsElementState()
         {
             // Arrange
-            var node = new CoreNodeModels.Input.DoubleInput();
-            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(node, true);
+            Open(@"UI\NodeWarningBarColorTest.dyn");
 
-            var nodeViewModel = ViewModel.CurrentSpaceViewModel.Nodes.First();
+            // Get the node view for a specific node in the graph
+            NodeView nodeViewNoWarningBar = NodeViewWithGuid(Guid.Parse("0ebe50b82c0946e089d99d5aa82bcf9a").ToString());
+            NodeView nodeViewNoWarningNoPreview = NodeViewWithGuid(Guid.Parse("d27869a007c848e59c9b337342c6e238").ToString());
+            NodeView nodeViewWarningBarWarning = NodeViewWithGuid(Guid.Parse("6bb495c40b88459f9118f0b447d6ddae").ToString());
+            NodeView nodeViewWarningBarError = NodeViewWithGuid(Guid.Parse("90007f8f5665438da11b53ccc2707ac2").ToString());
 
-            SolidColorBrush infoBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#6AC0E7"));
+            SolidColorBrush noPreviewBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#BBBBBB"));
             SolidColorBrush warningBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FAA21B"));
             SolidColorBrush errorBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#EB5555"));
 
-            NodeViewModel dummyNodeViewModel = nodeViewModel;
+            Assert.AreEqual(nodeViewNoWarningBar.ViewModel.IsVisible, true);
+            Assert.AreEqual(nodeViewNoWarningBar.ViewModel.GetWarningColor().ToString(), noPreviewBrush.ToString());
+            Assert.AreEqual(nodeViewNoWarningNoPreview.ViewModel.IsVisible, false);
+            Assert.AreEqual(nodeViewNoWarningNoPreview.ViewModel.GetWarningColor().ToString(), noPreviewBrush.ToString());
+            Assert.AreEqual(nodeViewWarningBarWarning.ViewModel.GetWarningColor().ToString(), warningBrush.ToString());
+            Assert.AreEqual(nodeViewWarningBarError.ViewModel.GetWarningColor().ToString(), errorBrush.ToString());
 
-            // Assert
-            Assert.AreEqual(dummyNodeViewModel.GetWarningColor(InfoBubbleViewModel.Style.None), null);
-            Assert.AreEqual(dummyNodeViewModel.GetWarningColor(InfoBubbleViewModel.Style.Info).ToString(), infoBrush.ToString());
-            Assert.AreEqual(dummyNodeViewModel.GetWarningColor(InfoBubbleViewModel.Style.Warning).ToString(), warningBrush.ToString());
-            Assert.AreEqual(dummyNodeViewModel.GetWarningColor(InfoBubbleViewModel.Style.WarningCondensed).ToString(), warningBrush.ToString());
-            Assert.AreEqual(dummyNodeViewModel.GetWarningColor(InfoBubbleViewModel.Style.Error).ToString(), errorBrush.ToString());
-            Assert.AreEqual(dummyNodeViewModel.GetWarningColor(InfoBubbleViewModel.Style.ErrorCondensed).ToString(), errorBrush.ToString());
+            var guid = System.Guid.Parse("90007f8f5665438da11b53ccc2707ac2");
+            Model.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                Model.CurrentWorkspace.Guid, guid, "Code", "5.6"));
+            
+            Assert.AreEqual(nodeViewWarningBarError.ViewModel.IsVisible, false);
+            Assert.AreEqual(nodeViewWarningBarError.ViewModel.GetWarningColor().ToString(), noPreviewBrush.ToString());
         }
     }
 }

--- a/test/UI/NodeWarningBarColorTest.dyn
+++ b/test/UI/NodeWarningBarColorTest.dyn
@@ -1,0 +1,197 @@
+{
+  "Uuid": "3baac463-02a7-4002-a1f5-a0bdd5484918",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "NodeWarningBarColorTest",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"Warning Bar Warning\";\na = b;\nb = a;",
+      "Id": "6bb495c40b88459f9118f0b447d6ddae",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "229d5a57adeb4450925b15b56a74361d",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cc3389ad9f274f37bca7d0da048d1265",
+          "Name": "",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7036538756674523930dcf61cf7fe376",
+          "Name": "",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Warning Bar Error\";",
+      "Id": "90007f8f5665438da11b53ccc2707ac2",
+      "Inputs": [],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"Warning Bar Preview Off\";",
+      "Id": "d27869a007c848e59c9b337342c6e238",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "45fca99cf8d34fb8a7efb6176104ff65",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"No Waring Bar\";",
+      "Id": "0ebe50b82c0946e089d99d5aa82bcf9a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "adfebd7a54bc459ab77be41ab4778486",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.13",
+      "Data": {}
+    },
+    {
+      "ExtensionGuid": "DFBD9CC0-DB40-457A-939E-8C8555555A9D",
+      "Name": "Generative Design",
+      "Version": "2.0",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.13.0.3447",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": false,
+        "Id": "6bb495c40b88459f9118f0b447d6ddae",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 158.0,
+        "Y": 186.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": false,
+        "Id": "90007f8f5665438da11b53ccc2707ac2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 462.55366083161175,
+        "Y": 187.76859344744139
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": false,
+        "Id": "d27869a007c848e59c9b337342c6e238",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 153.0,
+        "Y": 417.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "0ebe50b82c0946e089d99d5aa82bcf9a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 513.38834288555722,
+        "Y": 422.30578034232423
+      }
+    ],
+    "Annotations": [],
+    "X": -81.229454354460529,
+    "Y": -55.546784260988488,
+    "Zoom": 1.130842140625
+  }
+}


### PR DESCRIPTION
_###_ Purpose

https://jira.autodesk.com/browse/DYN-4461

This PR addresses the issue were once a node enters a warning or error state, the color will never reset back to grey to show preview off state.  This is especially confusing in situations where a null value sets a swath of nodes with preview off to a warning state.  Once the error or warning is actually resolved, the nodes still appear to be in that bad state.  See the example below:

https://user-images.githubusercontent.com/2145751/145697148-62d459e4-f2c1-452f-9733-f034d42466f9.mp4

I have not been able to find any work around that resets the `WarningBarColor` back to grey once this condition has been reached other than closing and reopening the file.  Please let me know if you find another way.

This PR changes how and when we set the color so that the preview color is restored.  The PR changes the logic so that we set the color when the `State` property or `IsVisible` property changes on the node.  The PR also changes the logic of `GetWarningColor`.  It does not need outside data to set the color as existing node properties drive the color.  

~~Note: It looks like the`WarningBarColor` property should not actually have a setter.  The getter should just have the logic found in the `GetWarningColor` function as it is determinant.  I wasn't sure if I could remove the internal setter and keep binary compatibility as 2.13 has been cut.  (Thoughts @mjkkirschner?) If I can remove the setter with binary compatibility we should make that change so that we don't have to remember to set `WarningBarColor` for other situations in the future.~~

[x] Todo update the tests

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Bug fixed with Warning Bar color persisting as warning or error state after resolution if the node is set preview off

### Reviewers

@QilongTang @mjkkirschner  

### FYIs

@Amoursol @OliverEGreen 
