### PR TITLE
Bump up libg version to .13.0.7686

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -21,10 +21,10 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_227_0_0" Version="2.13.0.6926" GeneratePathProperty="true">
+	<PackageReference Include="DynamoVisualProgramming.LibG_227_0_0" Version="2.13.0.7687" GeneratePathProperty="true">
 		<ExcludeAssets>all</ExcludeAssets>
 	</PackageReference>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" GeneratePathProperty="true" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" GeneratePathProperty="true" />
 	<PackageReference Include="Greg" Version="2.1.8012.31283" />
 	<PackageReference Include="Newtonsoft.Json" Version="8.0.3" CopyXML="true"/>
 	<PackageReference Include="RestSharp" Version="106.12.0" CopyXML="true"/>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -13,7 +13,7 @@
     <EnableDefaultEmbeddedResourceItems>False</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
 	<PackageReference Include="Greg" Version="2.1.8012.31283" />
 	<PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
 	<PackageReference Include="RestSharp" Version="106.12.0" />

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -50,7 +50,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -15,7 +15,7 @@
     <None Remove="AnalysisImages.resources" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">
       <Project>{7858fa8c-475f-4b8e-b468-1f8200778cf8}</Project>
       <Name>DynamoCore</Name>

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <PackageReference Include="ncalc" Version="1.3.8">
       <!--Exclude copying the runtime dlls because we need to keep binary compatibility with Revit for now -->
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/src/Libraries/GeometryColor/GeometryColor.csproj
+++ b/src/Libraries/GeometryColor/GeometryColor.csproj
@@ -11,7 +11,7 @@
     <DocumentationFile>$(OutputPath)\$(UICulture)\GeometryColor.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">

--- a/src/Libraries/GeometryUI/GeometryUI.csproj
+++ b/src/Libraries/GeometryUI/GeometryUI.csproj
@@ -17,7 +17,7 @@
 	 </ReferenceCopyLocalPaths>
 	</ItemDefinitionGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
 	<PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -17,7 +17,7 @@
 	</ReferenceCopyLocalPaths>
   </ItemDefinitionGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />

--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -11,7 +11,7 @@
     <DocumentationFile>$(OutputPath)\$(UICulture)\Tessellation.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" version="2.13.0.6925" />
+	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" version="2.13.0.7686" />
 	<PackageReference Include="MIConvexHull" version="1.1.17.0411" CopyPDB="true" />
 	<PackageReference Include="StarMath" version="2.0.14.1114" CopyPDB="true" />
   </ItemGroup>

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <PackageReference Include="Greg" Version="2.1.8012.31283" />
     <PackageReference Include="Magick.NET.Core" Version="7.0.1" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="2.6.3" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
+++ b/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.2.1507.0118" />
 	  <PackageReference Include="NUnit" Version="2.6.3" />
-	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
     <PackageReference Include="NUnit" Version="2.6.3" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
     <Reference Include="Microsoft.Practices.Prism">

--- a/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
+++ b/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="NUnit" Version="2.6.3" />
-	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/test/Libraries/IronPythonTests/IronPythonTests.csproj
+++ b/test/Libraries/IronPythonTests/IronPythonTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
 	  <PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
 	  <PackageReference Include="NUnit" Version="2.6.3" />
-	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
 	  <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />
 	  <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
 	  <PackageReference Include="IronPython" Version="2.7.9" />

--- a/test/Libraries/TestServices/TestServices.csproj
+++ b/test/Libraries/TestServices/TestServices.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="NUnit" Version="2.6.3" />
-	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="NUnit" Version="2.6.3" />
-	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.6925" />
+	  <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>


### PR DESCRIPTION
### Purpose

Bump up libg version to DynamoVisualProgramming.LibG_228_0_0 Version=2.13.0.7686

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Bump up libg version to DynamoVisualProgramming.LibG_228_0_0 Version=2.13.0.7686


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
