### PR TITLE
DYN-4135-UnpinFromNode Unpinning Fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -350,24 +350,7 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private bool CanUnpinFromNode(object parameters)
         {
-
-            var nodeSelection = DynamoSelection.Instance.Selection
-                    .OfType<NodeModel>();
-
-            var noteSelection = DynamoSelection.Instance.Selection
-                    .OfType<NoteModel>();
-
-            if (nodeSelection == null || noteSelection == null ||
-                nodeSelection.Count() != 1 || noteSelection.Count() != 1)
-                return false;
-
-            var nodeToPin = nodeSelection.FirstOrDefault();
-
-            var nodeAlreadyPinned = WorkspaceViewModel.Notes
-                .Where(n => n.PinnedNode != null)
-                .Any(n => n.PinnedNode.NodeModel.GUID == nodeToPin.GUID);
-
-            if (nodeAlreadyPinned == true)
+            if (PinnedNode != null)
                 return true;
 
             return false;


### PR DESCRIPTION
### Purpose

A bug was reported by Aabi that the functionality was not unpinning from the node if both (node, note) were not selected when clicking the unpin icon. Then I did a fix that the CanUnpinFromNode won't check if the nodes are selected or not, it will only check if the note has a pinned node or not.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing bug that was not unpinning from the node if both (node, note) were not selected 


### Reviewers

@QilongTang 

### FYIs

@filipeotero 
