### PR TITLE
DYN-4743-GroupStyles-SelectionState

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4540,4 +4540,67 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <SolidColorBrush x:Key="BorderBrushMouseOver" Color="#FFFFFF" Opacity="0.15"/>
+
+    <Style x:Key="ListBoxItemStyle" TargetType="ListBoxItem">
+        <Setter Property="Focusable" Value="{Binding Path=IsDefault, Converter={StaticResource InverseBooleanConverter}}"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Grid Margin="0,0,10,10"
+                                  MinWidth="186"
+                                  MinHeight="67">
+                        <Border x:Name="mouseOverBorder"
+                                        Margin="2"
+                                        BorderThickness="2"
+                                        BorderBrush="{StaticResource BorderBrushMouseOver}"
+                                        Visibility="Hidden"
+                                        CornerRadius="2"/>
+                        <Border x:Name="mousePressedBorder"
+                                        Margin="0"
+                                        BorderThickness="4"
+                                        Visibility="Hidden"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        Background="Transparent"
+                                        CornerRadius="4"/>
+                        <Border Name="selectedItemBorder"
+                                        Margin="4"
+                                        Background="Transparent"
+                                        SnapsToDevicePixels="true">
+                        </Border>
+                        <ContentPresenter/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsSelected" 
+                                         Value="True">
+                            <Setter Property="BorderBrush" 
+                                            TargetName="selectedItemBorder" 
+                                            Value="{StaticResource PreferencesWindowButtonColor}"/>
+                            <Setter Property="BorderThickness"
+                                            TargetName="selectedItemBorder"
+                                            Value="2"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" 
+                                                   Value="True"/>
+                                <Condition Property="Focusable"
+                                                   Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="selectedItemBorder" 
+                                                Property="Opacity" 
+                                                Value="0.9" />
+                                <Setter TargetName="mouseOverBorder" 
+                                                Property="Visibility" 
+                                                Value="Visible" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -36,21 +36,18 @@
             <controls:InverseBoolToVisibilityConverter  x:Key="InverseBoolToVisibilityConverter "/>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
 
-
-
-
             <!--This Template will be used for the controls generated in the Styles list when a new Style is saved-->
             <DataTemplate x:Key="styleViewItemTemplate">
-                <Border Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}"
-                        Margin="5,5,0,0"
-                        Width="160">
+                <Border Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}"     
+                        Margin="4"
+                        BorderThickness="1">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="30" />
                         </Grid.ColumnDefinitions>
                         <Grid Grid.Column="0">
-                            <Grid Margin="0,0,0,0">
+                            <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="*"></RowDefinition>
                                     <RowDefinition Height="*"></RowDefinition>
@@ -535,27 +532,28 @@
                                       Visibility="Visible">
                                 <ScrollViewer VerticalScrollBarVisibility="Auto" 
                                               Height="220">
-                                    <Grid Margin="8,0,0,0">
+                                    <Grid Margin="0,0,0,0">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <Button x:Name="AddStyleButton"
-                                                Style="{StaticResource SolidButtonStyleSmaller}" 
-                                                HorizontalAlignment="Left"                                             
+                                                Style="{StaticResource SolidButtonStyleSmaller}"      
+                                                HorizontalAlignment="Left"
                                                 Grid.Row="0"
-                                                Margin="0,10,0,10"
+                                                MinWidth="100"
+                                                MinHeight="25"
+                                                Margin="3,10,0,10"
                                                 Click="AddStyleButton_Click"
                                                 IsEnabled="{Binding IsEnabledAddStyleButton}"
                                                 Content="{x:Static p:Resources.AddStyleButton}" />
                                         <Border x:Name="AddStyleBorder"
                                                 Visibility="{Binding IsVisibleAddStyleBorder, Converter={StaticResource BooleanToVisibilityConverter}}"
                                                 CornerRadius="4" 
-                                                HorizontalAlignment="Left"
-                                                Height="100"
-                                                Width="335"
-                                                Margin="0,0,0,10"
+                                                MinHeight="100"
+                                                MinWidth="335"
+                                                Margin="7,0,72,10"
                                                 Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}"
                                                 Grid.Row="1">
                                             <Grid>
@@ -565,14 +563,12 @@
                                                 </Grid.RowDefinitions>
                                                 <TextBox  x:Name="groupNameBox"
                                                           CaretBrush="{StaticResource PreferencesWindowButtonColor}"
-                                                          VerticalAlignment="Center"
-                                                          HorizontalAlignment ="Left"
                                                           PreviewKeyDown="groupNameBox_PreviewKeyDown"
                                                           Style="{StaticResource TextBoxWaterMarkStyle}"
                                                           Grid.Row="0"
                                                           Margin="10"
-                                                          Height="25"
-                                                          Width="300"
+                                                          MinHeight="25"
+                                                          MinWidth="300"
                                                           Text="{Binding AddStyleControl.Name}"
                                                           Tag="{x:Static p:Resources.PreferencesViewVisualSettingsGroupStyleInput}"/>
                                                 <Grid Grid.Row="1"
@@ -620,16 +616,17 @@
                                                 </Grid>
                                             </Grid>
                                         </Border>
-                                        <ListBox Width="350" 
-                                                 Margin="-5,0,0,0"
+                                        <ListBox x:Name="GroupStylesListBox"
                                                  HorizontalAlignment="Left"
+                                                 BorderBrush="Transparent"
+                                                 BorderThickness="1"
+                                                 Margin="0"
                                                  Grid.Row="2"
-                                                 Padding="-5,0,0,0"
+                                                 LostFocus="GroupStylesListBox_LostFocus"
                                                  ItemsSource="{Binding StyleItemsList}"
                                                  ItemTemplate="{StaticResource styleViewItemTemplate}"
+                                                 ItemContainerStyle="{StaticResource ListBoxItemStyle}"
                                                  Background="{StaticResource PreferencesWindowVisualSettingsBackground}"
-                                                 BorderBrush="Transparent"
-                                                 BorderThickness="0,0,0,0"
                                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                                             <ListBox.ItemsPanel>
                                                 <ItemsPanelTemplate>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -316,5 +316,10 @@ namespace Dynamo.Wpf.Views
                 viewModel.IsWarningEnabled = false;
             }
         }
+
+        private void GroupStylesListBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            GroupStylesListBox.UnselectAll();
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Selection state of a style should remain after clicking on other place
Now every time that a GroupStyle box is selected a blue border of 2 px will be shown, the default ones cannot be selected just the custom ones, when the mouse is over a GroupStyle box a gray border of 2px will be shown (except for the default ones).
Also if a custom GroupStyle is selected and the user clicks over other parts of the Group Style section, the current selected one will be deselected.
Finally I did some re-organization in the layout so all the controls are vertically aligned (due that after showing the selected/mouseover border it was moving the groupsstyle boxes in a weird way).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Selection state of a style should remain after clicking on other place

### Reviewers

@QilongTang 

### FYIs

