### PR TITLE
Dummy Node Remove Color Overlays

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
@@ -34,17 +34,10 @@ namespace CoreNodeModelsWpf.Nodes
             nodeView.inputGrid.Children.Add(dummyNodeImage);
             model.Warning(model.GetDescription(), true);
 
-            UIElement child = nodeView.grid.FindName("zoomGlyphsGrid") as UIElement;
-            nodeView.grid.Children.Remove(child);
-
-            child = nodeView.grid.FindName("nodeColorOverlayZoomIn") as UIElement;
-            nodeView.grid.Children.Remove(child);
-
-            child = nodeView.grid.FindName("nodeBorder") as UIElement;
-            nodeView.grid.Children.Remove(child);
-
-            child = nodeView.grid.FindName("GlyphStackPanel") as UIElement;
-            nodeView.grid.Children.Remove(child);
+            // Grid containing the State overlay Glyphs in Zoomed Out state
+            // Remove so only the 'paperclip' icon appears 
+            UIElement child = nodeView.grid.FindName("zoomGlyphsGrid") as UIElement;    
+            if (child != null) nodeView.grid.Children.Remove(child);
         }
 
         public void Dispose()

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -24,12 +25,26 @@ namespace CoreNodeModelsWpf.Nodes
                 Width = 66.0,
                 Height = 66.0,
                 Stretch = Stretch.UniformToFill,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
                 Source = new BitmapImage(new Uri(src, UriKind.Relative))
             };
             RenderOptions.SetBitmapScalingMode(dummyNodeImage, BitmapScalingMode.HighQuality);
 
             nodeView.inputGrid.Children.Add(dummyNodeImage);
             model.Warning(model.GetDescription(), true);
+
+            UIElement child = nodeView.grid.FindName("zoomGlyphsGrid") as UIElement;
+            nodeView.grid.Children.Remove(child);
+
+            child = nodeView.grid.FindName("nodeColorOverlayZoomIn") as UIElement;
+            nodeView.grid.Children.Remove(child);
+
+            child = nodeView.grid.FindName("nodeBorder") as UIElement;
+            nodeView.grid.Children.Remove(child);
+
+            child = nodeView.grid.FindName("GlyphStackPanel") as UIElement;
+            nodeView.grid.Children.Remove(child);
         }
 
         public void Dispose()


### PR DESCRIPTION
### Purpose

A small change to the Dummy Node. The Dummy Node is used for Unresolved or Deprecated Nodes. It will effectively replace any node and has no functionality but to visually represent this state. As such, it does not require the visual candy used in normal nodes, and all the extra glyphs showing Frozen, Hidden, Warning, Error, or Info states were removed. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Visual update to the Dummy Node.

![dummy node fix - frozen reads](https://user-images.githubusercontent.com/5354594/160786786-e847f3cf-837b-46b8-970c-a7c05eafc6fe.gif)
![dummy node fix](https://user-images.githubusercontent.com/5354594/160473231-fc5adcce-ccd6-4b66-b5d4-be4cee6776b8.gif)


### Reviewers

@sm6srw 

### FYIs

@Amoursol

