### PR TITLE
DYN-4665-Fix-WarningIconStyle

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -3649,26 +3649,34 @@
                             <Canvas.ToolTip>
                                 <ToolTip Content="{Binding CurrentWarningMessage}" Style="{StaticResource GenericToolTipLight}"/>
                             </Canvas.ToolTip>
-                            <Polygon Points="10,5 18,20 2,20">
-                                <Polygon.Fill>
-                                    <SolidColorBrush Color="{StaticResource YellowOrange500}" />
-                                </Polygon.Fill>
-                            </Polygon>
-
-                            <Line x:Name="exclamationMark"
-                                  Stroke="Black"
-                                  StrokeThickness="2"
-                                  X1="10"
-                                  X2="10"
-                                  Y1="8"
-                                  Y2="15" />
-                            <Ellipse x:Name="exclamationPoint"
-                                     Canvas.Left="9"
-                                     Canvas.Top="17"
-                                     Canvas.Right="10"
-                                     Width="2"
-                                     Height="2"
-                                     Fill="Black" />
+                            <Path Fill="#FAA21B">
+                                <Path.Data>
+                                    <CombinedGeometry GeometryCombineMode="Exclude">
+                                        <CombinedGeometry.Geometry1>
+                                            <PathGeometry>
+                                                <PathGeometry.Figures>
+                                                    <PathFigureCollection>
+                                                        <PathFigure IsClosed="True" StartPoint="10,5">
+                                                            <PathFigure.Segments>
+                                                                <PathSegmentCollection>
+                                                                    <LineSegment Point="18,20" />
+                                                                    <LineSegment Point="2,20" />
+                                                                </PathSegmentCollection>
+                                                            </PathFigure.Segments>
+                                                        </PathFigure>
+                                                    </PathFigureCollection>
+                                                </PathGeometry.Figures>
+                                            </PathGeometry>
+                                        </CombinedGeometry.Geometry1>
+                                        <CombinedGeometry.Geometry2>
+                                            <GeometryGroup FillRule="EvenOdd">
+                                                <EllipseGeometry Center="10,18" RadiusX="1.5" RadiusY="1.5"/>
+                                                <RectangleGeometry Rect="8.5,8.5,3,7.5"/>
+                                            </GeometryGroup>
+                                        </CombinedGeometry.Geometry2>
+                                    </CombinedGeometry>
+                                </Path.Data>
+                            </Path>
                         </Canvas>
                     </Grid>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
### Purpose

Change for updating the Warning Icon Style to use a new one.
Now with this implementation is removing  (Exclude) the exclamation mark symbol from the orange warning triangle, so it looks like the exclamation mark is transparent.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Change for updating the Warning Icon Style to use a new one.


### Reviewers

@QilongTang 

### FYIs

