### PR TITLE
Update default ironpython package version

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -468,7 +468,7 @@ namespace Dynamo.Configuration
         /// This static property is not serialized and is assigned IronPythonResolveTargetVersion's value 
         /// if found at deserialize time.
         /// </summary>
-        internal static Version IronPythonResolveVersion = new Version(2, 1, 0);
+        internal static Version IronPythonResolveVersion = new Version(2, 2, 0);
 
         /// <summary>
         /// The Version of the IronPython package that Dynamo will download when it is found as missing in graphs.

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -468,7 +468,7 @@ namespace Dynamo.Configuration
         /// This static property is not serialized and is assigned IronPythonResolveTargetVersion's value 
         /// if found at deserialize time.
         /// </summary>
-        internal static Version IronPythonResolveVersion = new Version(2, 2, 0);
+        internal static Version IronPythonResolveVersion = new Version(2, 4, 0);
 
         /// <summary>
         /// The Version of the IronPython package that Dynamo will download when it is found as missing in graphs.


### PR DESCRIPTION
### Purpose

Update the default package to IronPython 2.4.0
2.4.0 has been compiled against Dynamo after the Dynamic Python PR https://github.com/DynamoDS/Dynamo/pull/12482
It has no new features or breaking APIs

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
