### PR TITLE
Connector (+Ellipse) ZIndex fix on group first collapse

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -810,7 +810,9 @@ namespace Dynamo.ViewModels
 
                 viewModel.IsCollapsed = true;
                 if (viewModel is NodeViewModel nodeViewModel)
+                {
                     nodeViewModel.IsNodeInCollapsedGroup = true;
+                }
             }
 
             if (!collapseConnectors) return;

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -809,6 +809,8 @@ namespace Dynamo.ViewModels
                 }
 
                 viewModel.IsCollapsed = true;
+                if (viewModel is NodeViewModel nodeViewModel)
+                    nodeViewModel.IsNodeInCollapsedGroup = true;
             }
 
             if (!collapseConnectors) return;

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -48,6 +48,7 @@ namespace Dynamo.ViewModels
         private double dotTop;
         private double dotLeft;
         private double endDotSize = 6;
+        private int zIndex = 2;
 
         private Point curvePoint1;
         private Point curvePoint2;
@@ -345,9 +346,6 @@ namespace Dynamo.ViewModels
         // and they will have a ZIndex of 2
         public double ZIndex
         {
-<<<<<<< Updated upstream
-            get { return 3; }
-=======
             get 
             {
                 return SetZIndex();

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -48,7 +48,7 @@ namespace Dynamo.ViewModels
         private double dotTop;
         private double dotLeft;
         private double endDotSize = 6;
-        private int zIndex = 2;
+        private double zIndex = 3;
 
         private Point curvePoint1;
         private Point curvePoint2;
@@ -177,6 +177,7 @@ namespace Dynamo.ViewModels
                 isCollapsed = value;
                 RaisePropertyChanged(nameof(IsCollapsed));
                 SetCollapseOfPins(IsCollapsed);
+                RaisePropertyChanged(nameof(ZIndex));
             }
         }
 
@@ -394,7 +395,6 @@ namespace Dynamo.ViewModels
         private bool ConnectingNodesBothInCollapsedGroup(NodeViewModel firstNode, NodeViewModel lastNode)
         {
             return firstNode.IsNodeInCollapsedGroup && lastNode.IsNodeInCollapsedGroup;
->>>>>>> Stashed changes
         }
 
         /// <summary>
@@ -481,6 +481,14 @@ namespace Dynamo.ViewModels
             get
             {
                 return workspaceViewModel.Nodes.FirstOrDefault(x => x.NodeLogic.GUID == model.Start.Owner.GUID);
+            }
+        }
+
+        public NodeViewModel NodeEnd
+        {
+            get
+            {
+                return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.End.Owner.GUID);
             }
         }
 
@@ -918,6 +926,7 @@ namespace Dynamo.ViewModels
             IsConnecting = true;
             MouseHoverOn = false;
             activeStartPort = port;
+            ZIndex = SetZIndex();
 
             Redraw(port.Center);
 
@@ -947,6 +956,7 @@ namespace Dynamo.ViewModels
             model = connectorModel;
             IsHidden = model.IsHidden;
             MouseHoverOn = false;
+            ZIndex = SetZIndex();
 
             model.PropertyChanged += HandleConnectorPropertyChanged;
             model.ConnectorPinModels.CollectionChanged += ConnectorPinModelCollectionChanged;
@@ -1332,6 +1342,8 @@ namespace Dynamo.ViewModels
             {
                 this.Redraw(this.ConnectorModel.End.Center);
             }
+
+            RaisePropertyChanged(nameof(ZIndex));
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -345,7 +345,58 @@ namespace Dynamo.ViewModels
         // and they will have a ZIndex of 2
         public double ZIndex
         {
+<<<<<<< Updated upstream
             get { return 3; }
+=======
+            get 
+            {
+                return SetZIndex();
+            }
+
+            protected set
+            {
+                zIndex = value;
+                RaisePropertyChanged(nameof(ZIndex));
+            }
+         
+        }
+
+        private int SetZIndex()
+        {
+            if (isConnecting)
+                return (int)zIndex;
+
+            var firstNode = this.Nodevm;
+            var lastNode = this.NodeEnd;
+
+            int index = firstNode is null || lastNode is null ? 1 : 3;
+
+            //reduce ZIndex if one of associated nodes is collapsed
+            bool oneNodeInCollapsedGroup = OneConnectingNodeInCollapsedGroup(firstNode, lastNode);
+            bool bothNodesInCollapsedGroup = ConnectingNodesBothInCollapsedGroup(firstNode, lastNode);
+            if (oneNodeInCollapsedGroup && !bothNodesInCollapsedGroup)
+            {
+                var lowestIndex = new int[] { this.Nodevm.ZIndex, this.NodeEnd.ZIndex }
+                .OrderBy(x => x)
+                .FirstOrDefault();
+
+                //if ZIndex above that of groups, set to be less than that of groups
+                if (index > 2)
+                {
+                    index = 1;
+                }
+            }
+
+            return index;
+        }
+        private bool OneConnectingNodeInCollapsedGroup(NodeViewModel firstNode, NodeViewModel lastNode)
+        {
+            return firstNode.IsNodeInCollapsedGroup || lastNode.IsNodeInCollapsedGroup;
+        }
+        private bool ConnectingNodesBothInCollapsedGroup(NodeViewModel firstNode, NodeViewModel lastNode)
+        {
+            return firstNode.IsNodeInCollapsedGroup && lastNode.IsNodeInCollapsedGroup;
+>>>>>>> Stashed changes
         }
 
         /// <summary>
