### PR TITLE
DYN-4735-GroupStyleMenu-MaxWidth

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -307,7 +307,7 @@
                                         <Border Height="1"
                                                 Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
                                             <Border Height="1"
-                                                    Width="129"
+                                                    MaxWidth="150"
                                                     Background="{StaticResource NodeContextMenuSeparatorColor}">
                                             </Border>
                                         </Border>
@@ -335,13 +335,14 @@
                                                    Background="{Binding HexColorString, Converter={StaticResource StringToBrushColorConverter}}" 
                                                    Width="15" 
                                                    Height="15"/>
-                                            <Label Name="GroupStyleLabelName"
-                                                   Content ="{Binding Name}"
-                                                   Margin="5,0,5,0"
-                                                   Foreground="{StaticResource NodeContextMenuForeground}"
-                                                   FontFamily="{StaticResource ArtifaktElementRegular}"
-                                                   FontSize="14px"
-                                                   FontWeight="Medium"/>
+                                            <TextBlock Text="{Binding Name}" 
+                                                        TextTrimming="CharacterEllipsis"
+                                                        MaxWidth="129"
+                                                        Margin="5,0,5,0"
+                                                        Foreground="{StaticResource NodeContextMenuForeground}"
+                                                        FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                        FontSize="14px"
+                                                        FontWeight="Medium"/>
                                         </StackPanel>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">


### PR DESCRIPTION
### Purpose

Modify the width of the GroupStyle context menu so if the GroupName is too long it will be adjusted.
I've replaced the Label that shows the group name by a TextBlock so I can use the TextTrimming property to show the text "...." when the group name is too long.
Also the Separator width was updated to be dynamically according to the group name length.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Modify the width of the GroupStyle context menu so if the GroupName is too long it will be adjusted.

### Reviewers

@QilongTang 

### FYIs

