### PR TITLE
Updating the colors of the ports according to the Function State

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -276,8 +276,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         protected override void RefreshPortColors()
         {
+            bool isPythonNode = node.NodeModel is PythonNodeModels.PythonNode;
             //Is in function state
-            if (node.NodeModel.IsPartiallyApplied)
+            if (node.NodeModel.IsPartiallyApplied && !isPythonNode)
             {
                 if (node.NodeModel.AreAllOutputsConnected)
                 {
@@ -292,7 +293,7 @@ namespace Dynamo.ViewModels
             }
             else
             {
-                SetupDefaultPortColorValues();
+                SetupDefaultPortColorValues(isPythonNode);
             }
         }
 
@@ -311,7 +312,7 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private void SetupDefaultPortColorValues()
+        private void SetupDefaultPortColorValues(bool isPythonNode = false)
         {
             // Special case for keeping list structure visual appearance
             if (port.UseLevels && port.KeepListStructure && port.IsConnected)
@@ -321,7 +322,7 @@ namespace Dynamo.ViewModels
                 PortBorderBrushColor = PortBorderBrushColorKeepListStructure;
             }
             // Port has a default value, shows blue marker
-            else if (UsingDefaultValue && DefaultValueEnabled)
+            else if (UsingDefaultValue && DefaultValueEnabled || isPythonNode)
             {
                 PortValueMarkerColor = PortValueMarkerBlue;
                 PortBackgroundColor = PortBackgroundColorDefault;

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -22,7 +22,7 @@ namespace Dynamo.ViewModels
         private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
 
         private bool portDefaultValueMarkerVisible;
-        private bool isReturningDefaultValue;
+        private bool isFunctionNode;
 
         private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
         private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
@@ -170,6 +170,8 @@ namespace Dynamo.ViewModels
         public override void Dispose()
         {
             port.PropertyChanged -= PortPropertyChanged;
+            node.NodeModel.PropertyChanged -= NodeModel_PropertyChanged;
+
             base.Dispose();
         }
 
@@ -288,14 +290,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         protected override void RefreshPortColors()
         {
-            //Boolean that defines if the node has a default value from the cache value
-            isReturningDefaultValue = !string.IsNullOrEmpty(node.NodeModel.CachedValue?.StringData);
-            
             //This variable checks if the node is a function class
-            bool isFunctionNode = node.NodeModel.CachedValue != null &&
-                                    node.NodeModel.CachedValue.Data == null &&
-                                    !node.NodeModel.CachedValue.IsNull &&
-                                    node.NodeModel.CachedValue.Class != null;
+            isFunctionNode = node.NodeModel.CachedValue != null &&
+                node.NodeModel.CachedValue.IsFunction;
 
             if (isFunctionNode)
             {
@@ -307,7 +304,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    SetupDefaultPortColorValues(isFunctionNode);
+                    SetupDefaultPortColorValues();
                 }
             }
             else
@@ -331,7 +328,7 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private void SetupDefaultPortColorValues(bool isFunctionNode = false)
+        private void SetupDefaultPortColorValues()
         {
             
             // Special case for keeping list structure visual appearance
@@ -342,7 +339,7 @@ namespace Dynamo.ViewModels
                 PortBorderBrushColor = PortBorderBrushColorKeepListStructure;
             }
             // Port has a default value, shows blue marker
-            else if (UsingDefaultValue && DefaultValueEnabled || (isReturningDefaultValue && !isFunctionNode))
+            else if ((UsingDefaultValue && DefaultValueEnabled) || !isFunctionNode)
             {
                 PortValueMarkerColor = PortValueMarkerBlue;
                 PortBackgroundColor = PortBackgroundColorDefault;

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -6,6 +6,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.UI.Commands;
+using ProtoCore.Utils;
 
 namespace Dynamo.ViewModels
 {
@@ -291,8 +292,9 @@ namespace Dynamo.ViewModels
         protected override void RefreshPortColors()
         {
             //This variable checks if the node is a function class
-            isFunctionNode = node.NodeModel.CachedValue != null &&
-                node.NodeModel.CachedValue.IsFunction;
+            isFunctionNode = node.NodeModel.IsPartiallyApplied && 
+                             node.NodeModel.CachedValue != null &&
+                             node.NodeModel.CachedValue.IsFunction;
 
             if (isFunctionNode)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -294,8 +294,10 @@ namespace Dynamo.ViewModels
         }
 
         protected override void RefreshPortColors()
-        {            
-            if (node.NodeModel.IsPartiallyApplied)
+        {
+            bool isPythonNode = node.NodeModel is PythonNodeModels.PythonNode;
+
+            if (node.NodeModel.IsPartiallyApplied && !isPythonNode)
             {
                 PortDefaultValueMarkerVisible = true;
                 portValueMarkerColor = PortValueMarkerGrey;

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -87,7 +87,7 @@ namespace Dynamo.ViewModels
             get => areConnectorsHidden;
             set
             {
-                areConnectorsHidden = value; 
+                areConnectorsHidden = value;
                 RaisePropertyChanged(nameof(AreConnectorsHidden));
             }
         }
@@ -100,7 +100,7 @@ namespace Dynamo.ViewModels
             get => hideWiresButtonEnabled;
             set
             {
-                hideWiresButtonEnabled = value; 
+                hideWiresButtonEnabled = value;
                 RaisePropertyChanged(nameof(HideWiresButtonEnabled));
             }
         }
@@ -119,7 +119,7 @@ namespace Dynamo.ViewModels
         }
 
 
-        public bool PortDefaultValueMarkerVisible 
+        public bool PortDefaultValueMarkerVisible
         {
             get => portDefaultValueMarkerVisible;
             set
@@ -151,6 +151,7 @@ namespace Dynamo.ViewModels
         public OutPortViewModel(NodeViewModel node, PortModel port) :base(node, port)
         {
             port.PropertyChanged += PortPropertyChanged;
+            node.NodeModel.PropertyChanged += NodeModel_PropertyChanged;
 
             RefreshHideWiresState();
         }
@@ -159,6 +160,16 @@ namespace Dynamo.ViewModels
         {
             port.PropertyChanged -= PortPropertyChanged;
             base.Dispose();
+        }
+
+        private void NodeModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(node.NodeModel.CachedValue):
+                    RefreshPortColors();
+                    break;
+            }
         }
 
         private void PortPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -228,7 +239,7 @@ namespace Dynamo.ViewModels
                 }
 
                 connectorViewModel.BreakConnectionCommand.Execute(null);
-            }            
+            }
         }
 
         /// <summary>
