### PR TITLE
Hot fix bug that doesnt unselect node/group after some undos

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -6,6 +6,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Properties;
+using Dynamo.Selection;
 using Dynamo.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -646,7 +647,12 @@ namespace Dynamo.Graph.Annotations
             this.textBlockHeight = helper.ReadDouble("TextblockHeight", DoubleValue);
             this.InitialTop = helper.ReadDouble("InitialTop", DoubleValue);
             this.InitialHeight = helper.ReadDouble("InitialHeight", DoubleValue);
-            this.IsSelected = helper.ReadBoolean(nameof(IsSelected), false);
+            this.IsSelected = helper.ReadBoolean(nameof(IsSelected), false);            
+
+            if (IsSelected)
+                DynamoSelection.Instance.Selection.Add(this);
+            else
+                DynamoSelection.Instance.Selection.Remove(this);
 
             //Deserialize Selected models
             if (element.HasChildNodes)

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2519,11 +2519,6 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
-        private void RemoveFromSelectionList()
-        {
-            
-        }
-
         #endregion
 
         #region Dirty Management

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2437,6 +2437,10 @@ namespace Dynamo.Graph.Nodes
             PreviewPinned = helper.ReadBoolean("isPinned", false);
             IsSelected = helper.ReadBoolean(nameof(IsSelected), IsSelected);
 
+            if (IsSelected)
+                DynamoSelection.Instance.Selection.Add(this);
+            else
+                DynamoSelection.Instance.Selection.Remove(this);
 
             var portInfoProcessed = new HashSet<int>();
 
@@ -2513,6 +2517,11 @@ namespace Dynamo.Graph.Nodes
                 ReportPosition();
 
             }
+        }
+
+        private void RemoveFromSelectionList()
+        {
+            
         }
 
         #endregion


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose
Thir PR solves the bug related to unselecting a node/annotation after a few undos.
The bug was caused because after the Deserialization of the model, the nodes were still in the selection list. 
To solve that, the model is now being removed or added according to `IsSelected ` boolean value.

![hotFixSelectionBug](https://user-images.githubusercontent.com/89042471/160494028-1d29f999-fa08-4716-a8aa-2c89863c45bf.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
