### PR TITLE
[DYN-4493] fix behavior with cleanup node layout feature and groups

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -681,6 +681,7 @@ namespace Dynamo.Graph.Annotations
             RaisePropertyChanged("FontSize");
             RaisePropertyChanged("AnnotationText");
             RaisePropertyChanged("Nodes");
+            this.ReportPosition();
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -311,6 +311,7 @@ namespace Dynamo.Graph.Workspaces
             if (!isGroupLayout)
             {
                 // Add all selected items to the undo recorder
+                undoItems.AddRange(workspace.Annotations);
                 undoItems.AddRange(workspace.Connectors.SelectMany(conn => conn.ConnectorPinModels));
                 undoItems.AddRange(workspace.Nodes);
                 undoItems.AddRange(workspace.Notes);

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -86,6 +86,14 @@ namespace Dynamo.Graph.Workspaces
             {
                 foreach (AnnotationModel group in workspace.Annotations)
                 {
+                    // We dont care about nested groups here,
+                    // as the parent group is treated as one big
+                    // node.
+                    if (workspace.Annotations.ContainsModel(group))
+                    {
+                        continue;
+                    }
+
                     // Treat a group as a graph layout node/vertex
                     combinedGraph.AddNode(group.GUID, group.Width, group.Height, group.X, group.Y,
                         group.IsSelected || DynamoSelection.Instance.Selection.Count == 0);
@@ -96,15 +104,15 @@ namespace Dynamo.Graph.Workspaces
             {
                 if (!isGroupLayout)
                 {
-                    AnnotationModel group = workspace.Annotations.Where(
-                        g => g.Nodes.Contains(node)).ToList().FirstOrDefault();
+                    AnnotationModel group = workspace.Annotations
+                        .Where(g => g.ContainsModel(node))
+                        .FirstOrDefault();
 
                     // Do not process nodes within groups
-                    if (group == null)
-                    {
-                        combinedGraph.AddNode(node.GUID, node.Width, node.Height, node.X, node.Y,
+                    if (group != null) continue;
+
+                    combinedGraph.AddNode(node.GUID, node.Width, node.Height, node.X, node.Y,
                             node.IsSelected || DynamoSelection.Instance.Selection.Count == 0);
-                    }
                 }
                 else
                 {
@@ -114,7 +122,7 @@ namespace Dynamo.Graph.Workspaces
                 }
             }
 
-            ///Adding all connectorPins (belonging to all connectors) as graph.nodes to the combined graph.
+            // Adding all connectorPins (belonging to all connectors) as graph.nodes to the combined graph.
             foreach (ConnectorModel edge in workspace.Connectors)
             {
                 foreach (var pin in edge.ConnectorPinModels)
@@ -133,10 +141,22 @@ namespace Dynamo.Graph.Workspaces
                 if (!isGroupLayout)
                 {
                     AnnotationModel startGroup = null, endGroup = null;
-                    startGroup = workspace.Annotations.Where(
-                        g => g.Nodes.Contains(edge.Start.Owner)).ToList().FirstOrDefault();
-                    endGroup = workspace.Annotations.Where(
-                        g => g.Nodes.Contains(edge.End.Owner)).ToList().FirstOrDefault();
+
+                    // To get the start/end group we first make sure
+                    // that all nested groups are filterd out as we dont
+                    // care about them. We then check if the edge
+                    // start/end owner is in either the parent or child group
+                    var groupsFiltered = workspace.Annotations.Where(g => !workspace.Annotations.ContainsModel(g));
+
+                    startGroup = groupsFiltered
+                        .Where(g => g.ContainsModel(edge.Start.Owner) || 
+                                    g.Nodes.OfType<AnnotationModel>().SelectMany(x => x.Nodes).Contains(edge.Start.Owner))
+                        .FirstOrDefault();
+
+                    endGroup = groupsFiltered
+                        .Where(g => g.ContainsModel(edge.End.Owner) || 
+                                    g.Nodes.OfType<AnnotationModel>().SelectMany(x => x.Nodes).Contains(edge.End.Owner))
+                        .FirstOrDefault();
 
                     // Treat a group as a node, but do not process edges within a group
                     if (startGroup == null || endGroup == null || startGroup != endGroup)
@@ -168,8 +188,9 @@ namespace Dynamo.Graph.Workspaces
                     continue;
                 }
 
-                AnnotationModel group = workspace.Annotations.Where(
-                    g => g.Nodes.Contains(note)).ToList().FirstOrDefault();
+                AnnotationModel group = workspace.Annotations
+                    .Where(g => g.Nodes.Contains(note))
+                    .FirstOrDefault();
 
                 GraphLayout.Node nd = null;
 
@@ -475,7 +496,13 @@ namespace Dynamo.Graph.Workspaces
 
                     double deltaX = n.X - group.X;
                     double deltaY = n.Y - group.Y + graph.OffsetY;
-                    foreach (var node in group.Nodes.OfType<NodeModel>())
+
+                    // We update the posistion of all nodes in the
+                    // parent group + all nodes in any potential
+                    // nested groups.
+                    foreach (var node in group.Nodes
+                        .OfType<NodeModel>()
+                        .Union(group.Nodes.OfType<AnnotationModel>().SelectMany(x => x.Nodes.OfType<NodeModel>())))
                     {
                         node.X += deltaX;
                         node.Y += deltaY;

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -183,6 +183,7 @@ namespace Dynamo.Graph.Workspaces
                     // We add this note to the LinkedNotes on the 
                     // pinned node. 
                     var graphNode = combinedGraph.FindNode(note.PinnedNode.GUID);
+                    if (graphNode is null) continue;
                     var height = note.PinnedNode.Rect.Top - note.Rect.Top;
                     graphNode.LinkNote(note, note.Width, height);
                     continue;
@@ -519,6 +520,8 @@ namespace Dynamo.Graph.Workspaces
                             note.ReportPosition();
                         }
                     }
+
+                    group.ReportPosition();
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1004,7 +1004,7 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged(nameof(ModelAreaRect));
                     RaisePropertyChanged(nameof(Width));
                     break;
-                case nameof(AnnotationModel.Position):
+                case nameof(ModelBase.Position):
                     RaisePropertyChanged(nameof(ModelAreaRect));
                     RaisePropertyChanged(nameof(AnnotationModel.Position));
                     UpdateProxyPortsPosition();

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1004,7 +1004,7 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged(nameof(ModelAreaRect));
                     RaisePropertyChanged(nameof(Width));
                     break;
-                case nameof(ModelBase.Position):
+                case nameof(AnnotationModel.Position):
                     RaisePropertyChanged(nameof(ModelAreaRect));
                     RaisePropertyChanged(nameof(AnnotationModel.Position));
                     UpdateProxyPortsPosition();

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -838,7 +838,9 @@ namespace Dynamo.ViewModels
                     // the nested group and the parent group, as the mouse coursor will be inside
                     // both of there rects. In these cases we want to get group that is nested
                     // inside the parent group.
-                    var dropGroup = dropGroups.FirstOrDefault(x => !x.AnnotationModel.HasNestedGroups) ?? dropGroups.FirstOrDefault();
+                    var dropGroup = dropGroups
+                        .FirstOrDefault(x => !x.AnnotationModel.HasNestedGroups) ?? dropGroups.FirstOrDefault();
+
 
                     // If the dropGroup is null or any of the selected items is already in the dropGroup,
                     // we disable the drop border by setting NodeHoveringState to false
@@ -881,6 +883,15 @@ namespace Dynamo.ViewModels
                             .ToList()
                             .ForEach(x => x.NodeHoveringState = false);
 
+                        // If the dropGroup belongs to another group
+                        // we need to check if the parent group is collapsed
+                        // if it is we dont want to be able to add new
+                        // models to the drop group.
+                        var parentGroup = owningWorkspace.Annotations
+                            .Where(x => x.AnnotationModel.ContainsModel(dropGroup.AnnotationModel))
+                            .FirstOrDefault();
+                        if (parentGroup != null && !parentGroup.IsExpanded) return false;
+                        
                         dropGroup.NodeHoveringState = true;
                     }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -906,7 +906,7 @@ namespace Dynamo.ViewModels
 
             foreach (var n in childlessModels)
             {
-                if (IsInRegion(region, n, fullyEnclosed))
+                if (IsInRegion(region, n, fullyEnclosed) && !IsCollapsed)
                 {
                     selection.AddUnique(n);
                 }
@@ -918,7 +918,7 @@ namespace Dynamo.ViewModels
 
             foreach (var n in Model.Annotations)
             {
-                if (IsInRegion(region, n, fullyEnclosed))
+                if (IsInRegion(region, n, fullyEnclosed) && !IsCollapsed)
                 {
                     selection.AddUnique(n);
                     // if annotation is selected its children should be added to selection too


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4493](https://jira.autodesk.com/browse/DYN-4493) and [DYN-4466](https://jira.autodesk.com/browse/DYN-4466)

#### DYN-4493
![AutoLayout](https://user-images.githubusercontent.com/13732445/149130483-0700b57d-1b8d-450f-af88-f2e299d41c4f.gif)
![AutoLayout2](https://user-images.githubusercontent.com/13732445/149130479-90bfcdab-6c98-4862-afb6-571ecf943990.gif)

#### DYN-4466
![CollapsedGroupsAutoLayout](https://user-images.githubusercontent.com/13732445/149131116-a335dfd0-437e-444b-839b-f4e9115bb953.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@QilongTang 

### FYIs

@Amoursol 
