### PR TITLE
Call the save method on the CustomNodeWorkspaceModel, when the custom node is being saved.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1690,9 +1690,9 @@ namespace Dynamo.ViewModels
                 Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
 
                 // If the current workspace is a CustomNodeWorkspaceModel, then call the save method on it.
-                if (currentWorkspaceViewModel.Model is CustomNodeWorkspaceModel)
+                if (CurrentSpaceViewModel.Model is CustomNodeWorkspaceModel)
                 {
-                    currentWorkspaceViewModel.Model.Save(path, false, Model.EngineController);
+                    CurrentSpaceViewModel.Model.Save(path, false, Model.EngineController);
                 }
                 else
                 {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1688,7 +1688,17 @@ namespace Dynamo.ViewModels
             try
             {
                 Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
-                CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController, saveContext);
+
+                // If the current workspace is a CustomNodeWorkspaceModel, then call the save method on it.
+                if (currentWorkspaceViewModel.Model is CustomNodeWorkspaceModel)
+                {
+                    currentWorkspaceViewModel.Model.Save(path, false, Model.EngineController);
+                }
+                else
+                {
+                    CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController, saveContext);
+                }
+
                 if (!isBackup) AddToRecentFiles(path);
             }
             catch (Exception ex)

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -160,12 +160,12 @@ namespace Dynamo.WorkspaceDependency
                     dependencyViewExtension.OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
                 }
 
-                HasDependencyIssue = info.Path == null;
+                HasDependencyIssue = string.IsNullOrEmpty(info.Path);
             }
 
             foreach (DependencyInfo info in externalFiles)
             {
-                HasDependencyIssue = info.Path == null;
+                HasDependencyIssue = string.IsNullOrEmpty(info.Path);
             }
 
             var pythonPackageDependencies = ws.OnRequestPackageDependencies();

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -152,7 +152,6 @@ namespace Dynamo.WorkspaceDependency
                             info.Path = customNodeInfo.Path;
                         }
                     }
-
                     info.Size = PathHelper.GetFileSize(info.Path);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
### Purpose

This PR is to fix the: https://jira.autodesk.com/browse/DYN-4460. 

When a new custom node is created and saved to a local path in a dynamo session, the custom node manager doesn't have the path information for that particular custom node. It will only have the path information after dynamo is restarted because Dynamo tries to load all the definitions from the node package paths. This was happening because when the CN is saved, during the InternalSaveAs method in dynamo view model, the workspace model's save function is always called. 

This save method  on the CustomNodeWorkspaceModel model is never called: https://github.com/DynamoDS/Dynamo/blob/master/src/DynamoCore/Graph/Workspaces/CustomNodeWorkspaceModel.cs#L298. When the custom node workspace is being saved, this method has to be called and that will make sure that the path information is updated in the custom node manager.

![Fix custom node saving issue](https://user-images.githubusercontent.com/43763136/157897066-e9c0727f-5237-4416-9a28-28a5d8e5264f.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Call the save method on the CustomNodeWorkspaceModel, when the custom node is being saved.


### Reviewers
@QilongTang @mjkkirschner @zeusongit 
