### PR TITLE
Dynamo Freeze context menu item should be enabled when multiple nodes selected.

### DIFF
--- a/src/DynamoCoreWpf/Commands/NodeCommands.cs
+++ b/src/DynamoCoreWpf/Commands/NodeCommands.cs
@@ -194,7 +194,7 @@ namespace Dynamo.ViewModels
             {
                 if (_computeRunStateOfTheNodeCommand == null)
                 {
-                    _computeRunStateOfTheNodeCommand = new DelegateCommand(ToggleIsFrozen, CanToggleIsFrozen);
+                    _computeRunStateOfTheNodeCommand = new DelegateCommand(ToggleIsFrozen);
                 }
 
                 return _computeRunStateOfTheNodeCommand;

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1614,11 +1614,6 @@ namespace Dynamo.ViewModels
             Analytics.TrackEvent(Actions.Freeze, Categories.NodeContextMenuOperations);
         }
 
-        private bool CanToggleIsFrozen(object parameters)
-        {
-            return DynamoSelection.Instance.Selection.Count() == 1;
-        }
-
         private void RaiseFrozenPropertyChanged()
         {
             RaisePropertyChanged("IsFrozen");


### PR DESCRIPTION
### Purpose

This PR address the task: https://jira.autodesk.com/browse/DYN-4300

The freeze menu item is already binded to the CanToggleFrozen property on NodeViewModel. This should handle enabling or disabling the freeze context menu. However, there was another property CanToggleIsFrozen on the NodeViewModel which was linked to ToggleIsFrozenCommand but i don't see any need for this. We can remove this redundant property which would fix the issue. 

![Freeze context menu](https://user-images.githubusercontent.com/43763136/152808157-ee4b0e99-e318-42dd-8799-1d95a1e2d80a.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Dynamo Freeze context menu item should be enabled when multiple nodes selected

### Reviewers
@QilongTang @zeusongit 

