### PR TITLE
WIP Start implementing feature flags for toy feature

### DIFF
--- a/src/Dynamo.All.sln
+++ b/src/Dynamo.All.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32106.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamoCore", "DynamoCore\DynamoCore.csproj", "{7858FA8C-475F-4B8E-B468-1F8200778CF8}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -240,6 +240,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyRenamerCLI", "Tools\AssemblyRenamerCLI\AssemblyRenamerCLI.csproj", "{F382C3F8-C55C-4350-800A-3D13A94F8E13}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyInfoGenerator", "AssemblySharedInfoGenerator\AssemblyInfoGenerator.csproj", "{133FC760-5699-46D9-BEA6-E816B5F01016}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoFeatureFlags", "DynamoFeatureFlags\DynamoFeatureFlags.csproj", "{018EE764-62CE-4376-A531-8AD9410B857E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -905,6 +907,14 @@ Global
 		{133FC760-5699-46D9-BEA6-E816B5F01016}.Release|Any CPU.Build.0 = Release|Any CPU
 		{133FC760-5699-46D9-BEA6-E816B5F01016}.Release|x64.ActiveCfg = Release|Any CPU
 		{133FC760-5699-46D9-BEA6-E816B5F01016}.Release|x64.Build.0 = Release|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Debug|x64.Build.0 = Debug|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Release|x64.ActiveCfg = Release|Any CPU
+		{018EE764-62CE-4376-A531-8AD9410B857E}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -41,6 +41,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DynamoFeatureFlags\DynamoFeatureFlags.csproj" />
     <ProjectReference Include="..\Engine\GraphLayout\GraphLayout.csproj">
       <Project>{c2595b04-856d-40ae-8b99-4804c7a70708}</Project>
       <Name>GraphLayout</Name>

--- a/src/DynamoCore/Logging/AnalyticsService.cs
+++ b/src/DynamoCore/Logging/AnalyticsService.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Logging
     {
         // Use the Analytics.Core interface so that we do not have to load the ADP assembly at this time.
         private static IAnalyticsUI adpAnalyticsUI;
-
+        private static IAnalyticsClient dynamoAnalyticsClient;
         /// <summary>
         /// Starts the client when DynamoModel is created. This method initializes
         /// the Analytics service and application life cycle start is tracked.
@@ -41,8 +41,9 @@ namespace Dynamo.Logging
             // This will also load the Analytics.Net.ADP assembly
             // We must initialize the ADPAnalyticsUI instance before the Analytics.Start call.
             adpAnalyticsUI = new ADPAnalyticsUI();
+            var dynamoAnalyticsClient = new DynamoAnalyticsClient(model);
 
-            Analytics.Start(new DynamoAnalyticsClient(model));
+            Analytics.Start(dynamoAnalyticsClient);
             model.WorkspaceAdded += OnWorkspaceAdded;
         }
 
@@ -106,6 +107,14 @@ namespace Dynamo.Logging
             {
                 adpAnalyticsUI.ShowOptInDialog(System.Threading.Thread.CurrentThread.CurrentUICulture.Name, false, host);
             }
+        }
+        internal static string GetUserIDForSession()
+        {
+            if (dynamoAnalyticsClient is DynamoAnalyticsClient dac)
+            {
+                return dac.Session.UserId;
+            }
+            return null;
         }
     }
 }

--- a/src/DynamoCore/Logging/AnalyticsService.cs
+++ b/src/DynamoCore/Logging/AnalyticsService.cs
@@ -41,7 +41,7 @@ namespace Dynamo.Logging
             // This will also load the Analytics.Net.ADP assembly
             // We must initialize the ADPAnalyticsUI instance before the Analytics.Start call.
             adpAnalyticsUI = new ADPAnalyticsUI();
-            var dynamoAnalyticsClient = new DynamoAnalyticsClient(model);
+            dynamoAnalyticsClient = new DynamoAnalyticsClient(model);
 
             Analytics.Start(dynamoAnalyticsClient);
             model.WorkspaceAdded += OnWorkspaceAdded;

