### PR TITLE
Add tooltips for add to group context menu items

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -502,7 +502,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add To Group.
+        ///   Looks up a localized string similar to Add Node To Group.
         /// </summary>
         public static string ContextAddGroupFromSelection {
             get {
@@ -2921,20 +2921,11 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Group to Group.
+        ///   Looks up a localized string similar to Add Group to This Group.
         /// </summary>
         public static string GroupContextMenuAddGroupToGroup {
             get {
                 return ResourceManager.GetString("GroupContextMenuAddGroupToGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Add selected groups to this group.
-        /// </summary>
-        public static string GroupContextMenuAddGroupToGroupTooltip {
-            get {
-                return ResourceManager.GetString("GroupContextMenuAddGroupToGroupTooltip", resourceCulture);
             }
         }
         
@@ -4050,15 +4041,6 @@ namespace Dynamo.Wpf.Properties {
         public static string NodeAutoCompleteNotAvailableForCollapsedGroups {
             get {
                 return ResourceManager.GetString("NodeAutoCompleteNotAvailableForCollapsedGroups", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Add selected nodes to group.
-        /// </summary>
-        public static string NodeContextMenuAddToGroupTooltip {
-            get {
-                return ResourceManager.GetString("NodeContextMenuAddToGroupTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2930,7 +2930,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add only selected groups to this group.
+        ///   Looks up a localized string similar to Add selected groups to this group.
         /// </summary>
         public static string GroupContextMenuAddGroupToGroupTooltip {
             get {
@@ -4054,7 +4054,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add only selected nodes to this group.
+        ///   Looks up a localized string similar to Add selected nodes to group.
         /// </summary>
         public static string NodeContextMenuAddToGroupTooltip {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2930,6 +2930,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add only selected groups to this group.
+        /// </summary>
+        public static string GroupContextMenuAddGroupToGroupTooltip {
+            get {
+                return ResourceManager.GetString("GroupContextMenuAddGroupToGroupTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Background.
         /// </summary>
         public static string GroupContextMenuBackground {
@@ -4041,6 +4050,15 @@ namespace Dynamo.Wpf.Properties {
         public static string NodeAutoCompleteNotAvailableForCollapsedGroups {
             get {
                 return ResourceManager.GetString("NodeAutoCompleteNotAvailableForCollapsedGroups", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add only selected nodes to this group.
+        /// </summary>
+        public static string NodeContextMenuAddToGroupTooltip {
+            get {
+                return ResourceManager.GetString("NodeContextMenuAddToGroupTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3041,9 +3041,9 @@ To install the latest version of a package, click Install. \n
     <value>Group Name</value>
   </data>
   <data name="GroupContextMenuAddGroupToGroupTooltip" xml:space="preserve">
-    <value>Add only selected groups to this group</value>
+    <value>Add selected groups to this group</value>
   </data>
   <data name="NodeContextMenuAddToGroupTooltip" xml:space="preserve">
-    <value>Add only selected nodes to this group</value>
+    <value>Add selected nodes to group</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3040,4 +3040,10 @@ To install the latest version of a package, click Install. \n
   <data name="PreferencesViewVisualSettingsGroupStyleInput" xml:space="preserve">
     <value>Group Name</value>
   </data>
+  <data name="GroupContextMenuAddGroupToGroupTooltip" xml:space="preserve">
+    <value>Add only selected groups to this group</value>
+  </data>
+  <data name="NodeContextMenuAddToGroupTooltip" xml:space="preserve">
+    <value>Add only selected nodes to this group</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -251,7 +251,7 @@
     <value>I agree to data collection in desktop products for Autodesk analytics programs.</value>
   </data>
   <data name="ContextAddGroupFromSelection" xml:space="preserve">
-    <value>Add To Group</value>
+    <value>Add Node To Group</value>
     <comment>Context menu item</comment>
   </data>
   <data name="ContextCreateGroupFromSelection" xml:space="preserve">
@@ -2540,7 +2540,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <value>&lt;Click here to edit the group title&gt;</value>
   </data>
   <data name="GroupContextMenuAddGroupToGroup" xml:space="preserve">
-    <value>Add Group to Group</value>
+    <value>Add Group to This Group</value>
   </data>
   <data name="NodeInformationalStateDismiss" xml:space="preserve">
     <value>Dismiss</value>
@@ -3039,11 +3039,5 @@ To install the latest version of a package, click Install. \n
   </data>
   <data name="PreferencesViewVisualSettingsGroupStyleInput" xml:space="preserve">
     <value>Group Name</value>
-  </data>
-  <data name="GroupContextMenuAddGroupToGroupTooltip" xml:space="preserve">
-    <value>Add selected groups to this group</value>
-  </data>
-  <data name="NodeContextMenuAddToGroupTooltip" xml:space="preserve">
-    <value>Add selected nodes to group</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -191,7 +191,7 @@
     <comment>Context menu item</comment>
   </data>
   <data name="ContextAddGroupFromSelection" xml:space="preserve">
-    <value>Add To Group</value>
+    <value>Add Node To Group</value>
     <comment>Context menu item</comment>
   </data>
   <data name="ContextMenuNodesFromGeometry" xml:space="preserve">
@@ -2767,7 +2767,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <value>&lt;Double click here to edit group title&gt;</value>
   </data>
   <data name="GroupContextMenuAddGroupToGroup" xml:space="preserve">
-    <value>Add Group to Group</value>
+    <value>Add Group to This Group</value>
   </data>
   <data name="ExitTourWindowContent" xml:space="preserve">
     <value>You can return to this guide later from the Help menu.</value>
@@ -3026,11 +3026,5 @@ To install the latest version of a package, click Install. \n
   </data>
   <data name="PreferencesViewVisualSettingsGroupStyleInput" xml:space="preserve">
     <value>Group Name</value>
-  </data>
-  <data name="GroupContextMenuAddGroupToGroupTooltip" xml:space="preserve">
-    <value>Add selected groups to this group</value>
-  </data>
-  <data name="NodeContextMenuAddToGroupTooltip" xml:space="preserve">
-    <value>Add selected nodes to group</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3028,9 +3028,9 @@ To install the latest version of a package, click Install. \n
     <value>Group Name</value>
   </data>
   <data name="GroupContextMenuAddGroupToGroupTooltip" xml:space="preserve">
-    <value>Add only selected groups to this group</value>
+    <value>Add selected groups to this group</value>
   </data>
   <data name="NodeContextMenuAddToGroupTooltip" xml:space="preserve">
-    <value>Add only selected nodes to this group</value>
+    <value>Add selected nodes to group</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3027,4 +3027,10 @@ To install the latest version of a package, click Install. \n
   <data name="PreferencesViewVisualSettingsGroupStyleInput" xml:space="preserve">
     <value>Group Name</value>
   </data>
+  <data name="GroupContextMenuAddGroupToGroupTooltip" xml:space="preserve">
+    <value>Add only selected groups to this group</value>
+  </data>
+  <data name="NodeContextMenuAddToGroupTooltip" xml:space="preserve">
+    <value>Add only selected nodes to this group</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
@@ -97,8 +97,7 @@ namespace Dynamo.Wpf.Utilities
             Binding isChecked = null,
             Binding visibility = null,
             Binding isEnabled = null,
-            Binding itemsSource = null,
-            ToolTip tooltip = null
+            Binding itemsSource = null
         )
         {
             MenuItem menuItem = new MenuItem { Header = header, IsCheckable = isCheckable };
@@ -110,11 +109,6 @@ namespace Dynamo.Wpf.Utilities
             if (visibility != null) menuItem.SetBinding(UIElement.VisibilityProperty, visibility);
             if (isEnabled != null) menuItem.SetBinding(UIElement.IsEnabledProperty, isEnabled);
             if (itemsSource != null) menuItem.SetBinding(ItemsControl.ItemsSourceProperty, itemsSource);
-            if (tooltip != null)
-            {
-                ToolTipService.SetShowOnDisabled(menuItem, true);
-                menuItem.ToolTip = tooltip;
-            }
 
             return menuItem;
         }
@@ -167,10 +161,6 @@ namespace Dynamo.Wpf.Utilities
                     {
                         Source = NodeViewModel,
                         Path = new PropertyPath(nameof(NodeViewModel.AddToGroupCommand))
-                    },
-                    tooltip: new ToolTip()
-                    {
-                        Content= Properties.Resources.NodeContextMenuAddToGroupTooltip
                     }
                 )
             );

--- a/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
@@ -85,7 +85,6 @@ namespace Dynamo.Wpf.Utilities
         /// <param name="visibility"></param>
         /// <param name="isEnabled"></param>
         /// <param name="itemsSource"></param>
-        /// <param name="tooltip"></param>
         /// <returns></returns>
         internal static MenuItem CreateMenuItem
         (

--- a/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
@@ -84,6 +84,8 @@ namespace Dynamo.Wpf.Utilities
         /// <param name="isChecked"></param>
         /// <param name="visibility"></param>
         /// <param name="isEnabled"></param>
+        /// <param name="itemsSource"></param>
+        /// <param name="tooltip"></param>
         /// <returns></returns>
         internal static MenuItem CreateMenuItem
         (
@@ -95,7 +97,8 @@ namespace Dynamo.Wpf.Utilities
             Binding isChecked = null,
             Binding visibility = null,
             Binding isEnabled = null,
-            Binding itemsSource = null
+            Binding itemsSource = null,
+            ToolTip tooltip = null
         )
         {
             MenuItem menuItem = new MenuItem { Header = header, IsCheckable = isCheckable };
@@ -107,6 +110,11 @@ namespace Dynamo.Wpf.Utilities
             if (visibility != null) menuItem.SetBinding(UIElement.VisibilityProperty, visibility);
             if (isEnabled != null) menuItem.SetBinding(UIElement.IsEnabledProperty, isEnabled);
             if (itemsSource != null) menuItem.SetBinding(ItemsControl.ItemsSourceProperty, itemsSource);
+            if (tooltip != null)
+            {
+                ToolTipService.SetShowOnDisabled(menuItem, true);
+                menuItem.ToolTip = tooltip;
+            }
 
             return menuItem;
         }
@@ -159,6 +167,10 @@ namespace Dynamo.Wpf.Utilities
                     {
                         Source = NodeViewModel,
                         Path = new PropertyPath(nameof(NodeViewModel.AddToGroupCommand))
+                    },
+                    tooltip: new ToolTip()
+                    {
+                        Content= Properties.Resources.NodeContextMenuAddToGroupTooltip
                     }
                 )
             );

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -285,11 +285,7 @@
                 <MenuItem Name="AddGroupToGroup"
                           Command="{Binding AddGroupToGroupCommand}"
                           Header="{x:Static p:Resources.GroupContextMenuAddGroupToGroup}"
-                          ToolTipService.ShowOnDisabled="True">
-                          <MenuItem.ToolTip>
-                        <ToolTip Content="{x:Static p:Resources.GroupContextMenuAddGroupToGroupTooltip}" Style="{StaticResource GenericToolTipLight}"/>
-                          </MenuItem.ToolTip>
-                </MenuItem>
+                          ToolTipService.ShowOnDisabled="True" />
                 <MenuItem Name="GraphLayoutAnnotation"
                           Click="OnGraphLayoutAnnotation"
                           Header="{x:Static p:Resources.GroupContextMenuGraphLayout}" />

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -284,8 +284,7 @@
                           Header="{x:Static p:Resources.ContextUnGroupFromSelection}" />
                 <MenuItem Name="AddGroupToGroup"
                           Command="{Binding AddGroupToGroupCommand}"
-                          Header="{x:Static p:Resources.GroupContextMenuAddGroupToGroup}"
-                          ToolTipService.ShowOnDisabled="True" />
+                          Header="{x:Static p:Resources.GroupContextMenuAddGroupToGroup}" />
                 <MenuItem Name="GraphLayoutAnnotation"
                           Click="OnGraphLayoutAnnotation"
                           Header="{x:Static p:Resources.GroupContextMenuGraphLayout}" />

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -284,7 +284,12 @@
                           Header="{x:Static p:Resources.ContextUnGroupFromSelection}" />
                 <MenuItem Name="AddGroupToGroup"
                           Command="{Binding AddGroupToGroupCommand}"
-                          Header="{x:Static p:Resources.GroupContextMenuAddGroupToGroup}" />
+                          Header="{x:Static p:Resources.GroupContextMenuAddGroupToGroup}"
+                          ToolTipService.ShowOnDisabled="True">
+                          <MenuItem.ToolTip>
+                        <ToolTip Content="{x:Static p:Resources.GroupContextMenuAddGroupToGroupTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                          </MenuItem.ToolTip>
+                </MenuItem>
                 <MenuItem Name="GraphLayoutAnnotation"
                           Click="OnGraphLayoutAnnotation"
                           Header="{x:Static p:Resources.GroupContextMenuGraphLayout}" />


### PR DESCRIPTION
### Purpose

[DYN-4599](https://jira.autodesk.com/browse/DYN-4599)
Adds tooltip to:
- `Add Group to Group` context menu item - `Add selected groups to this group`
- `Add to Group` context menu item - `Add selected nodes to group`

![tltp2](https://user-images.githubusercontent.com/32665108/157120126-bba4bbf2-3cbd-4832-9a15-e8b68df98835.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@DynamoDS/dynamo 
