### PR TITLE
Fix Annotation Deselect Behavior for Group with nested group

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -756,11 +756,16 @@ namespace Dynamo.Graph.Annotations
         /// </summary>
         public override void Deselect()
         {           
-            foreach (var models in Nodes)
+            foreach (var model in Nodes)
             {
-                models.IsSelected = false;
-            }   
-       
+                model.IsSelected = false;
+                // De-select all elements under the deleted group if there is any nested group
+                if (model is AnnotationModel)
+                {
+                    (model as AnnotationModel).Deselect();
+                }
+            }
+
             base.Deselect();
         }
 
@@ -787,7 +792,7 @@ namespace Dynamo.Graph.Annotations
                 foreach (var model in this.Nodes)
                 {
                     model.PropertyChanged -= model_PropertyChanged;
-                    model.Disposed -= model_Disposed;                    
+                    model.Disposed -= model_Disposed;
                 }
             }
             base.Dispose();


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-4597, Fix Annotation Deselect Behavior, by adding a condition that if there is any nested group, also deselect nested group and its elements. This should be done at Global launch and was missed. Adding this will help in the case when users ungroup parent groups and then continue group operations seamlessly. Added unit tests as well.

![UnGroup](https://user-images.githubusercontent.com/3942418/157129311-1ee68829-f500-433d-8c5e-47f734831610.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix Annotation Deselect Behavior for Group with nested group


### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
