### PR TITLE
Subscribing the event of fisnishing the tour to close the terms

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -75,7 +75,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         public static bool IsAnyGuideActive
         {
             get { return isAnyGuideActive; }
-            private set { isAnyGuideActive = value; }
+            set { isAnyGuideActive = value; }
         }
     }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -256,6 +256,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             exitGuideWindow.IsOpen = false;
             if (currentGuide != null)
             {
+                GuideFlowEvents.IsAnyGuideActive = true;
                 currentGuide.ContinueStep(currentGuide.CurrentStep.Sequence);
             }
         }

--- a/src/DynamoCoreWpf/Views/GuidedTour/ExitGuideWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/ExitGuideWindow.xaml
@@ -22,13 +22,13 @@
     </Popup.Resources>
 
     <Border
-        ClipToBounds="True" CornerRadius="3" Background="White" Name="brdEtikett">
+        ClipToBounds="True" CornerRadius="3" Name="brdEtikett">
         <Canvas Background="Transparent">
 
-            <Grid Name="RootLayout"                   
+            <Grid Name="RootLayout"    
+                  Background="White"
                  Width="{Binding Width}"
-                 Height="{Binding Height}"
-                  >
+                 Height="{Binding Height}" >
                 <Grid.RowDefinitions>
                     <RowDefinition Height="50"/>
                     <RowDefinition Height="*"/>
@@ -63,7 +63,7 @@
                     <!--This is the text section of the Popup-->
                     <localui:CustomRichTextBox x:Name="ContentRichTextBox" 
                                            IsDocumentEnabled="True"                   
-                                           Padding="20,20,100,5"
+                                           Padding="20,20,100,0"
                                            CustomText="{Binding FormattedText}"
                                            Style="{StaticResource CustomRichTextBoxStyle}">
 
@@ -71,7 +71,7 @@
                 </Grid>
 
                 <!--Group of buttons Exit/Continue-->
-                <Grid Grid.Row="2">
+                <Grid Grid.Row="2" Margin="0 0 0 10">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>


### PR DESCRIPTION
### Purpose

It's included in this PR the bug fix for the issue that opens multiple windows about the terms when closing the Packages Tour.
Also, it's included in this PR the fix for the design of the exit popup in the 3rd step (DYN-4842).

![TermsOfUseBugFix](https://user-images.githubusercontent.com/89042471/169601770-d62f74c7-781c-4c17-8bc9-131154dda8c7.gif)


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
