### PR TITLE
DYN-4421 Disable the textSearch, filter and sort

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -357,6 +357,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                     searchPackagesLoaded = true;
 
                     EnableNextButton(null, uiAutomationData, true, GuideFlow.FORWARD);
+                    packageManagerViewModel.DisableSearchTextBox();
 
                     //Unsubscribe from the PropertyChanged event otherwise it will enter everytime the SearchTextBox is updated
                     packageManagerViewModel.PropertyChanged -= searchPackagesPropertyChanged.Invoke;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -610,6 +610,7 @@ namespace Dynamo.PackageManager
         }
 
         public event EventHandler<PackagePathEventArgs> RequestShowFileDialog;
+        public event EventHandler<PackagePathEventArgs> RequestDisableTextSearch;
         public virtual void OnRequestShowFileDialog(object sender, PackagePathEventArgs e)
         {
             if (RequestShowFileDialog != null)
@@ -979,6 +980,17 @@ namespace Dynamo.PackageManager
                 return;
 
             SearchResults[SelectedIndex].Model.Execute();
+        }
+
+        /// <summary>
+        /// Once the sample package is filled in the textbox search we rise the event to the view to disable the actions to change it , filter and sort it.
+        /// </summary>
+        public void DisableSearchTextBox()
+        {
+            if (RequestDisableTextSearch != null)
+            {
+                RequestDisableTextSearch(null, null);
+            }
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -334,7 +334,7 @@
                                Visibility="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}" />
 
                     <!--  'X' button to reset search query text  -->
-                    <Button Margin="10"
+                    <Button Name="clearSearchTextBox" Margin="10"
                             HorizontalAlignment="Right"
                             Command="{Binding ClearSearchTextBoxCommand}"
                             Cursor="Hand"

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -30,7 +30,16 @@ namespace Dynamo.PackageManager.UI
             InitializeComponent();
             ViewModel.RegisterTransientHandlers();
             ViewModel.RequestShowFileDialog += OnRequestShowFileDialog;
+            ViewModel.RequestDisableTextSearch += ViewModel_RequestDisableTextSearch;
             Logging.Analytics.TrackScreenView("PackageManager");
+        }
+
+        private void ViewModel_RequestDisableTextSearch(object sender, PackagePathEventArgs e)
+        {
+            this.searchTextBox.IsEnabled = false;
+            this.clearSearchTextBox.IsEnabled = false;
+            this.filterResultsButton.IsEnabled = false;
+            this.sortResultsButton.IsEnabled = false;
         }
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
@@ -38,6 +47,7 @@ namespace Dynamo.PackageManager.UI
             var viewModel = DataContext as PackageManagerSearchViewModel;
 
             ViewModel.RequestShowFileDialog -= OnRequestShowFileDialog;
+            ViewModel.RequestDisableTextSearch -= ViewModel_RequestDisableTextSearch;
             viewModel.UnregisterTransientHandlers();
             
             // Clears the search text so that the 'Please Wait' prompt appears next time this dialog is opened.


### PR DESCRIPTION
### Purpose


Since the main purpose of the packages tour is only install the sample package we are disabling the text search , filtering and sorting results options.

Allowing to the user only the installation and view details from the sample package.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing the sample package behavior

### Reviewers

@QilongTang

### FYIs

@RobertGlobant20 @filipeotero
