### PR TITLE
Fix location show form owner inside uninstall package

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -52,7 +52,7 @@ namespace Dynamo.ViewModels
     public partial class DynamoViewModel : ViewModelBase, IDynamoViewModel
     {
         #region properties
-
+        public Window Owner { get; set; }
         private readonly DynamoModel model;
         private Point transformOrigin;
         private bool showStartPage = false;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -270,7 +270,7 @@ namespace Dynamo.ViewModels
             if (Model.LoadedAssemblies.Any())
             {
                 var resAssem =
-                    MessageBoxService.Show(string.Format(MessageNeedToRestart,
+                    MessageBoxService.Show(dynamoViewModel.Owner,string.Format(MessageNeedToRestart,
                         dynamoViewModel.BrandingResourceProvider.ProductName),
                         MessageNeedToRestartTitle,
                         MessageBoxButton.OKCancel,

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -280,7 +280,7 @@ namespace Dynamo.ViewModels
 
             if (!Model.BuiltInPackage)
             {
-                var res = MessageBoxService.Show(String.Format(Resources.MessageConfirmToDeletePackage, this.Model.Name),
+                var res = MessageBoxService.Show(dynamoViewModel.Owner,String.Format(Resources.MessageConfirmToDeletePackage, this.Model.Name),
                     Resources.MessageNeedToRestartAfterDeleteTitle,
                     MessageBoxButton.YesNo, MessageBoxImage.Question);
 
@@ -296,7 +296,7 @@ namespace Dynamo.ViewModels
             }
             catch (Exception)
             {
-                MessageBoxService.Show(string.Format(MessageFailedToDeleteOrUnload,
+                MessageBoxService.Show(dynamoViewModel.Owner,string.Format(MessageFailedToDeleteOrUnload,
                     dynamoViewModel.BrandingResourceProvider.ProductName),
                     MessageFailedToDeleteOrUnloadTitle,
                     MessageBoxButton.OK, MessageBoxImage.Error);

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -36,6 +36,7 @@ namespace Dynamo.Wpf.Views
         public PreferencesView(DynamoView dynamoView)
         {
             dynViewModel = dynamoView.DataContext as DynamoViewModel;
+            
             SetupPreferencesViewModel(dynViewModel);
 
             DataContext = dynViewModel.PreferencesViewModel;
@@ -46,6 +47,7 @@ namespace Dynamo.Wpf.Views
                 Categories.Preferences);
 
             Owner = dynamoView;
+            dynViewModel.Owner = this;
             if (DataContext is PreferencesViewModel viewModelTemp)
             {
                 viewModel = viewModelTemp;

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -817,7 +817,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, loader.LocalPackages.Count());
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
-            dlgMock.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.Is<MessageBoxButton>(x => x == MessageBoxButton.OKCancel || x == MessageBoxButton.OK), It.IsAny<MessageBoxImage>()))
+            dlgMock.Setup(m => m.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(), It.Is<MessageBoxButton>(x => x == MessageBoxButton.OKCancel || x == MessageBoxButton.OK), It.IsAny<MessageBoxImage>()))
                 .Returns(MessageBoxResult.OK);
             MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
 


### PR DESCRIPTION
### Purpose

this is a problem same with #12540, Fix location show message form uninstall package.
Before :
![DynamoSandbox_Rf1C3QTSWj](https://user-images.githubusercontent.com/31106432/155664774-17d348b6-96f6-4ce3-bcdb-77af294b1e09.png)
After fixed

![fuX7PE7Snj](https://user-images.githubusercontent.com/31106432/155664778-f272855f-2589-4804-8728-55c8233a0d58.png)

![image](https://user-images.githubusercontent.com/31106432/155666147-0cdf3355-bd15-42a5-8966-6b0c5d399584.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Always initialize uninstall package dialog with the right owner window


### Reviewers

@QilongTang 

### FYIs

