### PR TITLE
enable tests in vs 2022

### DIFF
--- a/src/Dynamo.All.sln
+++ b/src/Dynamo.All.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32106.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamoCore", "DynamoCore\DynamoCore.csproj", "{7858FA8C-475F-4B8E-B468-1F8200778CF8}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -764,8 +764,10 @@ Global
 		{F8D2E3E5-4505-4463-9367-2EB2629D7DCD}.Release|x64.ActiveCfg = Release|x64
 		{F8D2E3E5-4505-4463-9367-2EB2629D7DCD}.Release|x64.Build.0 = Release|x64
 		{AE7F2579-104A-4AF4-AA7B-614AE9E79279}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE7F2579-104A-4AF4-AA7B-614AE9E79279}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AE7F2579-104A-4AF4-AA7B-614AE9E79279}.Debug|x64.ActiveCfg = Debug|x64
 		{AE7F2579-104A-4AF4-AA7B-614AE9E79279}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE7F2579-104A-4AF4-AA7B-614AE9E79279}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AE7F2579-104A-4AF4-AA7B-614AE9E79279}.Release|x64.ActiveCfg = Release|x64
 		{C0D6DEE5-5532-4345-9C66-4C00D7FDB8BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C0D6DEE5-5532-4345-9C66-4C00D7FDB8BE}.Debug|Any CPU.Build.0 = Debug|Any CPU

--- a/src/DynamoCore/Extensions/ExtensionManager.cs
+++ b/src/DynamoCore/Extensions/ExtensionManager.cs
@@ -6,15 +6,6 @@ using System.Threading.Tasks;
 
 namespace Dynamo.Extensions
 {
-
-    internal interface ILayoutSpecSource
-    {
-        /// <summary>
-        /// Event that is raised when the LayoutSpecSource requests a LayoutSpec to be applied.
-        /// The string parameter here should be the layout spec json.
-        /// </summary>
-        event Action<string> RequestApplyLayoutSpec;
-    }
     /// <summary>
     /// An object which may request extensions to be loaded and added to the extensionsManager.
     /// </summary>
@@ -90,11 +81,6 @@ namespace Dynamo.Extensions
                 (obj as IExtensionSource).RequestLoadExtension -= RequestLoadExtensionHandler;
                 (obj as IExtensionSource).RequestAddExtension -= RequestAddExtensionHandler;
             }
-            if (obj is ILayoutSpecSource ls)
-            {
-                ls.RequestApplyLayoutSpec -= RequestApplyLayoutSpecHandler;
-            }
-
         }
 
         private void SubscribeExtension(IExtension obj)
@@ -106,46 +92,7 @@ namespace Dynamo.Extensions
                 (obj as IExtensionSource).RequestLoadExtension += RequestLoadExtensionHandler;
                 (obj as IExtensionSource).RequestAddExtension += RequestAddExtensionHandler;
             }
-            if(obj is ILayoutSpecSource ls)
-            {
-                ls.RequestApplyLayoutSpec += RequestApplyLayoutSpecHandler;
-            }
-
         }
-
-        private void RequestApplyLayoutSpecHandler(string specJSON)
-        {
-            Log($"an extension requested application of {specJSON} layout spec");
-            //TODO we actually want to do this AFTER the library view extension is loaded or we
-            //can't retrieve the current layout spec... and it really is not too useful without a view?
-            //maybe moving the events to the viewExtensionManager? Or we wait until library view is loaded
-            //or to the PackageManagerViewExtension etc... unclear, for now just wait a bit!
-
-            Task.Run(async () =>
-            {
-                try
-                {
-                    await Task.Delay(15000);
-                    //try to combine the layout specs at the top 2 levels.
-                    //ie matching section/category only.
-                    var customizationService = Service<ILibraryViewCustomization>();
-                    var originalLayoutSpec = customizationService.GetSpecification();
-
-                    var requestedLayoutSpec = LayoutSpecification.FromJSONString(specJSON);
-                    var merged = LayoutSpecification.PartialMergeSpecs(originalLayoutSpec, requestedLayoutSpec);
-                    customizationService.SetSpecification(merged);
-
-
-                }
-
-                catch (Exception ex)
-                {
-                    Log(ex.ToString());
-                }
-            });
-              
-        }
-
 
         /// <summary>
         /// Adds an extension to the current session.

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Dynamo.Configuration;
+using Dynamo.Core;
 using Dynamo.Exceptions;
 using Dynamo.Interfaces;
 using Dynamo.Library;
@@ -1079,7 +1080,8 @@ namespace Dynamo.Engine
                 IsVarArg = proc.IsVarArg,
                 ObsoleteMsg = obsoleteMessage,
                 CanUpdatePeriodically = canUpdatePeriodically,
