### PR TITLE
Fix context menu margin when placed to the left.

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -3398,7 +3398,6 @@
                                                                                             TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                     <Grid RenderOptions.ClearTypeHint="Enabled">
                                         <ItemsPresenter x:Name="ItemsPresenter"
-                                                        Margin="0"
                                                         Grid.IsSharedSizeScope="true"
                                                         KeyboardNavigation.DirectionalNavigation="Cycle"
                                                         KeyboardNavigation.TabNavigation="Cycle"
@@ -3499,7 +3498,6 @@
                                                                                             TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                     <Grid RenderOptions.ClearTypeHint="Enabled">
                                         <ItemsPresenter x:Name="ItemsPresenter"
-                                                        Margin="0"
                                                         Grid.IsSharedSizeScope="true"
                                                         KeyboardNavigation.DirectionalNavigation="Cycle"
                                                         KeyboardNavigation.TabNavigation="Cycle"
@@ -4746,7 +4744,6 @@
                                                                                             TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                     <Grid RenderOptions.ClearTypeHint="Enabled">
                                         <ItemsPresenter x:Name="ItemsPresenter"
-                                                        Margin="0"
                                                         Grid.IsSharedSizeScope="true"
                                                         KeyboardNavigation.DirectionalNavigation="Cycle"
                                                         KeyboardNavigation.TabNavigation="Cycle"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -154,7 +154,6 @@
                                                                                                                 TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                                         <Grid RenderOptions.ClearTypeHint="Enabled">
                                                             <ItemsPresenter x:Name="ItemsPresenter"
-                                                                            Margin="0"
                                                                             Grid.IsSharedSizeScope="true"
                                                                             KeyboardNavigation.DirectionalNavigation="Cycle"
                                                                             KeyboardNavigation.TabNavigation="Cycle"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -479,7 +479,6 @@
                                     <Popup x:Name="PART_Popup"
                                            AllowsTransparency="true"
                                            Focusable="false"
-                                           HorizontalOffset="-1"
                                            IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
                                            Placement="Right"
                                            VerticalOffset="-2">
@@ -492,7 +491,6 @@
                                                                                                         TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                                 <Grid RenderOptions.ClearTypeHint="Enabled">
                                                     <ItemsPresenter x:Name="ItemsPresenter"
-                                                                    Margin="1"
                                                                     Grid.IsSharedSizeScope="true"
                                                                     KeyboardNavigation.DirectionalNavigation="Cycle"
                                                                     KeyboardNavigation.TabNavigation="Cycle"


### PR DESCRIPTION
### Purpose

This is a minor followup change to the https://github.com/DynamoDS/Dynamo/pull/12890. This fixes the margin when the context menu is placed to the left.

<img width="1022" alt="Screen Shot 2022-05-19 at 10 23 09 AM" src="https://user-images.githubusercontent.com/43763136/169318196-9fb8b3a2-4bdf-4aec-8208-4b8dd2071b07.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix context menu margin when placed to the left.

### Reviewers
@QilongTang 
