### PR TITLE
Backup Location Display

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml
@@ -153,20 +153,7 @@
                           Background="White"
                           HorizontalAlignment="Stretch">
 
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1*"></ColumnDefinition>
-                            <ColumnDefinition Width="1*"></ColumnDefinition>
-                        </Grid.ColumnDefinitions>
-
                         <Label Grid.Column="0"
-                           Name ="openAll"
-                           FontFamily="{StaticResource ArtifaktElementRegular}"
-                           Margin="0,0,0,0"
-                           HorizontalAlignment="Left"
-                           Style="{StaticResource StartPageLabel}"
-                           Content="{x:Static p:Resources.StartPageOpenAll}"
-                           MouseLeftButtonUp="OpenAllFilesOnCrash" />
-                        <Label Grid.Column="1"
                            Name ="backupLocation"
                            FontFamily="{StaticResource ArtifaktElementRegular}"
                            Margin="0,0,0,0"

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -445,12 +445,14 @@ namespace Dynamo.UI.Controls
     {
         private DynamoViewModel dynamoViewModel;
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
         public StartPageView()
         {
             InitializeComponent();
             if (StabilityUtils.IsLastShutdownClean)
             {
-                openAll.Visibility = Visibility.Collapsed;
                 backupFilesList.Visibility = Visibility.Collapsed;
             }
 
@@ -529,16 +531,6 @@ namespace Dynamo.UI.Controls
             var startPageViewModel = this.DataContext as StartPageViewModel;
             Process.Start("explorer.exe", "/select," 
                 + startPageViewModel.SampleFolderPath);
-        }
-
-        private void OpenAllFilesOnCrash(object sender, MouseButtonEventArgs e)
-        {
-            var dvm = dynamoViewModel;
-            foreach (var filePath in dvm.Model.PreferenceSettings.BackupFiles)
-            {
-                if (dvm.OpenCommand.CanExecute(filePath))
-                    dvm.OpenCommand.Execute(filePath);
-            }
         }
 
         private void ShowBackupFilesInFolder(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7111,15 +7111,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open all.
-        /// </summary>
-        public static string StartPageOpenAll {
-            get {
-                return ResourceManager.GetString("StartPageOpenAll", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Open.
         /// </summary>
         public static string StartPageOpenFile {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1959,9 +1959,6 @@ Want to publish a different package?</value>
     <value>New</value>
     <comment>Start page | New </comment>
   </data>
-  <data name="StartPageOpenAll" xml:space="preserve">
-    <value>Open all</value>
-  </data>
   <data name="StartPageOpenFile" xml:space="preserve">
     <value>Open</value>
     <comment>Start page | Open files</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -787,9 +787,6 @@
   <data name="StartPageBackupLocation" xml:space="preserve">
     <value>Backup location</value>
   </data>
-  <data name="StartPageOpenAll" xml:space="preserve">
-    <value>Open all</value>
-  </data>
   <data name="StartPageDiscussionForum" xml:space="preserve">
     <value>Discussion forum</value>
   </data>


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Removing the `Open All` button which was never used on startup page but blocking `Backup Location` to be displayed correctly in the localized environment.

By looking at the history, the `Open All` button was introduced 7 years ago but never got used. What it does is try to open all the dyn/dyf files from the backup location. This function only make sense when Dynamo could open multiple homeworkspace. So removing seems to be the proper action here. 

What it looks after e.g. in German:
![image](https://user-images.githubusercontent.com/3942418/146570286-b30e22cf-bdd9-4815-826c-1c936a6ee42f.png)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix backup location display on startup page in localized environment


### Reviewers

@DynamoDS/dynamo 

### FYIs

