### PR TITLE
Visual indication of function state

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -891,7 +891,7 @@ namespace Dynamo.Graph.Nodes
         ///     Are all the outputs of this node connected?
         /// </summary>
         [JsonIgnore]
-        public bool AllOutputsConnected
+        public bool AreAllOutputsConnected
         {
             get { return outPorts.All(p => p.IsConnected); }
         }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -888,6 +888,15 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        ///     Are all the outputs of this node connected?
+        /// </summary>
+        [JsonIgnore]
+        public bool AllOutputsConnected
+        {
+            get { return outPorts.All(p => p.IsConnected); }
+        }
+
+        /// <summary>
         ///     Returns the description from type information
         /// </summary>
         /// <returns>The value or "No description provided"</returns>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -159,6 +159,9 @@
     <!--  Port color  -->
     <SolidColorBrush x:Key="PortKeepListStructureBackground" Color="#537E91" />
     <SolidColorBrush x:Key="PortUseLevelsCheckBoxColor" Color="#808080" />
+    <SolidColorBrush x:Key="PortValueMarkerBlue" Color="#6AC0E7" />
+    <SolidColorBrush x:Key="PortValueMarkerGrey" Color="#999999" />
+    <SolidColorBrush x:Key="PortValueMarkerRed" Color="#EB5555" />
 
     <!--  Connector  -->
     <SolidColorBrush x:Key="ConnectorHoverStateColor" Color="#808080" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -88,7 +88,7 @@
                     Height="27px"
                     Margin="0,0,1,0"
                     HorizontalAlignment="Right"
-                    Background="{StaticResource Blue300Brush}"
+                    Background="{Binding PortValueMarkerColor, UpdateSourceTrigger=PropertyChanged}"
                     Visibility="{Binding PortDefaultValueMarkerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <!--  The name of this port  -->

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -53,6 +53,7 @@
             <!--  Transparent rectangle used for port snapping, overhangs the edge of the port  -->
             <Rectangle Grid.Column="0"
                        x:Name="PortSnapping"
+                       Margin="-25,0,0,0"
                        Grid.ColumnSpan="7"
                        Canvas.ZIndex="1"
                        Fill="Transparent"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -20,6 +20,7 @@
               IsHitTestVisible="True">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Name="PortNameColumn" Width="*" />
+                <ColumnDefinition Name="ValueMarkerColumn" Width="5px" />
                 <ColumnDefinition Name="PortSnappingColumn" Width="25px" />
             </Grid.ColumnDefinitions>
 
@@ -51,8 +52,8 @@
 
             <!--  Transparent rectangle used for port snapping, overhangs the edge of the port  -->
             <Rectangle Grid.Column="0"
-                       Grid.ColumnSpan="2"
-                       Margin="-25,0,0,0"
+                       x:Name="PortSnapping"
+                       Grid.ColumnSpan="7"
                        Canvas.ZIndex="1"
                        Fill="Transparent"
                        IsHitTestVisible="{Binding IsHitTestVisible}"
@@ -70,6 +71,7 @@
             <!--  Sets the port background color  -->
             <Border x:Name="PortBackgroundBorder"
                     Grid.Column="0"
+                    Grid.ColumnSpan="2"
                     SnapsToDevicePixels="True">
                 <Border.Style>
                     <Style TargetType="Border">
@@ -93,6 +95,15 @@
                 </Border.Style>
             </Border>
 
+            <!--  A small marker on the left of the port, indicating whether it's been honored  -->
+            <Rectangle x:Name="PortValueMarker"
+                       Grid.Column="1"
+                       Height="27px"
+                       VerticalAlignment="Center"
+                       Fill="{Binding PortValueMarkerColor, UpdateSourceTrigger=PropertyChanged}"
+                       IsHitTestVisible="False"
+                       SnapsToDevicePixels="True" />
+       
             <!--  Grid containing the Port Name TextBox  -->
             <Grid Name="PortNameGrid"
                   Grid.Column="0"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -103,6 +103,7 @@
                        VerticalAlignment="Center"
                        Fill="{Binding PortValueMarkerColor, UpdateSourceTrigger=PropertyChanged}"
                        IsHitTestVisible="False"
+                       Visibility="{Binding PortDefaultValueMarkerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
                        SnapsToDevicePixels="True" />
        
             <!--  Grid containing the Port Name TextBox  -->

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
 using Dynamo.Graph.Nodes;
@@ -21,6 +22,7 @@ namespace Dynamo.ViewModels
         private bool portDefaultValueMarkerVisible;
         private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
         private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
+        private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
 
         private static readonly SolidColorBrush PortBackgroundColorKeepListStructure = new SolidColorBrush(Color.FromRgb(83, 126, 145));
         private static readonly SolidColorBrush PortBorderBrushColorKeepListStructure = new SolidColorBrush(Color.FromRgb(168, 181, 187));
@@ -146,7 +148,13 @@ namespace Dynamo.ViewModels
         public InPortViewModel(NodeViewModel node, PortModel port) : base(node, port)
         {
             port.PropertyChanged += PortPropertyChanged;
+            
             RefreshPortDefaultValueMarkerVisible();
+        }
+
+        private void OutPorts_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            
         }
 
         public override void Dispose()
