### PR TITLE
Assign F1 as the hotkey to display node help docs

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2714,7 +2714,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The library contains all default functions #(nodes)=https://www.dynamoprimer.com/03_Anatomy-of-a-Dynamo-Definition/3-1_dynamo_nodes.html of Dynamo, as well as custom nodes you may have loaded. \n\nTo find a node, search the library or browse its categories..
+        ///   Looks up a localized string similar to The library contains all default functions #(nodes)=https://primer2.dynamobim.org/4_nodes_and_wires of Dynamo, as well as custom nodes you may have loaded. \n\nTo find a node, search the library or browse its categories..
         /// </summary>
         public static string GetStartedGuideLibraryText {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2482,7 +2482,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <comment>Dynamo Guided Tours</comment>
   </data>
   <data name="GetStartedGuideLibraryText" xml:space="preserve">
-    <value>The library contains all default functions #(nodes)=https://www.dynamoprimer.com/03_Anatomy-of-a-Dynamo-Definition/3-1_dynamo_nodes.html of Dynamo, as well as custom nodes you may have loaded. \n\nTo find a node, search the library or browse its categories.</value>
+    <value>The library contains all default functions #(nodes)=https://primer2.dynamobim.org/4_nodes_and_wires of Dynamo, as well as custom nodes you may have loaded. \n\nTo find a node, search the library or browse its categories.</value>
   </data>
   <data name="GetStartedGuideLibraryTitle" xml:space="preserve">
     <value>Library</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2724,7 +2724,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <comment>Dynamo Guided Tours</comment>
   </data>
   <data name="GetStartedGuideLibraryText" xml:space="preserve">
-    <value>The library contains all default functions #(nodes)=https://www.dynamoprimer.com/03_Anatomy-of-a-Dynamo-Definition/3-1_dynamo_nodes.html of Dynamo, as well as custom nodes you may have loaded. \n\nTo find a node, search the library or browse its categories.</value>
+    <value>The library contains all default functions #(nodes)=https://primer2.dynamobim.org/4_nodes_and_wires of Dynamo, as well as custom nodes you may have loaded. \n\nTo find a node, search the library or browse its categories.</value>
   </data>
   <data name="GetStartedGuideLibraryTitle" xml:space="preserve">
     <value>Library</value>

--- a/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
@@ -152,8 +152,7 @@ namespace Dynamo.Wpf.Utilities
                     {
                         Source = NodeViewModel,
                         Path = new PropertyPath(nameof(NodeViewModel.UngroupCommand))
-                    },
-                    hotkey: "F2"
+                    }
                 )
             );
             groupsMenuItem.Items.Add(CreateMenuItem

--- a/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
+++ b/src/DynamoCoreWpf/Utilities/NodeContextMenuBuilder.cs
@@ -85,6 +85,7 @@ namespace Dynamo.Wpf.Utilities
         /// <param name="visibility"></param>
         /// <param name="isEnabled"></param>
         /// <param name="itemsSource"></param>
+        /// <param name="hotkey"></param>
         /// <returns></returns>
         internal static MenuItem CreateMenuItem
         (
@@ -96,7 +97,8 @@ namespace Dynamo.Wpf.Utilities
             Binding isChecked = null,
             Binding visibility = null,
             Binding isEnabled = null,
-            Binding itemsSource = null
+            Binding itemsSource = null,
+            string hotkey = null
         )
         {
             MenuItem menuItem = new MenuItem { Header = header, IsCheckable = isCheckable };
@@ -108,6 +110,7 @@ namespace Dynamo.Wpf.Utilities
             if (visibility != null) menuItem.SetBinding(UIElement.VisibilityProperty, visibility);
             if (isEnabled != null) menuItem.SetBinding(UIElement.IsEnabledProperty, isEnabled);
             if (itemsSource != null) menuItem.SetBinding(ItemsControl.ItemsSourceProperty, itemsSource);
+            if (!string.IsNullOrWhiteSpace(hotkey)) menuItem.InputGestureText = hotkey;
 
             return menuItem;
         }
@@ -149,7 +152,8 @@ namespace Dynamo.Wpf.Utilities
                     {
                         Source = NodeViewModel,
                         Path = new PropertyPath(nameof(NodeViewModel.UngroupCommand))
-                    }
+                    },
+                    hotkey: "F2"
                 )
             );
             groupsMenuItem.Items.Add(CreateMenuItem
@@ -433,7 +437,8 @@ namespace Dynamo.Wpf.Utilities
                 {
                     Source = NodeViewModel,
                     Path = new PropertyPath(nameof(NodeViewModel.ShowHelpCommand))
-                }
+                },
+                hotkey: "F1"
             );
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2676,6 +2676,24 @@ namespace Dynamo.ViewModels
             OnRequestOpenDocumentationLink((OpenDocumentationLinkEventArgs)parameter);
         }
 