-                IsBuiltIn = pathManager.PreloadedLibraries.Contains(library),
+                IsBuiltIn = pathManager.PreloadedLibraries.Contains(library)
+                    || library.StartsWith(PathManager.BuiltinPackagesDirectory),
                 IsPackageMember = packagedLibraries.Contains(library),
                 IsLacingDisabled = isLacingDisabled
             });

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionManager.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionManager.cs
@@ -2,9 +2,23 @@
 using System.Collections.Generic;
 using Dynamo.Extensions;
 using Dynamo.Logging;
+using Dynamo.Wpf.Interfaces;
 
 namespace Dynamo.Wpf.Extensions
 {
+
+    /// <summary>
+    /// An object which may request a layout specification to be applied to the current library.
+    /// </summary>
+    internal interface ILayoutSpecSource
+    {
+        /// <summary>
+        /// Event that is raised when the LayoutSpecSource requests a LayoutSpec to be applied.
+        /// The string parameter here should be the layout spec json to merge into the existing spec.
+        /// </summary>
+        event Action<string> RequestApplyLayoutSpec;
+    }
+
     /// <summary>
     /// An object which may request ViewExtensions to be loaded and added to the ViewExtensionsManager.
     /// </summary>
@@ -32,6 +46,7 @@ namespace Dynamo.Wpf.Extensions
         private readonly List<IViewExtension> viewExtensions = new List<IViewExtension>();
         private readonly List<IExtensionStorageAccess> storageAccessViewExtensions = new List<IExtensionStorageAccess>();
         private readonly ViewExtensionLoader viewExtensionLoader = new ViewExtensionLoader();
+        private IExtensionManager extensionManager;
 
         public ViewExtensionManager()
         {
@@ -46,6 +61,14 @@ namespace Dynamo.Wpf.Extensions
         public ViewExtensionManager(IEnumerable<string> directoriesToVerify) : this()
         {
             this.viewExtensionLoader.DirectoriesToVerifyCertificates.AddRange(directoriesToVerify);
+        }
+
+        /// <summary>
+        /// Creates ViewExtensionManager with directories which require package certificate verification and access to the ExtensionManager.
+        /// </summary>
+        internal ViewExtensionManager(IExtensionManager manager,IEnumerable<string> directoriesToVerify) : this(directoriesToVerify)
+        {
+            extensionManager = manager;
         }
 
         private void RequestAddViewExtensionHandler(IViewExtension viewExtension)
@@ -65,12 +88,37 @@ namespace Dynamo.Wpf.Extensions
             return null;
         }
 
+        private void RequestApplyLayoutSpecHandler(string specJSON)
+        {
+            Log($"an extension requested application of {specJSON} layout spec");
+              try
+                {
+                //try to combine the layout specs.
+                    var customizationService = extensionManager.Service<ILibraryViewCustomization>();
+                //TODO if the layoutspec is empty, we're calling this too early, we can retry after x seconds?
+                    var originalLayoutSpec = customizationService.GetSpecification();
+                    var requestedLayoutSpec = LayoutSpecification.FromJSONString(specJSON);
+                    var merged = LayoutSpecification.MergeLayoutSpecs(originalLayoutSpec, requestedLayoutSpec);
+                    //update the library with the merged spec.
+                    customizationService.SetSpecification(merged);
+                }
+
+                catch (Exception ex)
+                {
+                    Log(ex.ToString());
+                }
+        }
+
         private void UnsubscribeViewExtension(IViewExtension obj)
         {
             if (obj is IViewExtensionSource)
             {
                 (obj as IViewExtensionSource).RequestLoadExtension -= RequestLoadViewExtensionHandler;
                 (obj as IViewExtensionSource).RequestAddExtension -= RequestAddViewExtensionHandler ;
+            }
+            if (obj is ILayoutSpecSource ls)
+            {
+                ls.RequestApplyLayoutSpec -= RequestApplyLayoutSpecHandler;
             }
         }
 
@@ -80,6 +128,10 @@ namespace Dynamo.Wpf.Extensions
             {
                 (obj as IViewExtensionSource).RequestLoadExtension += RequestLoadViewExtensionHandler;
                 (obj as IViewExtensionSource).RequestAddExtension += RequestAddViewExtensionHandler;
+            }
+            if (obj is ILayoutSpecSource ls)
+            {
+                ls.RequestApplyLayoutSpec += RequestApplyLayoutSpecHandler;
             }
         }
         public ViewExtensionLoader ExtensionLoader

--- a/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
+++ b/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
@@ -46,6 +46,8 @@ using System.Windows;
 [assembly: InternalsVisibleTo("GraphMetadataViewExtension")]
 [assembly: InternalsVisibleTo("PackageDetailsViewExtension")]
 [assembly: InternalsVisibleTo("IronPythonTests")]
+[assembly: InternalsVisibleTo("DynamoPackagesWPF")]
+
 
 [assembly: TypeForwardedTo(typeof(Dynamo.Wpf.Interfaces.LayoutSpecification))]
 [assembly: TypeForwardedTo(typeof(Dynamo.Wpf.Interfaces.LayoutSection))]

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -120,7 +120,7 @@ namespace Dynamo.Controls
             tabSlidingWindowStart = tabSlidingWindowEnd = 0;
 
             //Initialize the ViewExtensionManager with the CommonDataDirectory so that view extensions found here are checked first for dll's with signed certificates
