### PR TITLE
DYN-4726-ButtonsUILayout-Localization

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -2927,7 +2927,6 @@
                         <Border x:Name="border"
                                 Margin="4"
                                 Height="24px"
-                                Width="78"
                                 Padding="8,0,8,0"
                                 BorderThickness="1"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -3966,8 +3965,14 @@
                             BorderBrush="{StaticResource Button.Outline.Default.Border}"
                             CornerRadius="2">
                         <Grid Background="Transparent">
-                            <Rectangle Stroke="#FFFFFF" RadiusX="2" RadiusY="2" Opacity="0.5" StrokeThickness="1"></Rectangle>
-                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <Rectangle Stroke="#FFFFFF" 
+                                       RadiusX="2" 
+                                       RadiusY="2" 
+                                       Opacity="0.5" 
+                                       StrokeThickness="1"/>
+                            <TextBlock HorizontalAlignment="Center" 
+                                       VerticalAlignment="Center" 
+                                       Padding="10,0,10,0">
                                 <ContentPresenter />
                             </TextBlock>
                         </Grid>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -580,7 +580,7 @@
                                                       Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*"></ColumnDefinition>
-                                                        <ColumnDefinition Width="*"></ColumnDefinition>
+                                                        <ColumnDefinition Width="Auto"></ColumnDefinition>
                                                     </Grid.ColumnDefinitions>
                                                     <StackPanel Orientation="Horizontal"
                                                             Height="30"
@@ -596,7 +596,7 @@
                                                                 Content="{Binding Background, ElementName=buttonColorPicker, Converter={StaticResource BrushColorToStringConverter}}"
                                                                 Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                                     </StackPanel>
-                                                    <Grid  Grid.Column="1" Margin="20,0,10,0">
+                                                    <Grid  Grid.Column="1">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="*"></ColumnDefinition>
                                                             <ColumnDefinition Width="*"></ColumnDefinition>
@@ -608,7 +608,6 @@
                                                                 IsEnabled="{Binding IsSaveButtonEnabled}"
                                                                 Click="AddStyle_SaveButton_Click"
                                                                 Content="{x:Static p:Resources.GroupStylesSaveButtonText}"
-                                                                Width="50"
                                                                 Height="30"/>
                                                         <Button x:Name="AddStyle_CancelButton" 
                                                                 Style="{StaticResource OutlinedButtonStyle}"
@@ -616,7 +615,6 @@
                                                                 HorizontalAlignment="Right"
                                                                 Click="AddStyle_CancelButton_Click"
                                                                 Content="{x:Static p:Resources.GroupStylesCancelButtonText}"
-                                                                Width="50"
                                                                 Height="30"/>
                                                     </Grid>
                                                 </Grid>


### PR DESCRIPTION
### Purpose

UI Layout fix for buttons in the Group Style section.
When testing Dynamo in the languages fr-FR, es-ES, ru-RU, de-DE.... the text in the "AddStyle", "Save" and "Cancel" buttons was appearing cut, then I did several changes in the Grid size and removed the Width property so the buttons can be auto-fit according to the Text content.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

UI Layout fix for buttons in the Group Style section.


### Reviewers

@QilongTang 

### FYIs

