### PR TITLE
input data deserialization proposal C.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -8,11 +8,17 @@ using Newtonsoft.Json.Converters;
 
 namespace Dynamo.Graph.Nodes
 {
+    // NodeInputTypes is now serialized twice as NodeInputData.Type and NodeInputData.Type2.
+    // This enables us to add new values to the enum while allowing previous dynamo versions to successfully
+    // load new files with those new types. This is the case because by default json.net ignores missing properties.
+    // So Type2 is not deserialized at all in previous versions of Dynamo.
+    // Type's setter limits the possible values to a subset of the enum to avoid clients setting this to a value that would break file
+    // deserialization in previous dynamo versions.
+    // TODO We should unify these properties (Type and Type2) when possible (Dynamo 3.x) 
+
     /// <summary>
     /// Possible graph input types. 
     /// </summary>
-    [Obsolete("please use InputTypes instead, will be removed in 3.x. Will not be updated with new types." +
-        "Serializing hostSelection or dropdownSelection will produce broken dynamo files. ")]
     [JsonConverter(typeof(StringEnumConverter))]
     public enum NodeInputTypes
     {
@@ -26,38 +32,20 @@ namespace Dynamo.Graph.Nodes
         colorInput,
         [EnumMember(Value = "date")]
         dateInput,
+        [Obsolete()]
         [EnumMember(Value = "selection")]
         selectionInput,
+        /// <summary>
+        /// Should not be used when setting NodeInputData.Type, use selection instead, can be used with Type2.
+        /// </summary>
         [EnumMember(Value = "hostSelection")]
         hostSelection,
+        /// <summary>
+        /// Should not be used when setting NodeInputData.Type, use selection instead, can be used with Type2.
+        /// </summary>
         [EnumMember(Value = "dropdownSelection")]
         dropdownSelection
     };
-    /// <summary>
-    /// Possible graph input types. This Enum replaces NodeInputTypes. 
-    /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum InputTypes
-    {
-        [EnumMember(Value = "number")]
-        numberInput,
-        [EnumMember(Value = "boolean")]
-        booleanInput,
-        [EnumMember(Value = "string")]
-        stringInput,
-        [EnumMember(Value = "color")]
-        colorInput,
-        [EnumMember(Value = "date")]
-        dateInput,
-        [Obsolete("Use hostSelection or dropdownSelection instead")]
-        [EnumMember(Value = "selection")]
-        selectionInput,
-        [EnumMember(Value = "hostSelection")]
-        hostSelection,
-        [EnumMember(Value = "dropdownSelection")]
-        dropdownSelection
-    };
-
 
     /// <summary>
     /// Represents a node which acts as a UI input for the graph
@@ -74,14 +62,28 @@ namespace Dynamo.Graph.Nodes
         /// Display name of the input node.
         /// </summary>
         public string Name { get; set; }
+        private NodeInputTypes type;
         /// <summary>
         /// The type of input this node is.
         /// </summary>
         [Obsolete("Obsolete, this member has been replaced by Type2, which may contain new input types.")]
-        public NodeInputTypes Type { get; set; }
+        public NodeInputTypes Type
+        {
+            get => type;
+            set
+            {
+                // we don't allow setting Type to these enum values as they cause old versions of dynamo to fail to load files.
+                // use NodeInputData.Type2 instead.
+                if (value is NodeInputTypes.dropdownSelection || value is NodeInputTypes.hostSelection)
+                {
+                    type = NodeInputTypes.selectionInput;
+                }
+                else { type = value; }
+            }
+        }
         /// The type of input this node is.
         /// </summary>
-        public InputTypes Type2 { get; set; }
+        public NodeInputTypes Type2 { get; set; }
         /// <summary>
         /// The value of the input when the graph was saved.
         /// This should always be a string for all types.
@@ -136,34 +138,12 @@ namespace Dynamo.Graph.Nodes
             { typeof(Int64),NodeInputTypes.numberInput},
             {typeof(float),NodeInputTypes.numberInput},
         };
