### PR TITLE
DYN-4595-reenable-github-actions

### DIFF
--- a/.github/workflows/issue_type_predicter.yaml
+++ b/.github/workflows/issue_type_predicter.yaml
@@ -48,11 +48,15 @@ jobs:
 
       #The IssuesTypePredicter program receives as a parameter a json string with the issue content, then It's creating the json string in this section based in the issue body
       - name: Create Issue JSON String
+        env:
+          ISSUE_NUMBER: ${{github.event.issue.number}}
+          ISSUE_TITLE: ${{github.event.issue.title}}
+          ISSUE_BODY: ${{env.parsed_issue_body}}
         if: env.analysis_response == 'Valid'
         id: create-issue-json
         run: |
           mkdir IssuesTypePredicter
-          echo "issue_json_string="$(pwsh  .\\.github\\scripts\\get_issue_json_body.ps1 "${{ github.event.issue.number }}" "${{ github.event.issue.title }}" "${{env.parsed_issue_body}}" )""  >> $GITHUB_ENV
+          echo "issue_json_string="$(pwsh  .\\.github\\scripts\\get_issue_json_body.ps1 "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" )""  >> $GITHUB_ENV
 
       #Now checkout the IssuesTypePredicter source code from the repo https://github.com/DynamoDS/IssuesTypePredicter
       - name: Checkout IssuesTypePredicter


### PR DESCRIPTION
### Purpose

Re-enable github actions after fixing security vulnerability
There was a security vulnerability due to a possible code injection in a GitHub Action called Issue Predicter
Based in the github site: https://securitylab.github.com/research/github-actions-untrusted-input/ some changes were done in the code.
Then following the security recommendations instead of using the issue information directly environment variables were declared and used.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Re-enable github actions after fixing security vulnerability


### Reviewers

@QilongTang 

### FYIs

