### PR TITLE
fix loading broken code block in Revit.

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -838,7 +838,7 @@ namespace Dynamo.Graph.Workspaces
                     // Check for the file path string value at each of the output ports of all nodes in the workspace. 
                     foreach (var port in node.OutPorts)
                     {
-                        var id = node.GetAstIdentifierForOutputIndex(port.Index).Name;
+                        var id = node.GetAstIdentifierForOutputIndex(port.Index)?.Name;
                         var mirror = homeWorkspaceModel.EngineController.GetMirror(id);
                         var data = mirror?.GetData().Data;
 

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1379,6 +1379,20 @@ var06 = g;
             Assert.AreEqual(0, codeBlockNode.InPorts.Count);
             Assert.AreEqual(1, codeBlockNode.OutPorts.Count);
         }
+        [Test]
+        [Category("RegressionTests")]
+        public void TestLoadFileWithBrokenCodeBlockAndGetExternalReferences()
+        {
+            string openPath = Path.Combine(TestDirectory,
+                @"core\cbn\classAsVariable.dyn");
+            Assert.DoesNotThrow(() =>
+            {
+                OpenModel(openPath);
+                var dummy = CurrentDynamoModel.CurrentWorkspace.ExternalFiles;
+            });
+         
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+        }
 
         [Test]
         public void Defect_MAGN_6723()

--- a/test/core/cbn/classAsVariable.dyn
+++ b/test/core/cbn/classAsVariable.dyn
@@ -1,0 +1,98 @@
+{
+  "Uuid": "e4cacf27-bef2-4040-8bbb-0a1a8e8cdf9e",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "classAsVariable",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Autodesk.DesignScript.Geometry.Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "List;",
+      "Id": "17d6527963974073a17fc170a0bfd4e5",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cf30003a16834fb48207e6e26f2e00c0",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.5018",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "17d6527963974073a17fc170a0bfd4e5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 236.0,
+        "Y": 233.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Checking external references for a broken code block should not stop graph from loading correctly.
The issue is that the graph was saved somehow when the codeblock was valid with an output port, now it is no longer valid as `Material` is a classname and not a variable name, so the node cannot be compiled correctly in the Revit context where `Material` is an imported classname.

![Screen Shot 2022-05-16 at 2 52 52 PM](https://user-images.githubusercontent.com/508936/168662343-756e47be-5dab-4d84-bbed-a97fa9965d32.png)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix bug in ExternalReferences check when loading code block with error.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