-        private static Dictionary<Type, InputTypes> dotNetTypeToInputType = new Dictionary<Type, InputTypes>
-        {
-            {typeof(String),InputTypes.stringInput},
-            { typeof(Boolean),InputTypes.booleanInput},
-            { typeof(DateTime),InputTypes.dateInput},
-            { typeof(double),InputTypes.numberInput},
-            { typeof(Int32),InputTypes.numberInput},
-            { typeof(Int64),InputTypes.numberInput},
-            {typeof(float),InputTypes.numberInput},
-        };
 
         [Obsolete("To be removed in Dynamo 3.x")]
         public static NodeInputTypes getNodeInputTypeFromType(Type type)
         {
             NodeInputTypes output;
             if (dotNetTypeToNodeInputType.TryGetValue(type, out output))
-            {
-                return output;
-            }
-            else
-            {
-                throw new ArgumentException("could not find an inputType for this type");
-            }
-        }
-        internal static InputTypes GetInputTypeFromType(Type type)
-        {
-            InputTypes output;
-            if (dotNetTypeToInputType.TryGetValue(type, out output))
             {
                 return output;
             }

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -8,8 +8,36 @@ using Newtonsoft.Json.Converters;
 
 namespace Dynamo.Graph.Nodes
 {
+    /// <summary>
+    /// Possible graph input types. 
+    /// </summary>
+    [Obsolete("please use InputTypes instead, will be removed in 3.x. Will not be updated with new types." +
+        "Serializing hostSelection or dropdownSelection will produce broken dynamo files. ")]
     [JsonConverter(typeof(StringEnumConverter))]
     public enum NodeInputTypes
+    {
+        [EnumMember(Value = "number")]
+        numberInput,
+        [EnumMember(Value = "boolean")]
+        booleanInput,
+        [EnumMember(Value = "string")]
+        stringInput,
+        [EnumMember(Value = "color")]
+        colorInput,
+        [EnumMember(Value = "date")]
+        dateInput,
+        [EnumMember(Value = "selection")]
+        selectionInput,
+        [EnumMember(Value = "hostSelection")]
+        hostSelection,
+        [EnumMember(Value = "dropdownSelection")]
+        dropdownSelection
+    };
+    /// <summary>
+    /// Possible graph input types. This Enum replaces NodeInputTypes. 
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum InputTypes
     {
         [EnumMember(Value = "number")]
         numberInput,
@@ -49,7 +77,11 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// The type of input this node is.
         /// </summary>
+        [Obsolete("Obsolete, this member has been replaced by Type2, which may contain new input types.")]
         public NodeInputTypes Type { get; set; }
+        /// The type of input this node is.
+        /// </summary>
+        public InputTypes Type2 { get; set; }
         /// <summary>
         /// The value of the input when the graph was saved.
         /// This should always be a string for all types.
@@ -104,10 +136,34 @@ namespace Dynamo.Graph.Nodes
             { typeof(Int64),NodeInputTypes.numberInput},
             {typeof(float),NodeInputTypes.numberInput},
         };
+        private static Dictionary<Type, InputTypes> dotNetTypeToInputType = new Dictionary<Type, InputTypes>
+        {
+            {typeof(String),InputTypes.stringInput},
+            { typeof(Boolean),InputTypes.booleanInput},
+            { typeof(DateTime),InputTypes.dateInput},
+            { typeof(double),InputTypes.numberInput},
+            { typeof(Int32),InputTypes.numberInput},
+            { typeof(Int64),InputTypes.numberInput},
+            {typeof(float),InputTypes.numberInput},
+        };
+
+        [Obsolete("To be removed in Dynamo 3.x")]
         public static NodeInputTypes getNodeInputTypeFromType(Type type)
         {
             NodeInputTypes output;
             if (dotNetTypeToNodeInputType.TryGetValue(type, out output))
+            {
+                return output;
+            }
+            else
+            {
+                throw new ArgumentException("could not find an inputType for this type");
+            }
+        }
+        internal static InputTypes GetNodeInputTypeFromType(Type type)
+        {
+            InputTypes output;
+            if (dotNetTypeToInputType.TryGetValue(type, out output))
             {
                 return output;
             }
@@ -143,6 +199,7 @@ namespace Dynamo.Graph.Nodes
                 this.NumberType == converted.NumberType &&
                 this.StepValue == converted.StepValue &&
                 this.Type == converted.Type &&
+                this.Type2 == converted.Type2 &&
                 //check if the value is the same or if the value is a number check is it similar
                 ((this.Value == converted.Value) || valNumberComparison || this.Value.ToString() == converted.Value.ToString());
         }

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -160,7 +160,7 @@ namespace Dynamo.Graph.Nodes
                 throw new ArgumentException("could not find an inputType for this type");
             }
         }
