### PR TITLE
DYN-4735-ContextMenu-FixedWidth

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -3295,6 +3295,107 @@
         </Setter>
     </Style>
 
+    <Style x:Key="ContextMenuItemFixedWidthStyle" TargetType="{x:Type MenuItem}">
+        <Setter Property="IsChecked" Value="{DynamicResource IsChecked}" />
+        <Setter Property="Height" Value="Auto" />
+        <Setter Property="MinWidth" Value="250" />
+        <Setter Property="Width" Value="Auto" />
+        <Setter Property="Padding" Value="20,0,0,0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type MenuItem}">
+                    <DockPanel x:Name="dockPanel"
+                               HorizontalAlignment="Stretch"
+                               Background="Transparent"
+                               SnapsToDevicePixels="true">
+                        <Label x:Name="checkBox"
+                               Margin="0,0,-20,0"
+                               HorizontalAlignment="Left"
+                               VerticalAlignment="Center"
+                               HorizontalContentAlignment="Center"
+                               VerticalContentAlignment="Center"
+                               Content="✓"
+                               DockPanel.Dock="Left"
+                               FontSize="9px"
+                               Foreground="White"
+                               Visibility="Collapsed" />
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="Center"
+                                          ContentSource="Header"
+                                          DockPanel.Dock="Left"
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          TextBlock.Foreground="{StaticResource NodeContextMenuForeground}" />
+                        <Label x:Name="subMenuArrow"
+                               Margin="0,0,15,7"
+                               Padding="0"
+                               VerticalAlignment="Center"
+                               Content="&gt;"
+                               DockPanel.Dock="Right"
+                               FontFamily="{StaticResource ArtifaktElementRegular}"
+                               FontSize="13px"
+                               Foreground="{StaticResource Blue300Brush}">
+                            <Label.RenderTransform>
+                                <ScaleTransform ScaleX="1" ScaleY="1.5" />
+                            </Label.RenderTransform>
+                            <Label.Style>
+                                <Style TargetType="{x:Type Label}">
+                                    <Setter Property="Visibility" Value="Hidden" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}, Path=HasItems}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Label.Style>
+                        </Label>
+                        <Popup x:Name="PART_Popup"
+                               AllowsTransparency="true"
+                               Focusable="false"
+                               HorizontalOffset="0"
+                               MaxWidth="182"
+                               IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                               Placement="Right"
+                               VerticalOffset="-2">
+                            <Border Background="{TemplateBinding Background}"
+                                    BorderThickness="0">
+                                <ScrollViewer x:Name="SubMenuScrollViewer"
+                                              CanContentScroll="true"
+                                              Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer,
+                                                                                            TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                    <Grid RenderOptions.ClearTypeHint="Enabled">
+                                        <ItemsPresenter x:Name="ItemsPresenter"
+                                                        Margin="2"
+                                                        Grid.IsSharedSizeScope="true"
+                                                        KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                        KeyboardNavigation.TabNavigation="Cycle"
+                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                    </Grid>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </DockPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="ContentPresenter" Property="TextBlock.Opacity" Value="0.5" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="False">
+                            <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="checkBox" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="ContextMenuSeparatorStyle" TargetType="Separator">
         <Setter Property="OverridesDefaultStyle" Value="true" />
         <Setter Property="Template">

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -44,13 +44,13 @@
             <Setter Property="ScrollViewer.CanContentScroll"
                     Value="true" />
             <Setter Property="Width"
-                    Value="152" />
+                    Value="150" />
             <Setter Property="Height"
                     Value="54" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ListBox">
-                        <Grid Margin="0,9,4,8">
+                        <Grid Margin="0,13,4,8">
                             <ScrollViewer Margin="0"
                                           Focusable="false">
                                 <WrapPanel IsItemsHost="True" />
@@ -337,7 +337,7 @@
                                                    Height="15"/>
                                             <TextBlock Text="{Binding Name}" 
                                                         TextTrimming="CharacterEllipsis"
-                                                        MaxWidth="129"
+                                                        MaxWidth="148"
                                                         Margin="5,0,5,0"
                                                         Foreground="{StaticResource NodeContextMenuForeground}"
                                                         FontFamily="{StaticResource ArtifaktElementRegular}"
@@ -358,7 +358,9 @@
                         </Style>
                     </MenuItem.Resources>
                 </MenuItem>
-                <MenuItem Name="ColorMenuItem" Header="{x:Static p:Resources.GroupContextMenuColor}">
+                <MenuItem Name="ColorMenuItem" 
+                          Header="{x:Static p:Resources.GroupContextMenuColor}"
+                          Style="{StaticResource ContextMenuItemFixedWidthStyle}">
                     <ListBox ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
                              SelectionChanged="OnNodeColorSelectionChanged"
                              Height="Auto"
@@ -383,7 +385,9 @@
                         </ListBox.Items>
                     </ListBox>
                 </MenuItem>
-                <MenuItem Name="ChangeSize" Header="{x:Static p:Resources.GroupContextMenuFont}">
+                <MenuItem Name="ChangeSize" 
+                          Header="{x:Static p:Resources.GroupContextMenuFont}"
+                          Style="{StaticResource ContextMenuItemFixedWidthStyle}">
                     <MenuItem Name="FontSize0"
                               Command="{Binding ChangeFontSize}"
                               CommandParameter="14"


### PR DESCRIPTION

### Purpose

Fixed width for ContextMenus "Group Styles", "Colors" and "Font Size"
I've added a new style that will set a Fixed Width for the Sub ContextMenus in "Colors" and "Font Size" entries, the "Group Style" entry the style was also modified for fit the expected Width.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixed width for ContextMenus "Group Styles", "Colors" and "Font Size"


### Reviewers

@QilongTang 

### FYIs

