### PR TITLE
DYN-3877-EX : use id instead of name to identify graph status extension

### DIFF
--- a/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
@@ -48,7 +48,8 @@ namespace Dynamo.Wpf.Controls
         private void StackPanel_MouseDown(object sender, MouseButtonEventArgs e)
         {
             var viewModel = this.DataContext as DynamoViewModel;
-            viewModel?.OnViewExtensionOpenRequest("Graph Status");
+            //Open Graph Status view extension
+            viewModel?.OnViewExtensionOpenRequest("3467481b-d20d-4918-a454-bf19fc5c25d7");
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2065,7 +2065,8 @@ namespace Dynamo.ViewModels
             if (args.ClickedButtonId == (int)DynamoModel.ButtonId.Cancel ||
                 args.ClickedButtonId == 0)
             {
-                OnViewExtensionOpenRequest("Graph Status");
+                //Open Graph Status view extension
+                OnViewExtensionOpenRequest("3467481b-d20d-4918-a454-bf19fc5c25d7");
                 return false;
             }
 

--- a/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
@@ -211,7 +211,8 @@ namespace Dynamo.GraphMetadata
 
         private void OpenGraphStatusExecute(object obj)
         {
-            viewLoadedParams.OpenViewExtension("Graph Status");
+            //Open Graph Status view extension            
+            viewLoadedParams.OpenViewExtension("3467481b-d20d-4918-a454-bf19fc5c25d7");
         }
 
         private void AddCustomPropertyExecute(object obj)

--- a/src/LintingViewExtension/LintingViewExtension.cs
+++ b/src/LintingViewExtension/LintingViewExtension.cs
@@ -48,9 +48,9 @@ namespace Dynamo.LintingViewExtension
             this.linterManager.PropertyChanged += OnLinterManagerPropertyChange;
         }
 
-        private void OnViewExtensionOpenRequest(string extensionName)
+        private void OnViewExtensionOpenRequest(string extensionId)
         {
-            if (extensionName != Name)
+            if (string.IsNullOrEmpty(extensionId) || !extensionId.Equals(UniqueId))
             {
                 return;
             }


### PR DESCRIPTION
### Purpose
There are issues when we rely on the extension name in a localized version of Dynamo.
Therefore we will use extension Id to identify Graph Status extension.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@saintentropy 