-        internal static InputTypes GetNodeInputTypeFromType(Type type)
+        internal static InputTypes GetInputTypeFromType(Type type)
         {
             InputTypes output;
             if (dotNetTypeToInputType.TryGetValue(type, out output))

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -507,7 +507,18 @@ namespace Dynamo.Graph.Workspaces
             var inputsToken = obj["Inputs"];
             if (inputsToken != null)
             {
-                var inputs = inputsToken.ToArray().Select(x => x.ToObject<NodeInputData>()).ToList();
+                var inputs = inputsToken.ToArray().Select(x =>
+                {
+                    try
+                    { return x.ToObject<NodeInputData>(); }
+                    catch (Exception ex)
+                    {
+                        engine?.AsLogger().Log(ex);
+                        return null;
+                    }
+                    //dump nulls
+                }).Where(x => !(x is null)).ToList();
+
                 // Use the inputs to set the correct properties on the nodes.
                 foreach (var inputData in inputs)
                 {

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -76,7 +76,7 @@ namespace CoreNodeModels
                     Name = this.Name,
                     //because selection makes more sense than defaulting to number...
                     Type = NodeInputTypes.selectionInput,
-                    Type2 = InputTypes.dropdownSelection,
+                    Type2 = NodeInputTypes.dropdownSelection,
                     Description = this.Description,
                     Value = this.SelectedString,
                     SelectedIndex = this.SelectedIndex

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -74,7 +74,9 @@ namespace CoreNodeModels
                 {
                     Id = this.GUID,
                     Name = this.Name,
-                    Type = NodeInputTypes.dropdownSelection,
+                    //because selection makes more sense than defaulting to number...
+                    Type = NodeInputTypes.selectionInput,
+                    Type2 = InputTypes.dropdownSelection,
                     Description = this.Description,
                     Value = this.SelectedString,
                     SelectedIndex = this.SelectedIndex

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -142,6 +142,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
+                    Type2 = InputTypes.numberInput,
                     Description = this.Description,
                     Value = Value,
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -142,7 +142,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
-                    Type2 = InputTypes.numberInput,
+                    Type2 = NodeInputTypes.numberInput,
                     Description = this.Description,
                     Value = Value,
 

--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -48,6 +48,7 @@ namespace CoreNodeModels.Input
                     //use the <T> type to convert to the correct nodeTypeString defined by
                     //the schema
                     Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
+                    Type2 = NodeInputData.GetInputTypeFromType(typeof(T)),
                     Description = this.Description,
                     Value = Value.ToString(),
                 };

--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -48,7 +48,7 @@ namespace CoreNodeModels.Input
                     //use the <T> type to convert to the correct nodeTypeString defined by
                     //the schema
                     Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
-                    Type2 = NodeInputData.GetInputTypeFromType(typeof(T)),
+                    Type2 = NodeInputData.getNodeInputTypeFromType(typeof(T)),
                     Description = this.Description,
                     Value = Value.ToString(),
                 };

--- a/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
@@ -51,7 +51,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputData.getNodeInputTypeFromType(typeof(System.Boolean)),
-                    Type2 = NodeInputData.GetInputTypeFromType(typeof(System.Boolean)),
+                    Type2 = NodeInputData.getNodeInputTypeFromType(typeof(System.Boolean)),
                     Description = this.Description,
                     Value = Value.ToString().ToLower(),
                 };

--- a/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
@@ -51,6 +51,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputData.getNodeInputTypeFromType(typeof(System.Boolean)),
+                    Type2 = NodeInputData.GetInputTypeFromType(typeof(System.Boolean)),
                     Description = this.Description,
                     Value = Value.ToString().ToLower(),
                 };

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -60,7 +60,7 @@ namespace CoreNodeModels.Input
                     Name = this.Name,
 
                     Type = NodeInputTypes.colorInput,
