### PR TITLE
Add trusted paths UI to Security tab in preferences

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -21,6 +21,7 @@
     <None Remove="UI\Images\warning_16px.png" />
     <None Remove="Views\GuidedTour\HtmlPages\getStartedOnboarding.html" />
     <None Remove="Views\GuidedTour\HtmlPages\Resources\emptyImage.png" />
+    <None Remove="Views\Menu\TrustedPathView.xaml" />
   </ItemGroup>
   <ItemGroup>
 	<PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.13.0.7686" />
@@ -266,6 +267,7 @@
     <Compile Include="ViewModels\GuidedTour\ExitGuideWindowViewModel.cs" />
     <Compile Include="ViewModels\GuidedTour\PopupWindowViewModel.cs" />
     <Compile Include="ViewModels\GuidedTour\SurveyPopupViewModel.cs" />
+    <Compile Include="ViewModels\Menu\TrustedPathViewModel.cs" />
     <Compile Include="ViewModels\Menu\PreferencesViewModel.cs" />
     <Compile Include="ViewModels\PackageManager\IPackageInstaller.cs" />
     <Compile Include="ViewModels\PackageManager\PackagePathViewModel.cs" />
@@ -337,6 +339,7 @@
       <DependentUpon>SurveyPopupWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Input\ParameterEditor.cs" />
+    <Compile Include="Views\Menu\TrustedPathView.xaml.cs" />
     <Compile Include="Views\Output\OutputEditor.cs" />
     <Compile Include="Views\PackageManager\PackagePathView.xaml.cs">
       <DependentUpon>PackagePathView.xaml</DependentUpon>
@@ -505,6 +508,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\Core\ConnectorPinView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Menu\TrustedPathView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -30,6 +30,7 @@ namespace Dynamo.ViewModels
         Large,
         ExtraLarge
     }
