### PR TITLE
Show dialog box when opening corrupt file

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -601,7 +601,7 @@ namespace Dynamo.Graph.Workspaces
             var nodeLocalDefinitions = new List<INodeLibraryDependencyInfo>();
             var externalFiles = new List<INodeLibraryDependencyInfo>();
 
-            if (obj[NodeLibraryDependenciesPropString] != null)
+            if (obj[NodeLibraryDependenciesPropString] != null && obj[NodeLibraryDependenciesPropString].HasValues)
             {
                 workspaceReferences = obj[NodeLibraryDependenciesPropString].ToObject<IEnumerable<INodeLibraryDependencyInfo>>(serializer);
             }

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -601,7 +601,7 @@ namespace Dynamo.Graph.Workspaces
             var nodeLocalDefinitions = new List<INodeLibraryDependencyInfo>();
             var externalFiles = new List<INodeLibraryDependencyInfo>();
 
-            if (obj[NodeLibraryDependenciesPropString] != null && obj[NodeLibraryDependenciesPropString].HasValues)
+            if (obj[NodeLibraryDependenciesPropString] != null)
             {
                 workspaceReferences = obj[NodeLibraryDependenciesPropString].ToObject<IEnumerable<INodeLibraryDependencyInfo>>(serializer);
             }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1761,7 +1761,7 @@ namespace Dynamo.Models
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);
-                return false;
+                throw e;
             }
         }
 


### PR DESCRIPTION
### Purpose

Show correct error dialog box when user opens a corrupt file.
To do this we are just throwing the error to the outer catch block where it is handled appropriately.

![DynamoSandbox_BzgLFDZSjQ](https://user-images.githubusercontent.com/32665108/158877424-5501d3ea-8f43-4ad8-8ef5-b628ae0c0e1e.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- [Fix] Display error message when a corrupt file is opened, the inner exception is exposed.


### Reviewers

@BogdanZavu 
