### PR TITLE
Fix input port colors for Nodemodel nodes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -25,8 +25,8 @@ namespace Dynamo.ViewModels
         private bool portDefaultValueMarkerVisible;
         private bool isFunctionNode;
 
-        private static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
-        private static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
+        internal static SolidColorBrush PortValueMarkerBlue = new SolidColorBrush(Color.FromRgb(106, 192, 231));
+        internal static SolidColorBrush PortValueMarkerRed = new SolidColorBrush(Color.FromRgb(235, 85, 85));
         private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
 
         private static readonly SolidColorBrush PortBackgroundColorKeepListStructure = new SolidColorBrush(Color.FromRgb(83, 126, 145));

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -20,7 +20,7 @@ namespace Dynamo.ViewModels
 
         private SolidColorBrush portValueMarkerColor = new SolidColorBrush(Color.FromArgb(255, 204, 204, 204));
 
-        private static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
+        internal static SolidColorBrush PortValueMarkerGrey = new SolidColorBrush(Color.FromRgb(153, 153, 153));
 
         private bool showContextMenu;
         private bool areConnectorsHidden;

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -25,6 +25,7 @@ namespace DynamoCoreWpfTests
         {
             libraries.Add("FunctionObject.ds");
             libraries.Add("BuiltIn.ds");
+            libraries.Add("DSCPython.dll");
             libraries.Add("FFITarget.dll");
         }
 
@@ -534,6 +535,49 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(nodeViewModelWarningWarningFrozenHidden.ImgGlyphOneSource.Split('/').Last(), "frozen-64px.png");
             Assert.AreEqual(nodeViewModelWarningWarningFrozenHidden.ImgGlyphTwoSource.Split('/').Last(), "hidden-64px.png");
             Assert.AreEqual(nodeViewModelWarningWarningFrozenHidden.ImgGlyphThreeSource.Split('/').Last(), "alert-64px.png");
+        }
+
+        [Test]
+        public void TestPortColors_NodeModel()
+        {
+            Open(@"UI\color_range_ports.dyn");
+            
+            // color range node
+            var nvm = NodeViewWithGuid("423d7eaf-9308-4129-b11f-14c186fa4279");
+
+            var portVMs = nvm.ViewModel.InPorts;
+            var outPorts = nvm.ViewModel.OutPorts;
+
+            Assert.AreEqual(3, portVMs.Count);
+            Assert.AreEqual(1, outPorts.Count);
+
+            Assert.AreEqual(InPortViewModel.PortValueMarkerRed.Color, (portVMs[0] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.AreEqual(InPortViewModel.PortValueMarkerRed.Color, (portVMs[1] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.AreEqual(InPortViewModel.PortValueMarkerBlue.Color, (portVMs[2] as InPortViewModel).PortValueMarkerColor.Color);
+
+            Assert.AreEqual(OutPortViewModel.PortValueMarkerGrey.Color, (outPorts[0] as OutPortViewModel).PortValueMarkerColor.Color);
+
+            // python node
+            nvm = NodeViewWithGuid("0be84b72-d0d9-4deb-8fa8-7af9594ec6bc");
+            var portVM = nvm.ViewModel.InPorts;
+            var outport = nvm.ViewModel.OutPorts;
+
+            Assert.AreEqual(1, portVM.Count);
+            Assert.AreEqual(1, outport.Count);
+
+            Assert.AreEqual(InPortViewModel.PortValueMarkerRed.Color, (portVM[0] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.AreEqual(OutPortViewModel.PortValueMarkerGrey.Color, (outport[0] as OutPortViewModel).PortValueMarkerColor.Color);
+
+            Run();
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(InPortViewModel.PortValueMarkerBlue.Color, (portVMs[0] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.AreEqual(InPortViewModel.PortValueMarkerBlue.Color, (portVMs[1] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.AreEqual(InPortViewModel.PortValueMarkerBlue.Color, (portVMs[2] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.False((outPorts[0] as OutPortViewModel).PortDefaultValueMarkerVisible);
+
+            Assert.AreEqual(InPortViewModel.PortValueMarkerBlue.Color, (portVM[0] as InPortViewModel).PortValueMarkerColor.Color);
+            Assert.False((outport[0] as OutPortViewModel).PortDefaultValueMarkerVisible);
         }
     }
 }

--- a/test/UI/color_range_ports.dyn
+++ b/test/UI/color_range_ports.dyn
@@ -1,0 +1,200 @@
+{
+  "Uuid": "01094aac-d08a-4234-b354-383a38e3deec",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "color_range_ports",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.ColorRange, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "423d7eaf93084129b11f14c186fa4279",
+      "Inputs": [
+        {
+          "Id": "f7b4587ae5594864acc23a2fee9833f0",
+          "Name": "colors",
+          "Description": "List of colors to include in the range",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b726075fe3dc498484f2ad0cf4b373b8",
+          "Name": "indices",
+          "Description": "List of values between 0.0 and 1.0 which position the input colors along the range",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0c7a6d591d7a4e53b4298888b685bc03",
+          "Name": "value",
+          "Description": "List of values between 0.0 and 1.0. These values define the colors that are picked along the color range to create the color list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5669c23b7a9a473d913c86efa25ab5bf",
+          "Name": "color",
+          "Description": "Selected colors",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Get a color given a color range."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "12;",
+      "Id": "13eacc2d04fb4a069b4b25ed5854396f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "6d109bb6b4a54ccc86ab1e8b1d909b77",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\nclr.AddReference('ProtoGeometry')\r\nfrom Autodesk.DesignScript.Geometry import *\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndataEnteringNode = IN\r\n\r\n# Place your code below this line\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = 0",
+      "Engine": "CPython3",
+      "EngineName": "CPython3",
+      "VariableInputPorts": true,
+      "Id": "0be84b72d0d94deb8fa87af9594ec6bc",
+      "Inputs": [
+        {
+          "Id": "78edd469d5104f59b36f0abf4f40cb55",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7fca66d6c55a4ccc89bfb979bef230eb",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded Python script."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "6d109bb6b4a54ccc86ab1e8b1d909b77",
+      "End": "0c7a6d591d7a4e53b4298888b685bc03",
+      "Id": "155f7a7a100c4fea9f97dd52d4ef343e",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4946",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Color Range",
+        "ShowGeometry": true,
+        "Id": "423d7eaf93084129b11f14c186fa4279",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 547.2,
+        "Y": 411.6
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "13eacc2d04fb4a069b4b25ed5854396f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 226.0,
+        "Y": 500.0
+      },
+      {
+        "Name": "Python Script",
+        "ShowGeometry": true,
+        "Id": "0be84b72d0d94deb8fa87af9594ec6bc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1077.6000000000001,
+        "Y": 231.20000000000005
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Fixes existing issue with some nodemodel nodes appearing as if all their input ports are satisfied even when they're not. 

Before:
![inputport_color](https://user-images.githubusercontent.com/5710686/167464837-6fc3dba5-d7e8-4086-b552-9931813ee551.gif)

After:
![inputport_color2](https://user-images.githubusercontent.com/5710686/167465707-89116210-2e85-47a0-a75c-4e092769ffab.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix input port colors for Nodemodel nodes.

### FYIs



#Amoursol 
