### PR TITLE
BugGroupStyles_MouseOver_Highlight

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -326,7 +326,8 @@
                             <Setter Property="MenuItem.Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="{x:Type MenuItem}">
-                                        <StackPanel Orientation="Horizontal"
+                                        <StackPanel x:Name="groupStyleStackPanel"
+                                                    Orientation="Horizontal"
                                                     MinWidth="150"
                                                     Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
                                             <Label x:Name="GroupStyleCheckmark"
@@ -351,8 +352,16 @@
                                                    Foreground="{StaticResource NodeContextMenuForeground}"
                                                    FontFamily="{StaticResource ArtifaktElementRegular}"
                                                    FontSize="14px"
-                                                   FontWeight="Medium"/>   
+                                                   FontWeight="Medium"/>
                                         </StackPanel>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="groupStyleStackPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="False">
+                                                <Setter TargetName="groupStyleStackPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
                                     </ControlTemplate>
                                 </Setter.Value>
                             </Setter>


### PR DESCRIPTION
### Purpose

Added triggers for showing the highlight when the mouse is over one of the GroupStyles in the Context Menu.
### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Added triggers for showing the highlight when the mouse is over one of the GroupStyles in the Context Menu.

### Reviewers

@QilongTang 

### FYIs

