### PR TITLE
Fix node2code for array indexing expressions

### DIFF
--- a/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
@@ -1102,10 +1102,10 @@ namespace Dynamo.Engine.NodeToCode
             IEnumerable<NodeModel> nodes,
             INamingProvider namingProvider)
         {
-            // The basic worflow is:
-            //   1. Compile each node to get its cde in AST format
+            // The basic workflow is:
+            //   1. Compile each node to get its code in AST format
             // 
-            //   2. Variable numbering to avoid confliction. For example, two 
+            //   2. Variable numbering to avoid conflicts. For example, two 
             //      code block nodes both have assignment "y = x", we need to 
             //      rename "y" to "y1" and "y2" respectively.
             //
@@ -1120,7 +1120,7 @@ namespace Dynamo.Engine.NodeToCode
             //   4. Generate short name for long name variables. Typically they
             //      are from output ports from other nodes.
             //
-            //   5. Do constant progation to optimize the generated code.
+            //   5. Do constant propagation to optimize the generated code.
             #region Step 1 AST compilation
 
             AstBuilder builder = new AstBuilder(null);
@@ -1130,7 +1130,7 @@ namespace Dynamo.Engine.NodeToCode
 
             #endregion
 
-            #region Step 2 Varialbe numbering
+            #region Step 2 Variable numbering
            
             // External inputs will be in input map
             // Internal non-cbn will be input map & output map

--- a/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
+++ b/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
@@ -81,7 +81,7 @@ namespace Dynamo.Engine
         /// <returns>true if input expression is of the form DesignScript.BuiltIn.Get.ValueAtIndex(exp1, exp2), false otherwise</returns>
         private bool TryBuildIndexingExpression(IdentifierListNode node, out ArrayNameNode indexExp)
         {
-
+            // If indxExp already has a rank >= 1, we need to append another [] to it with indx.
             SetArrayDimensionsDelegate setArrayDimensions = (ref ArrayNameNode indxExp, AssociativeNode indx) =>
             {
                 if (indxExp.ArrayDimensions != null)
@@ -126,38 +126,10 @@ namespace Dynamo.Engine
                             {
                                 if (TryBuildIndexingExpression(iln2, out ArrayNameNode index))
                                 {
-                                    // If indexExp already has a rank >= 1, we need to append another [] to it with index = exp2.
                                     setArrayDimensions(ref indexExp, index);
                                     return true;
-                                    //if (indexExp.ArrayDimensions != null)
-                                    //{
-                                    //    if (indexExp is IdentifierListNode iln)
-                                    //    {
-                                    //        if (iln.RightNode is ArrayNameNode arr)
-                                    //        {
-                                    //            arr.ArrayDimensions = indexExp.ArrayDimensions;
-                                    //        }
-                                    //    }
-                                    //    else indexExp = new IdentifierNode(indexExp.ToString());
-                                    //}
-                                    //indexExp.ArrayDimensions = new ArrayNode(index, null);
-                                    //return true;
                                 }
                             }
-                            // If indexExp already has a rank >= 1, we need to append another [] to it with index = exp2.
-                            //if (indexExp.ArrayDimensions != null)
-                            //{
-                            //    if(indexExp is IdentifierListNode iln)
-                            //    {
-                            //        if(iln.RightNode is ArrayNameNode arr)
-                            //        {
-                            //            arr.ArrayDimensions = indexExp.ArrayDimensions;
-                            //        }
-                            //    }
-                            //    else indexExp = new IdentifierNode(indexExp.ToString());
-                            //}
-                            //indexExp.ArrayDimensions = new ArrayNode(exp2, null);
-                            //return true;
                             setArrayDimensions(ref indexExp, exp2);
                             return true;
                         }

--- a/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
+++ b/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
@@ -16,6 +16,8 @@ namespace Dynamo.Engine
     /// automatically shortened to partial namespaces so that they can still be resolved uniquely.
     /// E.g., given {"A.B.C.D.E", "X.Y.A.B.E.C.E", "X.Y.A.C.B.E"}, all with the same class E,
     /// their shortest unique names would be: {"D.E", "E.E", "C.B.E"}.
+    /// 
+    /// Also replaces DesignScript.BuiltIn.Get.ValueAtIndex(exp1, exp2) calls to exp1[exp2] expressions.
     /// </summary>
     internal class ShortestQualifiedNameReplacer : AstReplacer
     {

--- a/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
+++ b/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
@@ -118,10 +118,6 @@ namespace Dynamo.Engine
                             indexExp.ArrayDimensions = new ArrayNode(exp2, null);
                             return true;
                         }
-                        else
-                        {
-                            return false;
-                        }
                     }
                 }
             }

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -586,7 +586,8 @@ namespace Dynamo.Graph.Nodes
                 {
                     func = targetClass.ProcTable.GetPropertyGetterByName(funcName);
                 }