-            viewExtensionManager = new ViewExtensionManager(new[] { dynamoViewModel.Model.PathManager.CommonDataDirectory });
+            viewExtensionManager = new ViewExtensionManager(dynamoViewModel.Model.ExtensionManager,new[] { dynamoViewModel.Model.PathManager.CommonDataDirectory });
 
             _timer = new Stopwatch();
             _timer.Start();

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -38,7 +38,6 @@ namespace Dynamo.PackageManager
         internal event Func<string, Graph.Workspaces.PackageInfo, IEnumerable<CustomNodeInfo>> RequestLoadCustomNodeDirectory;
         internal event Func<string, IExtension> RequestLoadExtension;
         internal event Action<IExtension> RequestAddExtension;
-        internal event Action<string> RequestApplyLayoutSpec;
 
         /// <summary>
         /// This event is raised when a package is first added to the list of packages this package loader is loading.
@@ -314,19 +313,6 @@ namespace Dynamo.PackageManager
                     }
                     requestedExtensions.Add(extension);
                 }
-
-                //if package is builtin and has a layout spec, try to apply it?
-                //TODO we may need to store it and apply it later..or perhaps before is actually better.
-                //TODO probably good to store it so we can see what specs we have applied / merged.
-                var packageLayoutSpecs = package.AdditionalFiles.Where(
-                    file => file.Model.Name.ToLowerInvariant().Contains("layoutspecs.json")).ToList();
-                //if an extension capable of handling layout specs is found, request
-                //they apply the spec.
-                foreach (var specPath in packageLayoutSpecs)
-                {   //TODO json or path?
-                    RequestApplyLayoutSpec?.Invoke(File.ReadAllText(specPath.Model.FullName));
-                }
-
 
                 package.SetAsLoaded();
                 PackgeLoaded?.Invoke(package);

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -38,6 +38,7 @@ namespace Dynamo.PackageManager
         internal event Func<string, Graph.Workspaces.PackageInfo, IEnumerable<CustomNodeInfo>> RequestLoadCustomNodeDirectory;
         internal event Func<string, IExtension> RequestLoadExtension;
         internal event Action<IExtension> RequestAddExtension;
+        internal event Action<string> RequestApplyLayoutSpec;
 
         /// <summary>
         /// This event is raised when a package is first added to the list of packages this package loader is loading.
@@ -313,6 +314,19 @@ namespace Dynamo.PackageManager
                     }
                     requestedExtensions.Add(extension);
                 }
