### PR TITLE
Thread safe MouseManipulator and some speed improvements

### DIFF
--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -196,7 +196,7 @@ namespace Dynamo.Manipulation
                 {
                     var amount = offset.Dot(v);
 
-                    if (Math.Abs(amount) > 0.001)
+                    if (Math.Abs(amount) > MIN_OFFSET_VAL)
                     {
                         dynamic uiNode = item.Value.Item2;
                         inputNodes.Add((uiNode, uiNode.Value + amount));

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Windows.Input;
 using Autodesk.DesignScript.Geometry;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -43,8 +43,10 @@ namespace Dynamo.Manipulation
         private const double NewNodeOffsetY = 50;
         private bool active;
         private string warning = string.Empty;
-
+        private Point originBeforeMove;// The manipulator position before the user moves the gizmo
+        private Point originAfterMove;// The manipulator position after the user moves the gizmo
         protected const double gizmoScale = 1.2;
+        protected readonly int ROUND_UP_PARAM = 3;
 
         #region properties
 
@@ -182,7 +184,14 @@ namespace Dynamo.Manipulation
         {
             if (!IsValidNode) return;
 
+            if (!Node.IsSelected) return;
+
             active = UpdatePosition();
+            if (Origin != null )
+            {
+                originBeforeMove = Point.ByCoordinates(Origin.X, Origin.Y, Origin.Z);
+                originAfterMove = Point.ByCoordinates(Origin.X, Origin.Y, Origin.Z);
+            }
 
             GizmoInAction = null; //Reset Drag.
 
@@ -222,6 +231,20 @@ namespace Dynamo.Manipulation
         {
             GizmoInAction = null;
 
+            if (originBeforeMove != null && originAfterMove != null)
+            {
+                var inputNodesToManipulate = InputNodesToUpdateAfterMove(Vector.ByTwoPoints(originBeforeMove, originAfterMove));
+                foreach (var (inputNode, amount) in inputNodesToManipulate)
+                {
+                    if (inputNode == null) continue;
+
+                    if (Math.Abs(amount) < 0.001) continue;
+
+                    dynamic uiNode = inputNode;
+                    uiNode.Value = Math.Round(amount, ROUND_UP_PARAM);
+                }
+            }
+
             //Update gizmo graphics after every camera view change
             var gizmos = GetGizmos(false);
             foreach (var gizmo in gizmos)
@@ -250,6 +273,13 @@ namespace Dynamo.Manipulation
 
             var offset = GizmoInAction.GetOffset(clickRay.GetOriginPoint(), clickRay.GetDirectionVector());
             if (offset.Length < 0.01) return;
+
+            if (originAfterMove != null)
+            {
+                var offsetPos = originAfterMove.Add(offset);
+                originAfterMove.Dispose();
+                originAfterMove = offsetPos;
+            }
 
             // Update input nodes attached to manipulator node 
             // Doing this triggers a graph update on scheduler thread
@@ -325,6 +355,7 @@ namespace Dynamo.Manipulation
         {
             bool manipulate = false;
             inputNode = null;
+            inputNode = null;
             Tuple<int, NodeModel> val;
             if (Node.InputNodes.TryGetValue(inputPortIndex, out val))
             {
@@ -343,6 +374,16 @@ namespace Dynamo.Manipulation
                 manipulate = true;
             }
             return manipulate;
+        }
+
+        /// <summary>
+        /// Retrieves a list of InputNodes that need to be updated. This method is called when MouseUp is triggered.
+        /// </summary>
+        /// <param name="offset">The offset vector with which the manipulator was moved by the user. This param is calculated as the vector between (Origin at MouseUp) and (Origin at MouseDown)</param>
+        /// <returns>A list of InputNodes and the new values that needs to be set to those input nodes</returns>
+        protected virtual List<(NodeModel inputNode, double amount)> InputNodesToUpdateAfterMove(Vector offset)
+        {
+            return new List<(NodeModel, double)>();
         }
 
         /// <summary>
@@ -556,6 +597,12 @@ namespace Dynamo.Manipulation
             {
                 Node.ClearTransientWarning(warning);
             }
+
+            if (originBeforeMove != null)
+                originBeforeMove.Dispose();
+     
+            if (originAfterMove != null)
+                originAfterMove.Dispose();
 
             DeleteGizmos();
             DetachHandlers();

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -376,10 +376,10 @@ namespace Dynamo.Manipulation
         }
 
         /// <summary>
-        /// Retrieves a list of InputNodes that need to be updated. This method is called when MouseUp is triggered.
+        /// Retrieves a list of InputNodes that need to be updated after the manipulator is moved. This method is called when MouseUp is triggered.
         /// </summary>
-        /// <param name="offset">The offset vector with which the manipulator was moved by the user. This param is calculated as the vector between (Origin at MouseUp) and (Origin at MouseDown)</param>
-        /// <returns>A list of InputNodes and the new values that needs to be set to those input nodes</returns>
+        /// <param name="offset">The offset vector with which the manipulator was moved by the user. This param is calculated as the vector between (Origin at MouseDown) and (Origin at MouseUp)</param>
+        /// <returns>A list of InputNodes and the new values that needs to be set to the corresponding input nodes</returns>
         protected virtual List<(NodeModel inputNode, double amount)> InputNodesToUpdateAfterMove(Vector offset)
         {
             return new List<(NodeModel, double)>();

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -47,6 +47,7 @@ namespace Dynamo.Manipulation
         private Point originAfterMove;// The manipulator position after the user moves the gizmo
         protected const double gizmoScale = 1.2;
         protected readonly int ROUND_UP_PARAM = 3;
+        protected readonly double MIN_OFFSET_VAL = 0.001;
 
         #region properties
 
@@ -184,8 +185,6 @@ namespace Dynamo.Manipulation
         {
             if (!IsValidNode) return;
 
-            if (!Node.IsSelected) return;
-
             active = UpdatePosition();
             if (Origin != null )
             {
@@ -238,7 +237,7 @@ namespace Dynamo.Manipulation
                 {
                     if (inputNode == null) continue;
 
-                    if (Math.Abs(amount) < 0.001) continue;
+                    if (Math.Abs(amount) < MIN_OFFSET_VAL) continue;
 
                     dynamic uiNode = inputNode;
                     uiNode.Value = Math.Round(amount, ROUND_UP_PARAM);

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -354,7 +354,6 @@ namespace Dynamo.Manipulation
         {
             bool manipulate = false;
             inputNode = null;
-            inputNode = null;
             Tuple<int, NodeModel> val;
             if (Node.InputNodes.TryGetValue(inputPortIndex, out val))
             {

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -134,16 +134,16 @@ namespace Dynamo.Manipulation
                     param = curve.ParameterAtPoint(closestPosition);
                 }
             }
-            param = Math.Round(param, 3);
-            
+            param = Math.Round(param, ROUND_UP_PARAM);
+
             tangent = curve.TangentAtParameter(param);
             pointOnCurve = curve.PointAtParameter(param);
+        }
 
-            if (inputNode != null)
-            {
-                dynamic uinode = inputNode;
-                uinode.Value = param;
-            }
+        protected override List<(NodeModel inputNode, double amount)> InputNodesToUpdateAfterMove(Vector offset)
+        {
+            double param = curve.ParameterAtPoint(pointOnCurve);
+            return new List<(NodeModel, double)>() { (inputNode, param) };
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
https://jira.autodesk.com/browse/DYN-4475

### Purpose

1. NodeManipulators will no longer update the graph on every MouseMove notification. 
    The graph will be update only on MouseUp.
    The Gizmo graphics will still be updated on each Mouse Move
2. Some of the MouseManipulator internal data is accessed from multiple threads.
    That data was made thread safe
    
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Thread safe MouseManipulator and some speed improvements


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
