### PR TITLE
Fix crash while installing package from view extension

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
@@ -139,9 +139,13 @@ namespace Dynamo.UI.Prompts
                 BodyText = messageBoxText,
                 TitleText = caption,
                 MessageBoxButton = button,
-                MessageBoxImage = icon,
-                Owner = owner
+                MessageBoxImage = icon
             };
+
+            if (owner.IsLoaded) 
+            {
+                dynamoMessageBox.Owner = owner;
+            }
 
             dynamoMessageBox.ConfigureButtons(button);
             dynamoMessageBox.ShowDialog();


### PR DESCRIPTION
### Purpose

This fixes the crash mentioned in the JIRA: https://jira.autodesk.com/browse/DYN-4848 

The crash was happening due to the owner object not being loaded when installing the package from view extension. The owner is the package manager search view and this was happening as the package manager search dialog is closed before installing the package. So when the owner is not loaded, initializing the dialog box with the owner object would fail. We will be setting the dialog box's owner only when the owner is loaded.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix crash while installing package from view extension


### Reviewers
@QilongTang @zeusongit 

