### PR TITLE
Add security tab to preference menu dialog

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7057,7 +7057,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Paths.
+        ///   Looks up a localized string similar to Add Path.
         /// </summary>
         public static string SecurityPathAddPathButtonName {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5820,6 +5820,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Security.
+        /// </summary>
+        public static string PreferencesSecuritySettingsTab {
+            get {
+                return ResourceManager.GetString("PreferencesSecuritySettingsTab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Style name already in use.
         /// </summary>
         public static string PreferencesViewAlreadyExistingStyleWarning {
@@ -6059,6 +6068,33 @@ namespace Dynamo.Wpf.Properties {
         public static string PreferencesViewTitle {
             get {
                 return ResourceManager.GetString("PreferencesViewTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trust warning.
+        /// </summary>
+        public static string PreferencesViewTrustWarningHeader {
+            get {
+                return ResourceManager.GetString("PreferencesViewTrustWarningHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable receiving trust warning.
+        /// </summary>
+        public static string PreferencesViewTrustWarningLabel {
+            get {
+                return ResourceManager.GetString("PreferencesViewTrustWarningLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to We recommend keeping this toggle off to reduce security risks..
+        /// </summary>
+        public static string PreferencesViewTrustWarningTooltipText {
+            get {
+                return ResourceManager.GetString("PreferencesViewTrustWarningTooltipText", resourceCulture);
             }
         }
         
@@ -7021,6 +7057,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add Paths.
+        /// </summary>
+        public static string SecurityPathAddPathButtonName {
+            get {
+                return ResourceManager.GetString("SecurityPathAddPathButtonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning.
+        /// </summary>
+        public static string SecurityWarningExpanderName {
+            get {
+                return ResourceManager.GetString("SecurityWarningExpanderName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select All.
         /// </summary>
         public static string SelectAllTitle {
@@ -7422,6 +7476,15 @@ namespace Dynamo.Wpf.Properties {
         public static string TourLabelProgressText {
             get {
                 return ResourceManager.GetString("TourLabelProgressText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trusted location.
+        /// </summary>
+        public static string TrustedPathsExpanderName {
+            get {
+                return ResourceManager.GetString("TrustedPathsExpanderName", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3084,4 +3084,25 @@ To install the latest version of a package, click Install. \n
   <data name="GroupContextMenuColor" xml:space="preserve">
     <value>Color</value>
   </data>
+  <data name="PreferencesSecuritySettingsTab" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="PreferencesViewTrustWarningHeader" xml:space="preserve">
+    <value>Trust warning</value>
+  </data>
+  <data name="PreferencesViewTrustWarningLabel" xml:space="preserve">
+    <value>Disable receiving trust warning</value>
+  </data>
+  <data name="PreferencesViewTrustWarningTooltipText" xml:space="preserve">
+    <value>We recommend keeping this toggle off to reduce security risks.</value>
+  </data>
+  <data name="SecurityPathAddPathButtonName" xml:space="preserve">
+    <value>Add Paths</value>
+  </data>
+  <data name="SecurityWarningExpanderName" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="TrustedPathsExpanderName" xml:space="preserve">
+    <value>Trusted location</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3097,7 +3097,7 @@ To install the latest version of a package, click Install. \n
     <value>We recommend keeping this toggle off to reduce security risks.</value>
   </data>
   <data name="SecurityPathAddPathButtonName" xml:space="preserve">
-    <value>Add Paths</value>
+    <value>Add Path</value>
   </data>
   <data name="SecurityWarningExpanderName" xml:space="preserve">
     <value>Warning</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3071,4 +3071,25 @@ To install the latest version of a package, click Install. \n
   <data name="GroupContextMenuColor" xml:space="preserve">
     <value>Color</value>
   </data>
+  <data name="PreferencesSecuritySettingsTab" xml:space="preserve">
+    <value>Security</value>
+  </data>
+  <data name="PreferencesViewTrustWarningHeader" xml:space="preserve">
+    <value>Trust warning</value>
+  </data>
+  <data name="PreferencesViewTrustWarningLabel" xml:space="preserve">
+    <value>Disable receiving trust warning</value>
+  </data>
+  <data name="PreferencesViewTrustWarningTooltipText" xml:space="preserve">
+    <value>We recommend keeping this toggle off to reduce security risks.</value>
+  </data>
+  <data name="SecurityPathAddPathButtonName" xml:space="preserve">
+    <value>Add Paths</value>
+  </data>
+  <data name="SecurityWarningExpanderName" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="TrustedPathsExpanderName" xml:space="preserve">
+    <value>Trusted location</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3084,7 +3084,7 @@ To install the latest version of a package, click Install. \n
     <value>We recommend keeping this toggle off to reduce security risks.</value>
   </data>
   <data name="SecurityPathAddPathButtonName" xml:space="preserve">
-    <value>Add Paths</value>
+    <value>Add Path</value>
   </data>
   <data name="SecurityWarningExpanderName" xml:space="preserve">
     <value>Warning</value>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -853,6 +853,91 @@
                             </Expander>
                         </Grid>
                     </TabItem>
+                    
+                    <!--Security Settings Tab-->
+                    <TabItem Header="{x:Static p:Resources.PreferencesSecuritySettingsTab}"
+                             Style="{StaticResource LeftTab}"
+                             Visibility="{Binding PreferencesDebugMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <!--This Grid contains the package manager settings tab-->
+                        <Grid x:Name="SecurityTab" 
+                              Margin="1"
+                              HorizontalAlignment="Stretch">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <Expander x:Name="SecurityWarningExpander"
+                                        Grid.Row="0"
+                                        Style="{StaticResource MenuExpanderStyle}" 
+                                        IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=SecurityWarningExpander}"
+                                        Header="{x:Static p:Resources.SecurityWarningExpanderName}">
+                                <StackPanel Orientation="Vertical" Margin="0,6,0,0">
+                                    <Label  Content="{x:Static p:Resources.PreferencesViewTrustWarningHeader}" 
+                                            Padding="0,5,5,5"
+                                            FontSize="13"
+                                            Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="0">
+                                            <ToggleButton Name="TrustWarningToggle"
+                                                            Width="{StaticResource ToggleButtonWidth}"
+                                                            Height="{StaticResource ToggleButtonHeight}"
+                                                            VerticalAlignment="Center"
+                                                            IsChecked="False"
+                                                            Style="{StaticResource EllipseToggleButton1}"/>
+                                            <Label Content="{x:Static p:Resources.PreferencesViewTrustWarningLabel}" 
+                                                    Margin="10,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                            <Label HorizontalAlignment="Left" 
+                                               Name="TrustWarningInfoLabel" 
+                                               VerticalAlignment="Center" 
+                                               Height="26" 
+                                               Width="53" 
+                                               Margin="0 3 0 0" >
+                                                <Label.ToolTip>
+                                                    <ToolTip Content="{x:Static p:Resources.PreferencesViewTrustWarningTooltipText}" Style="{StaticResource GenericToolTipLight}"/>
+                                                </Label.ToolTip>
+                                                <Label.Content>
+                                                    <fa:ImageAwesome Width="15" Height="15" VerticalAlignment="Bottom" HorizontalAlignment="Left" Icon="QuestionCircleOutline" Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                                </Label.Content>
+                                            </Label>
+                                        </StackPanel>
+                                    </Grid>
+                                </StackPanel>
+                            </Expander>
+
+                            <!--This Grid row contains the Trusted Paths section-->
+                            <Expander x:Name="TrustedPathsExpander"
+                                        Grid.Row="1"
+                                        Style="{StaticResource MenuExpanderStyle}" 
+                                        IsExpanded="{Binding PreferencesTabs[Features].ExpanderActive, Converter={StaticResource ExpandersBindingConverter}, ConverterParameter=TrustedPathsExpander}"
+                                        Header="{x:Static p:Resources.TrustedPathsExpanderName}">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <StackPanel Orientation="Vertical" Margin="0,6,0,0" Grid.Row="0">
+                                        <Button x:Name="AddPaths"
+                                            HorizontalAlignment="Left"
+                                            Margin="0"
+                                            Content="{x:Static p:Resources.SecurityPathAddPathButtonName}"
+                                            Command="{}">
+                                            <Button.Style>
+                                                <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
+                                                    <Setter Property="IsEnabled" Value="True"/>
+                                                </Style>
+                                            </Button.Style>
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
+                            </Expander>
+                        </Grid>
+                    </TabItem>
                 </TabControl>
             </Grid>
         </Grid>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -922,7 +922,7 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Orientation="Vertical" Margin="0,6,0,0" Grid.Row="0">
-                                        <Button x:Name="AddPaths"
+                                        <Button x:Name="AddPath"
                                             HorizontalAlignment="Left"
                                             Margin="0"
                                             Content="{x:Static p:Resources.SecurityPathAddPathButtonName}"

--- a/src/DynamoUtilities/DebugModes.cs
+++ b/src/DynamoUtilities/DebugModes.cs
@@ -34,6 +34,12 @@ namespace Dynamo.Utilities
             public bool IsEnabled;
         }
 
+        /// <summary>
+        /// Adds a debug mode
+        /// </summary>
+        /// <param name="name">Name of the debug mode</param>
+        /// <param name="description">Name about the debug mode</param>
+        /// /// <param name="isEnabled">Sets if the debug mode should be enabled on startup</param>
         internal static void AddDebugMode(string name, string description, bool isEnabled = false)
         {
             debugModes[name] = new DebugMode()
@@ -48,6 +54,8 @@ namespace Dynamo.Utilities
         {
             // Register app wide new debug modes here.
             AddDebugMode("DumpByteCode", "Dumps bytecode to a log file in a folder called ByteCodeLogs located in the current working dirrectory.", false);
+
+            AddDebugMode("DynamoPreferencesMenuDebugMode", "Enable/Disable the Preferences Panel new features in the Dynamo menu.", false);
         }
 
         internal static void LoadDebugModesStatusFromConfig(string configPath)


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-4802
Adds security tab with trust settings and a placeholder for trusted paths
Hidden under debug mode

![DynamoSandbox_DJdtbWUkAI](https://user-images.githubusercontent.com/32665108/163234251-871727d7-57ae-4473-bb98-92bddce8fa6f.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Release Notes

- Add security tab to preference menu dialog(UI)

### Reviewers

@DynamoDS/dynamo 