--- a/src/DynamoCore/Logging/AnalyticsService.cs
+++ b/src/DynamoCore/Logging/AnalyticsService.cs
@@ -112,7 +112,7 @@ namespace Dynamo.Logging
         {
             if (dynamoAnalyticsClient is DynamoAnalyticsClient dac)
             {
-                return dac.Session.UserId;
+                return dac.Session?.UserId;
             }
             return null;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -661,7 +661,7 @@ namespace Dynamo.Models
                 try
                 {
                     FeatureFlags = new DynamoFeatureFlags.FeatureFlagsManager(AnalyticsService.GetUserIDForSession());
-                    DynamoFeatureFlags.FeatureFlagsManager.LogRequest += LogMessageWrapper;
+                    DynamoFeatureFlags.FeatureFlagsManager.MessageLogged += LogMessageWrapper;
 
                 }
                 catch (Exception e) { Logger.LogError($"could not start feature flags manager {e}"); };
@@ -1217,7 +1217,7 @@ namespace Dynamo.Models
             CustomNodeManager.MessageLogged -= LogMessage;
             CustomNodeManager.Dispose();
             MigrationManager.MessageLogged -= LogMessage;
-            DynamoFeatureFlags.FeatureFlagsManager.LogRequest -= LogMessageWrapper;
+            DynamoFeatureFlags.FeatureFlagsManager.MessageLogged -= LogMessageWrapper;
         }
 
         private void InitializeCustomNodeManager()

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1008,6 +1008,23 @@ namespace Dynamo.Controls
                 this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(null); };
             }
             loaded = true;