+
+                //if package is builtin and has a layout spec, try to apply it?
+                //TODO we may need to store it and apply it later..or perhaps before is actually better.
+                //TODO probably good to store it so we can see what specs we have applied / merged.
+                var packageLayoutSpecs = package.AdditionalFiles.Where(
+                    file => file.Model.Name.ToLowerInvariant().Contains("layoutspecs.json")).ToList();
+                //if an extension capable of handling layout specs is found, request
+                //they apply the spec.
+                foreach (var specPath in packageLayoutSpecs)
+                {   //TODO json or path?
+                    RequestApplyLayoutSpec?.Invoke(File.ReadAllText(specPath.Model.FullName));
+                }
+
 
                 package.SetAsLoaded();
                 PackgeLoaded?.Invoke(package);

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -13,7 +13,7 @@ using Greg;
 
 namespace Dynamo.PackageManager
 {
-    public class PackageManagerExtension : IExtension, ILogSource, IExtensionSource, ILayoutSpecSource
+    public class PackageManagerExtension : IExtension, ILogSource, IExtensionSource 
     {
         #region Fields & Properties
 
@@ -24,15 +24,6 @@ namespace Dynamo.PackageManager
        
         public event Func<string, IExtension> RequestLoadExtension;
         public event Action<IExtension> RequestAddExtension;
-
-        private Action<string> layouthandler;
-        //explicit interface implementation lets us keep the event internal for now.
-        event Action<string> ILayoutSpecSource.RequestApplyLayoutSpec
-        {
-            add { layouthandler += value; }
-            remove { layouthandler -= value; }
-        }
-
         public event Action<ILogMessage> MessageLogged;
 
         private IWorkspaceModel currentWorkspace;
@@ -159,7 +150,6 @@ namespace Dynamo.PackageManager
             //raise the public events on this extension when the package loader requests.
             PackageLoader.RequestLoadExtension += RequestLoadExtension;
             PackageLoader.RequestAddExtension += RequestAddExtension;
-            PackageLoader.RequestApplyLayoutSpec += layouthandler;
             PackageLoader.PackagesLoaded += LoadPackagesHandler;
             PackageLoader.RequestLoadNodeLibrary += RequestLoadNodeLibraryHandler;
             PackageLoader.RequestLoadCustomNodeDirectory += RequestLoadCustomNodeDirectoryHandler;

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -13,7 +13,7 @@ using Greg;
 
 namespace Dynamo.PackageManager
 {
-    public class PackageManagerExtension : IExtension, ILogSource, IExtensionSource
+    public class PackageManagerExtension : IExtension, ILogSource, IExtensionSource, ILayoutSpecSource
     {
         #region Fields & Properties
 
@@ -24,6 +24,14 @@ namespace Dynamo.PackageManager
        
         public event Func<string, IExtension> RequestLoadExtension;
         public event Action<IExtension> RequestAddExtension;
+
+        private Action<string> layouthandler;
+        //explicit interface implementation lets us keep the event internal for now.
+        event Action<string> ILayoutSpecSource.RequestApplyLayoutSpec
+        {
+            add { layouthandler += value; }
+            remove { layouthandler -= value; }
+        }
 
         public event Action<ILogMessage> MessageLogged;
 
@@ -62,6 +70,7 @@ namespace Dynamo.PackageManager
         ///     Dynamo Package Manager Instance.
         /// </summary>
         public PackageManagerClient PackageManagerClient { get; private set; }
+
 
         #endregion
 
@@ -150,6 +159,7 @@ namespace Dynamo.PackageManager
             //raise the public events on this extension when the package loader requests.
             PackageLoader.RequestLoadExtension += RequestLoadExtension;
             PackageLoader.RequestAddExtension += RequestAddExtension;
+            PackageLoader.RequestApplyLayoutSpec += layouthandler;
             PackageLoader.PackagesLoaded += LoadPackagesHandler;
             PackageLoader.RequestLoadNodeLibrary += RequestLoadNodeLibraryHandler;
             PackageLoader.RequestLoadCustomNodeDirectory += RequestLoadCustomNodeDirectoryHandler;

--- a/src/DynamoPackages/Properties/AssemblyInfo.cs
+++ b/src/DynamoPackages/Properties/AssemblyInfo.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("PackageManagerTests")]
 [assembly: InternalsVisibleTo("DynamoCoreWpf")]
 [assembly: InternalsVisibleTo("DynamoPackagesUI")]
+[assembly: InternalsVisibleTo("DynamoPackagesWPF")]
 [assembly: InternalsVisibleTo("LibraryViewExtension")]
 [assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
+++ b/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
@@ -22,7 +22,9 @@ namespace Dynamo.PackageManager.UI
                 return "PackageManagerViewExtension";
             }
         }
-
+        /// <summary>
+        /// ViewExtensions that were requested to be loaded.
+        /// </summary>
         public IEnumerable<IViewExtension> RequestedExtensions
         {
             get
@@ -38,6 +40,10 @@ namespace Dynamo.PackageManager.UI
                 return "100f5ec3-fde7-4205-80a7-c968b3a5a27b";
             }
         }
+        /// <summary>
+        /// Collection of layout spec paths that were requested for merging into the library layout.
+        /// </summary>
+        internal IEnumerable<string> RequestedLayoutSpecPaths { get;private set;} = new List<string>();
 
         public event Action<IViewExtension> RequestAddExtension;
         public event Func<string, IViewExtension> RequestLoadExtension;
@@ -120,6 +126,7 @@ namespace Dynamo.PackageManager.UI
                 //they apply the spec.
                 foreach (var specPath in packageLayoutSpecs)
                 {
+                    (RequestedLayoutSpecPaths as IList<string>)?.Add(specPath.Model.FullName);
                     layouthandler?.Invoke(File.ReadAllText(specPath.Model.FullName));
                 }
             }

--- a/src/DynamoPackagesWPF/Properties/AssemblyInfo.cs
+++ b/src/DynamoPackagesWPF/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,3 +9,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("47d2166c-5261-4093-9660-e72b7035e666")]
+
+[assembly: InternalsVisibleTo("DynamoCoreWpfTests")] 

