### PR TITLE
Adjust NodeLibrary column header width

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -706,7 +706,7 @@
                           Style="{StaticResource DataGrid}">
                     <DataGrid.Columns>
                         <DataGridCheckBoxColumn MinWidth="85"
-                                                MaxWidth="85"
+                                                MaxWidth="130"
                                                 Binding="{Binding Path=IsNodeLibrary, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                 ElementStyle="{StaticResource CheckBoxStyle}"
                                                 Header="{x:Static p:Resources.PublishPackageViewNodeLibrary}"


### PR DESCRIPTION
### Purpose

Increase max-width for NodeLibrary column header

![Screen Shot 2022-05-17 at 1 08 17 PM](https://user-images.githubusercontent.com/32665108/168914654-de6ed3f4-0939-430c-a53b-d4067a96bcee.png)

English:
![Screen Shot 2022-05-18 at 1 15 15 PM](https://user-images.githubusercontent.com/32665108/169104108-536037eb-32fd-4c6f-944d-937140ab84ad.png)

Chinese:
![Screen Shot 2022-05-18 at 1 19 36 PM](https://user-images.githubusercontent.com/32665108/169104124-8292fde2-2c6c-4246-b162-21316d1b9fe5.png)

Russian:
![Screen Shot 2022-05-18 at 1 22 20 PM](https://user-images.githubusercontent.com/32665108/169104142-f99b995d-e15e-4b1f-b8d0-47c3cdad8350.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Increase max-width for NodeLibrary column header


