### PR TITLE
Global Zoom Level Variable

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -7948,6 +7948,15 @@ namespace Dynamo.Wpf.Properties {
         public static string ZeroTouchTypeShortString {
             get {
                 return ResourceManager.GetString("ZeroTouchTypeShortString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 0.4.
+        /// </summary>
+        public static string ZoomLevel {
+            get {
+                return ResourceManager.GetString("ZoomLevel", resourceCulture);
             }
         }
     }

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3105,4 +3105,7 @@ To install the latest version of a package, click Install. \n
   <data name="TrustedPathsExpanderName" xml:space="preserve">
     <value>Trusted location</value>
   </data>
+  <data name="ZoomLevel" xml:space="preserve">
+    <value>0.4</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3092,4 +3092,7 @@ To install the latest version of a package, click Install. \n
   <data name="TrustedPathsExpanderName" xml:space="preserve">
     <value>Trusted location</value>
   </data>
+  <data name="ZoomLevel" xml:space="preserve">
+    <value>0.4</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -25,6 +25,7 @@ using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.ViewModels;
 using DynamoUnits;
 using PythonNodeModels;
+using SharpDX.DXGI;
 using Color = System.Windows.Media.Color;
 using FlowDirection = System.Windows.FlowDirection;
 using HorizontalAlignment = System.Windows.HorizontalAlignment;
@@ -1593,7 +1594,7 @@ namespace Dynamo.Controls
         {
             double number = (double)System.Convert.ChangeType(value, typeof(double));
 
-            if (number <= 0.4)
+            if (number <= Double.Parse(Wpf.Properties.Resources.ZoomLevel))
                 return false;
 
             return true;
@@ -1604,14 +1605,14 @@ namespace Dynamo.Controls
             throw new NotSupportedException();
         }
     }
-
+    
     public class ZoomToOpacityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             double number = (double)System.Convert.ChangeType(value, typeof(double));
 
-            if (number <= 0.4)
+            if (number <= Double.Parse(Wpf.Properties.Resources.ZoomLevel))
                 return 0.0;
 
             return 0.5;
@@ -1632,7 +1633,7 @@ namespace Dynamo.Controls
         {
             double number = (double)System.Convert.ChangeType(value, typeof(double));
 
-            if (number > 0.4)
+            if (number > Double.Parse(Wpf.Properties.Resources.ZoomLevel))
                 return Visibility.Collapsed;
 
             return Visibility.Visible;    


### PR DESCRIPTION
### Purpose

This is a minimal quality of life addition - created a resource to contain the value for zoom in/out variable. This value can now be set in one place to affect all converters using it. 

To change the global zoom level variable, go to the Resources of DynamoCoreWpf and change the value of the 'ZoomLevel' variable. At the time of creating this change, the agreed level is **0.4**.

![global zoom level](https://user-images.githubusercontent.com/5354594/163732562-3a98a5cf-8578-497e-bca0-bbf7e899c421.jpg)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Added Global Zoom Level Variable 

### Reviewers

@reddyashish 

### FYIs
@Amoursol 