### PR TITLE
DYN-4716 Can't save a group style with single char as name

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -562,8 +562,8 @@
                                                     <RowDefinition Height="*"></RowDefinition>
                                                 </Grid.RowDefinitions>
                                                 <TextBox  x:Name="groupNameBox"
-                                                          CaretBrush="{StaticResource PreferencesWindowButtonColor}"
-                                                          PreviewKeyDown="groupNameBox_PreviewKeyDown"
+                                                          CaretBrush="{StaticResource PreferencesWindowButtonColor}"                                                          
+                                                          PreviewKeyUp="groupNameBox_PreviewKeyUp"
                                                           Style="{StaticResource TextBoxWaterMarkStyle}"
                                                           Grid.Row="0"
                                                           Margin="10"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -301,7 +301,7 @@ namespace Dynamo.Wpf.Views
             }
         }
 
-        private void groupNameBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        private void groupNameBox_PreviewKeyUp(object sender, KeyEventArgs e)
         {
             var groupNameTextBox = sender as TextBox;
             if (groupNameBox == null) return;


### PR DESCRIPTION
### Purpose

This PR contains the fix for the input of the group's name, allowing to add a name with a single char.
For this, instead of checking the string when the key is down, now it's detecting when the key is up.

![SingleCharGroupStyle](https://user-images.githubusercontent.com/89042471/162036980-4a7bdf77-bee9-49dc-8e59-395646d2bac8.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
