### PR TITLE
OutlinedButtonStyle add button shadow

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -3727,6 +3727,14 @@
         </Style.Triggers>
     </Style>
 
+    <SolidColorBrush x:Key="Button.Outline.MouseOver.Border"
+                     Opacity="0.15"
+                     Color="#FFFFFF" />
+    <SolidColorBrush x:Key="Button.Outline.Pressed.Border"
+                     Opacity="0.35"
+                     Color="#38ABDF" />
+    <SolidColorBrush x:Key="Button.Outline.Default.Border"
+                     Color="Transparent" />
     <!--  This Style will be used for the Buttons that have a border and transparent background like Save and Cancel in the Preferences->Visual Settings tab  -->
     <Style x:Key="OutlinedButtonStyle" TargetType="Button">
         <Setter Property="Foreground" Value="{StaticResource PreferencesWindowFontColor}" />
@@ -3734,33 +3742,26 @@
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
                     <Border x:Name="ButtonBorder"
+                            BorderThickness="2"
                             Background="Transparent"
-                            BorderBrush="#E0E0E0"
-                            BorderThickness="0.5"
-                            CornerRadius="4">
-                        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
-                            <ContentPresenter />
-                        </TextBlock>
+                            BorderBrush="{StaticResource Button.Outline.Default.Border}"
+                            CornerRadius="2">
+                        <Grid Background="Transparent">
+                            <Rectangle Stroke="#FFFFFF" RadiusX="2" RadiusY="2" Opacity="0.5" StrokeThickness="1"></Rectangle>
+                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <ContentPresenter />
+                            </TextBlock>
+                        </Grid>
                     </Border>
                     <!--  According to the Hig Autodesk standards for Outlined buttons some colors/properties will be changed according to the event generated  -->
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Button.Effect">
-                                <Setter.Value>
-                                    <DropShadowEffect BlurRadius="5"
-                                                      Direction="320"
-                                                      Opacity="0.5"
-                                                      ShadowDepth="3"
-                                                      Color="Black" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter TargetName="ButtonBorder" Property="BorderThickness" Value="1" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="{StaticResource Button.Outline.MouseOver.Border}" />
                             <Setter TargetName="ButtonBorder" Property="BorderThickness" Value="2" />
                         </Trigger>
-                        <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#A2D4EB" />
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="{StaticResource Button.Outline.Pressed.Border}" />
+                            <Setter TargetName="ButtonBorder" Property="BorderThickness" Value="2" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
### Purpose

This PR is to adjust the button style of the Group Style preferences window as discussed in this [task](https://jira.autodesk.com/browse/DYN-4542?focusedCommentId=8484246&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-8484246).

![StyleButtonShadow](https://user-images.githubusercontent.com/89042471/153946606-81df630e-c2be-46bb-aa9c-5aa205def502.gif)


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 @jesusalvino 