@@ -270,6 +278,43 @@ namespace Dynamo.ViewModels
         /// </summary>
         protected override void RefreshPortColors()
         {
+            //Is in function state
+            if (node.NodeModel.IsPartiallyApplied)
+            {
+                if (node.NodeModel.AllOutputsConnected)
+                {
+                    PortValueMarkerColor = PortValueMarkerGrey;
+                    PortBackgroundColor = PortBackgroundColorDefault;
+                    PortBorderBrushColor = PortBorderBrushColorDefault;
+                }
+                else
+                {
+                    SetupDefaultPortColorValues();
+                }
+            }
+            else
+            {
+                SetupDefaultPortColorValues();
+            }
+        }
+
+        internal void RefreshInputPortsByOutputConnectionChanged(bool isOutputConnected)
+        {
+            if (node.NodeModel.IsPartiallyApplied)
+            {
+                if (isOutputConnected)
+                {
+                    PortValueMarkerColor = PortValueMarkerGrey;
+                }
+                else 
+                {
+                    SetupDefaultPortColorValues();
+                }
+            }
+        }
+
+        private void SetupDefaultPortColorValues()
+        {
             // Special case for keeping list structure visual appearance
             if (port.UseLevels && port.KeepListStructure && port.IsConnected)
             {
@@ -287,7 +332,7 @@ namespace Dynamo.ViewModels
             // Port isn't connected and has no default value (or isn't using it)
             else
             {
-                PortValueMarkerColor = port.IsConnected ? PortValueMarkerBlue : PortValueMarkerRed;
+                PortValueMarkerColor = port.IsConnected ? PortValueMarkerBlue: PortValueMarkerRed;
                 PortBackgroundColor = PortBackgroundColorDefault;
                 PortBorderBrushColor = PortBorderBrushColorDefault;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Media;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
+using Dynamo.UI;
 using Dynamo.UI.Commands;
 
 namespace Dynamo.ViewModels
@@ -18,11 +19,13 @@ namespace Dynamo.ViewModels
 
         private bool showUseLevelMenu;
 
-        private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
+        private SolidColorBrush portValueMarkerColor;
+
         private bool portDefaultValueMarkerVisible;
-        private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
-        private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
-        private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
+
+        private SolidColorBrush PortValueMarkerBlue;
+        private SolidColorBrush PortValueMarkerRed;
+        private SolidColorBrush PortValueMarkerGrey;
 
         private static readonly SolidColorBrush PortBackgroundColorKeepListStructure = new SolidColorBrush(Color.FromRgb(83, 126, 145));
         private static readonly SolidColorBrush PortBorderBrushColorKeepListStructure = new SolidColorBrush(Color.FromRgb(168, 181, 187));
@@ -148,6 +151,13 @@ namespace Dynamo.ViewModels
         public InPortViewModel(NodeViewModel node, PortModel port) : base(node, port)
         {
             port.PropertyChanged += PortPropertyChanged;
+
+            var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
+
+            PortValueMarkerBlue = (SolidColorBrush)resourceDictionary["PortValueMarkerBlue"];
+            PortValueMarkerGrey = (SolidColorBrush)resourceDictionary["PortValueMarkerGrey"];
+            PortValueMarkerRed = (SolidColorBrush)resourceDictionary["PortValueMarkerRed"];
+
             RefreshPortDefaultValueMarkerVisible();
         }
 
@@ -158,7 +168,7 @@ namespace Dynamo.ViewModels
         }
 
         internal override PortViewModel CreateProxyPortViewModel(PortModel portModel)
-        {
+        {            
             portModel.IsProxyPort = true;
             return new InPortViewModel(node, portModel);
         }
@@ -275,7 +285,7 @@ namespace Dynamo.ViewModels
             //Is in function state
             if (node.NodeModel.IsPartiallyApplied)
             {
-                if (node.NodeModel.AllOutputsConnected)
+                if (node.NodeModel.AreAllOutputsConnected)
                 {
                     PortValueMarkerColor = PortValueMarkerGrey;
                     PortBackgroundColor = PortBackgroundColorDefault;

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -147,7 +147,7 @@ namespace Dynamo.ViewModels
 
         public InPortViewModel(NodeViewModel node, PortModel port) : base(node, port)
         {
-            port.PropertyChanged += PortPropertyChanged;            
+            port.PropertyChanged += PortPropertyChanged;
             RefreshPortDefaultValueMarkerVisible();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -147,14 +147,8 @@ namespace Dynamo.ViewModels
 
         public InPortViewModel(NodeViewModel node, PortModel port) : base(node, port)
         {
-            port.PropertyChanged += PortPropertyChanged;
-            
+            port.PropertyChanged += PortPropertyChanged;            
             RefreshPortDefaultValueMarkerVisible();
-        }
-
-        private void OutPorts_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            
         }
 
         public override void Dispose()
@@ -332,7 +326,7 @@ namespace Dynamo.ViewModels
             // Port isn't connected and has no default value (or isn't using it)
             else
             {
-                PortValueMarkerColor = port.IsConnected ? PortValueMarkerBlue: PortValueMarkerRed;
+                PortValueMarkerColor = port.IsConnected ? PortValueMarkerBlue : PortValueMarkerRed;
                 PortBackgroundColor = PortBackgroundColorDefault;
                 PortBorderBrushColor = PortBorderBrushColorDefault;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Media;
 using Dynamo.Graph.Nodes;
 using Dynamo.Logging;
+using Dynamo.UI;
 using Dynamo.UI.Commands;
 
 namespace Dynamo.ViewModels
@@ -16,15 +17,16 @@ namespace Dynamo.ViewModels
         private DelegateCommand hideConnectionsCommand;
         private DelegateCommand portMouseLeftButtonOnContextCommand;
 
-        private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
-        private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
-        private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
-        private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
+        private SolidColorBrush portValueMarkerColor;
+
+        private SolidColorBrush PortValueMarkerBlue;
+        private SolidColorBrush PortValueMarkerGrey;
 
         private bool showContextMenu;
         private bool areConnectorsHidden;
         private string showHideWiresButtonContent = "";
         private bool hideWiresButtonEnabled;
+        private bool portDefaultValueMarkerVisible;
 
         /// <summary>
         /// Sets the condensed styling on Code Block output ports.
@@ -116,7 +118,18 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged(nameof(PortValueMarkerColor));
             }
         }
-      
+
+
+        public bool PortDefaultValueMarkerVisible 
+        {
+            get => portDefaultValueMarkerVisible;
+            set
+            {
+                portDefaultValueMarkerVisible = value;
+                RaisePropertyChanged(nameof(PortDefaultValueMarkerVisible));
+            }
+        }
+
 
         /// <summary>
         /// Takes care of the multiple UI concerns when dealing with the Unhide/Hide Wires button
@@ -140,7 +153,18 @@ namespace Dynamo.ViewModels
         {
             port.PropertyChanged += PortPropertyChanged;
 
+            var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
+            
+            PortValueMarkerBlue = (SolidColorBrush)resourceDictionary["PortValueMarkerBlue"];
+            PortValueMarkerGrey = (SolidColorBrush)resourceDictionary["PortValueMarkerGrey"];
+
             RefreshHideWiresState();
+        }
+
+        public override void Dispose()
+        {
+            port.PropertyChanged -= PortPropertyChanged;
+            base.Dispose();
         }
 
         private void PortPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -269,6 +293,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+
         private void OnMouseLeftButtonDownOnContext(object parameter)
         {
             ShowContextMenu = true;
@@ -278,11 +303,12 @@ namespace Dynamo.ViewModels
         {            
             if (node.NodeModel.IsPartiallyApplied)
             {
+                PortDefaultValueMarkerVisible = true;
                 portValueMarkerColor = PortValueMarkerGrey;
             }
             else
             {
-                portValueMarkerColor = PortValueMarkerBlue;
+                PortDefaultValueMarkerVisible = false;
             }
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -379,6 +379,7 @@ namespace Dynamo.ViewModels
             {
                 case "ActiveConnector":
                     RaisePropertyChanged(nameof(IsHitTestVisible));
+                    RefreshPortColors();
                     break;
                 default:
                     break;
@@ -394,6 +395,7 @@ namespace Dynamo.ViewModels
                     break;
                 case nameof(State):
                     RaisePropertyChanged(nameof(State));
+                    RefreshPortColors();
                     break;
                 case nameof(ToolTipContent):
                     RaisePropertyChanged(nameof(ToolTipContent));


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

This PR implements visual improvements at node ports to indicate if a Function Node is in an active/inactive state.
A new rectangle was added in the output port to represent the active/inactive state.
Considering that Function State is represented by the boolean `IsPartiallyApplied`, here are how some states are working in the implementation of this PR.

**State 1** - Function state but not passing a function (Output port is **not connected** to another node) 

<img width="264" alt="State1" src="https://user-images.githubusercontent.com/89042471/161071170-7518f1d9-86e0-46e1-bf89-7091de92b912.png">

**State 2** - Function passing (Output port is **connected** to another node and passing a function)

<img width="307" alt="State2" src="https://user-images.githubusercontent.com/89042471/161071430-aae95ae2-5571-4ea2-abaf-d9442e92a20c.png">

**State 3** - All input ports are connected, so are not considered at function state anymore (Standard connected input colors)

<img width="302" alt="State3" src="https://user-images.githubusercontent.com/89042471/161071851-226b3f67-8728-49be-acd7-5d591340b675.png">
<img width="258" alt="State4" src="https://user-images.githubusercontent.com/89042471/161071944-04f04dce-c9b3-420f-b7b1-b4b7e09a4647.png">

**State 4** - The input ports have default values, so it's not considered at function state (Standard connected input colors)

<img width="286" alt="State5" src="https://user-images.githubusercontent.com/89042471/161072225-229da0ce-8a29-4d33-815d-93ebc4735097.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@jesusalvino @RobertGlobant20 