--- a/src/LibraryViewExtension/Handlers/NodeItemDataProvider.cs
+++ b/src/LibraryViewExtension/Handlers/NodeItemDataProvider.cs
@@ -84,8 +84,12 @@ namespace Dynamo.LibraryUI.Handlers
         /// </summary>
         public static string GetFullyQualifiedName(NodeSearchElement element)
         {
+            if (element.ElementType.HasFlag(ElementTypes.Packaged) && element.ElementType.HasFlag(ElementTypes.BuiltIn))
+            {
+                return string.Format("{0}{1}.{2}", "bltinpkg://", element.FullCategoryName, element.Name);
+            }
             //If the node search element is part of a package, then we need to prefix pkg:// for it
-            if (element.ElementType.HasFlag(ElementTypes.Packaged))
+            else if (element.ElementType.HasFlag(ElementTypes.Packaged))
             {
                 //Use FullCategory and name as read from _customization.xml file
                 return string.Format("{0}{1}.{2}", "pkg://", element.FullCategoryName, element.Name);

--- a/src/LibraryViewExtensionMSWebBrowser/Handlers/NodeItemDataProvider.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/Handlers/NodeItemDataProvider.cs
@@ -136,8 +136,12 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
         /// </summary>
         public static string GetFullyQualifiedName(NodeSearchElement element)
         {
+            if (element.ElementType.HasFlag(ElementTypes.Packaged) && element.ElementType.HasFlag(ElementTypes.BuiltIn))
+            {
+                return string.Format("{0}{1}.{2}", "bltinpkg://", element.FullCategoryName, element.Name);
+            }
             //If the node search element is part of a package, then we need to prefix pkg:// for it
-            if (element.ElementType.HasFlag(ElementTypes.Packaged))
+            else if (element.ElementType.HasFlag(ElementTypes.Packaged))
             {
                 //Use FullCategory and name as read from _customization.xml file
                 return string.Format("{0}{1}.{2}", "pkg://", element.FullCategoryName, element.Name);

--- a/src/LibraryViewExtensionMSWebBrowser/LibraryViewCustomization.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/LibraryViewCustomization.cs
@@ -145,6 +145,16 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
             return ToJSONStream(root, replaceIconURLWithData, iconResourceProvider);
         }
 
+        /// <summary>
+        /// Merges the passed spec with the current spec and sets the result as the current library layout.
+        /// </summary>
+        /// <param name="specToMerge"></param>
+        internal void MergeSpecification(LayoutSpecification specToMerge)
+        {
+            var result = LayoutSpecification.MergeLayoutSpecs(GetSpecification(), specToMerge);
+            SetSpecification(result);
+        }
+
 
         /// <summary>
         /// Notifies when a resource stream is registered. This event is

--- a/src/LibraryViewExtensionMSWebBrowser/Properties/AssemblyInfo.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/Properties/AssemblyInfo.cs
@@ -6,6 +6,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("LibraryViewExtensionMSWebBrowser")]
-
+[assembly: InternalsVisibleTo("ViewExtensionLibraryTests")]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1a5dc90a-477e-4d4a-87bd-0bfb01f056ce")]

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -15,12 +15,13 @@
 	  <PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
     <PackageReference Include="Moq" Version="4.2.1507.0118" />
 	  <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
-	  <PackageReference Include="Greg" Version="2.1.8122.28281"/>
+	  <PackageReference Include="Greg" Version="2.1.8122.28281" />
 	  <PackageReference Include="HelixToolkit" Version="2.17.0" />
 	  <PackageReference Include="HelixToolkit.Wpf" Version="2.17.0" />
 	  <PackageReference Include="HelixToolkit.Wpf.SharpDX" Version="2.17.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
 	  <PackageReference Include="NUnit" Version="2.6.3" />
+	  <PackageReference Include="NUnitTestAdapter" Version="2.3.0" />
 	  <PackageReference Include="RestSharp" Version="106.12.0" />
 	  <PackageReference Include="SharpDX" Version="4.2.0" />
 	  <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />

--- a/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Dynamo.Configuration;
+using Dynamo.Core;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.PackageManager;
@@ -20,6 +21,8 @@ namespace DynamoCoreWpfTests
     class PackageManagerViewExtensionTests : DynamoTestUIBase
     {
         private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "pkgs"); } }
+        internal string BuiltinPackagesTestDir { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "builtinpackages testdir", "Packages"); } }
+
 
         #region extensionGeneration
         private string extensionPath;
@@ -210,6 +213,29 @@ namespace DynamoCoreWpfTests
             dynamic testExtension = this.View.viewExtensionManager.ViewExtensions.Where(x => x.Name == "Test View Extension").FirstOrDefault();
             Assert.AreEqual(1, testExtension.startupCount);
             Assert.AreEqual(1, testExtension.loadedCount);
+        }
+
+        [Test]
+        public void PackageManagerViewExtesion_TriesToLoadLayoutSpecForBuiltInPackages()
+        {
+            //check that the packageManagerViewExtension requested the test layout spec to be applied.
+            var packageManagerViewExtension = this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
+            var packageManager = ViewModel.Model.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
+            Assert.IsNotNull(packageManagerViewExtension);
+            Assert.IsNotNull(packageManager);
+            //set builtin packages dir to test directory.
+            PathManager.BuiltinPackagesDirectory = BuiltinPackagesTestDir;
+
+            //load a bltin package manually. This package contains a layout spec.
+            var builtInPackageLocation = Path.Combine(BuiltinPackagesTestDir, "SignedPackage2");
+            var bltinPkg = packageManager.PackageLoader.ScanPackageDirectory(builtInPackageLocation);
+            packageManager.PackageLoader.LoadPackages(new List<Package> { bltinPkg });
+            
+
+            //trigger packmanViewExt to load layoutspecs. Usually this would just happen at startup, but we're loading the bltin package late.
+            packageManagerViewExtension.Loaded(new ViewLoadedParams(View, ViewModel));
+            Assert.AreEqual(1, packageManagerViewExtension.RequestedLayoutSpecPaths.Count());
+            Assert.AreEqual(Path.Combine(BuiltinPackagesTestDir,"SignedPackage2","extra","layoutspecs.json"), packageManagerViewExtension.RequestedLayoutSpecPaths.FirstOrDefault());
         }
 
 

