### PR TITLE
Dyn 4412 filters package manager

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -867,8 +867,8 @@ namespace Dynamo.PackageManager
             if (SelectedHosts.Count == 0) return list;
             IEnumerable<PackageManagerSearchElementViewModel> filteredList = null;
 
-            filteredList = (filteredList ?? Enumerable.Empty<PackageManagerSearchElementViewModel>()).Union(
-                list.Where(x => x.Model.Hosts != null && SelectedHosts.Intersect(x.Model.Hosts).Count() == SelectedHosts.Count()) ?? Enumerable.Empty<PackageManagerSearchElementViewModel>());
+            filteredList = filteredList ??
+                           list.Where(x => x.Model.Hosts != null && SelectedHosts.Intersect(x.Model.Hosts).Count() == SelectedHosts.Count()) ?? Enumerable.Empty<PackageManagerSearchElementViewModel>();
 
             return filteredList;
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -866,11 +866,10 @@ namespace Dynamo.PackageManager
             // No need to filter by host if nothing selected
             if (SelectedHosts.Count == 0) return list;
             IEnumerable<PackageManagerSearchElementViewModel> filteredList = null;
-            foreach (var host in SelectedHosts)
-            {
-                filteredList = (filteredList ?? Enumerable.Empty<PackageManagerSearchElementViewModel>()).Union(
-                    list.Where(x => x.Model.Hosts != null && x.Model.Hosts.Contains(host)) ?? Enumerable.Empty<PackageManagerSearchElementViewModel>());
-            }
+
+            filteredList = (filteredList ?? Enumerable.Empty<PackageManagerSearchElementViewModel>()).Union(
+                list.Where(x => x.Model.Hosts != null && SelectedHosts.Intersect(x.Model.Hosts).Count() == SelectedHosts.Count()) ?? Enumerable.Empty<PackageManagerSearchElementViewModel>());
+
             return filteredList;
         }
 

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -6,6 +6,8 @@ using Greg.Responses;
 using Greg;
 using Dynamo.Tests;
 using Dynamo.ViewModels;