@@ -294,10 +305,14 @@ namespace Dynamo.ViewModels
         }
 
         protected override void RefreshPortColors()
-        {
-            bool isPythonNode = node.NodeModel is PythonNodeModels.PythonNode;
+        { 
+            //This variable checks if the node is a function class
+            bool isFunctionNode = node.NodeModel.CachedValue != null &&
+                                    node.NodeModel.CachedValue.Data == null &&
+                                    !node.NodeModel.CachedValue.IsNull &&
+                                    node.NodeModel.CachedValue.Class != null;
 
-            if (node.NodeModel.IsPartiallyApplied && !isPythonNode)
+            if (node.NodeModel.IsPartiallyApplied && isFunctionNode)
             {
                 PortDefaultValueMarkerVisible = true;
                 portValueMarkerColor = PortValueMarkerGrey;

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -158,7 +158,9 @@ namespace Dynamo.ViewModels
 
         public override void Dispose()
         {
-            port.PropertyChanged -= PortPropertyChanged;
+            port.PropertyChanged -= PortPropertyChanged; 
+            node.NodeModel.PropertyChanged -= NodeModel_PropertyChanged;
+
             base.Dispose();
         }
 
@@ -305,12 +307,10 @@ namespace Dynamo.ViewModels
         }
 
         protected override void RefreshPortColors()
-        { 
+        {
             //This variable checks if the node is a function class
             bool isFunctionNode = node.NodeModel.CachedValue != null &&
-                                    node.NodeModel.CachedValue.Data == null &&
-                                    !node.NodeModel.CachedValue.IsNull &&
-                                    node.NodeModel.CachedValue.Class != null;
+                node.NodeModel.CachedValue.IsFunction;
 
             if (node.NodeModel.IsPartiallyApplied && isFunctionNode)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -6,6 +6,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Logging;
 using Dynamo.UI;
 using Dynamo.UI.Commands;
+using ProtoCore.Utils;
 
 namespace Dynamo.ViewModels
 {
@@ -309,8 +310,9 @@ namespace Dynamo.ViewModels
         protected override void RefreshPortColors()
         {
             //This variable checks if the node is a function class
-            bool isFunctionNode = node.NodeModel.CachedValue != null &&
-                node.NodeModel.CachedValue.IsFunction;
+            bool isFunctionNode = node.NodeModel.IsPartiallyApplied && 
+                                  node.NodeModel.CachedValue != null &&
+                                  node.NodeModel.CachedValue.IsFunction;
 
             if (node.NodeModel.IsPartiallyApplied && isFunctionNode)
             {

--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -246,6 +246,14 @@ namespace ProtoCore
 
             private LibraryMirror libraryMirror = null;
 
+            internal LibraryMirror LibraryMirror
+            {
+                get
+                {
+                    return libraryMirror;
+                }
+            }
+
             private ClassNode classNode = null;
             private ClassNode ClassNode
             {

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -25,7 +25,7 @@ namespace ProtoCore
             {
                 get
                 {
-                    return svData.IsPointer && Class.Name.Equals("Function") && Class.LibraryMirror.Name.Equals("FunctionObject.ds");
+                    return IsPointer && Class.Name.Equals(CoreUtils.NodeFunctionClassName) && Class.LibraryMirror.Name.Equals(CoreUtils.NodeLibraryMirronFunctionObjectName);
                 }
             }
 

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -21,6 +21,14 @@ namespace ProtoCore
             /// </summary>
             private StackValue svData;
 
+            public bool IsFunction
+            {
+                get
+                {
+                    return svData.IsPointer && Class.Name.Equals("Function") && Class.LibraryMirror.Name.Equals("FunctionObject.ds");
+                }
+            }
+
 
             //
             // Comment Jun:

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -25,7 +25,7 @@ namespace ProtoCore
             {
                 get
                 {
-                    return IsPointer && Class.Name.Equals(CoreUtils.NodeFunctionClassName) && Class.LibraryMirror.Name.Equals(CoreUtils.NodeLibraryMirronFunctionObjectName);
+                    return IsPointer && Class.Name.Equals(CoreUtils.FunctionObjectClass) && Class.LibraryMirror.Name.Equals(CoreUtils.FunctionObjectLibrary);
                 }
             }
 

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -7,8 +7,8 @@ namespace ProtoCore.Utils
 {
     public static class CoreUtils
     {
-        public static readonly string NodeFunctionClassName = "Function";        
-        public static readonly string NodeLibraryMirronFunctionObjectName = "FunctionObject.ds";
+        public static readonly string FunctionObjectClass = "Function";        
+        public static readonly string FunctionObjectLibrary = "FunctionObject.ds";
 
         public static void InsertPredefinedAndBuiltinMethods(Core core, CodeBlockNode root)
         {

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -7,6 +7,9 @@ namespace ProtoCore.Utils
 {
     public static class CoreUtils
     {
+        public static readonly string NodeFunctionClassName = "Function";        
+        public static readonly string NodeLibraryMirronFunctionObjectName = "FunctionObject.ds";
+
         public static void InsertPredefinedAndBuiltinMethods(Core core, CodeBlockNode root)
         {
             if (DSASM.InterpreterMode.Normal == core.Options.RunMode)


### PR DESCRIPTION
### Purpose

This PR contains the code improvement that changes the colors of the input/output of the nodes by checking the class and library of the object to define if the node is a 'Function'.

![colorInputOutputFunction](https://user-images.githubusercontent.com/89042471/165945334-1479300e-ba82-4db5-a7eb-57858c23c459.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner @QilongTang @Amoursol 

### FYIs

@RobertGlobant20 @jesusalvino 
