### PR TITLE
DYN-4602 Disabling clear selection when pasting elements

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2655,6 +2655,8 @@ namespace Dynamo.Models
                     newAnnotations.Add(annotationModel);
                 }
 
+                DynamoSelection.Instance.ClearSelectionDisabled = true;
+
                 // Add the new Annotation's to the Workspace
                 foreach (var newAnnotation in newAnnotations)
                 {
@@ -2668,6 +2670,8 @@ namespace Dynamo.Models
                 {
                     AddToSelection(item);
                 }
+
+                DynamoSelection.Instance.ClearSelectionDisabled = false;
 
                 // Record models that are created as part of the command.
                 CurrentWorkspace.RecordCreatedModels(createdModels);


### PR DESCRIPTION
### Purpose

This PR contains the solution for the bug DYN-4602 by disabling the deselection of the groups while pasting elements.

![DragingGroups](https://user-images.githubusercontent.com/89042471/163060517-ca42beec-5a0b-469a-8c09-e15763bb4d3b.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### Reviewers

@QilongTang 


