### PR TITLE
[DYN-4494] Groups will only be able to successfully contain nested groups that are created after them

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -467,7 +467,7 @@ namespace Dynamo.ViewModels
                         var groupViewModel = ViewModelBases.OfType<AnnotationViewModel>()
                             .Where(x => x.AnnotationModel.GUID == model.GUID)
                             .FirstOrDefault();
-                        groupViewModel.RaisePropertyChanged(nameof(ZIndex));
+
                         groupViewModel.AddToGroupCommand.RaiseCanExecuteChanged();
                         groupViewModel.AddGroupToGroupCommand.RaiseCanExecuteChanged();
                         groupViewModel.RemoveGroupFromGroupCommand.RaiseCanExecuteChanged();
@@ -488,6 +488,7 @@ namespace Dynamo.ViewModels
             this.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                 new DynamoModel.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
             WorkspaceViewModel.DynamoViewModel.UngroupModelCommand.Execute(null);
+            RaisePropertyChanged(nameof(ZIndex));
             Analytics.TrackEvent(Actions.RemovedFrom, Categories.GroupOperations, "Group");
         }
 
@@ -508,6 +509,7 @@ namespace Dynamo.ViewModels
             this.WorkspaceViewModel = workspaceViewModel;
             model.PropertyChanged += model_PropertyChanged;
             model.RemovedFromGroup += OnModelRemovedFromGroup;
+            model.AddedToGroup += OnModelAddedToGroup;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
 
             //https://jira.autodesk.com/browse/QNTM-3770
@@ -1012,6 +1014,12 @@ namespace Dynamo.ViewModels
             RaisePropertyChanged(nameof(ZIndex));
         }
 
+        private void OnModelAddedToGroup(object sender, EventArgs e)
+        {
+            Analytics.TrackEvent(Actions.AddedTo, Categories.GroupOperations, "Group");
+            RaisePropertyChanged(nameof(ZIndex));
+        }
+
         private void UpdateAllGroupedGroups()
         {
             ViewModelBases
@@ -1117,6 +1125,7 @@ namespace Dynamo.ViewModels
         {
             annotationModel.PropertyChanged -= model_PropertyChanged;
             annotationModel.RemovedFromGroup -= OnModelRemovedFromGroup;
+            annotationModel.AddedToGroup -= OnModelAddedToGroup;
             
             DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;
             base.Dispose();


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4494](https://jira.autodesk.com/browse/DYN-4494).

It also fixes a memory leak issue on the annotationModel, whenever something is added to a group we subscribe to `PropertyChanged` and `Disposed` on that model, but we didn't unsubscribe them if the model was removed. We know unsubscribe all old models before overwriting `nodes` with the new models.

![NestedGroupsLayeringIssue](https://user-images.githubusercontent.com/13732445/148201980-454f8cd2-52a5-41a0-857b-796f4ecb7092.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@QilongTang 

### FYIs

@Amoursol 
