### PR TITLE
performance graphs should be in manual run mode.

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/graphs/PythonReplication.dyn
+++ b/tools/Performance/DynamoPerformanceTests/graphs/PythonReplication.dyn
@@ -79,7 +79,7 @@
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
       "Version": "2.11.0.3854",
-      "RunType": "Automatic",
+      "RunType": "Manual",
       "RunPeriod": "1000"
     },
     "Camera": {


### PR DESCRIPTION
Python replication graph "OPEN" is failing on the perf CI since novemberish. 
It appears this graph has its run mode set to automatic so it's likely that it's runtime was affected by some changes to python updates / removal...

The underlying custom node graph that is referenced by this graph did have its engine type changed to `cpython` 2 months ago.

if this causes a failure on the CI still, we may need to update the baseline for the "RUN" perf test for this graph.
