### PR TITLE
DYN-4472-Localization-InstallPackageTour

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5263,6 +5263,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Install a package.
+        /// </summary>
+        public static string PackagesGuideInstallAPackageTitle {
+            get {
+                return ResourceManager.GetString("PackagesGuideInstallAPackageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package installations are typically quick, depending on their size and other factors. \n
         ///To install the latest version of a package, click Install. \n
         ///%./UI/Images/alert.png% The sample Autodesk package is already installed on your computer..

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3021,4 +3021,7 @@ To install the latest version of a package, click Install. \n
   <data name="UnpinNodeTooltip" xml:space="preserve">
     <value>Unpin this note from the node</value>
   </data>
+  <data name="PackagesGuideInstallAPackageTitle" xml:space="preserve">
+    <value>Install a package</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

The PackagesGuideInstallAPackageTitle resource was missing in Resources.resx, then that's why when the language was RU it was showing the title untranslated. I've just added the resource in the resx file.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

The title in the "install a package" popup was appearing not translated because the resource was missing


### Reviewers

@zeusongit 

### FYIs

