### PR TITLE
DYN-4686 several changes in the group style context menu.

### DIFF
--- a/src/DynamoCore/Configuration/GroupStyleItem.cs
+++ b/src/DynamoCore/Configuration/GroupStyleItem.cs
@@ -1,26 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Dynamo.Configuration
+﻿namespace Dynamo.Configuration
 {
     public class GroupStyleItem: StyleItem
     {
-        private bool isChecked = false;
-
-        /// <summary>
-        /// This property will say it we should display the checkmark in the MenuItem (appearing in the GroupStyles context menu)
-        /// </summary>
-        public bool IsChecked
-        {
-            get { return isChecked; }
-            set
-            {
-                isChecked = value;
-                RaisePropertyChanged(nameof(IsChecked));
-            }
-        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -175,9 +175,6 @@ namespace Dynamo.ViewModels
         }
 
         [JsonIgnore]
-        internal GroupStyleItem CurrentGroupStyleSelected { get; set; }
-
-        [JsonIgnore]
         public IEnumerable<ModelBase> Nodes
         {
             get { return annotationModel.Nodes; }
@@ -978,14 +975,6 @@ namespace Dynamo.ViewModels
         {
             if (itemEntryParameter == null) return;
 
-            var groupStyleItems = GroupStyleList.OfType<GroupStyleItem>();
-            groupStyleItems.Where(c => !c.Name.Equals(itemEntryParameter.Name)).ToList().ForEach(cc =>
-            {
-                cc.IsChecked = false;
-            });
-
-            itemEntryParameter.IsChecked = true;
-            CurrentGroupStyleSelected = itemEntryParameter;
             Background = (Color)ColorConverter.ConvertFromString("#"+itemEntryParameter.HexColorString);
 
             WorkspaceViewModel.HasUnsavedChanges = true;
@@ -1020,17 +1009,9 @@ namespace Dynamo.ViewModels
         internal void ReloadGroupStyles()
         {
             if (preferencesStyleItemsList == null) return;
-            var currentSelectedGroupStyle = groupStyleList.OfType<GroupStyleItem>().Where(style => style.IsChecked == true).FirstOrDefault();
             groupStyleList.Clear();
 
             LoadGroupStylesFromPreferences(preferencesStyleItemsList);
-            if (currentSelectedGroupStyle == null) return;
-
-            var currentCustomGroupStyles = groupStyleList.OfType<GroupStyleItem>();
-            var selectedGroupStyle = currentCustomGroupStyles.Where(style => style.Name.Equals(currentSelectedGroupStyle.Name)).FirstOrDefault();
-
-            if (selectedGroupStyle == null) return;
-            selectedGroupStyle.IsChecked = true;  
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -319,10 +319,8 @@
                         <Style x:Key="GroupStyleItemStyle" TargetType="{x:Type MenuItem}">
                             <Setter Property="MenuItem.IsChecked"
                                     Value="{Binding IsChecked}"/>
-                                <EventSetter Event="Click" 
+                            <EventSetter Event="Click" 
                                              Handler="GroupStyleCheckmark_Click"/>
-                                <EventSetter Event="Checked" 
-                                             Handler="GroupStyleCheckmark_Checked"/>
                             <Setter Property="MenuItem.Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="{x:Type MenuItem}">
@@ -330,15 +328,6 @@
                                                     Orientation="Horizontal"
                                                     MinWidth="150"
                                                     Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
-                                            <Label x:Name="GroupStyleCheckmark"
-                                                   HorizontalAlignment="Left"
-                                                   VerticalAlignment="Center"
-                                                   HorizontalContentAlignment="Center"
-                                                   VerticalContentAlignment="Center"
-                                                   Content="✓"
-                                                   FontSize="14px"
-                                                   Foreground="White"
-                                                   Visibility="{Binding Path=IsChecked,Converter={StaticResource BooleanToVisibilityConverter}}" />
                                             <Label x:Name="buttonColorPicker"
                                                    Margin="5,0,5,0"
                                                    FontFamily="{StaticResource ArtifaktElementRegular}"
@@ -367,6 +356,31 @@
                             </Setter>
                         </Style>
                     </MenuItem.Resources>
+                </MenuItem>
+                <MenuItem Name="ColorMenuItem" Header="Color">
+                    <ListBox ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
+                             SelectionChanged="OnNodeColorSelectionChanged"
+                             Height="Auto"
+                             Style="{StaticResource ColorSelectorListBox}">
+                        <ListBox.Items>
+                            <Rectangle Fill="#d4b6db" />
+                            <Rectangle Fill="#ffb8d8" />
+                            <Rectangle Fill="#ffc999" />
+                            <Rectangle Fill="#e8f7ad" />
+                            <Rectangle Fill="#b9f9e1" />
+                            <Rectangle Fill="#a4e1ff" />
+                            <Rectangle Fill="#b5b5b5" />
+                            <Rectangle Fill="#FFFFFF" />
+                            <Rectangle Fill="#bb87c6" />
+                            <Rectangle Fill="#ff7bac" />
+                            <Rectangle Fill="#ffaa45" />
+                            <Rectangle Fill="#c1d676" />
+                            <Rectangle Fill="#71c6a8" />
+                            <Rectangle Fill="#48b9ff" />
+                            <Rectangle Fill="#848484" />
+                            <Rectangle Fill="#d8d8d8" />
+                        </ListBox.Items>
+                    </ListBox>
                 </MenuItem>
                 <MenuItem Name="ChangeSize" Header="{x:Static p:Resources.GroupContextMenuFont}">
                     <MenuItem Name="FontSize0"
@@ -416,29 +430,6 @@
                               IsChecked="{Binding Path=FontSize, Converter={StaticResource MenuItemCheckConverter}, ConverterParameter=96}" />
 
                 </MenuItem>
-                <ListBox ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
-                         SelectionChanged="OnNodeColorSelectionChanged"
-                         Height="Auto"
-                         Style="{StaticResource ColorSelectorListBox}">
-                    <ListBox.Items>
-                        <Rectangle Fill="#d4b6db" />
-                        <Rectangle Fill="#ffb8d8" />
-                        <Rectangle Fill="#ffc999" />
-                        <Rectangle Fill="#e8f7ad" />
-                        <Rectangle Fill="#b9f9e1" />
-                        <Rectangle Fill="#a4e1ff" />
-                        <Rectangle Fill="#b5b5b5" />
-                        <Rectangle Fill="#FFFFFF" />
-                        <Rectangle Fill="#bb87c6" />
-                        <Rectangle Fill="#ff7bac" />
-                        <Rectangle Fill="#ffaa45" />
-                        <Rectangle Fill="#c1d676" />
-                        <Rectangle Fill="#71c6a8" />
-                        <Rectangle Fill="#48b9ff" />
-                        <Rectangle Fill="#848484" />
-                        <Rectangle Fill="#d8d8d8" />
-                    </ListBox.Items>
-                </ListBox>
             </ContextMenu>
         </Grid.ContextMenu>
 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -453,39 +453,7 @@ namespace Dynamo.Nodes
             var groupStyleItemSelected = menuItemSelected.DataContext as GroupStyleItem;
             if (groupStyleItemSelected == null) return;
 
-            //Means that no GroupStyle (Default, Custom) has been selected then the clicked one will be selected
-            if (ViewModel.CurrentGroupStyleSelected == null)
-            {
-                ViewModel.UpdateGroupStyle(groupStyleItemSelected);
-                return;
-            }           
-
-            //Means that the user clicked over a MenuItem that is already selected, when we need uncheck it if is not a Default Style
-            if (groupStyleItemSelected != ViewModel.CurrentGroupStyleSelected && groupStyleItemSelected.IsChecked == false)
-            {
-                ViewModel.UpdateGroupStyle(groupStyleItemSelected);
-                return;
-            }
-            
-            //Means that the GroupStyle selected is not a Default Style and is already checked
-            if (ViewModel.CurrentGroupStyleSelected.IsChecked == true && !groupStyleItemSelected.IsDefault)
-            {
-                var groupStyleItems = ViewModel.GroupStyleList.OfType<GroupStyleItem>();
-                var firstDefaultGroupStyle = groupStyleItems.Where(item => item.IsDefault == true).FirstOrDefault();
-                ViewModel.UpdateGroupStyle(firstDefaultGroupStyle);
-                return;
-            }
-        }
-
-        private void GroupStyleCheckmark_Checked(object sender, RoutedEventArgs e)
-        {
-            var menuItemSelected = sender as MenuItem;
-            if (menuItemSelected == null) return;
-
-            var groupStyleItemSelected = menuItemSelected.DataContext as GroupStyleItem;
-            if (groupStyleItemSelected == null) return;
-
-            ViewModel.CurrentGroupStyleSelected = groupStyleItemSelected;
+            ViewModel.UpdateGroupStyle(groupStyleItemSelected);                
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Several changes for the AnnotationView context menu for showing group styles and colors.
- Removed the IsChecked property so is not serialized into the dyn file.
- Removed the CurrentGroupStyleSelected property due that is was used for the checkmark functionality.
- All the functionality for checking and unchecking groupstyle menuitems was removed.
- Removed the checkmark label that was appearing next to the group style.
- The color contextmenu was moved to be a submenuitem.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Several changes for the AnnotationView context menu for showing group styles and colors.

### Reviewers

@reddyashish 

### FYIs

@QilongTang 
