### PR TITLE
DYN-4252-Shadow-Under-Pointer

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3294,4 +3294,48 @@ namespace Dynamo.Controls
             throw new NotImplementedException();
         }
     }
+
+    /// <summary>
+    /// Converts a PointColletion to a Geometry so the points can be drawn using a Path
+    /// </summary>
+    [ValueConversion(typeof(PointCollection), typeof(Geometry))]
+    public class PointsToPathConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value == null)
+                return null;
+
+            if (value.GetType() != typeof(PointCollection))
+                return null;
+
+            PointCollection points = (value as PointCollection);
+            if (points.Count > 0)
+            {
+                Point start = points[0];
+                List<LineSegment> segments = new List<LineSegment>();
+                for (int i = 1; i < points.Count; i++)
+                {
+                    segments.Add(new LineSegment(points[i], true));
+                }
+                PathFigure figure = new PathFigure(start, segments, false);
+                PathGeometry geometry = new PathGeometry();
+                geometry.Figures.Add(figure);
+                return geometry;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        #endregion
+    }
 }

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -132,6 +132,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
         public PointCollection TooltipPointerPoints { get; set; }
 
         /// <summary>
+        /// This will contains the shadow direction in degrees that will be shown in the pointer
+        /// </summary>
+        public double ShadowTooltipDirection { get; set; }
+
+        /// <summary>
         /// This property holds the DynamoViewModel that will be used when executing PreValidation functions
         /// </summary>
         internal DynamoViewModel DynamoViewModelStep { get; set; }

--- a/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
@@ -17,6 +17,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         double PointerTooltipOverlap = 5;
         double PointerVerticalOffset;
         double PointerHorizontalOffset;
+        enum SHADOW_DIRECTION { LEFT = 180, RIGHT = 0, BOTTOM = 270, TOP = 90};
 
         /// <summary>
         /// The Tooltip constructor
@@ -71,6 +72,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 pointX3 = 0;
                 pointY3 = PointerHeight / 2 + PointerVerticalOffset;
+                //Left Shadow
+                ShadowTooltipDirection = (double)SHADOW_DIRECTION.LEFT;
 
             }
             else if (direction == PointerDirection.BOTTOM_LEFT)
@@ -83,6 +86,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 pointX3 = 0;
                 pointY3 = Height - PointerHeight / 2 - PointerVerticalOffset;
+                //Left Shadow
+                ShadowTooltipDirection = (double)SHADOW_DIRECTION.LEFT;
             }
             else if (direction == PointerDirection.TOP_RIGHT)
             {
@@ -94,6 +99,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 pointX3 = realWidth;
                 pointY3 = PointerHeight / 2 + PointerVerticalOffset;
+                //Right Shadow
+                ShadowTooltipDirection = (double)SHADOW_DIRECTION.RIGHT;
 
             }
             else if (direction == PointerDirection.BOTTOM_RIGHT)
@@ -106,6 +113,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 pointX3 = realWidth;
                 pointY3 = Height - PointerHeight / 2 - PointerVerticalOffset;
