### PR TITLE
Update pkg `inUse` check

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -503,7 +503,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="package">package version being downloaded</param>
         /// <param name="duplicatePackage">local package found to be duplicate of one being downloaded</param>
-        /// <param name="conflicts">List of packages that are in conflict with the dependencies of the package version to be downloaded (does not include the main package)</param>
+        /// <param name="dependencyConflicts">List of packages that are in conflict with the dependencies of the package version to be downloaded (does not include the main package)</param>
         /// <returns>True if the User opted to continue with the download operation. False otherwise</returns>
         private bool WarnAboutDuplicatePackageConflicts(PackageVersion package, 
                                                         Package duplicatePackage, 

--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -488,10 +488,12 @@ namespace Dynamo.PackageManager
             return Directory.EnumerateFiles(RootDirectory, "*", SearchOption.AllDirectories).Any(s => s == path);
         }
 
+        // Checks if the package is used in the Dynamo model.
+        // The check does not take into account the package load state.
         internal bool InUse(DynamoModel dynamoModel)
         {
             return (LoadedAssemblies.Any() || IsWorkspaceFromPackageOpen(dynamoModel) || 
-                IsCustomNodeFromPackageInUse(dynamoModel)) && LoadState.State == PackageLoadState.StateTypes.Loaded;
+                IsCustomNodeFromPackageInUse(dynamoModel));
         }
 
         private bool IsCustomNodeFromPackageInUse(DynamoModel dynamoModel)


### PR DESCRIPTION
### Purpose

The method `InUse` will only check if the package is used in the Dynamo model regardless of the package load status
https://jira.autodesk.com/browse/DYN-4455

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

The method `InUse` will only check if the package is used in the Dynamo model regardless of the package load status


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
