### PR TITLE
Hide All context menu in workspace when displaying node context menu

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -597,11 +597,14 @@ namespace Dynamo.Models
             WorkspaceModel targetWorkspace = CurrentWorkspace;
             if (!command.WorkspaceGuid.Equals(Guid.Empty))
                 targetWorkspace = Workspaces.FirstOrDefault(w => w.Guid.Equals(command.WorkspaceGuid));
-
-            if (targetWorkspace != null)
+            try
             {
-                targetWorkspace.UpdateModelValue(command.ModelGuids,
+                targetWorkspace?.UpdateModelValue(command.ModelGuids,
                     command.Name, command.Value);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex.Message);
             }
         }
 

--- a/src/DynamoCoreWpf/Commands/WorkspaceCommands.cs
+++ b/src/DynamoCoreWpf/Commands/WorkspaceCommands.cs
@@ -26,6 +26,7 @@ namespace Dynamo.ViewModels
         private DelegateCommand showHideAllGeometryPreviewCommand;
         private DelegateCommand showInCanvasSearchCommand;
         private DelegateCommand pasteCommand;
+        private DelegateCommand hideAllPopupCommand;
 
         #endregion
 
@@ -212,6 +213,21 @@ namespace Dynamo.ViewModels
                     showInCanvasSearchCommand = new DelegateCommand(OnRequestShowInCanvasSearch);
 
                 return showInCanvasSearchCommand;
+            }
+        }
+
+        /// <summary>
+        /// View Command to hide all popup in special cases
+        /// </summary>
+        [JsonIgnore]
+        public DelegateCommand HideAllPopupCommand
+        {
+            get
+            {
+                if (hideAllPopupCommand == null)
+                    hideAllPopupCommand = new DelegateCommand(OnRequestHideAllPopup);
+
+                return hideAllPopupCommand;
             }
         }
         #endregion

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -162,10 +162,10 @@ namespace Dynamo.ViewModels
             RequestShowInCanvasSearch?.Invoke(flag);
         }
 
-        internal event Action RequestHideAllPopup;
+        internal event Action<object> RequestHideAllPopup;
         private void OnRequestHideAllPopup(object param)
         {
-            RequestHideAllPopup?.Invoke();
+            RequestHideAllPopup?.Invoke(param);
         }
 
         internal event Action<ShowHideFlags> RequestNodeAutoCompleteSearch;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -162,6 +162,12 @@ namespace Dynamo.ViewModels
             RequestShowInCanvasSearch?.Invoke(flag);
         }
 
+        internal event Action RequestHideAllPopup;
+        private void OnRequestHideAllPopup(object param)
+        {
+            RequestHideAllPopup?.Invoke();
+        }
+
         internal event Action<ShowHideFlags> RequestNodeAutoCompleteSearch;
         internal event Action<ShowHideFlags, PortViewModel> RequestPortContextMenu;
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1018,7 +1018,7 @@ namespace Dynamo.Controls
         {
             var workspace = this.ChildOfType<WorkspaceView>();
             if (workspace != null)
-                workspace.HidePopUp();
+                workspace.HideAllPopUp();
         }
 
         private void TrackStartupAnalytics()

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1005,7 +1005,7 @@ namespace Dynamo.Controls
             // will not work. Instead, we have to check if the Owner Window (DynamoView) is deactivated or not.  
             if (Application.Current == null)
             {
-                this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(); };
+                this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(null); };
             }
             loaded = true;
         }
@@ -1014,11 +1014,11 @@ namespace Dynamo.Controls
         /// Close Popup when the Dynamo window is not in the foreground.
         /// </summary>
 
-        private void HidePopupWhenWindowDeactivated()
+        private void HidePopupWhenWindowDeactivated(object obj)
         {
             var workspace = this.ChildOfType<WorkspaceView>();
             if (workspace != null)
-                workspace.HideAllPopUp();
+                workspace.HideAllPopUp(obj);
         }
 
         private void TrackStartupAnalytics()
