### PR TITLE
DYN-4251-Align-Tour-Title

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4067,7 +4067,7 @@
     <Style x:Key="PoupTitleLabelStyle" TargetType="{x:Type Label}">
         <Setter Property="FontFamily" Value="Artifakt Element" />
         <Setter Property="FontSize" Value="20" />
-        <Setter Property="MinHeight" Value="50" />
+        <Setter Property="Height" Value="34" />
         <Setter Property="Foreground" Value="#535353" />
     </Style>
 
@@ -4090,7 +4090,7 @@
     <Style x:Key="SurveyTitleLabelStyle" TargetType="{x:Type Label}">
         <Setter Property="FontFamily" Value="Artifakt Element" />
         <Setter Property="FontSize" Value="20" />
-        <Setter Property="MinHeight" Value="50" />
+        <Setter Property="Height" Value="34" />
         <Setter Property="Foreground" Value="#3C3C3C" />
     </Style>
 

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -112,8 +112,8 @@
                                Style="{StaticResource PoupTitleLabelStyle}"
                                />
                         <Button Name="CloseButton"
-                                Height="15"  
-                                Width="15"
+                                Height="12.8"  
+                                Width="12.8"
                                 Grid.Column="1"
                                 Style="{StaticResource PopupCloseButtonStyle}"
                                 Click="CloseButton_Click">


### PR DESCRIPTION
### Purpose

This PR aligns the title of the guided tour with the close button.
<img width="416" alt="image" src="https://user-images.githubusercontent.com/89042471/146443624-6cf29efb-4a83-4edf-a6c2-6d7140f8e008.png">

 
### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes


### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 