### PR TITLE
Fix for warnings not showing when created before node view is ready

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -797,16 +797,10 @@ namespace Dynamo.ViewModels
             {
                 ImageSource = imgSource;
             }
-            
-            if(nodeLogic.State == ElementState.Error)
-            {
-                BuildErrorBubble();
-                UpdateBubbleContent();
-            }
-            
             logic.NodeMessagesClearing += Logic_NodeMessagesClearing;
 
             logic_PropertyChanged(this, new PropertyChangedEventArgs(nameof(IsVisible)));
+            UpdateBubbleContent();
         }
 
         private void Infos_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -465,6 +465,17 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void InfoBubble_ShowsWarningOnDupVariableInCodeBlock()
+        {
+            Open(@"core\watch\cbn_dup_variable_open_file.dyn");
+
+            var nodeView = NodeViewWithGuid("2bea01fa-1534-4101-9b11-e6000cd17045");
+
+            Assert.AreEqual(2, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
+            Assert.IsTrue(nodeView.ViewModel.ErrorBubble.NodeMessages[0].Message.Contains("You cannot define a variable more than once."));
+        }
+
+        [Test]
         public void InfoBubble_ShowsWarningOnObsoleteZeroTouchNode()
         {
             Open(@"core\watch\obsolete_zero_touch_node.dyn");

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -32,6 +32,7 @@ namespace DynamoCoreWpfTests
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
+            libraries.Add("ProtoGeometry.dll");
             libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSCoreNodes.dll");
             libraries.Add("FFITarget.dll");
@@ -441,6 +442,37 @@ namespace DynamoCoreWpfTests
                 var nView = NodeViewWithGuid(node.GUID.ToString());
                 Assert.AreEqual(2, nView.ViewModel.ErrorBubble.NodeMessages.Count);
             }
+        }
+
+        [Test]
+        public void InfoBubble_ShowsWarningOnNode2Code()
+        {
+            Open(@"core\watch\infobubble_warning_on_n2c.dyn");
+
+            Dynamo.Selection.DynamoSelection.Instance.Selection.AddRange(Model.CurrentWorkspace.Nodes);
+
+            ViewModel.CurrentSpaceViewModel.NodeToCodeCommand.Execute(null);
+
+            DispatcherUtil.DoEvents();
+
+            var nodes = Model.CurrentWorkspace.Nodes;
+            Assert.AreEqual(1, nodes.Count());
+
+            var nView = NodeViewWithGuid(nodes.ElementAt(0).GUID.ToString());
+            var msgs = nView.ViewModel.ErrorBubble.NodeMessages;
+            Assert.IsTrue(msgs.Any());
+            Assert.IsTrue(msgs[0].Message.Contains("You cannot define a variable more than once."));
+        }
+
+        [Test]
+        public void InfoBubble_ShowsWarningOnObsoleteZeroTouchNode()
+        {
+            Open(@"core\watch\obsolete_zero_touch_node.dyn");
+
+            var nodeView = NodeViewWithGuid("cb146e7e-22ad-4e96-bfe4-5e506d3669d1");
+
+            Assert.AreEqual(1, nodeView.ViewModel.ErrorBubble.NodeMessages.Count);
+            Assert.IsTrue(nodeView.ViewModel.ErrorBubble.NodeMessages[0].Message.Contains("Obsolete"));
         }
 
         [Test]

--- a/test/Engine/FFITarget/TestCSharpAttribute.cs
+++ b/test/Engine/FFITarget/TestCSharpAttribute.cs
@@ -44,5 +44,11 @@ namespace FFITarget
         {
 
         }
+
+        [Obsolete]
+        public string Test2()
+        {
+            return "this node is obsolete.";
+        }
     }
 }

