### PR TITLE
DYN-4582, DYN-4557: Fix warning issues with Code block nodes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1594,7 +1594,7 @@ namespace Dynamo.Graph.Nodes
         private void ClearTooltipText()
         {
             ToolTipText = "";
-            infos.RemoveWhere(x => x.State == ElementState.Warning);
+            infos.RemoveWhere(x => x.State == ElementState.Warning || x.State == ElementState.Error);
         }
 
         private void ClearPersistentWarning()
@@ -1718,8 +1718,9 @@ namespace Dynamo.Graph.Nodes
         public void Error(string p)
         {
             State = ElementState.Error;
-            ToolTipText = p;
             infos.Add(new Info(p, ElementState.Error));
+
+            ToolTipText = p;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1625,23 +1625,38 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         internal void ClearTransientWarning(string t = null)
         {
-            if (State == ElementState.Warning)
+            if (State != ElementState.Warning) return;
+
+            bool cond = false;
+            infos.RemoveWhere(x =>
             {
-                if (string.IsNullOrEmpty(t) || infos.Any(x => x.Message == t && x.State == ElementState.Warning))
-                {// Called with null (or empty argument) or argument matched the existing transient warning
-                    infos.RemoveWhere(x => x.State == ElementState.Warning);
-                    if (!string.IsNullOrEmpty(persistentWarning))
-                    {// Still have persistent warnings then switch to the PersistentWarning state
-                        State = ElementState.PersistentWarning;
-                        ToolTipText = persistentWarning;
-                        infos.Add(new Info(persistentWarning, ElementState.PersistentWarning));
+                if (string.IsNullOrEmpty(t) && x.State == ElementState.Warning)
+                {
+                    cond = true;
+                }
+                else if (!string.IsNullOrEmpty(t))
+                {
+                    if (x.Message == t && x.State == ElementState.Warning)
+                    {
+                        cond = true;
                     }
-                    else
-                    {// No persistent warnings, go to default
-                        State = ElementState.Dead;
-                        ClearErrorsAndWarnings();
-                    }
-                } 
+                }
+                return cond;
+            });
+            if (cond)
+            {
+                if (!string.IsNullOrEmpty(persistentWarning))
+                {
+                    // Still have persistent warnings then switch to the PersistentWarning state
+                    State = ElementState.PersistentWarning;
+                    ToolTipText = persistentWarning;
+                }
+                else
+                {
+                    // No persistent warnings, go to default
+                    State = ElementState.Dead;
+                    ClearErrorsAndWarnings();
+                }
             }
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1736,8 +1736,12 @@ namespace Dynamo.Graph.Nodes
                 State = ElementState.PersistentWarning;
                 if (!string.Equals(persistentWarning, p))
                 {
-                    persistentWarning += string.IsNullOrEmpty(persistentWarning) ? p : $"{Environment.NewLine}{p}";
-                    infos.Add(new Info(p, State));
+                    persistentWarning += string.IsNullOrEmpty(persistentWarning) ? p : $"\n{p}";
+                    var texts = persistentWarning.Split(new[] { "\n" }, StringSplitOptions.None);
+                    foreach (var text in texts)
+                    {
+                        infos.Add(new Info(text, State));
+                    }
                 }
                 ToolTipText = persistentWarning;
             }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1717,7 +1717,7 @@ namespace Dynamo.Graph.Nodes
                 State = ElementState.PersistentWarning;
                 if (!string.Equals(persistentWarning, p))
                 {
-                    persistentWarning += p;
+                    persistentWarning += persistentWarning == "" ? p : $"{Environment.NewLine}{p}";
                 }
                 ToolTipText = persistentWarning;
             }
@@ -1725,7 +1725,7 @@ namespace Dynamo.Graph.Nodes
             {
                 State = ElementState.Warning;
                 transientWarning = p;
-                ToolTipText = string.IsNullOrEmpty(persistentWarning) ? p : string.IsNullOrEmpty(p) ? persistentWarning : $"{persistentWarning}\n{p}";
+                ToolTipText = string.IsNullOrEmpty(persistentWarning) ? p : string.IsNullOrEmpty(p) ? persistentWarning : $"{persistentWarning}{Environment.NewLine}{p}";
             }
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -364,7 +364,7 @@ namespace Dynamo.Graph.Nodes
             set
             {
                 toolTipText = value;
-                RaisePropertyChanged("ToolTipText");
+                RaisePropertyChanged(nameof(ToolTipText));
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -842,14 +842,6 @@ namespace Dynamo.Graph.Workspaces
                 // The workspace has been built for the first time
                 silenceNodeModifications = false;
 
-                // An event handler we can listen to on the NodeViewModel, to update the 
-                // node's informational state. This is required because Errors and Warnings 
-                // currently fire differently from one another. 
-                foreach (NodeModel nodeModel in task.ModifiedNodes)
-                {
-                    nodeModel.OnNodeMessagesClearing();
-                }
-
                 OnEvaluationStarted(EventArgs.Empty);
                 scheduler.ScheduleForExecution(task);
 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -847,6 +847,13 @@ namespace Dynamo.Graph.Workspaces
                 // currently fire differently from one another. 
                 foreach (NodeModel nodeModel in task.ModifiedNodes)
                 {
+                    // CodeBlockNodes are unique in that they can exhibit two types of warnings and errors - 
+                    // those that are found at precompilation (compile time errors and warnings),
+                    // and those that are found at execution time (runtime errors and warnings). In the case
+                    // of CBNs therefore, we need to retain errors and warnings from both stages, which is why we cannot 
+                    // clear them here (before execution) as this will wipe out those from the precompilation stage.
+                    if (nodeModel is CodeBlockNodeModel) continue;
+
                     nodeModel.OnNodeMessagesClearing();
                 }
 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -847,13 +847,6 @@ namespace Dynamo.Graph.Workspaces
                 // currently fire differently from one another. 
                 foreach (NodeModel nodeModel in task.ModifiedNodes)
                 {
-                    // CodeBlockNodes are unique in that they can exhibit two types of warnings and errors - 
-                    // those that are found at precompilation (compile time errors and warnings),
-                    // and those that are found at execution time (runtime errors and warnings). In the case
-                    // of CBNs therefore, we need to retain errors and warnings from both stages, which is why we cannot 
-                    // clear them here (before execution) as this will wipe out those from the precompilation stage.
-                    if (nodeModel is CodeBlockNodeModel) continue;
-
                     nodeModel.OnNodeMessagesClearing();
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -187,20 +187,18 @@ namespace Dynamo.Wpf.ViewModels.Core
                     SetCurrentWarning(NotificationLevel.Moderate, Properties.Resources.RunCompletedWithWarningsMessage);
                 }
             }
+        }
 
