### PR TITLE
DYN-4135-UnpinFromNode Added to ContextMenu

### DIFF
--- a/src/DynamoCoreWpf/Commands/NoteCommands.cs
+++ b/src/DynamoCoreWpf/Commands/NoteCommands.cs
@@ -88,7 +88,7 @@ namespace Dynamo.ViewModels
             {
                 if (unpinFromNodeCommand == null)
                 {
-                    unpinFromNodeCommand = new DelegateCommand(UnpinFromNode);
+                    unpinFromNodeCommand = new DelegateCommand(UnpinFromNode, CanUnpinFromNode);
                 }
                 return unpinFromNodeCommand;
             }

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7561,6 +7561,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unpin this note from the node.
+        /// </summary>
+        public static string UnpinNodeTooltip {
+            get {
+                return ResourceManager.GetString("UnpinNodeTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An update is available for Dynamo.
         ///Installing the latest update requires Dynamo and any host applications to close.
         ///Do you want to install the latest Dynamo update?.

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -799,6 +799,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unpin from node.
+        /// </summary>
+        public static string ContextUnpinFromNode {
+            get {
+                return ResourceManager.GetString("ContextUnpinFromNode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Continue.
         /// </summary>
         public static string ContinueButton {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3034,4 +3034,7 @@ To install the latest version of a package, click Install. \n
   <data name="ContextUnpinFromNode" xml:space="preserve">
     <value>Unpin from node</value>
   </data>
+  <data name="UnpinNodeTooltip" xml:space="preserve">
+    <value>Unpin this note from the node</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3027,8 +3027,11 @@ To install the latest version of a package, click Install. \n
   </data>
   <data name="TourLabelProgressText" xml:space="preserve">
     <value>of</value>
-   </data>
+  </data>
   <data name="StartTourButtonText" xml:space="preserve">
     <value>Start Tour</value>
+  </data>
+  <data name="ContextUnpinFromNode" xml:space="preserve">
+    <value>Unpin from node</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3018,4 +3018,7 @@ To install the latest version of a package, click Install. \n
   <data name="ContextUnpinFromNode" xml:space="preserve">
     <value>Unpin from node</value>
   </data>
+  <data name="UnpinNodeTooltip" xml:space="preserve">
+    <value>Unpin this note from the node</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3015,4 +3015,7 @@ To install the latest version of a package, click Install. \n
   <data name="StartTourButtonText" xml:space="preserve">
     <value>Start Tour</value>
   </data>
+  <data name="ContextUnpinFromNode" xml:space="preserve">
+    <value>Unpin from node</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -217,6 +217,7 @@ namespace Dynamo.ViewModels
                 case nameof(NoteModel.PinnedNode):
                     RaisePropertyChanged(nameof(this.PinnedNode));
                     PinToNodeCommand.RaiseCanExecuteChanged();
+                    UnpinFromNodeCommand.RaiseCanExecuteChanged();
                     break;
 
             }
@@ -310,7 +311,6 @@ namespace Dynamo.ViewModels
 
             WorkspaceModel.RecordModelsForModification(new List<ModelBase> { this.Model }, WorkspaceViewModel.Model.UndoRecorder);
             WorkspaceViewModel.HasUnsavedChanges = true;
-
         }
 
         private bool CanPinToNode(object parameters)
@@ -341,6 +341,36 @@ namespace Dynamo.ViewModels
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// This method will be executed for validate if the "Unpin from node" option should be shown or not in the context menu (when clicking right over the note)
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        private bool CanUnpinFromNode(object parameters)
+        {
+
+            var nodeSelection = DynamoSelection.Instance.Selection
+                    .OfType<NodeModel>();
+
+            var noteSelection = DynamoSelection.Instance.Selection
+                    .OfType<NoteModel>();
+
+            if (nodeSelection == null || noteSelection == null ||
+                nodeSelection.Count() != 1 || noteSelection.Count() != 1)
+                return false;
+
+            var nodeToPin = nodeSelection.FirstOrDefault();
+
+            var nodeAlreadyPinned = WorkspaceViewModel.Notes
+                .Where(n => n.PinnedNode != null)
+                .Any(n => n.PinnedNode.NodeModel.GUID == nodeToPin.GUID);
+
+            if (nodeAlreadyPinned == true)
+                return true;
+
+            return false;
         }
 
         private void UnpinFromNode(object parameters)

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml
@@ -81,7 +81,7 @@
                           Command="{Binding Path=UnpinFromNodeCommand}"
                           ToolTipService.ShowOnDisabled="True">
                     <MenuItem.ToolTip>
-                        <ToolTip Content="Unpin this note from the node" Style="{StaticResource GenericToolTipLight}"/>
+                        <ToolTip Content="{x:Static p:Resources.UnpinNodeTooltip}" Style="{StaticResource GenericToolTipLight}"/>
                     </MenuItem.ToolTip>
                 </MenuItem>
             </ContextMenu>

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml
@@ -76,6 +76,14 @@
                         <ToolTip Content="Select a node to pin to this note" Style="{StaticResource GenericToolTipLight}"/>
                     </MenuItem.ToolTip>
                 </MenuItem>
+                <MenuItem Name="UnpinToNode"
+                          Header="{x:Static p:Resources.ContextUnpinFromNode}" 
+                          Command="{Binding Path=UnpinFromNodeCommand}"
+                          ToolTipService.ShowOnDisabled="True">
+                    <MenuItem.ToolTip>
+                        <ToolTip Content="Unpin this note from the node" Style="{StaticResource GenericToolTipLight}"/>
+                    </MenuItem.ToolTip>
+                </MenuItem>
             </ContextMenu>
         </Grid.ContextMenu>
         <Canvas Background="{x:Null}">

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -98,7 +98,8 @@ namespace Dynamo.Nodes
            if (this.ViewModel.Model.PinnedNode != null)
             {
             var nodeGuid = this.ViewModel.Model.PinnedNode.GUID;
-                DynamoSelection.Instance.Selection.Add(ViewModel.Model.PinnedNode);
+                //We have to use AddUnique due that otherwise the node will be added several times when we click right over the note
+                DynamoSelection.Instance.Selection.AddUnique(ViewModel.Model.PinnedNode);
             }
             BringToFront();
 


### PR DESCRIPTION
### Purpose

I added the new option "unpin from node" in the Note Context Menu and also added the needed resources.
Also I added a new method CanUnpinFromNode so it will manage when the option will be enabled and disabled in the context menu.
Finally I did a fix in NoteView.xaml.cs due that every time that the right click was pressed over the note a new DoubleInput (number) node was added to the selection so it was making the CanUnpinFromNode() method to be non working in some cases.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

 Added the new option "unpin from node" in the note Context Menu

### Reviewers

@QilongTang 

### FYIs

@filipeotero 
