### PR TITLE
Reverting colors in dictionary

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -159,9 +159,6 @@
     <!--  Port color  -->
     <SolidColorBrush x:Key="PortKeepListStructureBackground" Color="#537E91" />
     <SolidColorBrush x:Key="PortUseLevelsCheckBoxColor" Color="#808080" />
-    <SolidColorBrush x:Key="PortValueMarkerBlue" Color="#6AC0E7" />
-    <SolidColorBrush x:Key="PortValueMarkerGrey" Color="#999999" />
-    <SolidColorBrush x:Key="PortValueMarkerRed" Color="#EB5555" />
 
     <!--  Connector  -->
     <SolidColorBrush x:Key="ConnectorHoverStateColor" Color="#808080" />

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -19,13 +19,13 @@ namespace Dynamo.ViewModels
 
         private bool showUseLevelMenu;
 
-        private SolidColorBrush portValueMarkerColor;
+        private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
 
         private bool portDefaultValueMarkerVisible;
 
-        private SolidColorBrush PortValueMarkerBlue;
-        private SolidColorBrush PortValueMarkerRed;
-        private SolidColorBrush PortValueMarkerGrey;
+        private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
+        private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
+        private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));        
 
         private static readonly SolidColorBrush PortBackgroundColorKeepListStructure = new SolidColorBrush(Color.FromRgb(83, 126, 145));
         private static readonly SolidColorBrush PortBorderBrushColorKeepListStructure = new SolidColorBrush(Color.FromRgb(168, 181, 187));
@@ -151,12 +151,6 @@ namespace Dynamo.ViewModels
         public InPortViewModel(NodeViewModel node, PortModel port) : base(node, port)
         {
             port.PropertyChanged += PortPropertyChanged;
-
-            var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
-
-            PortValueMarkerBlue = (SolidColorBrush)resourceDictionary["PortValueMarkerBlue"];
-            PortValueMarkerGrey = (SolidColorBrush)resourceDictionary["PortValueMarkerGrey"];
-            PortValueMarkerRed = (SolidColorBrush)resourceDictionary["PortValueMarkerRed"];
 
             RefreshPortDefaultValueMarkerVisible();
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -17,10 +17,9 @@ namespace Dynamo.ViewModels
         private DelegateCommand hideConnectionsCommand;
         private DelegateCommand portMouseLeftButtonOnContextCommand;
 
-        private SolidColorBrush portValueMarkerColor;
+        private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
 
-        private SolidColorBrush PortValueMarkerBlue;
-        private SolidColorBrush PortValueMarkerGrey;
+        private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
 
         private bool showContextMenu;
         private bool areConnectorsHidden;
@@ -152,11 +151,6 @@ namespace Dynamo.ViewModels
         public OutPortViewModel(NodeViewModel node, PortModel port) :base(node, port)
         {
             port.PropertyChanged += PortPropertyChanged;
-
-            var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
-            
-            PortValueMarkerBlue = (SolidColorBrush)resourceDictionary["PortValueMarkerBlue"];
-            PortValueMarkerGrey = (SolidColorBrush)resourceDictionary["PortValueMarkerGrey"];
 
             RefreshHideWiresState();
         }


### PR DESCRIPTION
### Purpose

This PR reverts the colors defined in a dictionary implemented in #12758

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