--- a/test/ViewExtensionLibraryTests/DynamoLibraryItemsTests.cs
+++ b/test/ViewExtensionLibraryTests/DynamoLibraryItemsTests.cs
@@ -4,12 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using CefSharp;
 using Dynamo;
 using Dynamo.Controls;
-using Dynamo.Interfaces;
-using Dynamo.LibraryUI;
-using Dynamo.LibraryUI.Handlers;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Interfaces;
 using Moq;
@@ -31,7 +27,7 @@ namespace ViewExtensionLibraryTests
             libraries.Add("DSCoreNodes.dll");
             base.GetLibrariesToPreload(libraries);
         }
-
+        /*
         [Test]
         [Category("UnitTests"), Category("Failure")]
         public void VerifyIconsForLibraryItems()
@@ -123,5 +119,6 @@ namespace ViewExtensionLibraryTests
                 return (LoadedTypeData< LoadedTypeItem>)serializer.Deserialize(sr, typeof(LoadedTypeData<LoadedTypeItem>));
             }
         }
+        */
     }
 }

--- a/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
@@ -5,13 +5,10 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using CefSharp;
 using Dynamo;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Interfaces;
-using Dynamo.LibraryUI;
-using Dynamo.LibraryUI.Handlers;
 using Dynamo.Search;
 using Dynamo.Search.SearchElements;
 using Moq;
@@ -39,7 +36,7 @@ namespace ViewExtensionLibraryTests
     public class LibraryResourceProviderTests : UnitTestBase
     {
         private const string EventX = "X";
-
+        /*
         [Test]
         [Category("UnitTests"), Category("Failure")]
         public void EventControllerCallback()
@@ -623,5 +620,6 @@ namespace ViewExtensionLibraryTests
             moq.Setup(e => e.CreationName).Returns(creationName);
             return moq;
         }
+        */
     }
 }

--- a/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
@@ -9,6 +9,8 @@ using Dynamo;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Interfaces;
+using Dynamo.LibraryViewExtensionMSWebBrowser;
+using Dynamo.LibraryViewExtensionMSWebBrowser.Handlers;
 using Dynamo.Search;
 using Dynamo.Search.SearchElements;
 using Moq;
@@ -229,6 +231,37 @@ namespace ViewExtensionLibraryTests
             var binaryPath = Path.Combine(packagePath, "bin", "Package.dll");
             Assert.AreEqual($"http://localhost/icons/{name}.Small?path={binaryPath}", url.Url);
         }
+        */
+        private static Mock<NodeSearchElement> MockNodeSearchElement(string fullname, string creationName)
+        {
+            var moq = new Mock<NodeSearchElement>() { CallBase = true };
+            moq.Setup(e => e.FullName).Returns(fullname);
+            moq.Setup(e => e.CreationName).Returns(creationName);
+            return moq;
+        }
+
+        [Test]
+        public void BuiltInPackagedNodeSearchElementLoadedType()
+        {
+            var category = "abc.xyz.somepackage";
+            var name = "My Node";
+            var creationName = "create abc xyz";
+            var expectedQualifiedName = "bltinpkg://abc.xyz.somepackage.My Node";
+            var path = @"C:\temp\packages\test.dll";
+            var moq = new Mock<TestNodeSearchElement>(category, name, ElementTypes.Packaged|ElementTypes.BuiltIn, path) { CallBase = true };
+            var element = moq.Object;
+            moq.Setup(e => e.CreationName).Returns(creationName);
+
+            var provider = new NodeItemDataProvider(new NodeSearchModel());
+            var item = provider.CreateLoadedTypeItem<LoadedTypeItem>(element);
+            Assert.AreEqual(expectedQualifiedName, item.fullyQualifiedName);
+            Assert.AreEqual(creationName, item.contextData);
+            Assert.AreEqual("abc, xyz, somepackage", item.keywords);
+
+            var url = new IconUrl(new Uri(item.iconUrl));
+            Assert.AreEqual("My%20Node.Small", url.Name);
+            Assert.AreEqual(path, url.Path);
+        }
 
         [Test]
         [Category("UnitTests"), Category("Failure")]
@@ -314,7 +347,7 @@ namespace ViewExtensionLibraryTests
             var url = new IconUrl(name, path, true);
             Assert.AreEqual(url.Url, item.iconUrl);
         }
