### PR TITLE
DYN-4586 Count of error/warning increases on source node upon copy/pasting a node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -774,7 +774,6 @@ namespace Dynamo.ViewModels
             DynamoViewModel.Model.PropertyChanged += Model_PropertyChanged;
             DynamoViewModel.Model.DebugSettings.PropertyChanged += DebugSettings_PropertyChanged;
 
-
             //Do a one time setup of the initial ports on the node
             //we can not do this automatically because this constructor
             //is called after the node's constructor where the ports
@@ -1193,8 +1192,7 @@ namespace Dynamo.ViewModels
 
             bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning;
 
-            if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
-            
+            if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;            
             if (ErrorBubble == null) BuildErrorBubble();
 
             if (!WorkspaceViewModel.Errors.Contains(ErrorBubble)) return;
@@ -1219,20 +1217,16 @@ namespace Dynamo.ViewModels
             {
                 DynamoViewModel.UIDispatcher.Invoke(() =>
                 {
-                    var messageNode = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
-                    ErrorBubble.NodeMessages.Add(messageNode);
+                    ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
                     WarningBarColor = GetWarningColor();
                 });
             }
             else
             {
-                var messageNode = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
-                ErrorBubble.NodeMessages.Add(messageNode);
+                ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
                 WarningBarColor = GetWarningColor();
             }
-
-            ErrorBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Pinned);
-            
+            ErrorBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Pinned);            
         }
 
         private void UpdateErrorBubblePosition()

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -774,6 +774,7 @@ namespace Dynamo.ViewModels
             DynamoViewModel.Model.PropertyChanged += Model_PropertyChanged;
             DynamoViewModel.Model.DebugSettings.PropertyChanged += DebugSettings_PropertyChanged;
 
+
             //Do a one time setup of the initial ports on the node
             //we can not do this automatically because this constructor
             //is called after the node's constructor where the ports
@@ -1217,14 +1218,21 @@ namespace Dynamo.ViewModels
             {
                 DynamoViewModel.UIDispatcher.Invoke(() =>
                 {
-                    ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
+                    var messageNode = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
+                    if(ErrorBubble.NodeMessages.Count(x=> x.TextMessageExists(content)) == 0)
+                    {
+                        ErrorBubble.NodeMessages.Add(messageNode);
+                    }
                     WarningBarColor = GetWarningColor();
                 });
             }
             else
             {
-                ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
-                WarningBarColor = GetWarningColor();
+                var messageNode = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
+                if (ErrorBubble.NodeMessages.Count(x => x.TextMessageExists(content)) == 0)
+                {
+                    ErrorBubble.NodeMessages.Add(messageNode);
+                }
             }
             
             ErrorBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Pinned);

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1192,8 +1192,9 @@ namespace Dynamo.ViewModels
             if (DynamoViewModel == null) return;
 
             bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning;
-            if (!NodeModel.WasInvolvedInExecution && !hasErrorOrWarning) return;
 
+            if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
+            
             if (ErrorBubble == null) BuildErrorBubble();
 
             if (!WorkspaceViewModel.Errors.Contains(ErrorBubble)) return;
@@ -1219,23 +1220,19 @@ namespace Dynamo.ViewModels
                 DynamoViewModel.UIDispatcher.Invoke(() =>
                 {
                     var messageNode = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
-                    if(ErrorBubble.NodeMessages.Count(x=> x.TextMessageExists(content)) == 0)
-                    {
-                        ErrorBubble.NodeMessages.Add(messageNode);
-                    }
+                    ErrorBubble.NodeMessages.Add(messageNode);
                     WarningBarColor = GetWarningColor();
                 });
             }
             else
             {
                 var messageNode = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
-                if (ErrorBubble.NodeMessages.Count(x => x.TextMessageExists(content)) == 0)
-                {
-                    ErrorBubble.NodeMessages.Add(messageNode);
-                }
+                ErrorBubble.NodeMessages.Add(messageNode);
+                WarningBarColor = GetWarningColor();
             }
-            
+
             ErrorBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Pinned);
+            
         }
 
         private void UpdateErrorBubblePosition()

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1021,6 +1021,10 @@ namespace Dynamo.ViewModels
         /// </summary>
         public string LinkText { get; set; }
 
+        internal Guid NodeGUID { get; set; }
+
+        private string TextWithLink;
+
         public InfoBubbleDataPacket(
             InfoBubbleViewModel.Style style,
             Point topLeft,
@@ -1037,12 +1041,19 @@ namespace Dynamo.ViewModels
             MessageNumber = "";
             Message = Text;
             LinkText = "";
+            NodeGUID = new Guid();
+            TextWithLink = text;
         }
 
+        internal bool TextMessageExists(string message)
+        {
+            return TextWithLink.Equals(message);
+        }
 
         //Check if has link
         private static string RemoveLinkFromText(string text)
         {
+            
             // if there is no link, we do nothing
             if (!text.Contains(externalLinkIdentifier)) return text;
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1036,13 +1036,12 @@ namespace Dynamo.ViewModels
             ConnectingDirection = connectingDirection;
             MessageNumber = "";
             Message = Text;
-            LinkText = "";         
+            LinkText = "";
         }
 
         //Check if has link
         private static string RemoveLinkFromText(string text)
         {
-            
             // if there is no link, we do nothing
             if (!text.Contains(externalLinkIdentifier)) return text;
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1021,8 +1021,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         public string LinkText { get; set; }
 
-        internal Guid NodeGUID { get; set; }
-
         private string TextWithLink;
 
         public InfoBubbleDataPacket(
@@ -1041,7 +1039,6 @@ namespace Dynamo.ViewModels
             MessageNumber = "";
             Message = Text;
             LinkText = "";
-            NodeGUID = new Guid();
             TextWithLink = text;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1021,8 +1021,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         public string LinkText { get; set; }
 
-        private string TextWithLink;
-
         public InfoBubbleDataPacket(
             InfoBubbleViewModel.Style style,
             Point topLeft,
@@ -1038,13 +1036,7 @@ namespace Dynamo.ViewModels
             ConnectingDirection = connectingDirection;
             MessageNumber = "";
             Message = Text;
-            LinkText = "";
-            TextWithLink = text;
-        }
-
-        internal bool TextMessageExists(string message)
-        {
-            return TextWithLink.Equals(message);
+            LinkText = "";         
         }
 
         //Check if has link

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -170,7 +170,7 @@ namespace DynamoCoreWpfTests
                 nodeView.PreviewControl.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
                 { RoutedEvent = Mouse.MouseEnterEvent });
             });
