### PR TITLE
fix crash when removing node from group that contains note.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1286,7 +1286,7 @@ namespace Dynamo.ViewModels
                     if (modelb is NodeModel node)
                     {
                         var pinnedNotes = CurrentSpaceViewModel.Notes
-                            .Where(x => x.PinnedNode.NodeModel == node)
+                            .Where(x => x.PinnedNode?.NodeModel == node)
                             .Select(x => x.Model.GUID);
 
                         if (pinnedNotes.Any())

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -164,6 +164,57 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(true, ViewModel.CanUngroupModel(null));
         }
 
+
+        [Test]
+        [Category("DynamoUI")]
+        public void CanUngroupNodeFromAGroupIfGroupContainsNote()
+        {
+            //Create a Node
+            var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+
+            //verify the node was created
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
+
+            //Select the node for group
+            DynamoSelection.Instance.Selection.Add(addNode);
+
+            //Create a Group around that node
+            ViewModel.AddAnnotationCommand.Execute(null);
+            var annotation = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault();
+
+            //Check if the group is created
+            Assert.IsNotNull(annotation);
+
+            //Clear the selection
+            DynamoSelection.Instance.ClearSelection();
+
+            //create a note.
+            ViewModel.AddNoteCommand.Execute(null);
+            var note = ViewModel.Model.CurrentWorkspace.Notes.FirstOrDefault();
+            Assert.IsNotNull(note);
+
+            //Select the note 
+            DynamoSelection.Instance.Selection.Add(note);
+            DynamoSelection.Instance.Selection.Add(annotation);
+
+            ViewModel.AddModelsToGroupModelCommand.Execute(null);
+
+            //Clear the selection
+            DynamoSelection.Instance.ClearSelection();
+            //Select the node 
+            DynamoSelection.Instance.Selection.Add(addNode);
+
+            Assert.AreEqual(2, annotation.Nodes.Count());
+            //remove it
+            Assert.DoesNotThrow(() =>
+            {
+                ViewModel.UngroupModelCommand.Execute(null);
+              
+            });
+            Assert.AreEqual(1, annotation.Nodes.Count());
+        }
+
         [Test]
         [Category("DynamoUI")]
         public void CanUngroupNodeWhichIsNotInAGroup()


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-4505

add null check to linq query
add test

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

fix crash when removing node from group that contains note.