-
+        /*
         [Test]
         [Category("UnitTests"), Category("Failure")]
         public void CustomNodePropertiesWindowValidateCategories()
@@ -613,13 +646,7 @@ namespace ViewExtensionLibraryTests
             Assert.IsTrue(result.IsCompleted);
         }
 
-        private static Mock<NodeSearchElement> MockNodeSearchElement(string fullname, string creationName)
-        {
-            var moq = new Mock<NodeSearchElement>() { CallBase = true };
-            moq.Setup(e => e.FullName).Returns(fullname);
-            moq.Setup(e => e.CreationName).Returns(creationName);
-            return moq;
-        }
+        
         */
     }
 }

--- a/test/ViewExtensionLibraryTests/LibraryViewControllerTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryViewControllerTests.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using CefSharp;
 using Dynamo.Configuration;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
-using Dynamo.LibraryUI;
 using Dynamo.Models;
 using Dynamo.Scheduler;
 using Dynamo.Search.SearchElements;
@@ -19,6 +17,7 @@ using NUnit.Framework;
 
 namespace ViewExtensionLibraryTests
 {
+    /*
     class LibraryViewControllerTests : DynamoTestUIBase
     {
         private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "pkgs"); } }
@@ -138,4 +137,5 @@ namespace ViewExtensionLibraryTests
 
         }
     }
+    */
 }

--- a/test/ViewExtensionLibraryTests/LibraryViewCustomizationTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryViewCustomizationTests.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.Linq;
-using Dynamo.Interfaces;
-using Dynamo.LibraryUI;
+using Dynamo.LibraryViewExtensionMSWebBrowser;
 using Dynamo.Wpf.Interfaces;
 using Moq;
 using NUnit.Framework;
+
 
 namespace ViewExtensionLibraryTests
 {
     public class LibraryViewCustomizationTests
     {
+        /*
         [Test, Category("UnitTests"), Category("Failure")]
         public void AddSections()
         {
@@ -287,6 +288,133 @@ namespace ViewExtensionLibraryTests
                 Assert.AreEqual(3, spec.sections.Count);
                 Assert.AreEqual("A, B, C", string.Join(", ", spec.sections.Select(s => s.text)));
             }
+        }
+*/
+        /// <summary>
+        /// new category and group should be merged with existing section.
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void MergeLayoutSpecWithSameSection()
+        {
+            var customization = new LibraryViewCustomization();
+            var spec = customization.GetSpecification();
+            Assert.False(spec.sections.Any()); //By default empty spec
+
+            customization.SpecificationUpdated += (o, e) => { };
+
+            var sections = new[] { "A", "B", "C" }.Select(s => new LayoutSection(s));
+            Assert.True(customization.AddSections(sections));
+
+            //create a new partial spec and merge into section A.
+            var specToMerge = new LayoutSpecification();
+            var sectionToMerge = new LayoutSection("A");
+            var category = new LayoutElement("category") { elementType = LayoutElementType.category };
+            category.childElements.Add(new LayoutElement("group") { elementType = LayoutElementType.group });
+
+            sectionToMerge.childElements.Add(category);
+            specToMerge.sections.Add(sectionToMerge);
+            customization.MergeSpecification(specToMerge);
+
+
+            spec = customization.GetSpecification();
+            Assert.AreEqual(3, spec.sections.Count);
+            Assert.AreEqual("A, B, C", string.Join(", ", spec.sections.Select(s => s.text)));
+            Assert.AreEqual("A, category, group, B, , C, ", string.Join(", ", spec.sections.Select(x=>x.text +", "+ string.Join(", ",x.EnumerateChildren().Select(c=>c.text)))));
+        }
+
+        /// <summary>
+        /// New group should be merged with exsisting sec/category.
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void MergeLayoutSpecWithSameCategory()
+        {
+            var customization = new LibraryViewCustomization();
+            var spec = customization.GetSpecification();
+            Assert.False(spec.sections.Any()); //By default empty spec
+
+            customization.SpecificationUpdated += (o, e) => { };
+
+            var sections = new[] { "A", "B", "C" }.Select(s => new LayoutSection(s));
+            var category = new LayoutElement("category") { elementType = LayoutElementType.category };
+            sections.ElementAt(0).childElements.Add(category);
+            Assert.True(customization.AddSections(sections));
+
+            //create a new partial spec and merge into section A.
+            var specToMerge = new LayoutSpecification();
+            var sectionToMerge = new LayoutSection("A");
+            category.childElements.Add(new LayoutElement("group") { elementType = LayoutElementType.group });
+
+            sectionToMerge.childElements.Add(category);
+            specToMerge.sections.Add(sectionToMerge);
+            customization.MergeSpecification(specToMerge);
+
+
+            spec = customization.GetSpecification();
+            Assert.AreEqual(3, spec.sections.Count);
+            Assert.AreEqual("A, B, C", string.Join(", ", spec.sections.Select(s => s.text)));
+            Assert.AreEqual("A, category, group, B, , C, ", string.Join(", ", spec.sections.Select(x => x.text + ", " + string.Join(", ", x.EnumerateChildren().Select(c => c.text)))));
+        }
+        /// <summary>
+        /// No changes if all items already exist.
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void MergeLayoutSpecWithSameGroup()
+        {
+            var customization = new LibraryViewCustomization();
+            var spec = customization.GetSpecification();
+            Assert.False(spec.sections.Any()); //By default empty spec
+
+            customization.SpecificationUpdated += (o, e) => { };
+
+            var sections = new[] { "A", "B", "C" }.Select(s => new LayoutSection(s));
+            var category = new LayoutElement("category") { elementType = LayoutElementType.category };
+            category.childElements.Add(new LayoutElement("group") { elementType = LayoutElementType.group });
+            sections.ElementAt(0).childElements.Add(category);
+            Assert.True(customization.AddSections(sections));
+
+            //create a new partial spec and merge into section A.
+            var specToMerge = new LayoutSpecification();
+            var sectionToMerge = new LayoutSection("A");
+            sectionToMerge.childElements.Add(category);
+            specToMerge.sections.Add(sectionToMerge);
+            customization.MergeSpecification(specToMerge);
+
+
+            spec = customization.GetSpecification();
+            Assert.AreEqual(3, spec.sections.Count);
+            Assert.AreEqual("A, B, C", string.Join(", ", spec.sections.Select(s => s.text)));
+            Assert.AreEqual("A, category, group, B, , C, ", string.Join(", ", spec.sections.Select(x => x.text + ", " + string.Join(", ", x.EnumerateChildren().Select(c => c.text)))));
+        }
+        /// <summary>
+        /// Entire new section / all children should me merged with layout spec.
+        /// </summary>
+        [Test, Category("UnitTests")]
+        public void MergeLayoutSpecWithNewSection()
+        {
+            var customization = new LibraryViewCustomization();
+            var spec = customization.GetSpecification();
+            Assert.False(spec.sections.Any()); //By default empty spec
+
+            customization.SpecificationUpdated += (o, e) => { };
+
+            var sections = new[] { "A", "B", "C" }.Select(s => new LayoutSection(s));
+            Assert.True(customization.AddSections(sections));
+
+            //create a new partial spec and merge into section A.
+            var specToMerge = new LayoutSpecification();
+            var sectionToMerge = new LayoutSection("D");
+            var category = new LayoutElement("category") { elementType = LayoutElementType.category };
+            category.childElements.Add(new LayoutElement("group") { elementType = LayoutElementType.group });
+
+            sectionToMerge.childElements.Add(category);
+            specToMerge.sections.Add(sectionToMerge);
+            customization.MergeSpecification(specToMerge);
+
+
+            spec = customization.GetSpecification();
+            Assert.AreEqual(4, spec.sections.Count);
+            Assert.AreEqual("A, B, C, D", string.Join(", ", spec.sections.Select(s => s.text)));
+            Assert.AreEqual("A, , B, , C, , D, category, group", string.Join(", ", spec.sections.Select(x => x.text + ", " + string.Join(", ", x.EnumerateChildren().Select(c => c.text)))));
         }
     }
 }

