### PR TITLE
Note Pin/Unpin Redo

### DIFF
--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Graph
     /// <summary>
     /// SaveContext represents several contexts, in which node can be serialized/deserialized.
     /// </summary>
-    public enum SaveContext { [Obsolete("Use Save or SaveAs, instead of File")] File, Copy, Undo, Preset, None, Save, SaveAs };
+    public enum SaveContext { [Obsolete("Use Save or SaveAs, instead of File")] File, Copy, Undo, Redo, Preset, None, Save, SaveAs };
 
     /// <summary>
     /// This class encapsulates the input parameters that need to be passed into nodes


### PR DESCRIPTION
### Purpose

This is a minor Bug fix. The ability to Redo after a Note has been Pinned to a Node and Undo is triggered.

![redo-pin-note](https://user-images.githubusercontent.com/5354594/169784169-91a13ac5-8f1b-47a7-a30b-aa5a2134cd12.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- ModelBase.cs - Redo added to SaveContext enum
- NodeModel.cs - new Action RedoRequest that is triggered on Redo
- NoteViewModel.cs - new RePintoNode method that contains the logic for dealing with Redo

### Reviewers

@reddyashish 

### FYIs
@mjkkirschner
@Amoursol 

