### PR TITLE
Connector Visibility Fix when nested group expanded/collapsed

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -879,6 +879,11 @@ namespace Dynamo.ViewModels
                 }
 
                 viewModel.IsCollapsed = false;
+
+                if (viewModel is NodeViewModel nodeViewModel)
+                {
+                    nodeViewModel.IsNodeInCollapsedGroup = false;
+                }
             }
 
             UpdateConnectorsAndPortsOnShowContents(Nodes);


### PR DESCRIPTION
### Description

This PR is a second iteration of/ is related to #12474. It updated `IsNodeInCollapsedGroup` property on `NodeViewModel` thus ensuring that `ConnectorViewModel` property `ZIndex` is updated as expected. This covers the nesteed group condition.

_Previous:_
![connector-nestedgroup-bug2](https://user-images.githubusercontent.com/24754290/149140658-1e016b69-37bd-4666-b082-8c6357766020.gif)


_Fix:_
![connector-nestedgroup-fix2](https://user-images.githubusercontent.com/24754290/149140667-1975c231-823a-4df1-8585-89d03cec0a6e.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

`NodeViewModel` flag `IsNodeInCollapsedGroup` is set to false for a node belonging to a just-expanded group, thus updating the connector visibility (ZIndex) to correct value.

### Reviewers
@QilongTang 

### FYIs
@SHKnudsen 
@Amoursol 