-            void UpdateNodeInfoBubbleContent(EvaluationCompletedEventArgs evalargs)
+        private void UpdateNodeInfoBubbleContent(EvaluationCompletedEventArgs evalargs)
+        {
+            if (evalargs.MessageKeys == null) return;
+
+            foreach (var messageID in evalargs.MessageKeys)
             {
-                if (e.MessageKeys == null)
-                {
-                    return;
-                }
-                foreach (var messageID in evalargs.MessageKeys)
-                { 
-                    var node = this.Nodes.FirstOrDefault(n => n.Id == messageID);
-                    if (node == null)
-                        continue;
-                    node.UpdateBubbleContent();
-                }
+                var node = Nodes.FirstOrDefault(n => n.Id == messageID);
+                if (node == null) continue;
+
+                node.UpdateBubbleContent();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1222,14 +1222,12 @@ namespace Dynamo.ViewModels
                 var infoStyle = info.State == ElementState.Error ? InfoBubbleViewModel.Style.Error : InfoBubbleViewModel.Style.Warning;
                 var data = new InfoBubbleDataPacket(infoStyle, topLeft, botRight, info.Message, connectingDirection);
                 packets.Add(data);
-                //ErrorBubble.UpdateContentCommand.Execute(data);
             }
             InfoBubbleViewModel.Style style = NodeModel.State == ElementState.Error
                 ? InfoBubbleViewModel.Style.Error
                 : InfoBubbleViewModel.Style.Warning;
 
             ErrorBubble.InfoBubbleStyle = style;
-            ErrorBubble.ConnectingDirection = connectingDirection;
 
             // If running Dynamo with UI, use dispatcher, otherwise not
             if (DynamoViewModel.UIDispatcher != null)

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1210,6 +1210,7 @@ namespace Dynamo.ViewModels
             const InfoBubbleViewModel.Direction connectingDirection = InfoBubbleViewModel.Direction.Bottom;
             var data = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
 
+            // TODO: Perhaps need to aggregate errors here instead of replacing/updating error content.
             ErrorBubble.UpdateContentCommand.Execute(data);
 
             // If running Dynamo with UI, use dispatcher, otherwise not

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1211,18 +1211,21 @@ namespace Dynamo.ViewModels
             var topLeft = new Point(NodeModel.X, NodeModel.Y);
             var botRight = new Point(NodeModel.X + NodeModel.Width, NodeModel.Y + NodeModel.Height);
 
-            InfoBubbleViewModel.Style style = NodeModel.State == ElementState.Error
-                ? InfoBubbleViewModel.Style.Error
-                : InfoBubbleViewModel.Style.Warning;
-
             const InfoBubbleViewModel.Direction connectingDirection = InfoBubbleViewModel.Direction.Bottom;
             var packets = new List<InfoBubbleDataPacket>(NodeModel.Infos.Count);
             foreach (var info in NodeModel.Infos)
             {
-                var data = new InfoBubbleDataPacket(style, topLeft, botRight, info.Message, connectingDirection);
+                var infoStyle = info.State == ElementState.Error ? InfoBubbleViewModel.Style.Error : InfoBubbleViewModel.Style.Warning;
+                var data = new InfoBubbleDataPacket(infoStyle, topLeft, botRight, info.Message, connectingDirection);
                 packets.Add(data);
-                ErrorBubble.UpdateContentCommand.Execute(data);
+                //ErrorBubble.UpdateContentCommand.Execute(data);
             }
+            InfoBubbleViewModel.Style style = NodeModel.State == ElementState.Error
+                ? InfoBubbleViewModel.Style.Error
+                : InfoBubbleViewModel.Style.Warning;
+
+            ErrorBubble.InfoBubbleStyle = style;
+            ErrorBubble.ConnectingDirection = connectingDirection;
 
             // If running Dynamo with UI, use dispatcher, otherwise not
             if (DynamoViewModel.UIDispatcher != null)

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -805,6 +805,7 @@ namespace Dynamo.ViewModels
             logic.NodeMessagesClearing += Logic_NodeMessagesClearing;
 
             logic_PropertyChanged(this, new PropertyChangedEventArgs(nameof(IsVisible)));
+            logic_PropertyChanged(this, new PropertyChangedEventArgs(nameof(ToolTipText)));
         }
 
 
