### PR TITLE
Set minimum height for notifications window

### DIFF
--- a/src/Notifications/NotificationsView.xaml
+++ b/src/Notifications/NotificationsView.xaml
@@ -10,6 +10,7 @@
         Title="{x:Static p:Resources.ExtensionName}"
         Height="450"
         Width="450"
+        MinHeight="300"
         MinWidth="400"
         MaxWidth="450"
         x:Name="notificationsWindow"


### PR DESCRIPTION
### Purpose

Setting minimum height for the notifications panel. The minimum height is same as the one set for other windows like the package manager search window.

https://jira.autodesk.com/browse/DYN-4321

<img width="1178" alt="Screen Shot 2022-02-23 at 8 32 37 PM" src="https://user-images.githubusercontent.com/43763136/155345855-78e05562-b3ce-4417-be4f-cc688a17e3d9.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Set minimum height for notifications window


### Reviewers
@QilongTang @zeusongit 