+using System.Collections.Generic;
+using static Dynamo.PackageManager.PackageManagerSearchViewModel;
 
 namespace Dynamo.PackageManager.Wpf.Tests
 {
@@ -98,6 +100,106 @@ namespace Dynamo.PackageManager.Wpf.Tests
             Assert.AreEqual(false, newSE2.CanInstall);
 
             packageManagerSearchViewModel.ClearSearchResults();
+        }
+
+        /// <summary>
+        /// This unit test will validate that after we set the filters in the package search, we will get an intersection of the results (instead of a union)
+        /// </summary>
+        [Test]
+        public void PackageSearchDialogSearchIntersectAgainstFilters()
+        {
+            //Arrange
+            int numberOfPackages = 9;
+            string packageId = "c5ecd20a-d41c-4e0c-8e11-8ddfb953d77f";
+            string packageVersionNumber = "1.0.0.0";
+            string packageCreatedDateString = "2016 - 12 - 02T13:13:20.135000 + 00:00";
+            string advSteelFilterName = "Advance Steel";
+            string formItFilterName = "FormIt";
+
+            //Formit Packages
+            List<string> formItPackagesName = new List<string> { "DynamoIronPython2.7", "dynamo", "Celery for Dynamo 2.5" };
+            //Advance Steel Packages
+            List<string> advanceSteelPackagesName = new List<string> { "DynamoIronPython2.7", "dynamo", "mise en barre", "Test-PackageDependencyFilter" };
+            //Advance Steel Packages & Formit
+            List<string> intersectionPackagesName = new List<string> { "DynamoTestPackage1", "DynamoTestPackage2"};
+
+            var mockGreg = new Mock<IGregClient>();
+            var clientmock = new Mock<PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
+            var pmCVM = new Mock<PackageManagerClientViewModel>(ViewModel, clientmock.Object);
+
+            var packageManagerSearchViewModel = new PackageManagerSearchViewModel(pmCVM.Object);
+            packageManagerSearchViewModel.RegisterTransientHandlers();
+
+            //Adds the filters for FormIt and Advance Steel
+            packageManagerSearchViewModel.HostFilter = new List<FilterEntry>
+            {
+                new FilterEntry(advSteelFilterName, packageManagerSearchViewModel) { OnChecked = true },
+                new FilterEntry(formItFilterName, packageManagerSearchViewModel) { OnChecked = true },
+            };
+
+            //Adding FormIt packages
+            foreach (var package in formItPackagesName)
+            {
+                var tmpPackageVersion = new PackageVersion { version = packageVersionNumber, host_dependencies = new List<string> { formItFilterName }, created = packageCreatedDateString };
+                var tmpPackage = new PackageManagerSearchElementViewModel(new PackageManagerSearchElement(new PackageHeader()
+                {
+                    _id = packageId,
+                    name = package,
+                    versions = new List<PackageVersion> { tmpPackageVersion },
+                    host_dependencies = new List<string> { formItFilterName },
+                }), false);
+                packageManagerSearchViewModel.AddToSearchResults(tmpPackage);
+            }
+
+            //Adding Advance Steel packages
+            foreach (var package in advanceSteelPackagesName)
+            {
+                var tmpPackageVersion = new PackageVersion { version = packageVersionNumber, host_dependencies = new List<string> { advSteelFilterName }, created = packageCreatedDateString };
+                var tmpPackage = new PackageManagerSearchElementViewModel(new PackageManagerSearchElement(new PackageHeader()
+                {
+                    _id = packageId,
+                    name = package,
+                    versions = new List<PackageVersion> { tmpPackageVersion },
+                    host_dependencies = new List<string> { advSteelFilterName },
+                }), false);
+                packageManagerSearchViewModel.AddToSearchResults(tmpPackage);
+            }
+
+            //Adding packages that belong to FormIt and Advance Steel (intersection packages)
+            foreach (var package in intersectionPackagesName)
+            {
+                var tmpPackageVersion = new PackageVersion { version = packageVersionNumber, host_dependencies = new List<string> { advSteelFilterName, formItFilterName }, created = packageCreatedDateString };
+                var tmpPackage = new PackageManagerSearchElementViewModel(new PackageManagerSearchElement(new PackageHeader()
+                {
+                    _id = packageId,
+                    name = package,
+                    versions = new List<PackageVersion> { tmpPackageVersion },
+                    host_dependencies = new List<string> { advSteelFilterName, formItFilterName },
+                }), false);
+                packageManagerSearchViewModel.AddToSearchResults(tmpPackage);
+            }
+
+            //We need to add the PackageManagerSearchElementViewModel because otherwise the search will crash
+            packageManagerSearchViewModel.LastSync = new List<PackageManagerSearchElement>();
+            foreach (var result in packageManagerSearchViewModel.SearchResults)
+            {
+                packageManagerSearchViewModel.LastSync.Add(result.Model);
+            }
+
+            //Validate the total added packages match
+            Assert.That(packageManagerSearchViewModel.SearchResults.Count == numberOfPackages);
+
+            //Act
+            //Check the Advance Steel filter
+            packageManagerSearchViewModel.HostFilter[0].FilterCommand.Execute(advSteelFilterName);
+            //Check the FormIt filter
+            packageManagerSearchViewModel.HostFilter[1].FilterCommand.Execute(formItFilterName);
+
+            //Assert
+            //Validates that we have results and that the result match the expected 2 packages (intersection)
+            Assert.IsNotNull(packageManagerSearchViewModel.SearchResults, "There was no results");
+            Assert.That(packageManagerSearchViewModel.SearchResults.Count > 0, "There was no results");
+            Assert.That(packageManagerSearchViewModel.SearchResults.Count == intersectionPackagesName.Count, "The search results are not getting the packages intersected");
         }
     }
 }


### PR DESCRIPTION
### Purpose

I did a fix in PackageManagerSearchViewModel.cs, so the filter after getting the result will be doing an intersection instead of a union.
Also I added a unit test that will adding 9 packages in total, 3 are from FormIt, 4 are from Advance Steel, and 2 are from both Formit and Advance Steel, then after applying the filters Formit and Advanced steel we will get only the two of them that belong to those two categories.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix in PackageManage Search functionality so will filter after getting the result will be doing an intersection instead of a union.

### Reviewers

@QilongTang 

### FYIs