@@ -1218,13 +1219,13 @@ namespace Dynamo.ViewModels
             {
                 DynamoViewModel.UIDispatcher.Invoke(() =>
                 {
-                    ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
+                    ErrorBubble.NodeMessages.Add(data);
                     WarningBarColor = GetWarningColor();
                 });
             }
             else
             {
-                ErrorBubble.NodeMessages.Add(new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection));
+                ErrorBubble.NodeMessages.Add(data);
                 WarningBarColor = GetWarningColor();
             }
             

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1201,7 +1201,7 @@ namespace Dynamo.ViewModels
             // 1. Compile-time warnings in CBNs
             // 2. Obsolete nodes with warnings
             // 3. Dummy or unresolved nodes
-            if (NodeModel.State != ElementState.PersistentWarning)
+            if (NodeModel.State != ElementState.PersistentWarning && !NodeModel.IsInErrorState)
             {
                 if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1193,7 +1193,14 @@ namespace Dynamo.ViewModels
 
             bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning;
 
-            if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
+            if (NodeModel is CodeBlockNodeModel)
+            {
+                if (!hasErrorOrWarning) return;
+            }
+            else
+            {
+                if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
+            }
 
             if (!NodeModel.Infos.Any()) return;
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -805,7 +805,6 @@ namespace Dynamo.ViewModels
             logic.NodeMessagesClearing += Logic_NodeMessagesClearing;
 
             logic_PropertyChanged(this, new PropertyChangedEventArgs(nameof(IsVisible)));
-            logic_PropertyChanged(this, new PropertyChangedEventArgs(nameof(ToolTipText)));
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1193,11 +1193,9 @@ namespace Dynamo.ViewModels
 
             bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning;
 
-            if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;  
+            if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
 
-            // NOTE!: If tooltip is not cached here, it will be cleared once the dispatcher is invoked below
-            string content = NodeModel.ToolTipText;
-            if (string.IsNullOrWhiteSpace(content)) return;
+            if (!NodeModel.Infos.Any()) return;
 
             if (ErrorBubble == null) BuildErrorBubble();
 
@@ -1211,11 +1209,10 @@ namespace Dynamo.ViewModels
                 : InfoBubbleViewModel.Style.Warning;
 
             const InfoBubbleViewModel.Direction connectingDirection = InfoBubbleViewModel.Direction.Bottom;
-            var warningTexts = content.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
-            var packets = new List<InfoBubbleDataPacket>(warningTexts.Length);
-            foreach (var text in warningTexts)
+            var packets = new List<InfoBubbleDataPacket>(NodeModel.Infos.Count);
+            foreach (var info in NodeModel.Infos)
             {
-                var data = new InfoBubbleDataPacket(style, topLeft, botRight, text, connectingDirection);
+                var data = new InfoBubbleDataPacket(style, topLeft, botRight, info.Message, connectingDirection);
                 packets.Add(data);
                 ErrorBubble.UpdateContentCommand.Execute(data);
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -830,7 +830,11 @@ namespace Dynamo.ViewModels
         {
             // Because errors are evaluated before the graph/node executes, we need to ensure 
             // errors aren't being dismissed when the graph runs.
-            if (nodeLogic.State == ElementState.Error || ErrorBubble == null) return;
+            // Persistent warnings should also not be dismissed when a graph runs as they can include:
+            // 1. Compile-time warnings in CBNs
+            // 2. Obsolete nodes with warnings
+            // 3. Dummy or unresolved nodes
+            if (nodeLogic.State == ElementState.Error || nodeLogic.State == ElementState.PersistentWarning || ErrorBubble == null) return;
 
             if (DynamoViewModel.UIDispatcher != null)
             {
@@ -1191,13 +1195,13 @@ namespace Dynamo.ViewModels
         {
             if (DynamoViewModel == null) return;
 
-            bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning;
+            bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning;
 
-            if (NodeModel is CodeBlockNodeModel)
-            {
-                if (!hasErrorOrWarning) return;
-            }
-            else
+            // Persistent warnings should not be dismissed even if nodes are not involved in an execution as they can include:
+            // 1. Compile-time warnings in CBNs
+            // 2. Obsolete nodes with warnings
+            // 3. Dummy or unresolved nodes
+            if (NodeModel.State != ElementState.PersistentWarning)
             {
                 if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1196,13 +1196,13 @@ namespace Dynamo.ViewModels
 
             bool hasErrorOrWarning = NodeModel.IsInErrorState || NodeModel.State == ElementState.Warning;
 
-            // Persistent warnings should not be dismissed even if nodes are not involved in an execution as they can include:
+            // Persistent warnings should continue to be displayed even if nodes are not involved in an execution as they can include:
             // 1. Compile-time warnings in CBNs
             // 2. Obsolete nodes with warnings
             // 3. Dummy or unresolved nodes
             if (NodeModel.State != ElementState.PersistentWarning && !NodeModel.IsInErrorState)
             {
-                if (!(NodeModel.WasInvolvedInExecution && hasErrorOrWarning)) return;
+                if (!NodeModel.WasInvolvedInExecution || !hasErrorOrWarning) return;
             }
 
             if (!NodeModel.Infos.Any()) return;

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -994,7 +994,7 @@ namespace Dynamo.ViewModels
         }
     }
 
-    public struct InfoBubbleDataPacket
+    public struct InfoBubbleDataPacket : IEquatable<InfoBubbleDataPacket>
     {
         private const string externalLinkIdentifier = "href=";
         public InfoBubbleViewModel.Style Style;
@@ -1047,7 +1047,7 @@ namespace Dynamo.ViewModels
             if (!text.Contains(externalLinkIdentifier)) return text;
 
             // return the text without the link or identifier
-            string[] split = text.Split(new string[] { externalLinkIdentifier, "\\n" }, StringSplitOptions.None);
+            string[] split = text.Split(new string[] { externalLinkIdentifier }, StringSplitOptions.None);
             return split[0];
         }
 
@@ -1072,5 +1072,15 @@ namespace Dynamo.ViewModels
             }
         }
 
+        public bool Equals(InfoBubbleDataPacket other)
+        {
+            return 
+                Style == other.Style &&
+                Text == other.Text &&
+                TopLeft == other.TopLeft &&
+                BotRight == other.BotRight &&
+                Link == other.Link &&
+                ConnectingDirection == other.ConnectingDirection;
+        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1047,7 +1047,7 @@ namespace Dynamo.ViewModels
             if (!text.Contains(externalLinkIdentifier)) return text;
 
             // return the text without the link or identifier
-            string[] split = text.Split(new string[] { externalLinkIdentifier }, StringSplitOptions.None);
+            string[] split = text.Split(new string[] { externalLinkIdentifier, "\\n" }, StringSplitOptions.None);
             return split[0];
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1076,8 +1076,6 @@ namespace Dynamo.ViewModels
             return 
                 Style == other.Style &&
                 Text == other.Text &&
-                TopLeft == other.TopLeft &&
-                BotRight == other.BotRight &&
                 Link == other.Link &&
                 ConnectingDirection == other.ConnectingDirection;
         }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
@@ -29,7 +29,7 @@ namespace CoreNodeModelsWpf.Nodes
             RenderOptions.SetBitmapScalingMode(dummyNodeImage, BitmapScalingMode.HighQuality);
 
             nodeView.inputGrid.Children.Add(dummyNodeImage);
-            model.Warning(model.GetDescription());
+            model.Warning(model.GetDescription(), true);
         }
 
         public void Dispose()

--- a/test/DynamoCoreTests/Models/NodeModelWarnings.cs
+++ b/test/DynamoCoreTests/Models/NodeModelWarnings.cs
@@ -30,19 +30,19 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent2", true);
 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2" }), cbn.ToolTipText);
 
             cbn.Warning("TestTransient0", false);
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning("TestTransientOther");
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning("TestTransient0");
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);
@@ -53,15 +53,15 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent2", true);
 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2" }), cbn.ToolTipText);
                                                                                                          
             cbn.Warning("TestTransient0", false);                                                        
             Assert.AreEqual(ElementState.Warning, cbn.State);                                            
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
                                                                                                          
             cbn.ClearTransientWarning();                                                                 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);                                  
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\nTestPermanent2" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);
@@ -95,12 +95,12 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent1", true);
   
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1" }), cbn.ToolTipText);
 
             cbn.Warning("TestTransient1", false);
 
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestTransient1" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestPermanent1", "\r\nTestTransient1" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);

