### PR TITLE
fix performance issue with error bars by suppressing property change notifications.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -68,7 +68,11 @@ namespace Dynamo.Graph.Nodes
 
         private readonly Dictionary<int, Tuple<int, NodeModel>> inputNodes;
         private readonly Dictionary<int, HashSet<Tuple<int, NodeModel>>> outputNodes;
-
+        /// <summary>
+        /// Can be used to suppress some property notifications related to node warnings/state. This is useful
+        /// to defer UI updates for better performance. //TODO should this be generic for all nodemodel props?
+        /// </summary>
+        internal bool SuppressStatePropertyNotifications { get; set; } = false;
         #endregion
 
         internal const double HeaderHeight = 46;
@@ -333,7 +337,10 @@ namespace Dynamo.Graph.Nodes
                 if (state == value) return;
 
                 state = value;
-                RaisePropertyChanged("State");
+                if (!SuppressStatePropertyNotifications)
+                {
+                    RaisePropertyChanged("State");
+                }
             }
         }
 
@@ -365,7 +372,10 @@ namespace Dynamo.Graph.Nodes
             set
             {
                 toolTipText = value;
-                RaisePropertyChanged("ToolTipText");
+                if (!SuppressStatePropertyNotifications)
+                {
+                    RaisePropertyChanged("ToolTipText");
+                }
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -750,8 +750,9 @@ namespace Dynamo.Graph.Workspaces
                 var node = workspace.Nodes.FirstOrDefault(n => n.GUID == guid);
                 if (node == null)
                     continue;
-
+                node.SuppressStatePropertyNotifications = true;
                 node.Warning(message.Value); // Update node warning message.
+                node.SuppressStatePropertyNotifications = false;
             }
 
             // Notify listeners (optional) of completion.
@@ -767,8 +768,8 @@ namespace Dynamo.Graph.Workspaces
             // Dispatch the failure message display for execution on UI thread.
             // 
             EvaluationCompletedEventArgs e = task.Exception == null || IsTestMode
-                ? new EvaluationCompletedEventArgs(true)
-                : new EvaluationCompletedEventArgs(true, task.Exception);
+                ? new EvaluationCompletedEventArgs(true,messages.Keys.Select(x=>x.ToString()),null)
+                : new EvaluationCompletedEventArgs(true, messages.Keys.Select(x => x.ToString()), task.Exception);
 
             EvaluationCount ++;
 

--- a/src/DynamoCore/Models/DynamoModelEventArgs.cs
+++ b/src/DynamoCore/Models/DynamoModelEventArgs.cs
@@ -143,6 +143,10 @@ namespace Dynamo.Models
         {
             get { return !error.HasValue(); }
         }
+        /// <summary>
+        /// IDs for messages generated during a run. These are node guids.
+        /// </summary>
+        internal IEnumerable<string> MessageKeys { get; private set; }
 
         /// <summary>
         /// Exception thrown during graph evaluation.
@@ -170,6 +174,12 @@ namespace Dynamo.Models
         {
             EvaluationTookPlace = evaluationTookPlace;
 
+            error = errorMsg != null ? Option.Some(errorMsg) : Option.None<Exception>();
+        }
+        internal EvaluationCompletedEventArgs(bool evaluationTookPlace, IEnumerable<string> messageKeys, Exception errorMsg = null)
+        {
+            EvaluationTookPlace = evaluationTookPlace;
+            MessageKeys = messageKeys;
             error = errorMsg != null ? Option.Some(errorMsg) : Option.None<Exception>();
         }
     }

--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -145,7 +145,11 @@ namespace Dynamo.Scheduler
                     node.WasInvolvedInExecution = true;
                     node.WasRenderPackageUpdatedAfterExecution = false;
                     if (node.State == ElementState.Warning)
+                    {
+                        node.SuppressStatePropertyNotifications = true;
                         node.ClearErrorsAndWarnings();
+                        node.SuppressStatePropertyNotifications = false;
+                    }
                 }
 
                 engineController.RemoveRecordedAstGuidsForSession(graphSyncData.SessionID);

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -188,13 +188,13 @@ namespace Dynamo.Wpf.ViewModels.Core
                 }
             }
 
