### PR TITLE
Dyn3629

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -530,6 +530,7 @@ namespace Dynamo.ViewModels
                         MessageBoxService.Show(message, Resources.CannotDownloadPackageMessageBoxTitle,
                             MessageBoxButton.OK, MessageBoxImage.Exclamation);
                     }
+                    //TODO add logging.
                     return false;// All conflicts with built-in packages must be first resolved manually before continuing to download.
                 }
 
@@ -609,7 +610,7 @@ namespace Dynamo.ViewModels
                 // Conflicts with builtin packages
                 var message = string.Format(Resources.MessagePackageDepsInBuiltinPackages, packageToDownload,
                         JoinPackageNames(builtinPackages));
-
+                //TODO add logging
                 var dialogResult = MessageBoxService.Show(message,
                     Resources.BuiltInPackageConflictMessageBoxTitle,
                     MessageBoxButton.OKCancel, MessageBoxImage.Exclamation);

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -12,6 +12,7 @@ using System.Windows.Input;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Logging;
 using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.PackageManager.UI;
@@ -530,7 +531,7 @@ namespace Dynamo.ViewModels
                         MessageBoxService.Show(message, Resources.CannotDownloadPackageMessageBoxTitle,
                             MessageBoxButton.OK, MessageBoxImage.Exclamation);
                     }
-                    //TODO add logging.
+                    Analytics.TrackEvent(Actions.BuiltInPackageConflict, Categories.PackageManagerOperations, packageToDownload);
                     return false;// All conflicts with built-in packages must be first resolved manually before continuing to download.
                 }
 
@@ -610,7 +611,7 @@ namespace Dynamo.ViewModels
                 // Conflicts with builtin packages
                 var message = string.Format(Resources.MessagePackageDepsInBuiltinPackages, packageToDownload,
                         JoinPackageNames(builtinPackages));
-                //TODO add logging
+                Analytics.TrackEvent(Actions.BuiltInPackageConflict, Categories.PackageManagerOperations, packageToDownload);
                 var dialogResult = MessageBoxService.Show(message,
                     Resources.BuiltInPackageConflictMessageBoxTitle,
                     MessageBoxButton.OKCancel, MessageBoxImage.Exclamation);

--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -83,7 +83,7 @@ namespace Dynamo.PackageManager
 
         internal void SetAsLoaded() { state = StateTypes.Loaded; errorMessage = ""; }
         internal void SetAsError(string msg = "") { state = StateTypes.Error; errorMessage = msg; }
-        internal void SetAsUnloaded() { state = StateTypes.Unloaded; /*TODO logging?*/ errorMessage = ""; }
+        internal void SetAsUnloaded() { state = StateTypes.Unloaded; errorMessage = ""; }
         internal void ResetState() { state = StateTypes.None; }
 
         internal void SetScheduledForDeletion() { scheduledState = ScheduledTypes.ScheduledForDeletion; }
@@ -528,7 +528,7 @@ namespace Dynamo.PackageManager
         {
             if (BuiltInPackage) 
             {
-                //TODO add logging, someone marked built in package for unload.
+                Analytics.TrackEvent(Actions.BuiltInPackageConflict, Categories.PackageManagerOperations, $"{Name } {versionName} marked to be unloaded");
                 LoadState.SetScheduledForUnload();
             } 
             else
@@ -600,6 +600,8 @@ namespace Dynamo.PackageManager
                 if (BuiltInPackage)
                 {
                     LoadState.SetAsUnloaded();
+                    Analytics.TrackEvent(Actions.BuiltInPackageConflict, Categories.PackageManagerOperations, $"{Name } {versionName} set unloaded");
+
                     RaisePropertyChanged(nameof(LoadState));
 
                     if (!prefs.PackageDirectoriesToUninstall.Contains(RootDirectory))

--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -83,7 +83,7 @@ namespace Dynamo.PackageManager
 
         internal void SetAsLoaded() { state = StateTypes.Loaded; errorMessage = ""; }
         internal void SetAsError(string msg = "") { state = StateTypes.Error; errorMessage = msg; }
-        internal void SetAsUnloaded() { state = StateTypes.Unloaded; errorMessage = ""; }
+        internal void SetAsUnloaded() { state = StateTypes.Unloaded; /*TODO logging?*/ errorMessage = ""; }
         internal void ResetState() { state = StateTypes.None; }
 
         internal void SetScheduledForDeletion() { scheduledState = ScheduledTypes.ScheduledForDeletion; }
@@ -528,6 +528,7 @@ namespace Dynamo.PackageManager
         {
             if (BuiltInPackage) 
             {
+                //TODO add logging, someone marked built in package for unload.
                 LoadState.SetScheduledForUnload();
             } 
             else

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -357,6 +357,10 @@ namespace Dynamo.Logging
         /// Hide event, e.g when a connection is hidden by user choice
         /// </summary>
         Hide,
+        /// <summary>
+        /// When a package conflict is encountered which involves at least one built-in package.
+        /// </summary>
+        BuiltInPackageConflict, 
     }
 
     /// <summary>


### PR DESCRIPTION
### Purpose

Add logging when we encounter a conflict with a builtin library package, or a built in library package is set unloaded or scheduled to be unloaded.

related PR:
https://git.autodesk.com/Dynamo/Analytics.NET/pull/48

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Adds analytics for builtin package conflicts

### Reviewers