--- a/test/core/watch/cbn_dup_variable_open_file.dyn
+++ b/test/core/watch/cbn_dup_variable_open_file.dyn
@@ -1,0 +1,111 @@
+{
+  "Uuid": "10a4d110-955a-4855-953d-2bdffe088a33",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "cbn_dup_variable_open_file",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "a=0;\na=\"\";\nb=0..1;\nc=b[2];",
+      "Id": "2bea01fa153441019b11e6000cd17045",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4dbe3e57dd6440ce8c8513b977d428ed",
+          "Name": "",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e26d70ef98bf44f7b158b7b19e46ef38",
+          "Name": "",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f34f12bbb5804797acf3f0ff4c8773d6",
+          "Name": "",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4472",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "2bea01fa153441019b11e6000cd17045",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 217.0,
+        "Y": 204.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/watch/infobubble_warning_on_n2c.dyn
+++ b/test/core/watch/infobubble_warning_on_n2c.dyn
@@ -1,0 +1,584 @@
+{
+  "Uuid": "58719020-b662-484e-937f-e8da67c1f1d7",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "infobubble_warning_on_n2c",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Arc.ByCenterPointRadiusAngle@Autodesk.DesignScript.Geometry.Point,double,double,double,Autodesk.DesignScript.Geometry.Vector",
+      "Id": "733db43629974449b0a4c5408e0b85da",
+      "Inputs": [
+        {
+          "Id": "0f09c45d6ca441c597dbf7d74f26d377",
+          "Name": "center",
+          "Description": "Center point of arc\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "979a69fa84db403a8fa13a2e2207b728",
+          "Name": "radius",
+          "Description": "Radius of the arc\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "acdcf14ce2624c33998bdd6324f5c9b6",
+          "Name": "startAngle",
+          "Description": "Start angle in degrees\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a15ae9ef1e59476e812832770dcb9f3c",
+          "Name": "endAngle",
+          "Description": "End angle in degrees\n\ndouble\nDefault value : 90",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "29027eed9e1340fe965fd3dc8207b48e",
+          "Name": "normal",
+          "Description": "A vector defining the normal of the arc\n\nVector\nDefault value : Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0, 0, 1)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c7683426d27346ef9f73b785600b1efa",
+          "Name": "Arc",
+          "Description": "Arc created by center point, radius, and angle",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create an arc by providing it's center point, radius, angle sweep, and normal vector\n\nArc.ByCenterPointRadiusAngle (center: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1, startAngle: double = 0, endAngle: double = 90, normal: Vector = Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0, 0, 1)): Arc"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "180;",
+      "Id": "23ecdb0861034bdb97d81e733a790c9c",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "30cd37dc0b6f4bbb8767dfb2beff1086",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "10;",
+      "Id": "08687472977f4a8d89f536555a9933f7",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "255f3312d8414417a10a0c98991c8a76",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "Id": "a0dbe4be2b46425aa0a056139909c778",
+      "Inputs": [
+        {
+          "Id": "62e2a4b761d244aeb83b6783fdc4e9c7",
+          "Name": "startPoint",
+          "Description": "Line start point\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a418aec16c6d48adbee3cc4f05f77af2",
+          "Name": "endPoint",
+          "Description": "Line end point\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "093e194d8fd64fce8da7751c5b34708e",
+          "Name": "Line",
+          "Description": "Line from start and end point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a straight Line between two input Points.\n\nLine.ByStartPointEndPoint (startPoint: Point, endPoint: Point): Line"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Curve.EndPoint",
+      "Id": "db6c25efafd447d2940364fa5fbe43a1",
+      "Inputs": [
+        {
+          "Id": "8d9107f1814c4dac95ec5bd1d4f7c3f4",
+          "Name": "curve",
+          "Description": "Autodesk.DesignScript.Geometry.Curve",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "710544696e1e4f07b8173111bd6d73b5",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the end Point along the Curve\n\nCurve.EndPoint: Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "d7a4c470fb94487baf4925030b47f2ac",
+      "Inputs": [
+        {
+          "Id": "537285c095be402ebd5f08b1050e353c",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4053a708a6504c4fa95b36bc1ff166c5",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1b742b40fdcf437ca3cf6ceb367365ef",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8c6d05e88d794512a95266ace21f5690",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "10;",
+      "Id": "cff0489f025d43ddbe9321d099884341",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8534edd99fd64bb6ac478beb99404c1f",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[a,b];",
+      "Id": "5dee6fc394dc4f44bc5a7168cf7bd779",
+      "Inputs": [
+        {
+          "Id": "88016a6b159d4ec9aee9d41ed7cc868e",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8ac1e26d6adf41f7a4a1f2c382f49d42",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b6d9898db26c41f3a9dd80f3d86df1bb",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.PolyCurve.ByJoinedCurves@Autodesk.DesignScript.Geometry.Curve[],double",
+      "Id": "073bbad2fbba4e6b9d0ba6a59d04d970",
+      "Inputs": [
+        {
+          "Id": "6c51f090a79e438881b5e786c07d6886",
+          "Name": "curves",
+          "Description": "Curves to join into polycurve\n\nCurve[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2eb673c50e6a48f1beb24825de59ee0a",
+          "Name": "joinTolerance",
+          "Description": "Tolerance to determine size of gap allowed between curves to be joined\n\ndouble\nDefault value : 0.001",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e240277bef434edeb4a2a2fa42df7d2e",
+          "Name": "PolyCurve",
+          "Description": "Polycurve created by joined curves",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Make PolyCurve by joining curves. Flips curve as needed for connectivity. Choose a preferred join tolerance between 1e-6 and 1e-3 units.\n\nPolyCurve.ByJoinedCurves (curves: Curve[], joinTolerance: double = 0.001): PolyCurve"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Curve.PointsAtEqualChordLength@int",
+      "Id": "a81dca5617f0498bb6b0b3ae8c625f34",
+      "Inputs": [
+        {
+          "Id": "af553fe2f2014210842d78bfd897cb1f",
+          "Name": "curve",
+          "Description": "Autodesk.DesignScript.Geometry.Curve",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7d674c0cb3f447929d4001577de8bd36",
+          "Name": "divisions",
+          "Description": "Number of divisions\n\nint\nDefault value : 10",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "323d444ae1134d4a963cf8a6885f53d9",
+          "Name": "Point[]",
+          "Description": "List of points on curve",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns points spaced along curve at equal chord length based on the input number of divisions\n\nCurve.PointsAtEqualChordLength (divisions: int = 10): Point[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "c7683426d27346ef9f73b785600b1efa",
+      "End": "8d9107f1814c4dac95ec5bd1d4f7c3f4",
+      "Id": "42d4892fec414110bfa1408eaf93c334",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "c7683426d27346ef9f73b785600b1efa",
+      "End": "8ac1e26d6adf41f7a4a1f2c382f49d42",
+      "Id": "30ea9c08020349019ba792153c076441",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "30cd37dc0b6f4bbb8767dfb2beff1086",
+      "End": "a15ae9ef1e59476e812832770dcb9f3c",
+      "Id": "dc5326600f0541308e6b6cd4fe38dbf8",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "255f3312d8414417a10a0c98991c8a76",
+      "End": "979a69fa84db403a8fa13a2e2207b728",
+      "Id": "38c574a14e8843bda420035aad1628c9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "093e194d8fd64fce8da7751c5b34708e",
+      "End": "88016a6b159d4ec9aee9d41ed7cc868e",
+      "Id": "f10985c7a024479696faea2c65ea4d46",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "710544696e1e4f07b8173111bd6d73b5",
+      "End": "62e2a4b761d244aeb83b6783fdc4e9c7",
+      "Id": "e60865755c5647feb282b72cc007d771",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "8c6d05e88d794512a95266ace21f5690",
+      "End": "a418aec16c6d48adbee3cc4f05f77af2",
+      "Id": "248d80578a1d4435a1715e6916475e20",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "8534edd99fd64bb6ac478beb99404c1f",
+      "End": "1b742b40fdcf437ca3cf6ceb367365ef",
+      "Id": "05d0031d09294f08b6d1ac83183dbb08",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "b6d9898db26c41f3a9dd80f3d86df1bb",
+      "End": "6c51f090a79e438881b5e786c07d6886",
+      "Id": "6d5b4ca1d79b43619707c67adf706cd7",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e240277bef434edeb4a2a2fa42df7d2e",
+      "End": "af553fe2f2014210842d78bfd897cb1f",
+      "Id": "8c6856b7b940413ebda4e435765e4c5a",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4472",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -2.2352211475372314,
+      "EyeY": 19.89985466003418,
+      "EyeZ": -17.918149948120117,
+      "LookX": 2.2352211475372314,
+      "LookY": -19.89985466003418,
+      "LookZ": 17.918149948120117,
+      "UpX": 0.071707285940647125,
+      "UpY": 0.81512778997421265,
+      "UpZ": 0.57482588291168213
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Arc.ByCenterPointRadiusAngle",
+        "ShowGeometry": false,
+        "Id": "733db43629974449b0a4c5408e0b85da",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 282.80124959185321,
+        "Y": 87.149203848495773
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "23ecdb0861034bdb97d81e733a790c9c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 28.801249591853207,
+        "Y": 228.97670384849579
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "08687472977f4a8d89f536555a9933f7",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 28.801249591853207,
+        "Y": 80.97670384849576
+      },
+      {
+        "Name": "Line.ByStartPointEndPoint",
+        "ShowGeometry": false,
+        "Id": "a0dbe4be2b46425aa0a056139909c778",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 994.78062480831056,
+        "Y": 108.42968758032069
+      },
+      {
+        "Name": "Curve.EndPoint",
+        "ShowGeometry": false,
+        "Id": "db6c25efafd447d2940364fa5fbe43a1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 684.80124959185321,
+        "Y": 104.64920384849577
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": false,
+        "Id": "d7a4c470fb94487baf4925030b47f2ac",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 669.92264444483578,
+        "Y": 441.11153571071736
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "cff0489f025d43ddbe9321d099884341",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 282.80124959185321,
+        "Y": 383.47670384849584
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": false,
+        "Id": "5dee6fc394dc4f44bc5a7168cf7bd779",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1380.8012495918533,
+        "Y": 161.6492038484958
+      },
+      {
+        "Name": "PolyCurve.ByJoinedCurves",
+        "ShowGeometry": true,
+        "Id": "073bbad2fbba4e6b9d0ba6a59d04d970",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1634.8012495918533,
+        "Y": 161.82170384849582
+      },
+      {
+        "Name": "Curve.PointsAtEqualChordLength",
+        "ShowGeometry": true,
+        "Id": "a81dca5617f0498bb6b0b3ae8c625f34",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1783.7688568782071,
+        "Y": 442.18615209516162
+      }
+    ],
+    "Annotations": [],
+    "X": 128.25631378087962,
+    "Y": 114.59266550342005,
+    "Zoom": 0.46313981277671745
+  }
+}

--- a/test/core/watch/obsolete_zero_touch_node.dyn
+++ b/test/core/watch/obsolete_zero_touch_node.dyn
@@ -1,0 +1,149 @@
+{
+  "Uuid": "96b9c6c7-b3fb-43b5-b93d-403331402a45",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "obsolete_zero_touch_node",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.TestCSharpAttribute.Test2",
+      "Id": "cb146e7e22ad4e96bfe45e506d3669d1",
+      "Inputs": [
+        {
+          "Id": "75b48c635f5d4ca3a2ce0a5cd5217eb8",
+          "Name": "testCSharpAttribute",
+          "Description": "FFITarget.TestCSharpAttribute",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ecd0db6179284d8fb3c229c29b4c4fe9",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "TestCSharpAttribute.Test2 ( ): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.TestCSharpAttribute.TestCSharpAttribute",
+      "Id": "7f095b0ef2b1456ea0d45ae31c432018",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "11a5739e8f9d4772abe39326040b6d21",
+          "Name": "TestCSharpAttribute",
+          "Description": "TestCSharpAttribute",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "TestCSharpAttribute.TestCSharpAttribute ( ): TestCSharpAttribute"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "11a5739e8f9d4772abe39326040b6d21",
+      "End": "75b48c635f5d4ca3a2ce0a5cd5217eb8",
+      "Id": "65601d14a9444461b22a76a1b3f436ad",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [
+    {
+      "Name": "FFITarget.dll",
+      "ReferenceType": "ZeroTouch",
+      "Nodes": [
+        "cb146e7e22ad4e96bfe45e506d3669d1",
+        "7f095b0ef2b1456ea0d45ae31c432018"
+      ]
+    }
+  ],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4472",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "TestCSharpAttribute.Test2",
+        "ShowGeometry": true,
+        "Id": "cb146e7e22ad4e96bfe45e506d3669d1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 336.0,
+        "Y": 300.80000000000007
+      },
+      {
+        "Name": "TestCSharpAttribute.TestCSharpAttribute",
+        "ShowGeometry": true,
+        "Id": "7f095b0ef2b1456ea0d45ae31c432018",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 132.80000000000007,
+        "Y": 47.999999999999986
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Fix for warnings not showing when created before node view is ready by explicitly updating bubble contents from `Nodemodel.Infos` property when `nodeviewmodel `is constructed.

Before this fix, there were cases where warnings were registered for a `nodemodel` but didn't update the error bubble as there was no `nodeviewmodel `to register the callback with at that instant. These cases included 1. node to code producing warnings on the resulting CBN, 2. obsolete node warnings on zero-touch nodes.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
