### PR TITLE
DYN-4676-GroupStyles-Localization

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3011,6 +3011,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string GroupStylesCancelButtonText {
+            get {
+                return ResourceManager.GetString("GroupStylesCancelButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        public static string GroupStylesSaveButtonText {
+            get {
+                return ResourceManager.GetString("GroupStylesSaveButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide Classic Node Library.
         /// </summary>
         public static string HideClassicNodeLibrary {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3049,4 +3049,10 @@ To install the latest version of a package, click Install. \n
   <data name="ContextPinToNodeTooltip" xml:space="preserve">
     <value>Select a node to pin to this note.</value>
   </data>
+  <data name="GroupStylesCancelButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="GroupStylesSaveButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3036,4 +3036,10 @@ To install the latest version of a package, click Install. \n
   <data name="ContextPinToNodeTooltip" xml:space="preserve">
     <value>Select a node to pin to this note.</value>
   </data>
+  <data name="GroupStylesCancelButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="GroupStylesSaveButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -608,15 +608,17 @@
                                                                 HorizontalAlignment="Right"
                                                                 IsEnabled="{Binding IsSaveButtonEnabled}"
                                                                 Click="AddStyle_SaveButton_Click"
+                                                                Content="{x:Static p:Resources.GroupStylesSaveButtonText}"
                                                                 Width="50"
-                                                                Height="30">Save</Button>
+                                                                Height="30"/>
                                                         <Button x:Name="AddStyle_CancelButton" 
                                                                 Style="{StaticResource OutlinedButtonStyle}"
                                                                 Grid.Column="1"
                                                                 HorizontalAlignment="Right"
                                                                 Click="AddStyle_CancelButton_Click"
+                                                                Content="{x:Static p:Resources.GroupStylesCancelButtonText}"
                                                                 Width="50"
-                                                                Height="30">Cancel</Button>
+                                                                Height="30"/>
                                                     </Grid>
                                                 </Grid>
                                             </Grid>


### PR DESCRIPTION
### Purpose

Adding entries in the resources file so the text for Save and Cancel button can be localized.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Adding entries in the resources file so the text for Save and Cancel button can be localized.


### Reviewers

@QilongTang 

### FYIs

