### PR TITLE
[DYN-4719] Add analytics tracking for guided tour events

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -209,6 +209,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 CalculateStep(GuideFlow.FORWARD, CurrentStepSequence);
                 CurrentStep.Show(GuideFlow.FORWARD);
+                Logging.Analytics.TrackEvent(Logging.Actions.Next, Logging.Categories.GuidedTourOperations, GuideNameResource, CurrentStep.Sequence);
             }
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using Dynamo.Controls;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
+using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.Views.GuidedTour;
 using Newtonsoft.Json;
 
@@ -209,7 +210,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 CalculateStep(GuideFlow.FORWARD, CurrentStepSequence);
                 CurrentStep.Show(GuideFlow.FORWARD);
-                Logging.Analytics.TrackEvent(Logging.Actions.Next, Logging.Categories.GuidedTourOperations, GuideNameResource, CurrentStep.Sequence);
+                Logging.Analytics.TrackEvent(Logging.Actions.Next, Logging.Categories.GuidedTourOperations, Resources.ResourceManager.GetString(GuideNameResource).Replace("_", ""), CurrentStep.Sequence);
             }
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -50,6 +50,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 isAnyGuideActive = false;
                 GuidedTourFinish(new GuidedTourStateEventArgs(name));
+                Logging.Analytics.TrackEvent(Logging.Actions.Completed, Logging.Categories.GuidedTourOperations, name);
             }
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dynamo.Wpf.Properties;
+using System;
 
 namespace Dynamo.Wpf.UI.GuidedTour
 {
@@ -50,7 +51,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 isAnyGuideActive = false;
                 GuidedTourFinish(new GuidedTourStateEventArgs(name));
-                Logging.Analytics.TrackEvent(Logging.Actions.Completed, Logging.Categories.GuidedTourOperations, name);
+                Logging.Analytics.TrackEvent(Logging.Actions.Completed, Logging.Categories.GuidedTourOperations, Resources.ResourceManager.GetString(name).Replace("_", ""));
             }
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -49,6 +50,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private const string guideBackgroundName = "GuidesBackground";
         private const string mainGridName = "mainGrid";
         private const string libraryViewName = "Browser";
+        private Stopwatch stopwatch;
 
         internal static string GuidesExecutingDirectory
         {
@@ -105,7 +107,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
             guideBackgroundElement.ClearCutOffSection();
             guideBackgroundElement.ClearHighlightSection();
-        }
+            stopwatch = Stopwatch.StartNew();
+    }
 
         /// <summary>
         /// Creates the background for the GuidedTour
@@ -160,6 +163,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 Initialize();
                 GuideFlowEvents.OnGuidedTourStart(tourName);
+                Logging.Analytics.TrackScreenView("InteractiveGuidedTours");
                 Logging.Analytics.TrackEvent(Logging.Actions.Start, Logging.Categories.GuidedTourOperations, currentGuide.GuideNameResource, currentGuide.SequenceOrder);
             }
         }
@@ -219,7 +223,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 {
                     tmpStep.StepClosed -= Popup_StepClosed;
                 }
-                Logging.Analytics.TrackEvent(Logging.Actions.End, Logging.Categories.GuidedTourOperations, currentGuide.SequenceOrder.ToString());
+                Logging.Analytics.TrackEvent(Logging.Actions.End, Logging.Categories.GuidedTourOperations, currentGuide.GuideNameResource, currentGuide.SequenceOrder);
+                Logging.Analytics.TrackTimedEvent(Logging.Categories.GuidedTourOperations, Logging.Actions.TimeElapsed.ToString(), stopwatch.Elapsed, currentGuide.GuideNameResource);
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Dynamo.ViewModels;
+using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.ViewModels.GuidedTour;
 using Dynamo.Wpf.Views.GuidedTour;
 using Newtonsoft.Json;
@@ -164,7 +165,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 Initialize();
                 GuideFlowEvents.OnGuidedTourStart(tourName);
                 Logging.Analytics.TrackScreenView("InteractiveGuidedTours");
