### PR TITLE
Fix node autocomplete window bug

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
@@ -38,6 +39,7 @@ namespace Dynamo.UI.Controls
                 Application.Current.Deactivated += currentApplicationDeactivated;
             }
             Unloaded += NodeAutoCompleteSearchControl_Unloaded;
+            HomeWorkspaceModel.WorkspaceClosed += this.CloseAutoCompletion;
         }
 
         private void NodeAutoCompleteSearchControl_Unloaded(object sender, RoutedEventArgs e)
@@ -277,6 +279,11 @@ namespace Dynamo.UI.Controls
         }
 
         internal void CloseAutocompletionWindow(object sender, RoutedEventArgs e)
+        {
+            OnRequestShowNodeAutoCompleteSearch(ShowHideFlags.Hide);
+        }
+
+        internal void CloseAutoCompletion()
         {
             OnRequestShowNodeAutoCompleteSearch(ShowHideFlags.Hide);
         }

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -47,7 +47,6 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated -= currentApplicationDeactivated;
-                HomeWorkspaceModel.WorkspaceClosed -= this.CloseAutoCompletion;
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -47,6 +47,7 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated -= currentApplicationDeactivated;
+                HomeWorkspaceModel.WorkspaceClosed -= this.CloseAutoCompletion;
             }
         }
 


### PR DESCRIPTION
### Purpose

Close the node autocomplete window when the workspace(showing node autocompletion window) is closed.

Jira: https://jira.autodesk.com/browse/DYN-4628

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix node autocomplete window bug


### Reviewers
@QilongTang @zeusongit 