+
+            //TODO... not sure I like this, it's easy to call, but it might confuse devs, it will silently
+            //return default when client is not setup, maybe should require a reference?
+            //Task.Run(async () =>
+            {
+                //    await Task.Delay(4000);
+                if (DynamoFeatureFlags.FeatureFlagsManager.CheckFeatureFlag<bool>("EasterEggIcon1", false))
+                {
+                    dynamoViewModel.Model.Logger.Log("EASTER EGG ICON IS TRUE");
+                    MessageBoxService.Show("feature flag 1 enabled", "easter", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+                }
+                else
+                {
+                    dynamoViewModel.Model.Logger.Log("EASTER EGG ICON IS FALSE");
+                }
+            }
+           // });
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1013,7 +1013,7 @@ namespace Dynamo.Controls
             if (DynamoFeatureFlags.FeatureFlagsManager.CheckFeatureFlag<bool>("EasterEggIcon1", false))
             {
                 dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true");
-                MessageBoxService.Show("EasterEggIcon1 was true", "eastereggicon1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+                MessageBoxService.Show(this,"EasterEggIcon1 was true", "eastereggicon1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
             }
             else
             {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1009,22 +1009,17 @@ namespace Dynamo.Controls
             }
             loaded = true;
 
-            //TODO... not sure I like this, it's easy to call, but it might confuse devs, it will silently
-            //return default when client is not setup, maybe should require a reference?
-            //Task.Run(async () =>
+            //feature flag test.
+            if (DynamoFeatureFlags.FeatureFlagsManager.CheckFeatureFlag<bool>("EasterEggIcon1", false))
             {
-                //    await Task.Delay(4000);
-                if (DynamoFeatureFlags.FeatureFlagsManager.CheckFeatureFlag<bool>("EasterEggIcon1", false))
-                {
-                    dynamoViewModel.Model.Logger.Log("EASTER EGG ICON IS TRUE");
-                    MessageBoxService.Show("feature flag 1 enabled", "eastereggicon1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
-                }
-                else
-                {
-                    dynamoViewModel.Model.Logger.Log("EASTER EGG ICON IS FALSE");
-                }
+                dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true");
+                MessageBoxService.Show("EasterEggIcon1 was true", "eastereggicon1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
             }
-           // });
+            else
+            {
+                dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is false");
+            }
+
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1017,7 +1017,7 @@ namespace Dynamo.Controls
                 if (DynamoFeatureFlags.FeatureFlagsManager.CheckFeatureFlag<bool>("EasterEggIcon1", false))
                 {
                     dynamoViewModel.Model.Logger.Log("EASTER EGG ICON IS TRUE");
-                    MessageBoxService.Show("feature flag 1 enabled", "easter", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+                    MessageBoxService.Show("feature flag 1 enabled", "eastereggicon1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
                 }
                 else
                 {

--- a/src/DynamoFeatureFlags/App.config
+++ b/src/DynamoFeatureFlags/App.config
@@ -4,6 +4,6 @@
     <!-- //LD Mobile keys are not secret and you can expose them in your client-side code without risk.
          //see:https://docs.launchdarkly.com/sdk/client-side/dotnet#getting-started-->
     <add key="ldmobilekey_dev" value="mob-ed7616de-a821-480a-b8f7-babcfeafa708"/>
-    <add key="ldmobilekey_prd" value="NA"/>
+    <add key="ldmobilekey_prd" value="mob-456dff9e-fb8f-4f06-a45c-2510b72bfc7c"/>
   </appSettings>
 </configuration>

--- a/src/DynamoFeatureFlags/App.config
+++ b/src/DynamoFeatureFlags/App.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <!-- //LD Mobile keys are not secret and you can expose them in your client-side code without risk.
+         //see:https://docs.launchdarkly.com/sdk/client-side/dotnet#getting-started-->
+    <add key="ldmobilekey_dev" value="mob-ed7616de-a821-480a-b8f7-babcfeafa708"/>
+    <add key="ldmobilekey_prd" value="NA"/>
+  </appSettings>
+</configuration>

--- a/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
+++ b/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
@@ -1,13 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)Config/CS_SDK.props" />
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!--force copying nuget netstd2 dependencies-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1">
+      <!--using this to avoid copying net461 deps of launch darkly -->
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!--to force LD package to reference system.collections.immutable of the same version. -->
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
+++ b/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
@@ -4,16 +4,44 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!--force copying nuget netstd2 dependencies-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1">
-      <!--using this to avoid copying net461 deps of launch darkly -->
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <!--to force LD package to reference system.collections.immutable of the same version. -->
+    <!--We want to us the netstandard2.0 flavor of launch darkly-->
+    <!--But we want nuget to resolve the non-ld assemblies (ex. the immutable pkg) -->
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1" IncludeAssets="none" GeneratePathProperty="true" PrivateAssets="all" />
+    <Reference Include="LaunchDarkly.ClientSdk">
+      <HintPath>$(PkgLaunchDarkly_ClientSdk)/lib/netstandard2.0/LaunchDarkly.ClientSdk.dll</HintPath>
+      <CopyLocal>True</CopyLocal>
+    </Reference>
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="5.5.0" IncludeAssets="none" GeneratePathProperty="true" PrivateAssets="all" />
+    <Reference Include="LaunchDarkly.CommonSdk">
+      <HintPath>$(PkgLaunchDarkly_CommonSdk)/lib/netstandard2.0/LaunchDarkly.CommonSdk.dll</HintPath>
+      <CopyLocal>True</CopyLocal>
+    </Reference>
+    <PackageReference Include="LaunchDarkly.EventSource" Version="4.1.3" IncludeAssets="none" GeneratePathProperty="true" PrivateAssets="all" />
+    <Reference Include="LaunchDarkly.EventSource">
+      <HintPath>$(PkgLaunchDarkly_EventSource)/lib/netstandard2.0/LaunchDarkly.EventSource.dll</HintPath>
+      <CopyLocal>True</CopyLocal>
+    </Reference>
+    <PackageReference Include="LaunchDarkly.InternalSdk" Version="2.3.2" IncludeAssets="none" GeneratePathProperty="true" PrivateAssets="all" />
+    <Reference Include="LaunchDarkly.InternalSdk">
+      <HintPath>$(PkgLaunchDarkly_InternalSdk)/lib/netstandard2.0/LaunchDarkly.InternalSdk.dll</HintPath>
+      <CopyLocal>True</CopyLocal>
+    </Reference>
+    <PackageReference Include="LaunchDarkly.JsonStream" Version="1.0.3" IncludeAssets="none" GeneratePathProperty="true" PrivateAssets="all" />
+    <Reference Include="LaunchDarkly.JsonStream">
+      <HintPath>$(PkgLaunchDarkly_JsonStream)/lib/netstandard2.0/LaunchDarkly.JsonStream.dll</HintPath>
+      <CopyLocal>True</CopyLocal>
+    </Reference>
+    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.1" IncludeAssets="none" GeneratePathProperty="true" PrivateAssets="all" />
+    <Reference Include="LaunchDarkly.Logging">
+      <HintPath>$(PkgLaunchDarkly_Logging)/lib/netstandard2.0/LaunchDarkly.Logging.dll</HintPath>
+      <CopyLocal>True</CopyLocal>
+    </Reference>
+    
+    <!--LaunchDarkly.ClientSdk has a transitive dependency on System.Collections.Immutable-->
+    <!--We need an explicit package reference so that nuget can copy the proper assemblies-->
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
+++ b/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)Config/CS_SDK.props" />
+  </ImportGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Configuration">
+      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Configuration.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
+++ b/src/DynamoFeatureFlags/DynamoFeatureFlags.csproj
@@ -10,10 +10,4 @@
     <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Configuration">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Configuration.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/src/DynamoFeatureFlags/FeatureFlagsManager.cs
+++ b/src/DynamoFeatureFlags/FeatureFlagsManager.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Configuration;
+
+namespace DynamoFeatureFlags
+{
+    //TODO make internal
+    public class FeatureFlagsManager:IDisposable
+    {
+        private LaunchDarkly.Sdk.User user;
+        private static LaunchDarkly.Sdk.Client.LdClient ldClient;
+        public static event Action<string> LogRequest; 
+        public FeatureFlagsManager(string userkey, string mobileKey = null)
+        {
+            //todo load sdk key from config if null
+            if(mobileKey == null)
+            {
+                //load from config
+#if DEBUG
+                var keystring = "ldmobilekey_dev";
+#else
+                var keystring = "ldmobilekey_prd";
+#endif
+                var path = GetType().Assembly.Location;
+                var config = ConfigurationManager.OpenExeConfiguration(path);
+                var key = config.AppSettings.Settings[keystring];
+               
+                if (key != null)
+                {
+                    mobileKey = key.Value;
+                }
+
+            }
+            user = LaunchDarkly.Sdk.User.Builder(userkey).Anonymous(true).Build();
+            Init(mobileKey);
+        }
+
+        internal async void Init(string mobileKey)
+        {
+            //start up client.
+            //TODO timeout?
+            ldClient = await LaunchDarkly.Sdk.Client.LdClient.InitAsync(mobileKey, user);
+            if (ldClient.Initialized)
+            {
+                LogRequest($"launch darkly initalized");
+            }
+        }
+
+        // TODO as we need more flag types, implement cases here or break out
+        // into more specific methods.
+        public static T CheckFeatureFlag<T>(string flagkey,T defaultval)
+        {
+            if (ldClient == null || !ldClient.Initialized)
+            {
+                LogRequest($"feature flags client not initalized for requested flagkey: {flagkey}, returning default value: {defaultval}");
+                return defaultval;
+            }
+
+            Object output = default(T);
+            switch (default(T))
+            {
+                case bool _:
+                    output = ldClient.BoolVariation(flagkey);
+                    break;
+                case string _ :
+                    output = ldClient.StringVariation(flagkey,defaultval as string);
+                    break;
+            }
+            return (T)output;
+        }
+
+        public void Dispose()
+        {
+            //TODO unclear how this should work in Hosts that can start Dynamo multiple times - 
+            //needs to be tested.
+            ldClient.Dispose();
+        }
+
+    }
+}

--- a/src/DynamoFeatureFlags/Properties/AssemblyInfo.cs
+++ b/src/DynamoFeatureFlags/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DynamoFeatureFlags.Properties")]
+
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2130b5f6-abd1-484d-8386-7ee4a4d5c49a")]
+
+[assembly: InternalsVisibleTo("DynamoCoreWpf")]
+[assembly: InternalsVisibleTo("DynamoCore")] 

--- a/src/Libraries/DesignScriptBuiltin/DesignScriptBuiltin.csproj
+++ b/src/Libraries/DesignScriptBuiltin/DesignScriptBuiltin.csproj
@@ -10,16 +10,8 @@
     <AssemblyName>DesignScriptBuiltin</AssemblyName>
     <DocumentationFile>$(OutputPath)\$(UICulture)\DesignScriptBuiltin.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup Label="System.Collections.Immutable@portable-net45+win8+wp8+wpa81">
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0">
-      <GeneratePathProperty>true</GeneratePathProperty>
-      <IncludeAssets>none</IncludeAssets>
-    </PackageReference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>$(PkgSystem_Collections_Immutable)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <ProjectReference Include="..\..\NodeServices\DynamoServices.csproj">
       <Project>{ef879a10-041d-4c68-83e7-3192685f1bae}</Project>
       <Name>DynamoServices</Name>

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -16,7 +16,7 @@
     <Compile Remove="Saving.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Greg" Version="2.1.8122.28281"/>
+    <PackageReference Include="Greg" Version="2.1.8122.28281" />
 	  <PackageReference Include="Moq" Version="4.2.1507.0118" ExcludeAssets="none" CopyXML="true" />
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
     <PackageReference Include="NUnit" Version="2.6.3" ExcludeAssets="none" CopyXML="true" />
@@ -24,7 +24,8 @@
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" GeneratePathProperty="true" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" GeneratePathProperty="true" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" GeneratePathProperty="true" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" GeneratePathProperty="true" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" GeneratePathProperty="true">
+    </PackageReference>
     <PackageReference Include="System.Memory" Version="4.5.4" GeneratePathProperty="true" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" />
     <Reference Include="Analytics.NET.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -146,7 +147,7 @@
       <Copy SourceFiles="$(PkgMicrosoft_Diagnostics_Runtime)\lib\net461\Microsoft.Diagnostics.Runtime.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
       <Copy SourceFiles="$(PkgSystem_Collections_Immutable)\lib\net461\System.Collections.Immutable.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
       <Copy SourceFiles="$(PkgSystem_Reflection_Metadata)\lib\net461\System.Reflection.Metadata.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
-      <Copy SourceFiles="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\net461\System.Runtime.CompilerServices.Unsafe.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
+      <Copy SourceFiles="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
       <Copy SourceFiles="$(PkgSystem_Memory)\lib\net461\System.Memory.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
       <Copy SourceFiles="$(PkgSystem_Buffers)\lib\net461\System.Buffers.dll" DestinationFolder="$(OutputPath)/../../../test/packages" />
   </Target>

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" GeneratePathProperty="true" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" GeneratePathProperty="true" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" GeneratePathProperty="true" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" GeneratePathProperty="true">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" GeneratePathProperty="true">
     </PackageReference>
     <PackageReference Include="System.Memory" Version="4.5.4" GeneratePathProperty="true" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" />


### PR DESCRIPTION
### Purpose

This PR onboards Dynamo onto launch darkly, it controls a popup at startup. The feature flag is enabled for debug builds, and disabled for production (release) builds.

PR does the following:
* adds a new project DynamoFeatureFlags that references the newest launch darkly client side dot net sdk nuget package.
* ~updates compiler unsafe to avoid conflict at build time~ ... latest changes revert this as LD is resolving the same version with Tibi's suggestion.
* Starts the launch darkly client if - analytics is not disabled by the configuration file, or the DisableAnalytics flag - otherwise LD will start, so it's not controllable via any UI setting, only by commandline, config file etc.
* We use the stable instrumentation id that is generated for analytics, if this cannot be created or loaded, we use a shared key. Shared key will also be used during testing etc.
* All users are logged as anonymous, which means that we cannot see them on the LD dashboard, but we can do targeted role outs / AB testing as long as the shared key is not used.
*  mobile sdk keys are embedded into the config file for the new project - according to LD docs, this is safe with no risk, these keys are not full sdk keys, they're more like a url for our dev/prod environments. 
* To avoid a slow startup the LD client is started async, so you can't immediately check feature flags unless you want to block - I have not implemented that, but it should be possible to add to the `CheckFeatureFlag<T>` method.

### New Binaries:

- LaunchDarkly.ClientSdk.dll                             - manual netstandard2.0
- LaunchDarkly.CommonSdk.dll                       - manual netstandard2.0
- LaunchDarkly.EventSource.dll                        - manual netstandard2.0
- LaunchDarkly.InternalSdk.dll                          - manual netstandard2.0
- LaunchDarkly.JsonStream.dll                          - manual netstandard2.0
- LaunchDarkly.Logging.dll                               - manual netstandard2.0
- ~Microsoft.Bcl.AsyncInterfaces.dll~
- System.Buffers.dll                                           - automatic net461
- System.Memory.dll                                         - automatic net461
- System.Numerics.Vectors.dll                           - automatic net461
- System.Runtime.CompilerServices.Unsafe.dll - automatic net461
- ~System.Text.Encodings.Web.dll~
- ~System.Text.Json.dll~
- ~System.Threading.Tasks.Extensions.dll~
- ~System.ValueTuple.dll~


package refs for the DynamoFeatureFlags Project:
```
'DynamoFeatureFlags' has the following package references
   [netstandard2.0]: 
   Top-level Package                Requested   Resolved
   > LaunchDarkly.ClientSdk         2.0.1       2.0.1   
   > NETStandard.Library      (A)   [2.0.3, )   2.0.3   

   Transitive Package                            Resolved
   > LaunchDarkly.CommonSdk                      5.5.0   
   > LaunchDarkly.EventSource                    4.1.3   
   > LaunchDarkly.InternalSdk                    2.3.2   
   > LaunchDarkly.JsonStream                     1.0.3   
   > LaunchDarkly.Logging                        1.0.1   
   > Microsoft.NETCore.Platforms                 1.1.0   
   > System.Buffers                              4.5.1   
   > System.Collections.Immutable                1.7.1   
   > System.Memory                               4.5.4   
   > System.Numerics.Vectors                     4.5.0   
   > System.Runtime.CompilerServices.Unsafe      4.5.3   
```

![Screen Shot 2022-04-12 at 7 10 09 PM](https://user-images.githubusercontent.com/508936/163073670-49494c3b-96ef-4039-9db3-75c10dab16d0.png)



### TODO:
- [ ] tests
- [ ] in a host like Revit where Dynamo is stopped and restarted, need to test if disposal/restarting of the LD client is smooth.
- [ ] if LD deps are missing, ensure that DynamoCore still starts fine.
- [ ] satisfied with new binaries this PR pulls in.
- [x] compiler.unsafe version alignment?
- [x] reference to system.configuration.dll in new csproj looks very wrong. (hint path)
- [x] if the user is logged in, we might want to add more attributes like email - so we can target specific emails for some features - we should add the private attribute flag if so to avoid storing any PII in LD.


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Add initial feature flags controls in Dynamo.


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
