### PR TITLE
Fix crash when placing the color palette node using the autocompletion dialog.

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -69,7 +69,8 @@ namespace CoreNodeModelsWpf.Nodes
             var convertedModelColor = ((Color)(converter.Convert(colorPaletteNode.DsColor, null, null, null)));
             var isSameColor = convertedModelColor
                  .Equals(ColorPaletteUINode.xceedColorPickerControl.SelectedColor);
-            if (!isSameColor)
+
+            if (ColorPaletteUINode.xceedColorPickerControl.SelectedColor != null && !isSameColor)
             {
                 //we need to record the colorPicker node before the model is updated.
                 var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-4753


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix crash when placing the color palette node using the autocompletion dialog.


### Reviewers
@QilongTang @zeusongit 
