### PR TITLE
Add warning bar color for info states.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1232,6 +1232,7 @@ namespace Dynamo.ViewModels
         private static SolidColorBrush errorColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#EB5555"));
         // SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodeWarningColor"];
         private static SolidColorBrush warningColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#FAA21B"));
+        private static SolidColorBrush infoColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#6AC0E7"));
         // SharedDictionaryManager.DynamoColorsAndBrushesDictionary["NodePreviewColor"];
         private static SolidColorBrush noPreviewColor = (SolidColorBrush)(new BrushConverter().ConvertFrom("#BBBBBB"));
 
@@ -1257,6 +1258,11 @@ namespace Dynamo.ViewModels
                 }
 
                 return warningColor;
+            }
+
+            if (NodeModel.State == ElementState.Info)
+            {
+                return infoColor;
             }
 
             return noPreviewColor;
@@ -1313,6 +1319,7 @@ namespace Dynamo.ViewModels
                     ImgGlyphThreeSource = infoGlyph;
                 }
             }
+
             if (NodeModel.State == ElementState.Warning || NodeModel.State == ElementState.PersistentWarning)
             {
                 result = warningColor;


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/DYN-4867

Adds a warning bar color when the node has an Info message.

<img width="1201" alt="Screen Shot 2022-04-27 at 9 15 01 AM" src="https://user-images.githubusercontent.com/43763136/165526822-45d89618-2c20-44b0-90af-e8e89cd26f59.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@QilongTang 
