### PR TITLE
improve intermittent package details extension test

### DIFF
--- a/src/PackageDetailsViewExtension/PackageDetailsViewModel.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewModel.cs
@@ -144,7 +144,7 @@ namespace Dynamo.PackageDetails
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        internal PackageManagerSearchElement GetPackageByName(string name)
+        internal virtual PackageManagerSearchElement GetPackageByName(string name)
         {
             List<PackageManagerSearchElement> packageManagerSearchElements;
 

--- a/src/PackageDetailsViewExtension/Properties/AssemblyInfo.cs
+++ b/src/PackageDetailsViewExtension/Properties/AssemblyInfo.cs
@@ -10,3 +10,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("12fb4da4-7e9c-4c2e-91cd-1d0b523a9535")]
 [assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
### Purpose

Mock `GetPackageByName` method to avoid calling/depending on dynamo package manager from a test.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

improved test

### Reviewers