+
     public class PreferencesViewModel : ViewModelBase, INotifyPropertyChanged
     {
         #region Private Properties
@@ -71,6 +72,8 @@ namespace Dynamo.ViewModels
         private string selectedPackagePathForInstall;
         private bool isVisibleAddStyleBorder;
         private bool isEnabledAddStyleButton;
+
+        private readonly List<string> trustedPathsList = new List<string>();
         #endregion Private Properties
 
         public GeometryScaleSize ScaleSize { get; set; }
@@ -791,6 +794,11 @@ namespace Dynamo.ViewModels
         public PackagePathViewModel PackagePathsViewModel { get; set; }
 
         /// <summary>
+        /// Trusted Paths view model.
+        /// </summary>
+        public TrustedPathViewModel TrustedPathsViewModel { get; set; }
+
+        /// <summary>
         /// The PreferencesViewModel constructor basically initialize all the ItemsSource for the corresponding ComboBox in the View (PreferencesView.xaml)
         /// </summary>
         public PreferencesViewModel(DynamoViewModel dynamoViewModel)
@@ -882,6 +890,7 @@ namespace Dynamo.ViewModels
             var customNodeManager = dynamoViewModel.Model.CustomNodeManager;
             var packageLoader = dynamoViewModel.Model.GetPackageManagerExtension()?.PackageLoader;            
             PackagePathsViewModel = new PackagePathViewModel(packageLoader, loadPackagesParams, customNodeManager);
+            TrustedPathsViewModel = new TrustedPathViewModel();
 
             WorkspaceEvents.WorkspaceSettingsChanged += PreferencesViewModel_WorkspaceSettingsChanged;
 

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -72,8 +72,6 @@ namespace Dynamo.ViewModels
         private string selectedPackagePathForInstall;
         private bool isVisibleAddStyleBorder;
         private bool isEnabledAddStyleButton;
-
-        private readonly List<string> trustedPathsList = new List<string>();
         #endregion Private Properties
 
         public GeometryScaleSize ScaleSize { get; set; }

--- a/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Dynamo.Core;
+using Dynamo.Interfaces;
+using Dynamo.Wpf.Properties;
+using DelegateCommand = Dynamo.UI.Commands.DelegateCommand;
+using Dynamo.Models;
+using System.Windows.Data;
+using System.Globalization;
+using System.Linq;
+using Dynamo.Configuration;
+
+namespace Dynamo.ViewModels
+{
+
+    public class TrustedPathEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Indicate whether user wants to add the current path to the list
+        /// </summary>
+        public bool Cancel { get; set; }
+
+        /// <summary>
+        /// Indicate the path to the custom packages folder
+        /// </summary>
+        public string Path { get; set; }
+    }
+
+    public class TrustedPathViewModel : ViewModelBase
+    {
+        public ObservableCollection<string> TrustedLocations { get; private set; }
+        [Obsolete("SelectedIndex is no longer referenced, do not use.")]
+        public int SelectedIndex { get; set; }
+       
+        public event EventHandler<TrustedPathEventArgs> RequestShowFileDialog;
+        public virtual void OnRequestShowFileDialog(object sender, TrustedPathEventArgs e)
+        {
+            if (RequestShowFileDialog != null)
+            {
+                RequestShowFileDialog(sender, e);
+            }
+        }
+
+        public DelegateCommand AddPathCommand { get; private set; }
+        public DelegateCommand DeletePathCommand { get; private set; }
+        public DelegateCommand UpdatePathCommand { get; private set; }
+        public DelegateCommand SaveSettingCommand { get; private set; }
+
+        public TrustedPathViewModel()
+        { 
+            InitializeTrustedLocations();
+            InitializeCommands();
+        }
+        /// <summary>
+        /// This constructor overload has been added for backwards comptability.
+        /// </summary>
+        /// <param name="setting"></param>
+        public TrustedPathViewModel(IPreferences setting)
+        {
+            InitializeTrustedLocations();
+            InitializeCommands();
+        }
+        private void InitializeCommands() 
+        {
+            AddPathCommand = new DelegateCommand(p => InsertPath());
+            DeletePathCommand = new DelegateCommand(p => RemovePathAt(ConvertPathToIndex(p)), p => CanDelete(ConvertPathToIndex(p)));
+            UpdatePathCommand = new DelegateCommand(p => UpdatePathAt(ConvertPathToIndex(p)), p => CanUpdate(ConvertPathToIndex(p)));
+            SaveSettingCommand = new DelegateCommand(CommitChanges);
+        }
+
+        private int ConvertPathToIndex(object path)
+        {
+            if(path is int pint)
+            {
+                return pint;
+            }
+            return TrustedLocations.IndexOf(path as string);
+        }
+
+        private void RaiseCanExecuteChanged()
+        {
+            AddPathCommand.RaiseCanExecuteChanged();
+            DeletePathCommand.RaiseCanExecuteChanged();
+            UpdatePathCommand.RaiseCanExecuteChanged();
+        }
+
+        private bool CanDelete(int param)
+        {
+            return TrustedLocations.Count > 1;
+        }
+
+        private bool CanUpdate(int param)
+        {
+            //add any exceptions or built in trusted locations here
+            return true;
+        }
+
+        private void InsertPath()
+        {
+            var args = new TrustedPathEventArgs();
+
+            ShowFileDialog(args);
+
+            if (args.Cancel)
+                return;
+
+            TrustedLocations.Insert(TrustedLocations.Count, args.Path);
+            RaiseCanExecuteChanged();
+        }
+
+        private void ShowFileDialog(TrustedPathEventArgs e)
+        {
+            OnRequestShowFileDialog(this, e);
+
+            if (e.Cancel == false && TrustedLocations.Contains(e.Path))
+                e.Cancel = true;
+        }
+
+        private void UpdatePathAt(int index)
+        {
+            var args = new TrustedPathEventArgs
+            {
+                Path = TrustedLocations[index]
+            };
+
+            ShowFileDialog(args);
+
+            if (args.Cancel)
+                return;
+
+            TrustedLocations[index] = args.Path;
+        }
+
+        private void RemovePathAt(int index)
+        {
+            var pathToRemove = TrustedLocations[index];
+            TrustedLocations.RemoveAt(index);
+            RaiseCanExecuteChanged();
+        }
+
+        private void CommitChanges(object param)
+        {
+            var newpaths = CommitTrustedLocations();
+            //to be implemented
+        }
+
+        internal void InitializeTrustedLocations()
+        {
+            TrustedLocations = new ObservableCollection<string>();
+        }
+
+        private List<string> CommitTrustedLocations()
+        {
+            var trustedLocations = new List<string>(TrustedLocations);
+            return trustedLocations;
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
@@ -30,8 +30,6 @@ namespace Dynamo.ViewModels
     public class TrustedPathViewModel : ViewModelBase
     {
         public ObservableCollection<string> TrustedLocations { get; private set; }
-        [Obsolete("SelectedIndex is no longer referenced, do not use.")]
-        public int SelectedIndex { get; set; }
        
         public event EventHandler<TrustedPathEventArgs> RequestShowFileDialog;
         public virtual void OnRequestShowFileDialog(object sender, TrustedPathEventArgs e)
@@ -52,6 +50,7 @@ namespace Dynamo.ViewModels
             InitializeTrustedLocations();
             InitializeCommands();
         }
+
         /// <summary>
         /// This constructor overload has been added for backwards comptability.
         /// </summary>
@@ -71,10 +70,6 @@ namespace Dynamo.ViewModels
 
         private int ConvertPathToIndex(object path)
         {
-            if(path is int pint)
-            {
-                return pint;
-            }
             return TrustedLocations.IndexOf(path as string);
         }
 
@@ -142,11 +137,12 @@ namespace Dynamo.ViewModels
         private void CommitChanges(object param)
         {
             var newpaths = CommitTrustedLocations();
-            //to be implemented
+            //TODO: to be implemented
         }
 
         internal void InitializeTrustedLocations()
         {
+            //TODO: to be implemented
             TrustedLocations = new ObservableCollection<string>();
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -924,7 +924,7 @@
                                     </Grid.RowDefinitions>
                                     <StackPanel Orientation="Vertical" Margin="0,6,0,0" Grid.Row="0">
                                         <ScrollViewer Height="200" VerticalScrollBarVisibility="Auto">
-                                            <trustedpaths:TrustedPathView x:Name="TrustedPathView" DataContext="{Binding TrustedPathViewModel}"/>
+                                            <trustedpaths:TrustedPathView x:Name="TrustedPathView" DataContext="{Binding TrustedPathsViewModel}"/>
                                         </ScrollViewer>
                                     </StackPanel>
                                 </Grid>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -13,6 +13,7 @@
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:fa="http://schemas.fontawesome.io/icons/" 
         xmlns:packagemanager="clr-namespace:Dynamo.Wpf.Views.PackageManager"
+        xmlns:trustedpaths="clr-namespace:Dynamo.Wpf.Views"
         xmlns:wpfControls="clr-namespace:Dynamo.Wpf.Controls"
         WindowStartupLocation="CenterOwner"
         WindowStyle="None"
@@ -922,17 +923,9 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Orientation="Vertical" Margin="0,6,0,0" Grid.Row="0">
-                                        <Button x:Name="AddPath"
-                                            HorizontalAlignment="Left"
-                                            Margin="0"
-                                            Content="{x:Static p:Resources.SecurityPathAddPathButtonName}"
-                                            Command="{}">
-                                            <Button.Style>
-                                                <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
-                                                    <Setter Property="IsEnabled" Value="True"/>
-                                                </Style>
-                                            </Button.Style>
-                                        </Button>
+                                        <ScrollViewer Height="200" VerticalScrollBarVisibility="Auto">
+                                            <trustedpaths:TrustedPathView x:Name="TrustedPathView" DataContext="{Binding TrustedPathViewModel}"/>
+                                        </ScrollViewer>
                                     </StackPanel>
                                 </Grid>
                             </Expander>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -68,6 +68,7 @@ namespace Dynamo.Wpf.Views
             dynamoViewModel.PreferencesViewModel.SavedChangesLabel = string.Empty;
             dynamoViewModel.PreferencesViewModel.SavedChangesTooltip = string.Empty;
             dynamoViewModel.PreferencesViewModel.PackagePathsViewModel?.InitializeRootLocations();
+            dynamoViewModel.PreferencesViewModel.TrustedPathsViewModel?.InitializeTrustedLocations();
 
             // Init package paths for install 
             dynamoViewModel.PreferencesViewModel.InitPackagePathsForInstall();

--- a/src/DynamoCoreWpf/Views/Menu/TrustedPathView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/TrustedPathView.xaml
@@ -1,0 +1,95 @@
+﻿<UserControl x:Class="Dynamo.Wpf.Views.TrustedPathView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:ViewModels="clr-namespace:Dynamo.ViewModels"
+        mc:Ignorable="d"
+        xmlns:ui="clr-namespace:Dynamo.UI"
+        xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
+        xmlns:fa="http://schemas.fontawesome.io/icons/"
+        Background="#535353"
+        d:DataContext="{d:DesignInstance ViewModels:TrustedPathViewModel, IsDesignTimeCreatable=False}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+            <DataTemplate x:Key="trustedPathItemTemplate">
+
+                <Grid>
+                    <Grid.ToolTip>
+                        <ToolTip Content="{Binding}" Style="{StaticResource GenericToolTipLight}"/>
+                    </Grid.ToolTip>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition MaxWidth="250"></ColumnDefinition>
+                        <ColumnDefinition Width="Auto"></ColumnDefinition>
+                        <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+
+                    <!--the path text-->
+                    <TextBlock x:Name="PathTextBlock" Style="{StaticResource DarkTextBlock}" 
+                                Text="{Binding}"
+                                Grid.Column="0"
+                                Margin="7,4,7,4"
+                                Background="{StaticResource PreferencesWindowItemDarkerBackgroundColor}"
+                                MinHeight="24"
+                                Padding="5,5,5,5"
+                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                    <!--the the edit path button-->
+                    <Button
+                         Grid.Column="1"
+                         Margin="7,7,7,7"
+                         x:Name="UpdatePathButton"
+                         Command="{Binding Path=DataContext.UpdatePathCommand,
+                         RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                         CommandParameter="{Binding}"
+                         ToolTipService.ShowOnDisabled="True"
+                         Background="{StaticResource PreferencesWindowBackgroundColor}"
+                         Style="{StaticResource FolderButtonStyle}">
+                        <Button.ToolTip>
+                            <ToolTip Content="{x:Static p:Resources.PackagePathUpdatePathTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                        </Button.ToolTip>
+                    </Button>
+                    <!--the delete path button-->
+                    <Button x:Name="DeletePathButton"
+                        Grid.Column="2"
+                        Margin="7,7,7,7"
+                        Command="{Binding Path=DataContext.DeletePathCommand,
+                            RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                        CommandParameter="{Binding}"
+                        ToolTipService.ShowOnDisabled="True"
+                        Background="{StaticResource PreferencesWindowBackgroundColor}"
+                        Style="{StaticResource CloseButtonStyle}">
+                        <Button.ToolTip>
+                            <ToolTip Content="{x:Static p:Resources.PackagePathViewToolTipMinus}" Style="{StaticResource GenericToolTipLight}"/>
+                        </Button.ToolTip>
+                    </Button>
+                </Grid>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <StackPanel Orientation="Vertical" Margin="0,6,0,0">
+        <Button x:Name="AddPaths"
+                HorizontalAlignment="Left"
+                Margin="0"
+                Content="{x:Static p:Resources.PackagePathAddPathButtonName}"
+                Command="{Binding Path=AddPathCommand}">
+            <Button.ToolTip>
+                <ToolTip Content="{x:Static p:Resources.PackagePathViewToolTipPlus}" Style="{StaticResource GenericToolTipLight}"/>
+            </Button.ToolTip>
+            <Button.Style>
+                <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
+                    <Setter Property="IsEnabled" Value="True"/>
+                </Style>
+            </Button.Style>
+        </Button>
+        <ItemsControl
+            Background="{StaticResource PreferencesWindowVisualSettingsBackground}"
+            ItemsSource="{Binding TrustedLocations}"
+            ItemTemplate="{StaticResource trustedPathItemTemplate}">
+        </ItemsControl>
+    </StackPanel>
+</UserControl>
+    
+    

--- a/src/DynamoCoreWpf/Views/Menu/TrustedPathView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/TrustedPathView.xaml.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Forms;
+using Dynamo.UI;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Utilities;
+using DynamoUtilities;
+
+namespace Dynamo.Wpf.Views
+{
+    /// <summary>
+    /// Interaction logic for TrustedPathView.xaml
+    /// </summary>
+    public partial class TrustedPathView : System.Windows.Controls.UserControl
+    {
+        #region Class Properties
+
+        private TrustedPathViewModel ViewModel
+        {
+            get { return this.DataContext as TrustedPathViewModel; }
+        }
+
+        #endregion
+
+        #region Public Class Operational Methods
+
+        public TrustedPathView()
+        {
+            InitializeComponent();
+            DataContextChanged += TrustedPathView_DataContextChanged;
+        }
+
+        internal void Dispose()
+        {
+            ViewModel.RequestShowFileDialog -= OnRequestShowFileDialog;
+        }
+
+        #endregion
+
+        #region Private Helper Methods and Event Handlers
+        private void TrustedPathView_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.RequestShowFileDialog += OnRequestShowFileDialog;
+            }
+        }
+
+        private void OnRequestShowFileDialog(object sender, EventArgs e)
+        {
+            var args = e as TrustedPathEventArgs;
+            args.Cancel = true;
+
+            // Handle for the case, args.Path does not exist.
+            var errorCannotCreateFolder = PathHelper.CreateFolderIfNotExist(args.Path);
+            // args.Path == null condition is to handle when user want to create new path.
+            if (errorCannotCreateFolder == null || args.Path == null)
+            {
+                var dialog = new DynamoFolderBrowserDialog
+                {
+                    // Navigate to initial folder.
+                    SelectedPath = args.Path,
+                    Owner = Window.GetWindow(this)
+                };
+
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    args.Cancel = false;
+                    args.Path = dialog.SelectedPath;
+                }
+
+            }
+            else
+            {
+                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, args.Path);
+                MessageBoxService.Show(errorMessage, Wpf.Properties.Resources.UnableToAccessPackageDirectory, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
### Purpose

- Adds the skeleton UI for adding trusted paths to security tab in preferences.

![Screen Shot 2022-05-02 at 3 37 51 PM](https://user-images.githubusercontent.com/32665108/166313870-bfe4dacc-5d46-4dbe-a0d6-7f67fa021044.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Add trusted paths UI to Security tab in preferences

### Reviewers

@DynamoDS/dynamo 
