### PR TITLE
Add special case for number containment test to List.Contains

### DIFF
--- a/src/Engine/ProtoCore/Utils/MathUtils.cs
+++ b/src/Engine/ProtoCore/Utils/MathUtils.cs
@@ -58,7 +58,8 @@ namespace ProtoCore.Utils
                     || value is ulong
                     || value is float
                     || value is double
-                    || value is decimal;
+                    || value is decimal
+                    || value is System.Numerics.BigInteger;
         }
     }
 }

--- a/src/Engine/ProtoCore/Utils/MathUtils.cs
+++ b/src/Engine/ProtoCore/Utils/MathUtils.cs
@@ -45,5 +45,20 @@ namespace ProtoCore.Utils
         {
             return Equals(lhs, rhs, Tolerance);
         }
+
+        public static bool IsNumber(object value)
+        {
+            return value is sbyte
+                    || value is byte
+                    || value is short
+                    || value is ushort
+                    || value is int
+                    || value is uint
+                    || value is long
+                    || value is ulong
+                    || value is float
+                    || value is double
+                    || value is decimal;
+        }
     }
 }

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -1,12 +1,11 @@
-﻿#region
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.DesignScript.Runtime;
 using DSCore.Properties;
+using ProtoCore.Utils;
 
-#endregion
 
 namespace DSCore
 {
@@ -1385,9 +1384,9 @@ namespace DSCore
         {
             for (int index = 0; index < list.Count; index++)
             {
-                if ((list[index] is long || list[index] is double) && (item is long || item is double))
+                if (MathUtils.IsNumber(list[index]) && MathUtils.IsNumber(item))
                 {
-                    if (ProtoCore.Utils.MathUtils.Equals(Convert.ToDouble(list[index]), Convert.ToDouble(item)))
+                    if (MathUtils.Equals(Convert.ToDouble(list[index]), Convert.ToDouble(item)))
                         return index;
                 }
                 if (list[index] is ArrayList && item is ArrayList)

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -56,7 +56,6 @@ namespace DSCore
             {
                 if (obj is IList) result = result || Contains((IList)obj, item);
             }
-
             // After checking all sublists, check if the current list contains the item
             return result || (IndexInList(list, item) >= 0);
         }
@@ -1386,6 +1385,11 @@ namespace DSCore
         {
             for (int index = 0; index < list.Count; index++)
             {
+                if ((list[index] is long || list[index] is double) && (item is long || item is double))
+                {
+                    if (ProtoCore.Utils.MathUtils.Equals(Convert.ToDouble(list[index]), Convert.ToDouble(item)))
+                        return index;
+                }
                 if (list[index] is ArrayList && item is ArrayList)
                 {
                     if (((ArrayList)list[index]).Cast<object>().SequenceEqual<object>(((ArrayList)item).Cast<object>())) return index;

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -112,6 +112,17 @@ namespace DSCoreNodesTests
 
         [Test]
         [Category("UnitTests")]
+        public static void ListContainsNumbers()
+        {
+            var list = new[] { 1, 2, 3, 4, 5 };
+            foreach(var l in list)
+            {
+                Assert.IsTrue(List.Contains(list, (double)(l / 3.0) * 3));
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public static void ListIsHomogeneous()
         {
             Assert.IsTrue(List.IsHomogeneous(new ArrayList { 1, 2, 4, 8 }));


### PR DESCRIPTION
### Purpose
List.Contains now gives consistent results with Equals node for number equality.

See https://forum.dynamobim.com/t/list-contains-doesnt-give-the-right-answer/73927/12

![image](https://user-images.githubusercontent.com/5710686/156863304-6e24d747-fe57-4f02-946c-294913ef5f11.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

`List.Contains` now gives consistent results with `Equals` node for number equality.



### FYIs

@Amoursol 
