### PR TITLE
fix iron python's API breaking change

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1602,7 +1602,7 @@ namespace Dynamo.PackageManager
                 }
 
                 Package.AddAssemblies(Assemblies);
-
+                Package.LoadState.SetAsLoaded();
                 return files;
             }
             catch (Exception e)
@@ -1610,6 +1610,7 @@ namespace Dynamo.PackageManager
                 UploadState = PackageUploadHandle.State.Error;
                 ErrorString = e.Message;
                 dynamoViewModel.Model.Logger.Log(e);
+                Package?.LoadState.SetAsError(ErrorString);
             }
 
             return new string[] {};

--- a/src/Libraries/DSIronPython/IronPythonCodeCompletionProviderCore.cs
+++ b/src/Libraries/DSIronPython/IronPythonCodeCompletionProviderCore.cs
@@ -300,7 +300,11 @@ namespace DSIronPython
         /// <returns></returns>
         public override bool IsSupportedEngine(string engineName)
         {
-           if (engineName == PythonEngineManager.IronPython2EngineName)
+            // Do not reference 'PythonEngineManager.IronPython2EngineName' here
+            // because it will break compatibility with Dynamo2.13.X
+            //
+            //if (engineName == PythonEngineManager.IronPython2EngineName)
+            if (engineName == "IronPython2")
             {
                 return true;
             }

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -55,7 +55,16 @@ namespace DSIronPython
         /// </summary>
         public const string packageExtraFolderName = @"extra";
 
-        public override string Name => PythonEngineManager.IronPython2EngineName;
+        // Do not reference 'PythonEngineManager.IronPython2EngineName' here
+        // because it will break compatibility with Dynamo2.13.X
+        //
+        //public override string Name => PythonEngineManager.IronPython2EngineName;
+        
+        /// <summary>
+        /// Returns the name of this Python engine implementation.
+        /// This name will appear in the Dynamo's UI.
+        /// </summary>
+        public override string Name => "IronPython2";
 
         /// <summary>
         /// Use Lazy&lt;PythonEngineManager&gt; to make sure the Singleton class is only initialized once

--- a/src/Libraries/DSIronPython/pkg.json
+++ b/src/Libraries/DSIronPython/pkg.json
@@ -1,0 +1,19 @@
+{
+    "license": "",
+    "file_hash": null,
+    "name": "DynamoIronPython2.7",
+    "version": "2.5.0",
+    "description": "*** This is the official version of the IronPython Extension which will load the IronPython2 evaluation engine for Dynamo. *** \r\n\r\nIf you see the following warning 'The configured Python engine could not be found' when you try to run a Python Script node which is set to use IronPython2, the host application for Dynamo (Such as Revit or Civil 3d) will have chosen to exclude IronPython2 as default installed content and you will need to download this extension in order to enable IronPython2 again.\r\n\r\nYou have the ability to either download this IronPython2 Extension or use the alternative out-of-the-box CPython3 engine and migrate your legacy IronPython2 code to CPython3. While there are differences in language the Python basis is the same and we have provided a Migration Assistant to help you migrate your code to Python3.",
+    "group": "",
+    "keywords": [ "python", "ironpython" ],
+    "dependencies": [],
+    "host_dependencies": [ "Revit", "Civil 3D", "Alias", "Advance Steel", "FormIt" ],
+    "contents": "",
+    "engine_version": "2.13.0",
+    "engine": "dynamo",
+    "engine_metadata": "This pacakge is compatible with Dynamo2.13.0 release or newer",
+    "site_url": "https://dynamobim.org/",
+    "repository_url": "https://github.com/DynamoDS/Dynamo",
+    "contains_binaries": true,
+    "node_libraries": []
+}


### PR DESCRIPTION
https://jira.autodesk.com/browse/DYN-4877
ISsue:
Latest (2.14.0) version of the IronPython package is not compatible with DynamoCore2.13

### Purpose

Fix API breaking change for the IronPython package

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix IronPython breaking API change


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