@@ -919,6 +970,7 @@ namespace Dynamo.ViewModels
 
             workspaceViewModel.DynamoViewModel.PropertyChanged += DynamoViewModel_PropertyChanged;
             Nodevm.PropertyChanged += nodeViewModel_PropertyChanged;
+            NodeEnd.PropertyChanged += nodeEndViewModel_PropertyChanged;
             Redraw();
             InitializeCommands();
 
@@ -1068,6 +1120,7 @@ namespace Dynamo.ViewModels
             workspaceViewModel.DynamoViewModel.PropertyChanged -= DynamoViewModel_PropertyChanged;
             workspaceViewModel.DynamoViewModel.Model.PreferenceSettings.PropertyChanged -= DynamoViewModel_PropertyChanged;
             Nodevm.PropertyChanged -= nodeViewModel_PropertyChanged;
+            NodeEnd.PropertyChanged -= nodeEndViewModel_PropertyChanged;
             ConnectorPinViewCollection.CollectionChanged -= HandleCollectionChanged;         
 
             foreach (var pin in ConnectorPinViewCollection.ToList())
@@ -1100,6 +1153,21 @@ namespace Dynamo.ViewModels
                 case nameof(NodeViewModel.IsFrozen):
                     RaisePropertyChanged(nameof(IsFrozen));
                     break;
+                case nameof(NodeViewModel.IsNodeInCollapsedGroup):
+                    RaisePropertyChanged(nameof(ZIndex));
+                    break;
+                default: break;
+            }
+        }
+
+        private void nodeEndViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(NodeViewModel.IsNodeInCollapsedGroup):
+                    RaisePropertyChanged(nameof(ZIndex));
+                    break;
+                default: break;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -59,6 +59,7 @@ namespace Dynamo.ViewModels
         private bool isexplictFrozen;
         private bool canToggleFrozen = true;
         private bool isRenamed = false;
+        private bool isNodeInCollapsedGroup = false;
         #endregion
 
         #region public members
@@ -661,6 +662,20 @@ namespace Dynamo.ViewModels
                 if (ErrorBubble == null) return;
                 ErrorBubble.IsCollapsed = value;
                 RaisePropertyChanged(nameof(NodeWarningBarVisible));
+            }
+        }
+
+        /// <summary>
+        /// Used as a flag to indicate to associated connectors what ZIndex to be drawn at.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsNodeInCollapsedGroup
+        {
+            get => isNodeInCollapsedGroup;
+            set
+            {
+                isNodeInCollapsedGroup = value;
+                RaisePropertyChanged(nameof(IsNodeInCollapsedGroup));
             }
         }
 


### PR DESCRIPTION
### Description
This PR allows the ConnectorViewModel to listen to changes in the `IsNodeInCollapsedGroup` state of start/end nodes it corresponds to. This way, when that flag flips for one of those `NodeViewModels` the connector updates it ZIndex accordingly (RaisePropertyChanged is raised).

Previously we were relying on the selection of those NodeViewModels to trigger an update to the connector ZIndex.
Thus, _on first collapse_ ZIndex is rendered correctly now.

*Most important contribution of this PR are lines **1164-1178** of `ConnectorViewModel.cs`. Other changes should have been merged from #12475. As you recall that PR's branch had the incorrect branch as a base, thus but on rebasing to master unable to capture those previous changes, so added them to this PR. 

Previous behaviour:
![wire-group-error-previous](https://user-images.githubusercontent.com/24754290/148376990-4788c797-0b4d-4767-850b-b2b8caa967d8.gif)

Fixed behaviour:
![wire-group-error-fix](https://user-images.githubusercontent.com/24754290/148375828-8c4d8a44-cc75-4914-a628-14621b7be52e.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] All tests pass using the self-service CI.
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
`ConnectorViewModel` ZIndex alerted/updated when adjacent nodes are collapsed/expanded in a group.


### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
@Amoursol 