-                Logging.Analytics.TrackEvent(Logging.Actions.Start, Logging.Categories.GuidedTourOperations, currentGuide.GuideNameResource, currentGuide.SequenceOrder);
+                Logging.Analytics.TrackEvent(Logging.Actions.Start, Logging.Categories.GuidedTourOperations, Resources.ResourceManager.GetString(currentGuide.GuideNameResource).Replace("_", ""), currentGuide.SequenceOrder);
             }
         }
 
@@ -223,8 +224,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 {
                     tmpStep.StepClosed -= Popup_StepClosed;
                 }
-                Logging.Analytics.TrackEvent(Logging.Actions.End, Logging.Categories.GuidedTourOperations, currentGuide.GuideNameResource, currentGuide.SequenceOrder);
-                Logging.Analytics.TrackTimedEvent(Logging.Categories.GuidedTourOperations, Logging.Actions.TimeElapsed.ToString(), stopwatch.Elapsed, currentGuide.GuideNameResource);
+                string guidName = Resources.ResourceManager.GetString(currentGuide.GuideNameResource).Replace("_", "");
+                Logging.Analytics.TrackEvent(Logging.Actions.End, Logging.Categories.GuidedTourOperations, guidName, currentGuide.SequenceOrder);
+                Logging.Analytics.TrackTimedEvent(Logging.Categories.GuidedTourOperations, Logging.Actions.TimeElapsed.ToString(), stopwatch.Elapsed, guidName);
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -160,6 +160,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 Initialize();
                 GuideFlowEvents.OnGuidedTourStart(tourName);
+                Logging.Analytics.TrackEvent(Logging.Actions.Start, Logging.Categories.GuidedTourOperations, currentGuide.GuideNameResource, currentGuide.SequenceOrder);
             }
         }
 
@@ -218,6 +219,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 {
                     tmpStep.StepClosed -= Popup_StepClosed;
                 }
+                Logging.Analytics.TrackEvent(Logging.Actions.End, Logging.Categories.GuidedTourOperations, currentGuide.SequenceOrder.ToString());
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -401,7 +401,7 @@ namespace Dynamo.Logging
         Next,
 
         /// <summary>
-        /// Next event, e.g. when a user clicks next on a guided tour
+        /// TimeElapsed event, e.g. tracks the time elapsed since an event
         /// </summary>
         TimeElapsed,
     }

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -399,6 +399,11 @@ namespace Dynamo.Logging
         /// Next event, e.g. when a user clicks next on a guided tour
         /// </summary>
         Next,
+
+        /// <summary>
+        /// Next event, e.g. when a user clicks next on a guided tour
+        /// </summary>
+        TimeElapsed,
     }
 
     /// <summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -121,6 +121,11 @@ namespace Dynamo.Logging
         /// Events Category related to group styles
         /// </summary>
         GroupStyleOperations,
+
+        /// <summary>
+        /// Events Category related to guided tours
+        /// </summary>
+        GuidedTourOperations,
     }
 
     /// <summary>
@@ -384,6 +389,16 @@ namespace Dynamo.Logging
         /// Cancel operation, e.g. cancel adding a new group style 
         /// </summary>
         Cancel,
+
+        /// <summary>
+        /// Completed event, e.g. when a user completes a guided tour
+        /// </summary>
+        Completed,
+
+        /// <summary>
+        /// Next event, e.g. when a user clicks next on a guided tour
+        /// </summary>
+        Next,
     }
 
     /// <summary>


### PR DESCRIPTION
### Purpose

Track various actions regarding user interaction with guided tours.

- How far do they go through the guide before abandoning it?
    - Track resource name with step number on which user ends the tour
- Are they doing the interactive bits? or just clicking Next?
     - Track resource name with step number on which user clicks next.
- rating at the end (already covered in Global launch).
- how long users stays in a single guide, e.g. Packages guide
    - Track time elapsed from guided tour initiation.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Track various actions regarding user interaction with guided tours.


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
