### PR TITLE
Add test for GetExternalFiles not executing concurrently with graph execution

### DIFF
--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -342,5 +342,21 @@ namespace DynamoCoreWpfTests
                 Assert.Contains(dependencyInfo.Name, dependenciesList);
             }
         }
+        [Test]
+        public void GetExternalFilesShouldBailIfGraphExecuting()
+        {
+            DynamoModel.IsTestMode = false;
+
+            // Open test file to verify the external file references. 
+            var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
+            Open(examplePath);
+            (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = false;
+            var results = Model.CurrentWorkspace.ExternalFiles;
+            Assert.AreEqual(0, results.Count());
+            (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = true;
+            results = Model.CurrentWorkspace.ExternalFiles;
+            Assert.AreEqual(2, results.Count());
+
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -347,7 +347,7 @@ namespace DynamoCoreWpfTests
         {
             DynamoModel.IsTestMode = false;
 
-            // Open test file to verify the external file references. 
+            // Open test file to verify the external file references are not computed when RunEnabled is false. 
             var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
             Open(examplePath);
             (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = false;


### PR DESCRIPTION
Adds simple test for https://github.com/DynamoDS/Dynamo/pull/12564