+                //Right Shadow
+                ShadowTooltipDirection = (double)SHADOW_DIRECTION.RIGHT;
             }
             else if (direction == PointerDirection.BOTTOM_DOWN)
             {
@@ -117,6 +126,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 pointX3 = PointerDownWidth / 2 + PointerHorizontalOffset;
                 pointY3 = realHeight - PointerHeight;
+                //Bottom Shadow
+                ShadowTooltipDirection = (double)SHADOW_DIRECTION.BOTTOM;
             }
 
             TooltipPointerPoints = new PointCollection(new[] { new Point(pointX1, pointY1),

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4075,7 +4075,7 @@
         <Setter Property="Fill" Value="{StaticResource PopupWhiteColor}" />
     </Style>
 
-    <Style x:Key="PoupPolygonPointerStyle" TargetType="{x:Type Polygon}">
+    <Style x:Key="PoupPathPointerStyle" TargetType="{x:Type Path}">
         <Setter Property="Fill" Value="{StaticResource PopupWhiteColor}" />
     </Style>
 

--- a/src/DynamoCoreWpf/ViewModels/GuidedTour/PopupWindowViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/GuidedTour/PopupWindowViewModel.cs
@@ -42,6 +42,21 @@ namespace Dynamo.Wpf.ViewModels.GuidedTour
         }
 
         /// <summary>
+        /// This will contains the shadow direction in degrees that will be shown in the pointer
+        /// </summary>
+        public double ShadowTooltipDirection
+        { 
+            get
+            {
+                return Step.ShadowTooltipDirection;
+            }
+            set
+            {
+                Step.ShadowTooltipDirection = value;
+            } 
+        }
+
+        /// <summary>
         /// Due that some popups doesn't need the pointer then this property hides or show the pointer
         /// </summary>
         public bool ShowPopupPointer 

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -63,7 +63,7 @@
             </Path.Effect>
         </Path>
 
-        <!--This Polygon will draw on the Canvas the pointer (a triangle) that will be available only for tooltips but for the Welcome popup will be hidden-->
+        <!--This Path will draw on the Canvas the pointer (a triangle) that will be available only for tooltips but for the Welcome popup will be hidden-->
         <Path  x:Name="TooltipPointer"
                Visibility="{Binding ShowPopupPointer, Converter={StaticResource BooleanToVisibilityConverter}}"
                Data="{Binding Path=TooltipPointerPoints, Converter={StaticResource PointsToPathConverter}}"

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:localui="clr-namespace:Dynamo.Wpf.UI.GuidedTour"
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+       xmlns:controls="clr-namespace:Dynamo.Controls"
         mc:Ignorable="d"
         PopupAnimation="Fade"
         AllowsTransparency="True"
@@ -23,6 +24,7 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <controls:PointsToPathConverter x:Key="PointsToPathConverter"/>
         </ResourceDictionary>
     </Popup.Resources>
 
@@ -62,18 +64,18 @@
         </Path>
 
         <!--This Polygon will draw on the Canvas the pointer (a triangle) that will be available only for tooltips but for the Welcome popup will be hidden-->
-        <Polygon x:Name="TooltipPointer"
-                 Visibility="{Binding ShowPopupPointer, Converter={StaticResource BooleanToVisibilityConverter}}"
-                 Points="{Binding TooltipPointerPoints}" 
-                 Style="{StaticResource PoupPolygonPointerStyle}">
-            <Polygon.BitmapEffect>
-                <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 315 grades by default-->
-                <DropShadowBitmapEffect Color="Black" 
-                                        Direction="135" 
-                                        ShadowDepth="4" 
-                                        Opacity="0.2" />
-            </Polygon.BitmapEffect>
-        </Polygon>
+        <Path  x:Name="TooltipPointer"
+               Visibility="{Binding ShowPopupPointer, Converter={StaticResource BooleanToVisibilityConverter}}"
+               Data="{Binding Path=TooltipPointerPoints, Converter={StaticResource PointsToPathConverter}}"
+               Style="{StaticResource PoupPathPointerStyle}">
+            <Path.Effect>
+                <DropShadowEffect Opacity="0.2" 
+                                  Color="Black"
+                                  ShadowDepth="4"
+                                  BlurRadius="4"
+                                  Direction="{Binding Path=ShadowTooltipDirection}"/>
+            </Path.Effect>
+        </Path>
 
         <Grid  x:Name="mainPopupGrid"
                Width="{Binding Width}"


### PR DESCRIPTION
### Purpose

Removing one side of the shadow in the Popup pointer.
I had to replace the Polygon (tree points connected by 3 lines) by a Path (tree points connected by 2 lines) due that the shadow was being applied to all sides of the Polygon(triangle), then now due that is a Path with 2 lines the shadow will be applied just in two lines, also I had to add a Converter so a PointCollection can be converted to a Path.Data.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Removing one side of the shadow in the Popup pointer.

### Reviewers

 @QilongTang 

### FYIs

@filipeotero 