+        internal void ShowNodeDocumentation(object parameter)
+        {
+            var node = DynamoSelection.Instance.Selection.OfType<NodeModel>().LastOrDefault();
+
+            var nodeAnnotationEventArgs = new OpenNodeAnnotationEventArgs(node, this);
+            OpenDocumentationLink(nodeAnnotationEventArgs);
+        }
+        internal bool CanShowNodeDocumentation(object parameter)
+        {
+            var node = DynamoSelection.Instance.Selection.OfType<NodeModel>().LastOrDefault();
+
+            if (node == null || !(node is NodeModel))
+            {
+                return false;
+            }
+            return true;
+        }
+
         private bool CanZoomIn(object parameter)
         {
             return CurrentSpaceViewModel.CanZoomIn;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -85,6 +85,7 @@ namespace Dynamo.ViewModels
             ShowNewPresetsDialogCommand = new DelegateCommand(ShowNewPresetStateDialogAndMakePreset, CanShowNewPresetStateDialog);
             NodeFromSelectionCommand = new DelegateCommand(CreateNodeFromSelection, CanCreateNodeFromSelection);
             OpenDocumentationLinkCommand = new DelegateCommand(OpenDocumentationLink);
+            ShowNodeDocumentationCommand = new DelegateCommand(ShowNodeDocumentation, CanShowNodeDocumentation);
         }
         public DelegateCommand OpenFromJsonIfSavedCommand { get; set; }
         public DelegateCommand OpenFromJsonCommand { get; set; }
@@ -167,5 +168,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand ShowNewPresetsDialogCommand { get; set; }
         public DelegateCommand NodeFromSelectionCommand { get; set; }
         public DelegateCommand OpenDocumentationLinkCommand { get; set; }
+        public DelegateCommand ShowNodeDocumentationCommand { get; set; }
+        
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -175,6 +175,8 @@
         <KeyBinding Key="T"
                     Modifiers="Control"
                     Command="{Binding Path=DataContext.ShowNewPresetsDialogCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <KeyBinding Key="F1"
+                    Command="{Binding Path=DataContext.ShowNodeDocumentationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
     </Window.InputBindings>
 
     <Grid Name="mainGrid"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -130,6 +130,14 @@
                                                     </Style>
                                                 </Label.Style>
                                             </Label>
+                                            <TextBlock x:Name="InputGestureText"
+                                               Margin="0,2,2,2"
+                                               DockPanel.Dock="Right"
+                                               HorizontalAlignment="Right"
+                                               VerticalAlignment="Center"
+                                               Text="{TemplateBinding InputGestureText}"
+                                               TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
+                                               TextBlock.FontSize="13px" />
                                             <Popup x:Name="PART_Popup"
                                                    AllowsTransparency="true"
                                                    Focusable="false"


### PR DESCRIPTION
### Purpose

- Assign F1 as the hotkey to display node help docs [DYN-4900](https://jira.autodesk.com/browse/DYN-4900)
- Update primer links [DYN-4875](https://jira.autodesk.com/browse/DYN-4875)

![DynamoSandbox_HUHRJpoNcb](https://user-images.githubusercontent.com/32665108/169111026-433fc5f9-21ba-4074-be97-f4ab2c29414c.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Assign F1 as the hotkey to display node help docs


### Reviewers

@DynamoDS/dynamo 
