### PR TITLE
Adjust the proxy ports for the groups that have CBN.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -696,7 +696,12 @@ namespace Dynamo.ViewModels
             {
                 case PortType.Input:
                     return new Point2D(Left, y);
-                case PortType.Output:         
+                case PortType.Output:
+                    if (portModel.Owner is CodeBlockNodeModel)
+                    {
+                        // Special case because code block outputs are smaller than regular outputs.
+                        return new Point2D(Left + Width, y + 6);
+                    }
                     return new Point2D(Left + Width, y);
             }
             return new Point2D();

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -724,7 +724,6 @@
                               Grid.Row="0"
                               Canvas.ZIndex="20"
                               HorizontalContentAlignment="Left"
-                              Style="{StaticResource InOutPortControlStyle}"
                               ItemsSource="{Binding Path=InPorts}"
                               Margin="-25,10">
                 </ItemsControl>
@@ -735,7 +734,6 @@
                               Grid.Row="0"
                               Canvas.ZIndex="20"
                               HorizontalContentAlignment="Right"
-                              Style="{StaticResource InOutPortControlStyle}"
                               ItemsSource="{Binding Path=OutPorts}"
                               Margin="-25,10">
                 </ItemsControl>


### PR DESCRIPTION
### Purpose

These changes are to adjust the proxy port positions for the collapsed groups that have code block nodes in it.

This fix would not resolve the port design issues as we would need to have multiple controls to adjust based on the port size. In the current design, the ports get overlapped but after this fix, the ports will be stacked below each other. 

Before:
![image-2021-12-11-21-33-16-684](https://user-images.githubusercontent.com/43763136/150811269-82aadaae-30d3-48fe-a177-44580373ab32.png)

After: 
<img width="1119" alt="Screen Shot 2022-01-24 at 8 51 45 PM" src="https://user-images.githubusercontent.com/43763136/150811305-ad5de250-f681-4301-8d57-d9f4c8cd0ef9.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix the proxy ports positions for groups that have CBN's. 


### Reviewers

@QilongTang @SHKnudsen @Amoursol 