-                    Type2 = InputTypes.colorInput,
+                    Type2 = NodeInputTypes.colorInput,
                     Description = this.Description,
                     Value = JsonConvert.SerializeObject(colorObj),
                 };

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -60,6 +60,7 @@ namespace CoreNodeModels.Input
                     Name = this.Name,
 
                     Type = NodeInputTypes.colorInput,
+                    Type2 = InputTypes.colorInput,
                     Description = this.Description,
                     Value = JsonConvert.SerializeObject(colorObj),
                 };

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -39,6 +39,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputData.getNodeInputTypeFromType(typeof(System.DateTime)),
+                    Type2 = NodeInputData.GetInputTypeFromType(typeof(System.DateTime)),
                     Description = this.Description,
                     //format dateTime with swagger spec in mind:  ISO 8601.
                     Value = Value.ToString("o", CultureInfo.InvariantCulture),

--- a/src/Libraries/CoreNodeModels/Input/DateTime.cs
+++ b/src/Libraries/CoreNodeModels/Input/DateTime.cs
@@ -39,7 +39,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputData.getNodeInputTypeFromType(typeof(System.DateTime)),
-                    Type2 = NodeInputData.GetInputTypeFromType(typeof(System.DateTime)),
+                    Type2 = NodeInputData.getNodeInputTypeFromType(typeof(System.DateTime)),
                     Description = this.Description,
                     //format dateTime with swagger spec in mind:  ISO 8601.
                     Value = Value.ToString("o", CultureInfo.InvariantCulture),

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -50,6 +50,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
+                    Type2 = InputTypes.numberInput,
                     Description = this.Description,
                     Value = Value.ToString(CultureInfo.InvariantCulture),
 

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -50,7 +50,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
-                    Type2 = InputTypes.numberInput,
+                    Type2 = NodeInputTypes.numberInput,
                     Description = this.Description,
                     Value = Value.ToString(CultureInfo.InvariantCulture),
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -55,7 +55,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
-                    Type2 = InputTypes.numberInput,
+                    Type2 = NodeInputTypes.numberInput,
                     Description = this.Description,
                     Value = Value.ToString(CultureInfo.InvariantCulture),
 
@@ -251,7 +251,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
-                    Type2 = InputTypes.numberInput,
+                    Type2 = NodeInputTypes.numberInput,
                     Description = this.Description,
                     Value = Value.ToString(CultureInfo.InvariantCulture),
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -55,6 +55,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
+                    Type2 = InputTypes.numberInput,
                     Description = this.Description,
                     Value = Value.ToString(CultureInfo.InvariantCulture),
 
@@ -250,6 +251,7 @@ namespace CoreNodeModels.Input
                     Id = this.GUID,
                     Name = this.Name,
                     Type = NodeInputTypes.numberInput,
+                    Type2 = InputTypes.numberInput,
                     Description = this.Description,
                     Value = Value.ToString(CultureInfo.InvariantCulture),
 

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -43,7 +43,9 @@ namespace CoreNodeModels
                 {
                     Id = this.GUID,
                     Name = this.Name,
-                    Type = NodeInputTypes.hostSelection,
+                    //because selection makes more sense than defaulting to number...
+                    Type = NodeInputTypes.selectionInput,
+                    Type2 = InputTypes.hostSelection,
                     Description = this.Description,
                     Value = string.Join(",", this.SelectionIdentifier.ToArray())
                 };  

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -45,7 +45,7 @@ namespace CoreNodeModels
                     Name = this.Name,
                     //because selection makes more sense than defaulting to number...
                     Type = NodeInputTypes.selectionInput,
-                    Type2 = InputTypes.hostSelection,
+                    Type2 = NodeInputTypes.hostSelection,
                     Description = this.Description,
                     Value = string.Join(",", this.SelectionIdentifier.ToArray())
                 };  

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -785,6 +785,19 @@ namespace Dynamo.Tests
             //this is still set true as its also serialized on the nodeView and deserialized in the workspaceReadConverter.
             Assert.AreEqual(selectionNode.IsSetAsInput, true);
         }