--- a/test/ViewExtensionLibraryTests/ViewExtensionLibraryTests.csproj
+++ b/test/ViewExtensionLibraryTests/ViewExtensionLibraryTests.csproj
@@ -49,11 +49,7 @@
       <Name>CoreNodeModels</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\LibraryViewExtension\LibraryViewExtension.csproj">
-      <Project>{8eacbfd1-1cd4-4519-a5fc-215d40a67204}</Project>
-      <Name>LibraryViewExtension</Name>
-      <Private>False</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\LibraryViewExtensionMSWebBrowser\LibraryViewExtensionMSWebBrowser.csproj" />
     <ProjectReference Include="..\..\src\Tools\DynamoShapeManager\DynamoShapeManager.csproj">
       <Project>{263FA9C1-F81E-4A8E-95E0-8CDAE20F177B}</Project>
       <Name>DynamoShapeManager</Name>
@@ -78,6 +74,10 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="resources\Dynamo.svg" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.2.1507.118" />
+    <PackageReference Include="NUnit" Version="2.6.3" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/builtinpackages testdir/Packages/SignedPackage2/extra/layoutspecs.json
+++ b/test/builtinpackages testdir/Packages/SignedPackage2/extra/layoutspecs.json
@@ -1,0 +1,33 @@
+{
+  "sections": [
+    {
+      "text": "default",
+      "iconUrl": "",
+      "elementType": "section",
+      "showHeader": false,
+      "include": [ ],
+      "childElements": [
+        {
+          "text": "Revit",
+          "iconUrl": "",
+          "elementType": "category",
+          "include": [],
+          "childElements": [
+            {
+              "text": "some goup name",
+              "iconUrl": "",
+              "elementType": "group",
+              "include": [
+                {
+                  "path": "bltinpkg://somepath.path",
+                  "inclusive": false
+                }
+              ],
+              "childElements": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose

bring in nunit adapter package for vs 2022 - NOTE this PR currently brings in new deps into the bin folder. We should remove them from the deployed build somehow ❓ 🤷 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
