### PR TITLE
Missing DynamoUnit.xml docs file in Release build

### DIFF
--- a/src/Libraries/DynamoUnits/Units.csproj
+++ b/src/Libraries/DynamoUnits/Units.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\..\..\bin\AnyCPU\Release\DynamoUnits.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ForgeUnitsCLR, Version=3.2.2.0, Culture=neutral, processorArchitecture=AMD64">


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-4531

The release build configuration is missing the DynamoUnit.xml file which means the DynamoUnits ZT nodes will be missing the Description and tooltip information in Dynamo 2.13.  This PR fixes that so they will be added.

Note this has already been resolved in the main branch.  

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Dynamo Unit ZT nodes have their description and port tooltip documentation restored in the Dynamo UI.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@kronz 