+        [Test]
+        public void NodeWithInputTypeAndType2FromTheFutureShouldNotBreakFileDeserialization()
+        {
+            // When an input node has a type from the future, we don't deserialize that inputData, but 
+            // the node and the rest of graph should still deserialize correctly.
+
+            var testFile = Path.Combine(TestDirectory, @"core\serialization\type1and2_future.dyn");
+            OpenModel(testFile);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            var selectionNode = this.CurrentDynamoModel.CurrentWorkspace.Nodes.ToList().Where(x => x.GUID == Guid.Parse("60316051425445ab8728f099bdf6f0d1")).FirstOrDefault();
+            //this is still set true as its also serialized on the nodeView and deserialized in the workspaceReadConverter.
+            Assert.AreEqual(selectionNode.IsSetAsInput, true);
+        }
 
 
         [Test]

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -773,6 +773,21 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void NodeWithInputTypeFromTheFutureShouldNotBreakFileDeserialization()
+        {
+            // When an input node has a type from the future, we don't deserialize that inputData, but 
+            // the node and the rest of graph should still deserialize correctly.
+
+            var testFile = Path.Combine(TestDirectory, @"core\serialization\input_type_from_future.dyn");
+            OpenModel(testFile);
+            Assert.AreEqual(9, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            var selectionNode = this.CurrentDynamoModel.CurrentWorkspace.Nodes.ToList().Where(x => x.GUID == Guid.Parse("da7f5c18d72d4f649602197e0aa0d0fa")).FirstOrDefault();
+            //this is still set true as its also serialized on the nodeView and deserialized in the workspaceReadConverter.
+            Assert.AreEqual(selectionNode.IsSetAsInput, true);
+        }
+
+
+        [Test]
         public void NodeIsSetAsOutputStateDeserilizationTest()
         {
             // The IsSetAsOutput state of the node is saved in node view block. However the property on node model

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -23,6 +23,7 @@ using Dynamo.Wpf.ViewModels.Core;
 using Dynamo.Wpf.ViewModels.Watch3D;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using TestUINodes;
 using DoubleSlider = CoreNodeModels.Input.DoubleSlider;
 
 namespace DynamoCoreWpfTests
@@ -1055,6 +1056,23 @@ namespace DynamoCoreWpfTests
 
             Assert.AreEqual(numXMLNotes, 0);
             Assert.AreEqual(numXMLAnnotations, numJsonAnnotations);
+        }
+
+        [Test]
+        public void DropDownsHaveCorrectInputDataTypes()
+        {
+            var dropnode = new EnumAsStringConcrete();
+            var data = dropnode.InputData;
+            Assert.AreEqual(NodeInputTypes.selectionInput, data.Type);
+            Assert.AreEqual(InputTypes.dropdownSelection, data.Type2);
+        }
+        [Test]
+        public void SelectionNodesHaveCorrectInputDataTypes()
+        {
+            var selectNode = new SelectionConcrete(SelectionType.One, SelectionObjectType.None, "", "");
+            var data = selectNode.InputData;
+            Assert.AreEqual(NodeInputTypes.selectionInput, data.Type);
+            Assert.AreEqual(InputTypes.hostSelection, data.Type2);
         }
 
         public object[] FindWorkspaces()

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -1064,7 +1064,7 @@ namespace DynamoCoreWpfTests
             var dropnode = new EnumAsStringConcrete();
             var data = dropnode.InputData;
             Assert.AreEqual(NodeInputTypes.selectionInput, data.Type);
-            Assert.AreEqual(InputTypes.dropdownSelection, data.Type2);
+            Assert.AreEqual(NodeInputTypes.dropdownSelection, data.Type2);
         }
         [Test]
         public void SelectionNodesHaveCorrectInputDataTypes()
@@ -1072,7 +1072,7 @@ namespace DynamoCoreWpfTests
             var selectNode = new SelectionConcrete(SelectionType.One, SelectionObjectType.None, "", "");
             var data = selectNode.InputData;
             Assert.AreEqual(NodeInputTypes.selectionInput, data.Type);
-            Assert.AreEqual(InputTypes.hostSelection, data.Type2);
+            Assert.AreEqual(NodeInputTypes.hostSelection, data.Type2);
         }
 
         public object[] FindWorkspaces()

