### PR TITLE
DYN-4408-UILayout-Issue-Guides (Localization)

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -15,7 +15,6 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Views.GuidedTour;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Dynamo.Wpf.UI.GuidedTour
 {
@@ -454,6 +453,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <param name="enableUIAutomation">Enable/Disable the automation action for a specific UIElement</param>
         private void ExecuteUIAutomationStep(StepUIAutomation uiAutomationData, bool enableUIAutomation, Guide.GuideFlow currentFlow)
         {
+            var popupBorderName = "SubmenuBorder";
             //This section will search the UIElement dynamically in the Dynamo VisualTree in which an automation action will be executed
             UIElement automationUIElement = Guide.FindChild(MainWindow, uiAutomationData.Name);
             if (automationUIElement != null)
@@ -474,6 +474,17 @@ namespace Dynamo.Wpf.UI.GuidedTour
                             menuEntry.IsSubmenuOpen = enableUIAutomation;
                             menuEntry.StaysOpenOnClick = enableUIAutomation;
                             break;                    
+                    }
+                    //Means that the Popup location needs to be updated after the MenuItem is opened
+                    if(uiAutomationData.UpdatePlacementTarget)
+                    {
+                        //We need to find the border inside the MenuItem.Popup so we can get its Width (this template is defined in MenuStyleDictionary.xaml)
+                        var menuPopupBorder = menuEntry.Template.FindName(popupBorderName, menuEntry) as Border;
+                        if (menuPopupBorder == null) return;
+
+                        //We need to do this substraction so the Step Popup wil be located at the end of the MenuItem Popup.
+                        stepUIPopup.HorizontalOffset = (menuPopupBorder.ActualWidth - menuEntry.ActualWidth) + HostPopupInfo.HorizontalPopupOffSet;
+                        UpdatePopupLocationInvoke(stepUIPopup);
                     }
                     break;
                 //In this case the UI Automation will be done using a Function located in the static class GuidesValidationMethods

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -107,7 +107,7 @@
 					"HostUIElementString": "dynamoMenu",
 					"VerticalPopupOffset": 100,
 					"HighlightColor": "#EF9362",
-					"HorizontalPopupOffset": 250,
+					"HorizontalPopupOffset": 10,
 					"HighlightRectArea": {
 						"HighlightColor": "#EF9362",
 						"WidthBoxDelta": 0,
@@ -123,7 +123,8 @@
 						"Sequence": 1,
 						"ControlType": "MenuItem",
 						"Name": "dynamoMenu",
-						"Action": "open"
+						"Action": "open",
+						"UpdatePlacementTarget": true
 					}
 				]
 			},
@@ -142,7 +143,7 @@
 					"PopupPlacement": "right",
 					"HostUIElementString": "HelpMenu",
 					"VerticalPopupOffset": 20,
-					"HorizontalPopupOffset": 170,
+					"HorizontalPopupOffset": 10,
 					"HighlightRectArea": {
 						"HighlightColor": "#EF9362",
 						"WidthBoxDelta": 0,
@@ -158,7 +159,8 @@
 						"Sequence": 1,
 						"ControlType": "MenuItem",
 						"Name": "HelpMenu",
-						"Action": "open"
+						"Action": "open",
+						"UpdatePlacementTarget": true
 					}
 				]
 			},
@@ -248,7 +250,7 @@
 					"PopupPlacement": "right",
 					"HostUIElementString": "PackageManagerMenu",
 					"VerticalPopupOffset": 0,
-					"HorizontalPopupOffset": 200,
+					"HorizontalPopupOffset": 10,
 					"HighlightRectArea": {
 						"HighlightColor": "#EF9362",
 						"UIElementTypeString": "MenuItem",
@@ -267,7 +269,8 @@
 						"Sequence": 1,
 						"ControlType": "MenuItem",
 						"Name": "PackageManagerMenu",
-						"Action": "open"
+						"Action": "open",
+						"UpdatePlacementTarget": true
 					},
 					{
 						"Sequence": 2,


### PR DESCRIPTION
### Purpose
Fix for not overlapping the Menu and the Popup when the language is Russian (ru-RU).
I reduced the HorizontalPopupOffset value in the json file due that now the HorizontalOffset is auto-calculated automatically based in the MenuItem.Popup width (just when there is an UIAutomation that is executed for opening a Menu).
For calculating the HorizontalOffset first we need to get the MenuItem.Popup border so we can get the Width.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix for not overlapping the Menu and the Popup when the language is Russian (ru-RU).


### Reviewers

@QilongTang 

### FYIs

@filipeotero 
