### PR TITLE
Package publish crash fix and package files pre-populate bug fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1343,7 +1343,7 @@ namespace Dynamo.PackageManager
             }
 
             PackageContents.Remove(PackageContents
-                .First(x => x.FileInfo.FullName == packageItemRootViewModel.FileInfo.FullName));
+                .First(x => x.FileInfo?.FullName == packageItemRootViewModel.FileInfo.FullName));
         }
 
         private bool CanShowAddFileDialogAndAdd()

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -930,6 +930,10 @@ namespace Dynamo.PackageManager
                 }
             }
 
+            //after dependencies are loaded refresh package contents
+            vm.RefreshPackageContents();
+            vm.UpdateDependencies();
+
             if (assembliesLoadedTwice.Any())
             {
                 vm.UploadState = PackageUploadHandle.State.Error;


### PR DESCRIPTION
### Purpose

**JIRA:**
https://jira.autodesk.com/browse/DYN-4918
https://jira.autodesk.com/browse/DYN-4919

This PR fixes 2 problems:
- When user deletes package files from publish dialog box Dynamo used to crash, the bug was a null `FileInfo` object.
- When user wants to publish a new version the dialog box won't pre-populate all its files, the bug was un-refreshed package contents.

**GIF:**
![Revit_37Ye284j4y](https://user-images.githubusercontent.com/32665108/167034215-5d6a0317-323e-47b0-a922-7b17985e7b60.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Crash fix on deleting package files from publish window.
- Bug fix to pre-populate package contents on publish window.


### Reviewers

@DynamoDS/dynamo 
@Amoursol 