### PR TITLE
DYN-4254 Package labels are not aligned

### DIFF
--- a/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
@@ -109,7 +109,7 @@
                                                     </TextBlock.ToolTip>
                                                 </TextBlock>
                                                 <TextBlock Text="{Binding Path=Model.VersionName}"
-                                                               MinWidth="50"
+                                                               MinWidth="70"
                                                                FontSize="11"
                                                                Foreground="{StaticResource PreferencesWindowFontColor}"></TextBlock>
                                                 <Grid Height="18"


### PR DESCRIPTION
### Purpose

[DYN-4254](https://jira.autodesk.com/browse/DYN-4254) Package labels are not aligned

This pull request does:
* Increase minimum width on the version field to 70.

![image](https://user-images.githubusercontent.com/7033002/158217650-05bded53-0fb1-45bb-aea2-e09839547085.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

`Preferences->Package Manager->Installed Packages` now format package labels properly when version strings are long.
