### PR TITLE
Added Info States

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1270,8 +1270,6 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         internal SolidColorBrush GetBorderColor()
         {
-            // TODO: What defines 'info' state?
-            bool infoState = false;
             SolidColorBrush result = null;
 
             /*
@@ -1301,10 +1299,10 @@ namespace Dynamo.ViewModels
                     ImgGlyphTwoSource = previewGlyph;
                 }
             }
-            if (infoState)
+            if (NodeModel.State == ElementState.Info)
             {
                 result = (SolidColorBrush)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeInfoColor"];
-                if (ImgGlyphTwoSource != null)
+                if (ImgGlyphTwoSource == null)
                 {
                     ImgGlyphTwoSource = infoGlyph;
                 }


### PR DESCRIPTION
### Purpose

This is a small PR that accomodates the changes necessary to display Info State for Nodes when Zoomed Out. The infrastructure was previously there, this PR makes minor adjustments to incorporate the now existing Info State.
- When a Node is in Info State (i.e. Integer Slider with the input of 99999999999999999999) the node will display glyph and border color to indicate this state when zoomed out

![info state](https://user-images.githubusercontent.com/5354594/163712195-067aa557-4470-4bbb-b0a0-a3cb2925455f.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Added Info State visual behavior to Zoom State for Nodes

### Reviewers

@sm6srw 

### FYIs
@mjkkirschner
@Amoursol 