### PR TITLE
GroupStyle ContextMenu crashing

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -221,7 +221,7 @@
                                         </Image.Style>
                                     </Image>
 
-                                           <!--Expander button-->
+                                    <!--Expander button-->
                                     <ToggleButton OverridesDefaultStyle="True"
                                                   Grid.Column="1"
                                                   Margin="0,0,0,2.5"
@@ -265,66 +265,6 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <Style x:Key="GroupStyleSeparatorStyle" TargetType="{x:Type MenuItem}">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate>
-                        <Border Height="1"
-                                Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
-                            <Border Height="1"
-                                Width="129"
-                                Background="{StaticResource NodeContextMenuSeparatorColor}">
-                            </Border>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style x:Key="GroupStyleItemStyle" TargetType="{x:Type MenuItem}">
-            <Setter Property="MenuItem.IsChecked"
-                    Value="{Binding IsChecked}"/>
-            <EventSetter Event="Click" 
-                     Handler="GroupStyleCheckmark_Click"/>
-            <EventSetter Event="Checked" 
-                     Handler="GroupStyleCheckmark_Checked"/>
-            <Setter Property="MenuItem.Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type MenuItem}">
-                        <StackPanel Orientation="Horizontal"
-                                    MinWidth="150"
-                                    Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
-                            <Label x:Name="GroupStyleCheckmark"
-                                   HorizontalAlignment="Left"
-                                   VerticalAlignment="Center"
-                                   HorizontalContentAlignment="Center"
-                                   VerticalContentAlignment="Center"
-                                   Content="✓"
-                                   FontSize="14px"
-                                   Foreground="White"
-                                   Visibility="{Binding Path=IsChecked,Converter={StaticResource BooleanToVisibilityConverter}}" />
-                            <Label x:Name="buttonColorPicker"
-                                    Margin="5,0,5,0"
-                                    FontFamily="{StaticResource ArtifaktElementRegular}"
-                                    FontSize="14px"
-                                    Background="{Binding HexColorString, Converter={StaticResource StringToBrushColorConverter}}" 
-                                    Width="15" 
-                                    Height="15"/>
-                            <Label Name="GroupStyleLabelName"
-                                    Content ="{Binding Name}"
-                                    Margin="5,0,5,0"
-                                    Foreground="{StaticResource NodeContextMenuForeground}"
-                                    FontFamily="{StaticResource ArtifaktElementRegular}"
-                                    FontSize="14px"
-                                    FontWeight="Medium"/>
-                        </StackPanel>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-       
-      
     </UserControl.Resources>
 
     <Grid Name="AnnotationGrid"
@@ -359,6 +299,65 @@
                           SubmenuOpened="GroupStyleAnnotation_SubmenuOpened"
                           Header="{x:Static p:Resources.GroupStyleContextAnnotation}"
                           ItemContainerStyleSelector="{StaticResource GroupStyleItemSelector}">
+                    <MenuItem.Resources>
+                        <Style x:Key="GroupStyleSeparatorStyle" TargetType="{x:Type MenuItem}">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate>
+                                        <Border Height="1"
+                                                Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
+                                            <Border Height="1"
+                                                    Width="129"
+                                                    Background="{StaticResource NodeContextMenuSeparatorColor}">
+                                            </Border>
+                                        </Border>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+
+                        <Style x:Key="GroupStyleItemStyle" TargetType="{x:Type MenuItem}">
+                            <Setter Property="MenuItem.IsChecked"
+                                    Value="{Binding IsChecked}"/>
+                                <EventSetter Event="Click" 
+                                             Handler="GroupStyleCheckmark_Click"/>
+                                <EventSetter Event="Checked" 
+                                             Handler="GroupStyleCheckmark_Checked"/>
+                            <Setter Property="MenuItem.Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type MenuItem}">
+                                        <StackPanel Orientation="Horizontal"
+                                                    MinWidth="150"
+                                                    Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
+                                            <Label x:Name="GroupStyleCheckmark"
+                                                   HorizontalAlignment="Left"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalContentAlignment="Center"
+                                                   VerticalContentAlignment="Center"
+                                                   Content="✓"
+                                                   FontSize="14px"
+                                                   Foreground="White"
+                                                   Visibility="{Binding Path=IsChecked,Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                            <Label x:Name="buttonColorPicker"
+                                                   Margin="5,0,5,0"
+                                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                   FontSize="14px"
+                                                   Background="{Binding HexColorString, Converter={StaticResource StringToBrushColorConverter}}" 
+                                                   Width="15" 
+                                                   Height="15"/>
+                                            <Label Name="GroupStyleLabelName"
+                                                   Content ="{Binding Name}"
+                                                   Margin="5,0,5,0"
+                                                   Foreground="{StaticResource NodeContextMenuForeground}"
+                                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                   FontSize="14px"
+                                                   FontWeight="Medium"/>   
+                                        </StackPanel>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </MenuItem.Resources>
                 </MenuItem>
                 <MenuItem Name="ChangeSize" Header="{x:Static p:Resources.GroupContextMenuFont}">
                     <MenuItem Name="FontSize0"


### PR DESCRIPTION
### Purpose

During testing a crash was reported when opening the Group ContextMenu using the three dots, when opening the ContextMenu by clicking right over the Group was not crashing.

The problem was due that the Styles were at the level of <UserControl.Resources> then the method call FrameworkElement.FindResource() was failing (Resource not found) then I moved the Styles to the scope of <MenuItem.Resources> so they are always found (I've tested both cases of showing the ContextMenu).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing Group ContextMenu crashing when opening the menu using the three dots over the Group.

### Reviewers

@QilongTang 
