### PR TITLE
Add node info to Integer slider node

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1639,7 +1639,6 @@ namespace Dynamo.Graph.Nodes
         {
             infos.RemoveWhere(x => x.State == ElementState.Info);
             State = ElementState.Dead;
-            ClearTooltipText();
             OnNodeInfoMessagesClearing();
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1638,7 +1638,6 @@ namespace Dynamo.Graph.Nodes
         public virtual void ClearInfoMessages()
         {
             infos.RemoveWhere(x => x.State == ElementState.Info);
-            State = ElementState.Dead;
             OnNodeInfoMessagesClearing();
         }
 
@@ -1771,8 +1770,6 @@ namespace Dynamo.Graph.Nodes
         {
             State = ElementState.Info;
             infos.Add(new Info(p, ElementState.Info));
-
-            ToolTipText = p;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -179,7 +179,6 @@ namespace Dynamo.Graph.Nodes
             NodeInfoMessagesClearing?.Invoke(this);
         }
 
-
         internal void OnNodeExecutionBegin()
         {
             NodeExecutionBegin?.Invoke(this);

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1643,8 +1643,7 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Clears the errors/warnings that are generated when running the graph,
-        /// the State will be set to ElementState.Dead.
+        /// Clears the errors/warnings that are generated when running the graph
         /// </summary>
         public virtual void ClearErrorsAndWarnings()
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -855,6 +855,8 @@ namespace Dynamo.ViewModels
         /// <param name="obj"></param>
         private void Logic_NodeInfoMessagesClearing(NodeModel obj)
         {
+            if (ErrorBubble == null) return;
+
             if (DynamoViewModel.UIDispatcher != null)
             {
                 DynamoViewModel.UIDispatcher.Invoke(() =>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1249,18 +1249,20 @@ namespace Dynamo.ViewModels
 
             const InfoBubbleViewModel.Direction connectingDirection = InfoBubbleViewModel.Direction.Bottom;
             var packets = new List<InfoBubbleDataPacket>(NodeModel.Infos.Count);
+
             foreach (var info in NodeModel.Infos)
             {
-                var infoStyle = info.State == ElementState.Error ? InfoBubbleViewModel.Style.Error : InfoBubbleViewModel.Style.Warning;
-                infoStyle = info.State == ElementState.Info ? InfoBubbleViewModel.Style.Info : infoStyle;
+                var infoStyle = info.State == ElementState.Info ? InfoBubbleViewModel.Style.Info : InfoBubbleViewModel.Style.None;
+                infoStyle = info.State == ElementState.Warning ? InfoBubbleViewModel.Style.Warning : infoStyle;
+                infoStyle = info.State == ElementState.Error ? InfoBubbleViewModel.Style.Error : infoStyle;
+
                 var data = new InfoBubbleDataPacket(infoStyle, topLeft, botRight, info.Message, connectingDirection);
                 packets.Add(data);
             }
-            InfoBubbleViewModel.Style style = NodeModel.State == ElementState.Error
-                ? InfoBubbleViewModel.Style.Error
-                : InfoBubbleViewModel.Style.Warning;
 
-            style = NodeModel.State == ElementState.Info ? InfoBubbleViewModel.Style.Info : style;
+            InfoBubbleViewModel.Style style = NodeModel.State == ElementState.Info ? InfoBubbleViewModel.Style.Info : InfoBubbleViewModel.Style.None;
+            style = NodeModel.State == ElementState.Warning ? InfoBubbleViewModel.Style.Warning : style;
+            style = NodeModel.State == ElementState.Error ? InfoBubbleViewModel.Style.Error : style;
 
             ErrorBubble.InfoBubbleStyle = style;
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -323,7 +323,8 @@ namespace CoreNodeModels.Input
                     return true; // UpdateValueCore handled.
                 case nameof(Value):
                 case "ValueText":
-                    Value = ConvertStringToInt64(value);                   
+                    UpdateNodeInfo(value);
+                    Value = ConvertStringToInt64(value);
                     return true; // UpdateValueCore handled.
                 case nameof(Step):
                 case "StepText":
@@ -332,6 +333,18 @@ namespace CoreNodeModels.Input
             }
 
             return base.UpdateValueCore(updateValueParams);
+        }
+
+        private void UpdateNodeInfo(string value)
+        {
+            if (IsValueInt64(value))
+            {
+                ClearInfoMessages();
+            }
+            else
+            {
+                Info(Resources.IntegerSliderInfoMessage);
+            }
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -160,5 +160,23 @@ namespace CoreNodeModels.Input
             }
             return result;
         }
+
+        /// <summary>
+        /// check if the value is within int64 range
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        protected static bool IsValueInt64(string value)
+        {
+            try
+            {
+                var result = Convert.ToInt64(value);
+                return true;
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -665,6 +665,15 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value entered is not in the int64 range..
+        /// </summary>
+        public static string IntegerSliderInfoMessage {
+            get {
+                return ResourceManager.GetString("IntegerSliderInfoMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A slider that produces integer values..
         /// </summary>
         public static string IntegerSliderNodeDescription {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -620,4 +620,7 @@ Default value: {0}</value>
   <data name="ConversionNodeObsoleteMessage" xml:space="preserve">
     <value>is obsolete, please use the new Convert Units node.</value>
   </data>
+  <data name="IntegerSliderInfoMessage" xml:space="preserve">
+    <value>The value entered is not in the int64 range.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -620,4 +620,7 @@ Default value: {0}</value>
   <data name="ConversionNodeObsoleteMessage" xml:space="preserve">
     <value>is obsolete, please use the new Convert Units node.</value>
   </data>
+  <data name="IntegerSliderInfoMessage" xml:space="preserve">
+    <value>The value entered is not in the int64 range.</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

This PR is a first prototype for the node info messages. https://jira.autodesk.com/browse/DYN-4543. This will be done for more nodes as per the needs.

The example here is for IntegerSlider node, which will show an info message when the value entered in the node is not in the int64 range. We will be using the same UpdateBubbleContent() to add the info message. 

![node info integer slider](https://user-images.githubusercontent.com/43763136/158396183-db5083bd-432b-4f75-a910-82c976a497b7.gif)



### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Add node info to Integer slider node

### Reviewers

@QilongTang @aparajit-pratap @zeusongit  
