### PR TITLE
Add tooltips for Input/Output Nodes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -381,7 +381,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         /// </summary>
         public Symbol()
         {
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("", Properties.Resources.ToolTipSymbol)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("", Properties.Resources.ToolTipInputData)));
 
             RegisterAllPorts();
 
@@ -664,7 +664,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         /// </summary>
         public Output()
         {
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("", Properties.Resources.ToolTipSymbol)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("", Properties.Resources.ToolTipOutputData)));
 
             RegisterAllPorts();
 

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -664,7 +664,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         /// </summary>
         public Output()
         {
-            InPorts.Add(new Nodes.PortModel(PortType.Input, this, new PortData("", "")));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("", Properties.Resources.ToolTipSymbol)));
 
             RegisterAllPorts();
 

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1912,6 +1912,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Input Data.
+        /// </summary>
+        public static string ToolTipInputData {
+            get {
+                return ResourceManager.GetString("ToolTipInputData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Output #.
         /// </summary>
         public static string ToolTipOutput {
@@ -1921,20 +1930,20 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Output Data.
+        /// </summary>
+        public static string ToolTipOutputData {
+            get {
+                return ResourceManager.GetString("ToolTipOutputData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to return value.
         /// </summary>
         public static string ToolTipReturnValue {
             get {
                 return ResourceManager.GetString("ToolTipReturnValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Symbol.
-        /// </summary>
-        public static string ToolTipSymbol {
-            get {
-                return ResourceManager.GetString("ToolTipSymbol", resourceCulture);
             }
         }
         

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -499,8 +499,8 @@ Sorry about that.</value>
   <data name="ToolTipOutput" xml:space="preserve">
     <value>Output #</value>
   </data>
-  <data name="ToolTipSymbol" xml:space="preserve">
-    <value>Symbol</value>
+  <data name="ToolTipOutputData" xml:space="preserve">
+    <value>Output Data</value>
   </data>
   <data name="WarningCannotFindType" xml:space="preserve">
     <value>Cannot find type '{0}'</value>
@@ -857,5 +857,8 @@ This package likely contains an assembly that is blocked. You will need to load 
   </data>
   <data name="GroupStyleDefaultReviewColor" xml:space="preserve">
     <value>A4E1FF</value>
+  </data>
+  <data name="ToolTipInputData" xml:space="preserve">
+    <value>Input Data</value>
   </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -499,9 +499,6 @@ Sorry about that.</value>
   <data name="ToolTipOutput" xml:space="preserve">
     <value>Output #</value>
   </data>
-  <data name="ToolTipSymbol" xml:space="preserve">
-    <value>Symbol</value>
-  </data>
   <data name="WarningCannotFindType" xml:space="preserve">
     <value>Cannot find type '{0}'</value>
   </data>
@@ -860,5 +857,11 @@ This package likely contains an assembly that is blocked. You will need to load 
   </data>
   <data name="GroupStyleDefaultReviewColor" xml:space="preserve">
     <value>A4E1FF</value>
+  </data>
+  <data name="ToolTipInputData" xml:space="preserve">
+    <value>Input Data</value>
+  </data>
+  <data name="ToolTipOutputData" xml:space="preserve">
+    <value>Output Data</value>
   </data>
 </root>


### PR DESCRIPTION
### Purpose

- Fix empty tooltip for Output nodes
- Update tooltips for Input and Output Node

![DynamoSandbox_e5Td3lw9Ac](https://user-images.githubusercontent.com/32665108/158839168-092eb4e2-127f-4af3-8f91-32f289c3955a.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Added appropriate tooltips for Input and Output Nodes

### Reviewers

@Amoursol 
@QilongTang 