-                type = func.ReturnType;
+                if(func != null) type = func.ReturnType;
+
                 return type;
             }
 

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -377,6 +377,11 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class ArrayNameNode : AssociativeNode
     {
+        internal virtual ArrayNameNode CreateInstance()
+        {
+            return new ArrayNameNode(this);
+        }
+
         public ArrayNode ArrayDimensions
         {
             get;
@@ -498,6 +503,11 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class GroupExpressionNode : ArrayNameNode
     {
+        internal override ArrayNameNode CreateInstance()
+        {
+            return new GroupExpressionNode(this);
+        }
+
         public AssociativeNode Expression
         {
             get;
@@ -557,6 +567,11 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class IdentifierNode : ArrayNameNode
     {
+        internal override ArrayNameNode CreateInstance()
+        {
+            return new IdentifierNode(this);
+        }
+
         public IdentifierNode(string identName = null)
         {
             datatype = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.InvalidType, 0);
@@ -659,6 +674,11 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class IdentifierListNode : ArrayNameNode
     {
+        internal override ArrayNameNode CreateInstance()
+        {
+            return new IdentifierListNode(this);
+        }
+
         public bool IsLastSSAIdentListFactor { get; set; }
 
         public AssociativeNode LeftNode
@@ -716,7 +736,7 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override string ToString()
         {
-            return LeftNode + "." + RightNode;
+            return LeftNode + "." + RightNode + base.ToString();
         }
 
         public override AstKind Kind
@@ -1064,6 +1084,11 @@ namespace ProtoCore.AST.AssociativeAST
         public int DynamicTableIndex { get; set; }
         public AssociativeNode Function { get; set; }
         public List<AssociativeNode> FormalArguments { get; set; }
+
+        internal override ArrayNameNode CreateInstance()
+        {
+            return new FunctionCallNode(this);
+        }
 
         public FunctionCallNode()
         {
@@ -2268,6 +2293,11 @@ namespace ProtoCore.AST.AssociativeAST
         public RangeStepOperator StepOperator { get; set; }
         public bool HasRangeAmountOperator { get; set; }
 
+        internal override ArrayNameNode CreateInstance()
+        {
+            return new RangeExprNode(this);
+        }
+
         public RangeExprNode()
         {
         }
@@ -2375,6 +2405,11 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class ExprListNode : ArrayNameNode
     {
+        internal override ArrayNameNode CreateInstance()
+        {
+            return new ExprListNode(this);
+        }
+
         public ExprListNode()
         {
             Exprs = new List<AssociativeNode>();

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -377,11 +377,6 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class ArrayNameNode : AssociativeNode
     {
-        internal virtual ArrayNameNode CreateInstance()
-        {
-            return new ArrayNameNode(this);
-        }
-
         public ArrayNode ArrayDimensions
         {
             get;
@@ -503,11 +498,6 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class GroupExpressionNode : ArrayNameNode
     {
-        internal override ArrayNameNode CreateInstance()
-        {
-            return new GroupExpressionNode(this);
-        }
-
         public AssociativeNode Expression
         {
             get;
@@ -567,11 +557,6 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class IdentifierNode : ArrayNameNode
     {
-        internal override ArrayNameNode CreateInstance()
-        {
-            return new IdentifierNode(this);
-        }
-
         public IdentifierNode(string identName = null)
         {
             datatype = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.InvalidType, 0);
@@ -674,11 +659,6 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class IdentifierListNode : ArrayNameNode
     {
-        internal override ArrayNameNode CreateInstance()
-        {
-            return new IdentifierListNode(this);
-        }
-
         public bool IsLastSSAIdentListFactor { get; set; }
 
         public AssociativeNode LeftNode
@@ -1084,11 +1064,6 @@ namespace ProtoCore.AST.AssociativeAST
         public int DynamicTableIndex { get; set; }
         public AssociativeNode Function { get; set; }
         public List<AssociativeNode> FormalArguments { get; set; }
-
-        internal override ArrayNameNode CreateInstance()
-        {
-            return new FunctionCallNode(this);
-        }
 
         public FunctionCallNode()
         {
@@ -2293,11 +2268,6 @@ namespace ProtoCore.AST.AssociativeAST
         public RangeStepOperator StepOperator { get; set; }
         public bool HasRangeAmountOperator { get; set; }
 
-        internal override ArrayNameNode CreateInstance()
-        {
-            return new RangeExprNode(this);
-        }
-
         public RangeExprNode()
         {
         }
@@ -2405,11 +2375,6 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class ExprListNode : ArrayNameNode
     {
-        internal override ArrayNameNode CreateInstance()
-        {
-            return new ExprListNode(this);
-        }
-
         public ExprListNode()
         {
             Exprs = new List<AssociativeNode>();

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1364,6 +1364,70 @@ namespace Dynamo.Tests
             Assert.IsTrue(cbn.Code.Contains(@"D:\\foo\\bar"));
         }
 
+        [Test, Category("Failure")]
+        public void ImperativeArrayIndexingInCodeBlockToCode()
+        {
+            OpenModel(@"core\node2code\imperative_indexing.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains("return = p[0].DistanceTo(p[1]);"));
+        }
+
+        [Test]
+        public void ArrayIndexingInCodeBlockToCode()
+        {
+            OpenModel(@"core\node2code\array_indexing.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains("p[0].DistanceTo(p[1]);"));
+        }
+
+        [Test]
+        public void StringIndexingInCodeBlockToCode()
+        {
+            OpenModel(@"core\node2code\string_indexing.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains("t1 = s[1..2];"));
+        }
+
+        [Test]
+        public void DictIndexingInCodeBlockToCode()
+        {
+            OpenModel(@"core\node2code\dict_indexing.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains("dict[\"abc\"];"));
+        }
+
         [Test]
         public void TestDirectoryToCode()
         {

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1429,6 +1429,38 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void NestedIndexingInCodeBlockToCode1()
+        {
+            OpenModel(@"core\node2code\func()[][].dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains("Point.ByCoordinates(x<1>, y<2>)[0][0];"));
+        }
+
+        [Test]
+        public void NestedIndexingInCodeBlockToCode2()
+        {
+            OpenModel(@"core\node2code\func()[func()[]].dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains("Math.Pow(x<1>, y<2>)[0][Math.Round(1..2)[0]];"));
+        }
+
+        [Test]
         public void TestDirectoryToCode()
         {
             OpenModel(@"core\node2code\directory.dyn");

--- a/test/core/node2code/array_indexing.dyn
+++ b/test/core/node2code/array_indexing.dyn
@@ -1,0 +1,328 @@
+{
+  "Uuid": "1f7352ed-89a0-4207-896d-779d06d2fd22",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "array_indexing",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "10;",
+      "Id": "5b636abc2d2140979c4f887666042fb5",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "532bda0c95a84e39886392b304b8a956",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "ba7b874d0b314f9cadab9a2d96966542",
+      "Inputs": [
+        {
+          "Id": "21a16412f1e442d9a4cbe336292bc4d5",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cebe6c9395db4b36b8c51a8c8e295acd",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a7930c3b428a439a84502e3a84588908",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c5539fcde52144589582bad8f2c4522c",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "8c0063616dff4991b3d0fa568751cde5",
+      "Inputs": [
+        {
+          "Id": "975e2676b7e648d7905f4925b302d8d6",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4faea928731343809feb419a583eb3b1",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e81b7e5f8a5a41d28ec67d6c10eb3743",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3e642bb61a1e49158073437e882a5835",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[a,b];",
+      "Id": "207e9ab9ba844f22bf253270bb67d590",
+      "Inputs": [
+        {
+          "Id": "19650f2781904bcf88fc17dabac6121d",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7f177536e3d2402797b8e23d676f805a",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "33fa6b22d9424a3e8333b1a4808d1c9d",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "p[0].DistanceTo(p[1]);",
+      "Id": "a8c123fe5deb4a45990516b5602e4f74",
+      "Inputs": [
+        {
+          "Id": "cd67c8d5f6994623afbe31f4008fb571",
+          "Name": "p",
+          "Description": "p",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aa2e995e05814d4282b8532710713c0b",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "532bda0c95a84e39886392b304b8a956",
+      "End": "975e2676b7e648d7905f4925b302d8d6",
+      "Id": "acb9ed8466bf45a08c26382308552627",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "c5539fcde52144589582bad8f2c4522c",
+      "End": "19650f2781904bcf88fc17dabac6121d",
+      "Id": "aa98e963568a47e7ac72d73174b3e658",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "3e642bb61a1e49158073437e882a5835",
+      "End": "7f177536e3d2402797b8e23d676f805a",
+      "Id": "b494ef52f8c14056990244b1c9f5bfaf",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "33fa6b22d9424a3e8333b1a4808d1c9d",
+      "End": "cd67c8d5f6994623afbe31f4008fb571",
+      "Id": "076a522edb184b1bb5e1bf679b8905fe",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4651",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "5b636abc2d2140979c4f887666042fb5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 160.0,
+        "Y": 397.0
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "ba7b874d0b314f9cadab9a2d96966542",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 362.8,
+        "Y": 120.0
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "8c0063616dff4991b3d0fa568751cde5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 381.6,
+        "Y": 344.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "207e9ab9ba844f22bf253270bb67d590",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 719.0,
+        "Y": 230.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "a8c123fe5deb4a45990516b5602e4f74",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 926.0,
+        "Y": 295.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/node2code/dict_indexing.dyn
+++ b/test/core/node2code/dict_indexing.dyn
@@ -1,0 +1,145 @@
+{
+  "Uuid": "1f7352ed-89a0-4207-896d-779d06d2fd22",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "dict_indexing",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{\"abc\" : 123};",
+      "Id": "efc654077ff5468098a7075dbf579ff3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e642a2aa48d3438f8857237cf4e9649f",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "dict[\"abc\"];",
+      "Id": "d5aaf847123b427c9371233bb90346b7",
+      "Inputs": [
+        {
+          "Id": "5f7152f847084a128e4e63bfb93c1d74",
+          "Name": "dict",
+          "Description": "dict",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c460cfa7051c4ad1ad3313488967644b",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "e642a2aa48d3438f8857237cf4e9649f",
+      "End": "5f7152f847084a128e4e63bfb93c1d74",
+      "Id": "3b81dad8af384b248858f5a40b5fe426",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4651",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "efc654077ff5468098a7075dbf579ff3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 300.40000000000003,
+        "Y": 318.20000000000005
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "d5aaf847123b427c9371233bb90346b7",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 556.40000000000009,
+        "Y": 328.4
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/node2code/func()[][].dyn
+++ b/test/core/node2code/func()[][].dyn
@@ -1,0 +1,155 @@
+{
+  "Uuid": "1a1e71c9-5a11-487f-88b2-10ec20c0ab8c",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "func()[][]",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..2;",
+      "Id": "a63de445b1aa48d6a58ebae858f5fd01",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e5fc683ee7504e2982217f7a6ce8fbff",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Autodesk.Point.ByCoordinates(x<1>, y<2>)[0][0];",
+      "Id": "7070baed25354f1eabb5bd2209982e4f",
+      "Inputs": [
+        {
+          "Id": "a1bcc2e2bed84da8bbe361d82ea39578",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f2c062fbbf1d410a8368700d312e1331",
+          "Name": "y",
+          "Description": "y",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "417f90eae30e40f081ddc339d88fc2fd",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "e5fc683ee7504e2982217f7a6ce8fbff",
+      "End": "f2c062fbbf1d410a8368700d312e1331",
+      "Id": "9ba6ae7c3dd6412c90c7f662bf82c316",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e5fc683ee7504e2982217f7a6ce8fbff",
+      "End": "a1bcc2e2bed84da8bbe361d82ea39578",
+      "Id": "b1af19cd2e3e44f890551c094fa88e34",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4651",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "a63de445b1aa48d6a58ebae858f5fd01",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 109.0,
+        "Y": 185.2
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "7070baed25354f1eabb5bd2209982e4f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 347.2,
+        "Y": 175.8
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/node2code/func()[func()[]].dyn
+++ b/test/core/node2code/func()[func()[]].dyn
@@ -1,0 +1,160 @@
+{
+  "Uuid": "1a1e71c9-5a11-487f-88b2-10ec20c0ab8c",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "func()[func()[]]",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Math": {
+        "Key": "DSCore.Math",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Math.Pow(x<1>, y<2>)[0][Math.Round(1..2)[0]];",
+      "Id": "47e4b4775d7e4102bdf225f096173111",
+      "Inputs": [
+        {
+          "Id": "e027054ae31746c7a5fc72156eee69a7",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3ff25fc8f2a2479babdaac3cc6a57364",
+          "Name": "y",
+          "Description": "y",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b30f6979306347b4a1158abd2c4e2aae",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..4;",
+      "Id": "c65900a3b8b54c81b1374a2de5ed5b63",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "16632dd41c7c4bfd8e06a04b3c702b84",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "16632dd41c7c4bfd8e06a04b3c702b84",
+      "End": "3ff25fc8f2a2479babdaac3cc6a57364",
+      "Id": "6f38747d26cb4ac89279bde016d84477",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "16632dd41c7c4bfd8e06a04b3c702b84",
+      "End": "e027054ae31746c7a5fc72156eee69a7",
+      "Id": "f7c5bf1f795049fb8f675bb007eba856",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4651",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "47e4b4775d7e4102bdf225f096173111",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 366.36841352447,
+        "Y": 456.037810181632
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "c65900a3b8b54c81b1374a2de5ed5b63",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 63.8719078002664,
+        "Y": 446.591066096767
+      }
+    ],
+    "Annotations": [],
+    "X": 50.1261108418671,
+    "Y": -66.95024468402562,
+    "Zoom": 1.0117759304742113
+  }
+}

--- a/test/core/node2code/imperative_indexing.dyn
+++ b/test/core/node2code/imperative_indexing.dyn
@@ -1,0 +1,337 @@
+{
+  "Uuid": "1f7352ed-89a0-4207-896d-779d06d2fd22",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "imperative_indexing",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "10;",
+      "Id": "5b636abc2d2140979c4f887666042fb5",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "532bda0c95a84e39886392b304b8a956",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "ba7b874d0b314f9cadab9a2d96966542",
+      "Inputs": [
+        {
+          "Id": "21a16412f1e442d9a4cbe336292bc4d5",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cebe6c9395db4b36b8c51a8c8e295acd",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a7930c3b428a439a84502e3a84588908",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c5539fcde52144589582bad8f2c4522c",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "8c0063616dff4991b3d0fa568751cde5",
+      "Inputs": [
+        {
+          "Id": "975e2676b7e648d7905f4925b302d8d6",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4faea928731343809feb419a583eb3b1",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e81b7e5f8a5a41d28ec67d6c10eb3743",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3e642bb61a1e49158073437e882a5835",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[a,b];",
+      "Id": "207e9ab9ba844f22bf253270bb67d590",
+      "Inputs": [
+        {
+          "Id": "19650f2781904bcf88fc17dabac6121d",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7f177536e3d2402797b8e23d676f805a",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "33fa6b22d9424a3e8333b1a4808d1c9d",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "p;\n[Imperative]\n{\nreturn p[0].DistanceTo(p[1]);\n};",
+      "Id": "a8c123fe5deb4a45990516b5602e4f74",
+      "Inputs": [
+        {
+          "Id": "7671716b5bee45cb8b765af97e6ccb55",
+          "Name": "p",
+          "Description": "p",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "778da6c42f8845c8940f41e7413d9658",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3121ff9f302248d0af815ee1471e3fa9",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "532bda0c95a84e39886392b304b8a956",
+      "End": "975e2676b7e648d7905f4925b302d8d6",
+      "Id": "acb9ed8466bf45a08c26382308552627",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "c5539fcde52144589582bad8f2c4522c",
+      "End": "19650f2781904bcf88fc17dabac6121d",
+      "Id": "aa98e963568a47e7ac72d73174b3e658",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "3e642bb61a1e49158073437e882a5835",
+      "End": "7f177536e3d2402797b8e23d676f805a",
+      "Id": "b494ef52f8c14056990244b1c9f5bfaf",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "33fa6b22d9424a3e8333b1a4808d1c9d",
+      "End": "7671716b5bee45cb8b765af97e6ccb55",
+      "Id": "fb89e2d70ad94c5a9a9df2ffe839fff0",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4651",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "5b636abc2d2140979c4f887666042fb5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 160.0,
+        "Y": 397.0
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "ba7b874d0b314f9cadab9a2d96966542",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 362.8,
+        "Y": 120.0
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "8c0063616dff4991b3d0fa568751cde5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 381.6,
+        "Y": 344.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "207e9ab9ba844f22bf253270bb67d590",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 719.0,
+        "Y": 230.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "a8c123fe5deb4a45990516b5602e4f74",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 926.0,
+        "Y": 295.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/node2code/string_indexing.dyn
+++ b/test/core/node2code/string_indexing.dyn
@@ -1,0 +1,149 @@
+{
+  "Uuid": "1f7352ed-89a0-4207-896d-779d06d2fd22",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "string_indexing",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      },
+      "Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "s[1..2];",
+      "Id": "cabbcdaf70e54a249af731385a45249f",
+      "Inputs": [
+        {
+          "Id": "460862059c4b466a93d3e358fdd9f831",
+          "Name": "s",
+          "Description": "s",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9d169b9b01b54220a9aad7343f1c6ad2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"string\";",
+      "Id": "dcead77f1f0a4ba8a2e0fe394f1c13e6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "45a78badb7394875a7405c44fdaa5189",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "45a78badb7394875a7405c44fdaa5189",
+      "End": "460862059c4b466a93d3e358fdd9f831",
+      "Id": "b0dc5531af2b4d619cf36397cca4fba2",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4651",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "cabbcdaf70e54a249af731385a45249f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 679.2,
+        "Y": 166.39999999999998
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "dcead77f1f0a4ba8a2e0fe394f1c13e6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 360.20000000000005,
+        "Y": 178.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Fixes node2code for array indexing expressions. Previously n2c would transform an array indexing expression to this:
```
arr[2]; => DesignScript.BuiltIn.Get.ValueAtIndex(arr, 2);
```
Even though behind the scenes this transformation is necessary to invoke the ZT function, for the user it doesn't make sense when they are trying to understand the DesignScript in the resulting code block. After this change, it doesn't transform such expressions to the ZT function call in the backend anymore. This also prevents a crash from occurring when more complex expressions such as this were transformed:
```
p[2].DistanceTo(p[3]); => DesignScript.BuiltIn.Get.ValueAtIndex(p, 2).DistanceTo(DesignScript.BuiltIn.Get.ValueAtIndex(p, 3));
```


Future TODOs:
- The same issue exists for other cases, where the conversion to the backend function call can be avoided, for example, dictionary expressions:
```
{string_exp1 : exp2} => DesignScript.Builtin.Dictionary.ByKeysValues([string_exp1], [exp2]);
```
- Similar expressions in Imperative blocks still convert to backend function calls

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate 
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes Node To Code for list indexing expressions. 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
