### PR TITLE
[DYN-4473] Plugging a wire from an output port into an input port and moving a collapsed group doesn't update wire locations

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -627,8 +627,12 @@ namespace Dynamo.ViewModels
             if (ownerNodes != null)
             {
                 return ownerNodes.SelectMany(x => x.InPorts
-                        .Where(p => !p.IsConnected || !p.Connectors.Any(c => ownerNodes.Contains(c.Start.Owner)))
-                    ) ;
+                        .Where(p => !p.IsConnected ||
+                                    !p.Connectors.Any(c => ownerNodes.Contains(c.Start.Owner)) ||
+                                    // If the port is connected to any of the groups outports
+                                    // we need to return it as well
+                                    p.Connectors.Any(c => outPorts.Select(m => m.PortModel).Contains(c.Start)))
+                        );
             }
 
             // If this group does contain any AnnotationModels
@@ -636,7 +640,11 @@ namespace Dynamo.ViewModels
             // not belong to a group.
             return Nodes.OfType<NodeModel>()
                 .SelectMany(x => x.InPorts
-                    .Where(p => !p.IsConnected || !p.Connectors.Any(c => Nodes.Contains(c.Start.Owner)))
+                    .Where(p => !p.IsConnected || 
+                                !p.Connectors.Any(c => Nodes.Contains(c.Start.Owner)) ||
+                                // If the port is connected to any of the groups outports
+                                // we need to return it as well
+                                p.Connectors.Any(c => outPorts.Select(m => m.PortModel).Contains(c.Start)))
                 );
         }
 
@@ -649,7 +657,11 @@ namespace Dynamo.ViewModels
             {
                 return ownerNodes
                     .SelectMany(x => x.OutPorts
-                        .Where(p => !p.IsConnected || !p.Connectors.Any(c => ownerNodes.Contains(c.End.Owner)))
+                        .Where(p => !p.IsConnected ||
+                                    !p.Connectors.Any(c => ownerNodes.Contains(c.End.Owner)) ||
+                                    // If the port is connected to any of the groups inports
+                                    // we need to return it as well
+                                    p.Connectors.Any(c => inPorts.Select(m => m.PortModel).Contains(c.End)))
                     );
             }
 
@@ -658,7 +670,11 @@ namespace Dynamo.ViewModels
             // not belong to a group.
             return Nodes.OfType<NodeModel>()
                 .SelectMany(x => x.OutPorts
-                    .Where(p => !p.IsConnected || !p.Connectors.Any(c => Nodes.Contains(c.End.Owner)))
+                    .Where(p => !p.IsConnected || 
+                                !p.Connectors.Any(c => Nodes.Contains(c.End.Owner)) ||
+                                // If the port is connected to any of the groups inports
+                                // we need to return it as well
+                                p.Connectors.Any(c => inPorts.Select(m => m.PortModel).Contains(c.End)))
                 );
         }
 


### PR DESCRIPTION
### Purpose

This PR fixes [DYN-4473](https://jira.autodesk.com/browse/DYN-4473)
![ConnectingCollapsedGroupPorts](https://user-images.githubusercontent.com/13732445/149145299-4e621ed5-24eb-4893-9039-b79914d83913.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@QilongTang 

### FYIs

@Amoursol 