--- a/test/DynamoCoreTests/Models/NodeModelWarnings.cs
+++ b/test/DynamoCoreTests/Models/NodeModelWarnings.cs
@@ -30,19 +30,19 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent2", true);
 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
 
             cbn.Warning("TestTransient0", false);
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "\nTestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning("TestTransientOther");
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "\nTestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.ClearTransientWarning("TestTransient0");
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);
@@ -53,15 +53,15 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestPermanent2", true);
 
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
-
-            cbn.Warning("TestTransient0", false);
-            Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2", "\nTestTransient0" }), cbn.ToolTipText);
-
-            cbn.ClearTransientWarning();
-            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "TestPermanent2" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
+                                                                                                         
+            cbn.Warning("TestTransient0", false);                                                        
+            Assert.AreEqual(ElementState.Warning, cbn.State);                                            
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2", "\r\nTestTransient0" }), cbn.ToolTipText);
+                                                                                                         
+            cbn.ClearTransientWarning();                                                                 
+            Assert.AreEqual(ElementState.PersistentWarning, cbn.State);                                  
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestPermanent2" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);
@@ -90,17 +90,17 @@ namespace Dynamo.Tests.Models
             cbn.Warning("TestTransient0", false);
 
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\nTestTransient0" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestTransient0" }), cbn.ToolTipText);
 
             cbn.Warning("TestPermanent1", true);
   
             Assert.AreEqual(ElementState.PersistentWarning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1" }), cbn.ToolTipText);
 
             cbn.Warning("TestTransient1", false);
 
             Assert.AreEqual(ElementState.Warning, cbn.State);
-            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "TestPermanent1", "\nTestTransient1" }), cbn.ToolTipText);
+            Assert.AreEqual(string.Join("", new List<string>() { "TestPermanent0", "\r\nTestPermanent1", "\r\nTestTransient1" }), cbn.ToolTipText);
 
             cbn.ClearErrorsAndWarnings();
             Assert.AreEqual(ElementState.Active, cbn.State);

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -395,7 +395,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void PreviewBubble_AvoidDuplicatedWarningMessages()
+        public void InfoBubble_AvoidDuplicatedWarningMessages()
         {
             Open(@"core\watch\WatchDuplicatedWarningMessages.dyn");
             var nodeView = NodeViewWithGuid("67b46c3f-b60f-49d7-a8cf-bb9cc4a03450");
@@ -413,6 +413,33 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
 
             Assert.AreEqual(1, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
+        }
+
+        [Test]
+        public void InfoBubble_ShowsWarningOnCopyPastedCBN()
+        {
+            Open(@"core\watch\ShowsWarningOnCopyPastedCBN.dyn");
+            var nodeView = NodeViewWithGuid("686892b3-ea1d-4a1a-9c50-a891eb4479f6");
+
+            Assert.AreEqual(2, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
+
+            var selectNodeCommand =
+             new Dynamo.Models.DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
+
+            Model.ExecuteCommand(selectNodeCommand);
+
+            Model.Copy();
+            Model.Paste();
+
+            DispatcherUtil.DoEvents();
+
+            var nodes = Model.CurrentWorkspace.Nodes;
+            Assert.AreEqual(2, nodes.Count());
+            foreach (var node in nodes)
+            {
+                var nView = NodeViewWithGuid(node.GUID.ToString());
+                Assert.AreEqual(2, nView.ViewModel.ErrorBubble.NodeMessages.Count);
+            }
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -8,6 +8,7 @@ using CoreNodeModels;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Utilities;
+using Dynamo.Models;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 
@@ -403,7 +404,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
 
             var selectNodeCommand =
-             new Dynamo.Models.DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
+             new DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
 
             Model.ExecuteCommand(selectNodeCommand);
 
@@ -424,7 +425,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
 
             var selectNodeCommand =
-             new Dynamo.Models.DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
+             new DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
 
             Model.ExecuteCommand(selectNodeCommand);
 
@@ -452,7 +453,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
 
             var cbnGuid = Guid.Parse(guid);
-            var command = new Dynamo.Models.DynamoModel.UpdateModelValueCommand(
+            var command = new DynamoModel.UpdateModelValueCommand(
                 Guid.Empty, cbnGuid, "Code", @"a=0;
                                                a="";
                                                b=0..1;
@@ -479,6 +480,54 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
 
             var cbnGuid = Guid.Parse(guid);
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, cbnGuid, "Code", @"a=0;
+                                               a="";
+                                               b=0..1;
+                                               c=b[2];
+                                               %$#^$@;");
+            Model.ExecuteCommand(command);
+
+            var selectNodeCommand =
+             new DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
+
+            Model.ExecuteCommand(selectNodeCommand);
+
+            Model.Copy();
+            Model.Paste();
+
+            DispatcherUtil.DoEvents();
+
+            var nodes = Model.CurrentWorkspace.Nodes;
+            Assert.AreEqual(2, nodes.Count());
+
+            var msgs = nodeView.ViewModel.ErrorBubble.NodeMessages;
+            Assert.AreEqual(3, msgs.Count);
+            var warnings = msgs.Where(x => x.Style == Dynamo.ViewModels.InfoBubbleViewModel.Style.Warning);
+            Assert.AreEqual(2, warnings.Count());
+
+            var errors = msgs.Where(x => x.Style == Dynamo.ViewModels.InfoBubbleViewModel.Style.Error);
+            Assert.AreEqual(1, errors.Count());
+
+            var copy = nodes.Where(n => n.GUID.ToString() != guid).FirstOrDefault();
+            nodeView = NodeViewWithGuid(copy.GUID.ToString());
+            msgs = nodeView.ViewModel.ErrorBubble.NodeMessages;
+            Assert.AreEqual(1, msgs.Count);
+
+            errors = msgs.Where(x => x.Style == Dynamo.ViewModels.InfoBubbleViewModel.Style.Error);
+            Assert.AreEqual(1, errors.Count());
+        }
+
+        [Test]
+        public void InfoBubble_ShowsError_CopyPastedCBN_UndoRedo()
+        {
+            Open(@"core\watch\ShowsWarningOnCopyPastedCBN.dyn");
+            var guid = "686892b3-ea1d-4a1a-9c50-a891eb4479f6";
+            var nodeView = NodeViewWithGuid(guid);
+
+            Assert.AreEqual(2, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
+
+            var cbnGuid = Guid.Parse(guid);
             var command = new Dynamo.Models.DynamoModel.UpdateModelValueCommand(
                 Guid.Empty, cbnGuid, "Code", @"a=0;
                                                a="";
@@ -488,12 +537,18 @@ namespace DynamoCoreWpfTests
             Model.ExecuteCommand(command);
 
             var selectNodeCommand =
-             new Dynamo.Models.DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
+             new DynamoModel.SelectModelCommand(nodeView.ViewModel.Id.ToString(), System.Windows.Input.ModifierKeys.None.AsDynamoType());
 
             Model.ExecuteCommand(selectNodeCommand);
 
             Model.Copy();
             Model.Paste();
+
+            var undoCommand = new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Undo);
+            Model.ExecuteCommand(undoCommand);
+
+            var redoCommand = new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Redo);
+            Model.ExecuteCommand(redoCommand);
 
             DispatcherUtil.DoEvents();
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
@@ -52,7 +52,7 @@ namespace DynamoCoreWpfTests.ViewExtensions
             using (new MousePointManipulatorTest(pntNode, dme))
             {
                 Assert.AreEqual(ElementState.Warning, pntNode.State);
-                Assert.AreEqual("TestPersistentWarning" + "\n" + 
+                Assert.AreEqual("TestPersistentWarning" + "\r\n" + 
                     "Failed to create manipulator for Direct Manipulation of geometry: Exception of type 'System.Exception' was thrown.", 
                     pntNode.ToolTipText);
             }

--- a/test/core/watch/ShowsWarningOnCopyPastedCBN.dyn
+++ b/test/core/watch/ShowsWarningOnCopyPastedCBN.dyn
@@ -1,0 +1,111 @@
+{
+  "Uuid": "f42ef6a5-5e6e-44fe-9b17-a739812b3e53",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "ShowsWarningOnCopyPastedCBN",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "a=0;\na=\"\";\nb=0..1;\nc=b[2];",
+      "Id": "686892b3ea1d4a1a9c50a891eb4479f6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "51aba061af8c4fcd93914aea7bdb16e0",
+          "Name": "",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "254aa03fbcd348909503c343132f6a8d",
+          "Name": "",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6dbe636d66d949268a6965e9e66a7a2d",
+          "Name": "",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4355",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "686892b3ea1d4a1a9c50a891eb4479f6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 227.40000000000003,
+        "Y": 283.40000000000003
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/watch/obsolete_if_node.dyn
+++ b/test/core/watch/obsolete_if_node.dyn
@@ -1,0 +1,120 @@
+{
+  "Uuid": "a6bbfb52-366d-45ec-bbcc-dc46643e022c",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "obsolete_if_node",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Logic.If, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "c4c8875cc4234bfbbf728bac361394b5",
+      "Inputs": [
+        {
+          "Id": "1da6bba914234c02af74947028ae2f1b",
+          "Name": "test",
+          "Description": "Boolean test",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "edf26fefd0e34368819d8ffb92954be8",
+          "Name": "true",
+          "Description": "Returned if test is true",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d12d9d85206447bfb2cb683082f71821",
+          "Name": "false",
+          "Description": "Returned if test is false",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0252c8b5b82a4e8bb2419a6b0643b358",
+          "Name": "result",
+          "Description": "Result block produced",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Conditional statement"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4362",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "c4c8875cc4234bfbbf728bac361394b5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Name": "If",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 447.60000000000008,
+        "Y": 215.60000000000002
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/watch/selectbycat.dyn
+++ b/test/core/watch/selectbycat.dyn
@@ -1,0 +1,223 @@
+{
+  "Uuid": "10624e95-988b-42eb-9773-a14ff6518e2c",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "selectbycat",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.ComboNodes.DSModelElementByCategorySelection, DSRevitNodesUI",
+      "SelectedIndex": 307,
+      "SelectedString": "OST_Levels",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [],
+      "Id": "74018f127ada41608cff93af2c8c960f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "822e017d0250493e97a0935e3505c123",
+          "Name": "Element",
+          "Description": "Die ausgewählten Elemente",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.SpecTypes, DSRevitNodesUI",
+      "SelectedIndex": 66,
+      "SelectedString": "autodesk.spec.aec:length",
+      "NodeType": "ExtensionNode",
+      "Id": "6b7a6d2cfd8c4459bafc6783eb8ff485",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "59d22dead2844a099858cd0b54241cd7",
+          "Name": "SpecType",
+          "Description": "SpecType sélectionné",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Spec type."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Application.Document.UnitTypeBySpecType@Revit.Elements.ForgeType",
+      "Id": "baee542fbccb404c97880afa766d0cb8",
+      "Inputs": [
+        {
+          "Id": "2e9406f83bc34897ba102ad37efa48ae",
+          "Name": "document",
+          "Description": "Revit.Application.Document",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f92c885285354088abf797c95dbf755e",
+          "Name": "specType",
+          "Description": "ForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "16afe15ad38a45d9984d2d3aeeb66ed4",
+          "Name": "Unit",
+          "Description": "Unit",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Provide the Unit type from the associated with the SpecType in the Revit Document.\n\nDocument.UnitTypeBySpecType (specType: ForgeType): Unit"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Application.Document.Current",
+      "Id": "14a5422153be4a609dfbbe1283c5771c",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5ad87824b29d4dbaa711701ee6407d45",
+          "Name": "Document",
+          "Description": "Document",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the current document\n\nDocument.Current: Document"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "59d22dead2844a099858cd0b54241cd7",
+      "End": "f92c885285354088abf797c95dbf755e",
+      "Id": "b782e7bc092c4c8ba695cbeba30d6c51",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5ad87824b29d4dbaa711701ee6407d45",
+      "End": "2e9406f83bc34897ba102ad37efa48ae",
+      "Id": "d12af19bd5fc421d8a65686df7394cab",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.13",
+      "Data": {}
+    },
+    {
+      "ExtensionGuid": "DFBD9CC0-DB40-457A-939E-8C8555555A9D",
+      "Name": "Generative Design",
+      "Version": "2.0",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.13.1.3887",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Select Model Element By Category",
+        "ShowGeometry": true,
+        "Id": "74018f127ada41608cff93af2c8c960f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 327.99999999999966,
+        "Y": 29.600000000000009
+      },
+      {
+        "Name": "Spec Types",
+        "ShowGeometry": true,
+        "Id": "6b7a6d2cfd8c4459bafc6783eb8ff485",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 37.599999999999966,
+        "Y": 213.60000000000002
+      },
+      {
+        "Name": "Document.UnitTypeBySpecType",
+        "ShowGeometry": true,
+        "Id": "baee542fbccb404c97880afa766d0cb8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 304.00000000000006,
+        "Y": 325.6
+      },
+      {
+        "Name": "Document.Current",
+        "ShowGeometry": true,
+        "Id": "14a5422153be4a609dfbbe1283c5771c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 21.599999999999966,
+        "Y": 418.40000000000003
+      }
+    ],
+    "Annotations": [],
+    "X": 225.96499999999992,
+    "Y": 68.839999999999947,
+    "Zoom": 0.8425
+  }
+}


### PR DESCRIPTION
### Purpose

- DYN-4582: All compile-time and runtime warnings are now displayed on a CBN as multiple unique warnings upon execution
- Copy-pasting a CBN with warnings correctly shows warnings on the new node
- DYN-4557 - Obsolete node warnings are displayed as expected
- Multiple warnings and errors are displayed as expected
- Treat dummy node warnings as persistent warnings

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

All compile-time and runtime warnings are now displayed on a CBN correctly as multiple unique warnings 


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