@@ -2368,7 +2368,7 @@ namespace Dynamo.Controls
             //if original sender was scroll bar(i.e Thumb) don't close the popup.
             if(!(e.OriginalSource is Thumb))
             {
-                HidePopupWhenWindowDeactivated();
+                HidePopupWhenWindowDeactivated(sender);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -735,7 +735,7 @@ namespace Dynamo.Controls
         private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
         {
             Guid nodeGuid = ViewModel.NodeModel.GUID;
-            ViewModel.WorkspaceViewModel.HideAllPopupCommand.Execute(null);
+            ViewModel.WorkspaceViewModel.HideAllPopupCommand.Execute(sender);
             ViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.SelectModelCommand(nodeGuid, Keyboard.Modifiers.AsDynamoType()));
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -735,6 +735,7 @@ namespace Dynamo.Controls
         private void DisplayNodeContextMenu(object sender, RoutedEventArgs e)
         {
             Guid nodeGuid = ViewModel.NodeModel.GUID;
+            ViewModel.WorkspaceViewModel.HideAllPopupCommand.Execute(null);
             ViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.SelectModelCommand(nodeGuid, Keyboard.Modifiers.AsDynamoType()));
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -124,16 +124,17 @@ namespace Dynamo.Views
         private void RemoveViewModelsubscriptions(WorkspaceViewModel ViewModel)
         {
             ViewModel.RequestShowInCanvasSearch -= ShowHideInCanvasControl;
+            ViewModel.RequestHideAllPopup -= HideAllPopUp;
             ViewModel.RequestNodeAutoCompleteSearch -= ShowHideNodeAutoCompleteControl;
             ViewModel.RequestPortContextMenu -= ShowHidePortContextMenu;
             ViewModel.DynamoViewModel.PropertyChanged -= ViewModel_PropertyChanged;
-           
+
             ViewModel.ZoomChanged -= vm_ZoomChanged;
             ViewModel.RequestZoomToViewportCenter -= vm_ZoomAtViewportCenter;
             ViewModel.RequestZoomToViewportPoint -= vm_ZoomAtViewportPoint;
             ViewModel.RequestZoomToFitView -= vm_ZoomToFitView;
             ViewModel.RequestCenterViewOnElement -= CenterViewOnElement;
-         
+
             ViewModel.RequestAddViewToOuterCanvas -= vm_RequestAddViewToOuterCanvas;
             ViewModel.WorkspacePropertyEditRequested -= VmOnWorkspacePropertyEditRequested;
             ViewModel.RequestSelectionBoxUpdate -= VmOnRequestSelectionBoxUpdate;
@@ -151,6 +152,7 @@ namespace Dynamo.Views
         private void AttachViewModelsubscriptions(WorkspaceViewModel ViewModel)
         {
             ViewModel.RequestShowInCanvasSearch += ShowHideInCanvasControl;
+            ViewModel.RequestHideAllPopup += HideAllPopUp;
             ViewModel.RequestNodeAutoCompleteSearch += ShowHideNodeAutoCompleteControl;
             ViewModel.RequestPortContextMenu += ShowHidePortContextMenu;
             ViewModel.DynamoViewModel.PropertyChanged += ViewModel_PropertyChanged;
@@ -172,7 +174,7 @@ namespace Dynamo.Views
         }
 
         private void ShowHideNodeAutoCompleteControl(ShowHideFlags flag)
-        {            
+        {
             ShowHidePopup(flag, NodeAutoCompleteSearchBar);
         }
 
@@ -239,7 +241,7 @@ namespace Dynamo.Views
                     // If the dispatcher is not used in this scenario when switching
                     // from inputPort context menu to Output port context menu,
                     // the popup will display before the new content is fully rendered
-                    this.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background, new Action(() =>{
+                    this.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background, new Action(() => {
                         popup.Child.Visibility = Visibility.Visible;
                         popup.Child.UpdateLayout();
                         popup.IsOpen = displayPopup;
@@ -255,7 +257,7 @@ namespace Dynamo.Views
         /// <summary>
         /// Hides Context Menu as well as InCanvasControl (Right Click PopUp)
         /// </summary>
-        public void HidePopUp()
+        public void HideAllPopUp()
         {
             if (InCanvasSearchBar.IsOpen || ContextMenuPopup.IsOpen)
             {

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -255,14 +255,22 @@ namespace Dynamo.Views
         }
 
         /// <summary>
-        /// Hides Context Menu as well as InCanvasControl (Right Click PopUp)
+        /// Hides all popups in the view, the amount of popup hidden will be different depending on
+        /// if the hide view command is triggered on node level or workspace level
         /// </summary>
-        public void HideAllPopUp()
+        public void HideAllPopUp(object sender)
         {
+            // First make sure workspace level popups are hidden
             if (InCanvasSearchBar.IsOpen || ContextMenuPopup.IsOpen)
             {
                 ShowHideContextMenu(ShowHideFlags.Hide);
                 ShowHideInCanvasControl(ShowHideFlags.Hide);
+            }
+            // If triggered on node level, make sure node popups are also hidden
+            if(sender is NodeView && (PortContextMenu.IsOpen || NodeAutoCompleteSearchBar.IsOpen) )
+            {
+                ShowHidePopup(ShowHideFlags.Hide, PortContextMenu);
+                ShowHidePopup(ShowHideFlags.Hide, NodeAutoCompleteSearchBar);
             }
         }
 

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -431,7 +431,8 @@ namespace Dynamo.Tests
             CurrentDynamoModel.CurrentWorkspace.RemoveAndDisposeNode(addNode);
 
             var command = new DynCmd.UpdateModelValueCommand(Guid.Empty, addNode.GUID, "Code", "");
-            Assert.Throws<InvalidOperationException>(() => CurrentDynamoModel.ExecuteCommand(command));
+            Assert.Throws<InvalidOperationException>(() => CurrentDynamoModel.CurrentWorkspace.UpdateModelValue(command.ModelGuids,
+                    command.Name, command.Value));
         }
 
         [Test]
@@ -439,7 +440,8 @@ namespace Dynamo.Tests
         public void UpdateModelValue_EmptyList_ThrowsException()
         {
             var command = new DynCmd.UpdateModelValueCommand(Guid.Empty, new Guid[] { }, "", "");
-            Assert.Throws<ArgumentNullException>(() => CurrentDynamoModel.ExecuteCommand(command));
+            Assert.Throws<ArgumentNullException>(() => CurrentDynamoModel.CurrentWorkspace.UpdateModelValue(command.ModelGuids,
+                    command.Name, command.Value));
         }
 
         [Test]


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-4509, https://jira.autodesk.com/browse/DYN-4459 and https://github.com/DynamoDS/Dynamo/issues/12532, fixing the issue that other popups are not hidden when displaying the node context menu. This fact will create all kinds of weird interactions.

1. Hide All other popups in workspace when displaying node context menu
2. Even if it fail, `UpdateModelValueImp` should not crash Dynamo. Catching the exception and logging it to Dynamo console

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Hide All context menu in workspace when displaying node context menu


### Reviewers

@reddyashish @zeusongit 

### FYIs

@johnpierson 