--- a/test/core/serialization/input_type_from_future.dyn
+++ b/test/core/serialization/input_type_from_future.dyn
@@ -1,0 +1,537 @@
+{
+  "Uuid": "bf5a5431-8c3d-4d68-a837-77f8f0578a13",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "version test",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Category": {
+        "Key": "Revit.Elements.Category",
+        "Value": "RevitNodes.dll"
+      }
+    }
+  },
+  "Inputs": [
+    {
+      "Id": "da7f5c18d72d4f649602197e0aa0d0fa",
+      "Name": "Select Roof",
+      "Type": "SOMETYPEFROMTHEFUTURE",
+      "Value": "ae35d28e-2b14-4ef6-aca7-d0dbeccd6182-00057817",
+      "Description": "Select a model element from the document.",
+      "SelectedIndex": 0
+    }
+  ],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Nodes.DSModelElementSelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "ae35d28e-2b14-4ef6-aca7-d0dbeccd6182-00057817"
+      ],
+      "Id": "da7f5c18d72d4f649602197e0aa0d0fa",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "39ed34ac56d34602b9a03df4f9892fd6",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Element.Geometry",
+      "Id": "1d112b3b04a8437385052b081b3c76bc",
+      "Inputs": [
+        {
+          "Id": "8d632541b6dc44918133931063d0b492",
+          "Name": "element",
+          "Description": "Revit.Elements.Element",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ccb3ec2c3f48422597df0c92556350d8",
+          "Name": "var[]",
+          "Description": "var[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get all of the Geometry associated with this object\n\nElement.Geometry ( ): var[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Geometry.Explode",
+      "Id": "892f9f8d19fd4cdc9447395c3e78135c",
+      "Inputs": [
+        {
+          "Id": "3e2dfb3900d348fbadb49a6efe09bcfc",
+          "Name": "geometry",
+          "Description": "Autodesk.DesignScript.Geometry.Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b54f9c9f5b214f83a18c0c4f47cb5547",
+          "Name": "Geometry[]",
+          "Description": "Geometry[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Separates compound or non-separated elements into their component parts.\n\nGeometry.Explode ( ): Geometry[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Id": "891a9cbf28d2449caac453df271b7e78",
+      "Inputs": [
+        {
+          "Id": "01ae2b111bc64a5c80423c89d44bce85",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4905da66de874d42a1624128c966cb5a",
+          "Name": "amount",
+          "Description": "Layers of list nesting to remove (-1 will remove all list nestings)\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8d6b47999076499b8cc43eb176494dc0",
+          "Name": "list",
+          "Description": "Flattened list by amount",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amount: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double",
+      "Id": "967b6ecd05cd400787b092bb3858172a",
+      "Inputs": [
+        {
+          "Id": "bfe6894e483f4e4cb86d6f2f1139c394",
+          "Name": "surface",
+          "Description": "Autodesk.DesignScript.Geometry.Surface",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "51b9253e47fc4a20a6da650e060e0624",
+          "Name": "u",
+          "Description": "U component of parameter\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "19e15c0b945f4a1fb3d072560834758b",
+          "Name": "v",
+          "Description": "V component of parameter\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "08e8f13d3d9948e4beefb8f26bf38acd",
+          "Name": "Vector",
+          "Description": "Normal at parameter",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Return the normal Vector at specified U and V parameters.\n\nSurface.NormalAtParameter (u: double = 0, v: double = 0): Vector"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0.5;",
+      "Id": "c8f798027f0d481f8a364b5e3451fee7",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "c60095ce682941198a453e323c7f497e",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Vector.Z",
+      "Id": "9c160f4379ca4b1c87e9a758c19584ee",
+      "Inputs": [
+        {
+          "Id": "d4ee01015f5b4df1b3f14a56d6fb2861",
+          "Name": "vector",
+          "Description": "Autodesk.DesignScript.Geometry.Vector",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "79f3c9c095fd4602922f3c89560f7ffa",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the Z value of a vector.\n\nVector.Z: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "z>0.01;",
+      "Id": "ad2869a225fa4029abf7a7431e52b160",
+      "Inputs": [
+        {
+          "Id": "27914a4bf6cc4035925d1bccdf043cc2",
+          "Name": "z",
+          "Description": "z",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bd2604dc0f18420a8c30bc12b34bf595",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.FilterByBoolMask@var[]..[],var[]..[]",
+      "Id": "6251ed513dfb4d93b46a1551c59183c3",
+      "Inputs": [
+        {
+          "Id": "a16d675210714ed2a0117c809cfdbdac",
+          "Name": "list",
+          "Description": "List to filter.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0d60e9721e8b4b75baf62af2b0b96b83",
+          "Name": "mask",
+          "Description": "List of booleans representing a mask.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f67a68939cca46598f56f7a2cde6adcc",
+          "Name": "in",
+          "Description": "Items whose mask index is true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9e13a19184f34706b8413d58bf4da051",
+          "Name": "out",
+          "Description": "Items whose mask index is false.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Filters a sequence by looking up corresponding indices in a separate list of booleans.\n\nList.FilterByBoolMask (list: var[]..[], mask: var[]..[]): var[]..[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "39ed34ac56d34602b9a03df4f9892fd6",
+      "End": "8d632541b6dc44918133931063d0b492",
+      "Id": "71dc80e825fa464f93be5c8e3cb90e5c"
+    },
+    {
+      "Start": "ccb3ec2c3f48422597df0c92556350d8",
+      "End": "3e2dfb3900d348fbadb49a6efe09bcfc",
+      "Id": "c42f53b6f8464eca8ea868785df538ce"
+    },
+    {
+      "Start": "b54f9c9f5b214f83a18c0c4f47cb5547",
+      "End": "01ae2b111bc64a5c80423c89d44bce85",
+      "Id": "c2322e5d097540a9a8051b3276f3f37f"
+    },
+    {
+      "Start": "8d6b47999076499b8cc43eb176494dc0",
+      "End": "bfe6894e483f4e4cb86d6f2f1139c394",
+      "Id": "bbfd8b4f3db242c388814fac3caf4287"
+    },
+    {
+      "Start": "8d6b47999076499b8cc43eb176494dc0",
+      "End": "a16d675210714ed2a0117c809cfdbdac",
+      "Id": "472d7f03b9fa4f5cb4e6ddf6f65c730e"
+    },
+    {
+      "Start": "08e8f13d3d9948e4beefb8f26bf38acd",
+      "End": "d4ee01015f5b4df1b3f14a56d6fb2861",
+      "Id": "380d6ef97cb742f78694d0b201cff8d8"
+    },
+    {
+      "Start": "c60095ce682941198a453e323c7f497e",
+      "End": "51b9253e47fc4a20a6da650e060e0624",
+      "Id": "fc3a3fd5970248f4b1dbe02145b862f4"
+    },
+    {
+      "Start": "c60095ce682941198a453e323c7f497e",
+      "End": "19e15c0b945f4a1fb3d072560834758b",
+      "Id": "409f701b5ab5458f9ee6b5fbc5af30d3"
+    },
+    {
+      "Start": "79f3c9c095fd4602922f3c89560f7ffa",
+      "End": "27914a4bf6cc4035925d1bccdf043cc2",
+      "Id": "22c8686d264148ebb87b683952d7538f"
+    },
+    {
+      "Start": "bd2604dc0f18420a8c30bc12b34bf595",
+      "End": "0d60e9721e8b4b75baf62af2b0b96b83",
+      "Id": "057ecca9fb7f482fa7fa8fd56312b9b7"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.12",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.12.0.5650",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": 17359.402053626429,
+      "EyeY": 15070.612541938071,
+      "EyeZ": 16515.168641356206,
+      "LookX": -18287.914381910552,
+      "LookY": -10092.511091367234,
+      "LookZ": -20090.665624344198,
+      "UpX": -0.093684336060442519,
+      "UpY": 0.99026806874164952,
+      "UpZ": -0.10291937236379338
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Select Roof",
+        "Id": "da7f5c18d72d4f649602197e0aa0d0fa",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -1283.732069860496,
+        "Y": -204.2138205082158
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Element.Geometry",
+        "Id": "1d112b3b04a8437385052b081b3c76bc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -737.42370362472,
+        "Y": 281.16280147054545
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Geometry.Explode",
+        "Id": "892f9f8d19fd4cdc9447395c3e78135c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -466.54041805365478,
+        "Y": 278.18053807552508
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Flatten",
+        "Id": "891a9cbf28d2449caac453df271b7e78",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -127.79513191595811,
+        "Y": 260.58131334145537
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Surface.NormalAtParameter",
+        "Id": "967b6ecd05cd400787b092bb3858172a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 95.745319836069257,
+        "Y": 341.51853504462855
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "c8f798027f0d481f8a364b5e3451fee7",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -25.59036404029348,
+        "Y": 381.22135572347577
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Vector.Z",
+        "Id": "9c160f4379ca4b1c87e9a758c19584ee",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 321.56016747238777,
+        "Y": 336.85217781614136
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "ad2869a225fa4029abf7a7431e52b160",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 543.77097477780012,
+        "Y": 337.08379212877094
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.FilterByBoolMask",
+        "Id": "6251ed513dfb4d93b46a1551c59183c3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 708.36222464899583,
+        "Y": 253.306851455965
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "298d2cfc28654e18944b58ff6ec8d442",
+        "Title": "Find upper surface",
+        "Nodes": [
+          "1d112b3b04a8437385052b081b3c76bc",
+          "892f9f8d19fd4cdc9447395c3e78135c",
+          "891a9cbf28d2449caac453df271b7e78",
+          "967b6ecd05cd400787b092bb3858172a",
+          "c8f798027f0d481f8a364b5e3451fee7",
+          "9c160f4379ca4b1c87e9a758c19584ee",
+          "ad2869a225fa4029abf7a7431e52b160",
+          "6251ed513dfb4d93b46a1551c59183c3"
+        ],
+        "Left": -747.42370362472,
+        "Top": 200.306851455965,
+        "Width": 1636.7859282737159,
+        "Height": 286.21168358866356,
+        "FontSize": 36.0,
+        "InitialTop": 253.306851455965,
+        "InitialHeight": 272.91450426751078,
+        "TextblockHeight": 43.0,
+        "Background": "#FFC1D676"
+      }
+    ],
+    "X": 831.33358486632324,
+    "Y": 515.14503377431765,
+    "Zoom": 0.5053283164735819
+  }
+}

--- a/test/core/serialization/type1and2_future.dyn
+++ b/test/core/serialization/type1and2_future.dyn
@@ -1,0 +1,111 @@
+{
+  "Uuid": "c1d1afd2-a87d-458f-8179-a51cb457dd28",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "type1and2",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [
+    {
+      "Id": "60316051425445ab8728f099bdf6f0d1",
+      "Name": "Number Slider",
+      "Type": "FUTURE",
+      "Type2": "FUTURE",
+      "Value": "28.6",
+      "MaximumValue": 100.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "NumberType": "Double",
+      "Description": "A slider that produces numeric values.",
+      "SelectedIndex": 0
+    }
+  ],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "MaximumValue": 100.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "InputValue": 28.6,
+      "Id": "60316051425445ab8728f099bdf6f0d1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "131d99d540d648488d3b2c68fd9efa9d",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces numeric values."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4280",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Number Slider",
+        "ShowGeometry": true,
+        "Id": "60316051425445ab8728f099bdf6f0d1",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 485.0,
+        "Y": 363.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Most closely resembles proposal C from this wiki: https://wiki.autodesk.com/pages/viewpage.action?pageId=1204716652
does the following:
* just wraps input deserialization in a try catch, and forget about inputs which fail to deserialize for any reason.
* introduces new `Type2` property to `NodeInputs` so that old dynamo versions don't try to deserialize them (and fail). We now serialize both `Type` and `Type2`. and `Type` no longer serializes as hostSelection or dropdownSelection.
* ⚠️ An important finding I made while looking at this section of code is that **Dynamo doesn't care what the values are in the input section** when deserializing!!!!!!!, really only the name and the existence in the section are important, the others are just thrown away... for that reason it doesn't really matter what we return from this deserialization - at least not at the current time.

This set of changes fixes two issues:
* files from the future with new InputTypes won't break file deserialization
* stop producing files that legacy dynamo versions can't open.


### Declarations

### TODO - 
- [x] test that Type is not serialized as hostSelection or dropdownSelection for our nodes.
- [x] test that unknown type does not cause deserialization failure

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

* no longer produce files that cannot be read by dynamo versions < 2.12.
* serialize a new `Type2` property on graph `Inputs` - this should be used instead of `Type`

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