-            DispatcherUtil.DoEvents();
+            DispatcherUtil.DoEvents();            
 
             Assert.IsTrue(nodeView.PreviewControl.IsHidden);
         }
@@ -392,6 +392,27 @@ namespace DynamoCoreWpfTests
             // open preview bubble
             RaiseMouseEnterOnNode(nodeView);
             Assert.IsFalse(nodeView.PreviewControl.IsHidden, "Preview bubble for color range should be shown");
+        }
+
+        [Test]
+        public void PreviewBubble_AvoidDuplicatedWarningMessages()
+        {
+            Open(@"core\watch\WatchDuplicatedWarningMessages.dyn");
+            var nodeView = NodeViewWithGuid("67b46c3f-b60f-49d7-a8cf-bb9cc4a03450");
+
+            Assert.AreEqual(1, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
+
+            var selectNodeCommand =
+             new Dynamo.Models.DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
+
+            Model.ExecuteCommand(selectNodeCommand);
+
+            Model.Copy();
+            Model.Paste();
+
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(1, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
         }
 
         [Test]

--- a/test/core/watch/WatchDuplicatedWarningMessages.dyn
+++ b/test/core/watch/WatchDuplicatedWarningMessages.dyn
@@ -1,0 +1,155 @@
+{
+  "Uuid": "82afa68f-d33a-4140-866f-e18f959a038e",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "WarningError",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "null;",
+      "Id": "27d877e250ab49dfbcf5d37e7781e1cf",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "45fe501819ed442fa9c281b3ed12e755",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.ByKeysValues@string[],var[]..[]",
+      "Id": "67b46c3fb60f49d7a8cfbb9cc4a03450",
+      "Inputs": [
+        {
+          "Id": "ecc049b5a68f438cb224ee359c6e2dd0",
+          "Name": "keys",
+          "Description": "Keys of dictionary\n\nstring[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "433bb3fe09c54545b4572c867cbca06a",
+          "Name": "values",
+          "Description": "Values of dictionary\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e469c57af5d74f04a89132df4d16c92d",
+          "Name": "dictionary",
+          "Description": "Dictionary from keys and values",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Longest",
+      "Description": "Produces a Dictionary with the supplied keys and values. The number of entries is the shorter of keys or values.\n\nDictionary.ByKeysValues (keys: string[], values: var[]..[]): Dictionary"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "45fe501819ed442fa9c281b3ed12e755",
+      "End": "433bb3fe09c54545b4572c867cbca06a",
+      "Id": "3d0ff43d84c44d10b9bdbe2a01146a36",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "45fe501819ed442fa9c281b3ed12e755",
+      "End": "ecc049b5a68f438cb224ee359c6e2dd0",
+      "Id": "c4d7e311d83346cf9c7c99f24277f22e",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.3986",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "27d877e250ab49dfbcf5d37e7781e1cf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 323.5,
+        "Y": 240.0
+      },
+      {
+        "Name": "Dictionary.ByKeysValues",
+        "ShowGeometry": true,
+        "Id": "67b46c3fb60f49d7a8cfbb9cc4a03450",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 676.5,
+        "Y": 269.0
+      }
+    ],
+    "Annotations": [],
+    "X": -182.66388525850004,
+    "Y": -98.1486609280874,
+    "Zoom": 1.0792537289518349
+  }
+}


### PR DESCRIPTION
### Purpose

This PR is to solve the issue of increasing the number of warnings in the nodes after the node has been copied and pasted. 
During the investigation of this issue, it was noticed the bug not only happens with copy/paste actions but also by creating, linking, and deleting a node.

![warningNodeActionsExample](https://user-images.githubusercontent.com/89042471/155543729-8cff0a6e-f0fc-4a20-a94b-a00a60e4249a.gif)

First, in this part of the code, there can be noticed that the warning messages related to a node are being concatenated at a single string. With this, the warning messages of the same are not being separated.

```
   // Runtime warnings take precedence over build warnings.
            foreach (var warning in updateTask.RuntimeWarnings)
            {
                var message = string.Join(Environment.NewLine, warning.Value.Select(w => w.Message));
                messages.Add(warning.Key, message);
            }
```

The reason for the bug was that at every end of the workspace evaluation, all the messages (even the processed ones), were being added again in the `NodeMessages ` list.

So, to avoid that, and assuming that the difference between a new message and a message that has already been added to the list is the 
string itself, it was added a previous verification if the string already exists in the list. It avoids the incrementation of the counter and maintains multiple messages for the same node as shown below:

![warningNodeSolution](https://user-images.githubusercontent.com/89042471/155546179-96311a16-73b1-4146-b2c4-d385b34fc37e.gif)


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@jesusalvino 
@RobertGlobant20 
