### PR TITLE
Cherry-Pick  DYN-4773-Color-Localization (#12770)

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2948,6 +2948,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Color.
+        /// </summary>
+        public static string GroupContextMenuColor {
+            get {
+                return ResourceManager.GetString("GroupContextMenuColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete Group.
         /// </summary>
         public static string GroupContextMenuDeleteGroup {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3063,4 +3063,7 @@ To install the latest version of a package, click Install. \n
   <data name="GroupStylesSaveButtonText" xml:space="preserve">
     <value>Save</value>
   </data>
+  <data name="GroupContextMenuColor" xml:space="preserve">
+    <value>Color</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3050,4 +3050,7 @@ To install the latest version of a package, click Install. \n
   <data name="GroupStylesSaveButtonText" xml:space="preserve">
     <value>Save</value>
   </data>
+  <data name="GroupContextMenuColor" xml:space="preserve">
+    <value>Color</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -358,7 +358,7 @@
                         </Style>
                     </MenuItem.Resources>
                 </MenuItem>
-                <MenuItem Name="ColorMenuItem" Header="Color">
+                <MenuItem Name="ColorMenuItem" Header="{x:Static p:Resources.GroupContextMenuColor}">
                     <ListBox ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
                              SelectionChanged="OnNodeColorSelectionChanged"
                              Height="Auto"


### PR DESCRIPTION

### Purpose

Cherry-Pick https://github.com/DynamoDS/Dynamo/pull/12770
In the context menu appearing when clicking right over the Group the Color menu item was not localized, then in this fix I'm adding the needed resources so it can be localized.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Cherry-Pick https://github.com/DynamoDS/Dynamo/pull/12770


### Reviewers

@QilongTang 

### FYIs