-            void UpdateNodeInfoBubbleContent(EvaluationCompletedEventArgs e)
+            void UpdateNodeInfoBubbleContent(EvaluationCompletedEventArgs evalargs)
             {
                 if (e.MessageKeys == null)
                 {
                     return;
                 }
-                foreach (var messageID in e.MessageKeys)
+                foreach (var messageID in evalargs.MessageKeys)
                 { //TODO pass guid direct?
                     var node = this.Nodes.FirstOrDefault(n => n.Id == Guid.Parse(messageID));
                     if (node == null)

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -150,21 +150,18 @@ namespace Dynamo.Wpf.ViewModels.Core
 
         void hwm_EvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
-            //now that execution is complete, we need to 
-            DynamoViewModel.UIDispatcher.BeginInvoke(new Action(() =>
-            {   if(e.MessageKeys == null)
+            if (DynamoViewModel.UIDispatcher != null)
+            {
+                DynamoViewModel.UIDispatcher.BeginInvoke(new Action(() =>
                 {
-                    return;
-                }
-                foreach (var messageID in e.MessageKeys)
-                {//TODO pass guid direct?
-                    var node = this.Nodes.FirstOrDefault(n => n.Id == Guid.Parse(messageID));
-                    if (node == null)
-                        continue;
-
-                    node.UpdateBubbleContent();
-                }
-            }));
+                    UpdateNodeInfoBubbleContent(e);
+                }));
+            }
+            else
+            {
+                //just call it directly 
+                UpdateNodeInfoBubbleContent(e);
+            }
         
             bool hasWarnings = Model.Nodes.Any(n => n.State == ElementState.Warning || n.State == ElementState.PersistentWarning);
 
@@ -188,6 +185,22 @@ namespace Dynamo.Wpf.ViewModels.Core
                 else
                 {
                     SetCurrentWarning(NotificationLevel.Moderate, Properties.Resources.RunCompletedWithWarningsMessage);
+                }
+            }
+
+            void UpdateNodeInfoBubbleContent(EvaluationCompletedEventArgs e)
+            {
+                if (e.MessageKeys == null)
+                {
+                    return;
+                }
+                foreach (var messageID in e.MessageKeys)
+                { //TODO pass guid direct?
+                    var node = this.Nodes.FirstOrDefault(n => n.Id == Guid.Parse(messageID));
+                    if (node == null)
+                        continue;
+
+                    node.UpdateBubbleContent();
                 }
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -150,6 +150,22 @@ namespace Dynamo.Wpf.ViewModels.Core
 
         void hwm_EvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
+            //now that execution is complete, we need to 
+            DynamoViewModel.UIDispatcher.BeginInvoke(new Action(() =>
+            {   if(e.MessageKeys == null)
+                {
+                    return;
+                }
+                foreach (var messageID in e.MessageKeys)
+                {//TODO pass guid direct?
+                    var node = this.Nodes.FirstOrDefault(n => n.Id == Guid.Parse(messageID));
+                    if (node == null)
+                        continue;
+
+                    node.UpdateBubbleContent();
+                }
+            }));
+        
             bool hasWarnings = Model.Nodes.Any(n => n.State == ElementState.Warning || n.State == ElementState.PersistentWarning);
 
             if (!hasWarnings)

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -698,9 +698,9 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(pynode.Engine, PythonEngineVersion.IronPython2);
 
             Assert.AreEqual(pynode.State, Dynamo.Graph.Nodes.ElementState.Warning);
-
+            DispatcherUtil.DoEvents();
             var nodeView = NodeViewWithGuid(nodeModel.GUID.ToString());
-  
+            
             Assert.IsNotNull(nodeView);
             Assert.IsNotNull(nodeView.ViewModel.ErrorBubble);
 


### PR DESCRIPTION
### Purpose
alternative to:
https://github.com/DynamoDS/Dynamo/pull/12498

This PR is a bit more brute force than the other, but I think it's simpler to reason about. ~(at least until the tests run)~..

A new internal property `SuppressStatePropertyNotifications` is added to `NodeModel` to stop property notifications for `ToolTipText` and `State` from being raised to the View temporarily.

These properties kick off `error bubble` and `warning color` updates which are quite slow when marshaled between threads.
Something I didn't know is that WPF will automatically marshal property change events for properties that are part of a binding to the dispatcher thread. This means that both `WarningBarColor` and `TooltipText` changes on other threads are the real culprits for this slow down, and changes to `State` kick off changes to `WarningBarColor`.

To avoid the cross thread chatter, we disable the change notifications and manually update all node error bubbles that had generated a message to display.

So far, simple testing look ok, will see what the tests come back with.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 

