### PR TITLE
Note PinUnpin Bugfix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -16,7 +16,7 @@ using DynCmd = Dynamo.Models.DynamoModel;
 
 namespace Dynamo.ViewModels
 {
-    public partial class NoteViewModel: ViewModelBase
+    public partial class NoteViewModel : ViewModelBase
     {
         private int DISTANCE_TO_PINNED_NODE = 16;
         private int DISTANCE_TO_PINNED_NODE_WITH_WARNING = 64;
@@ -131,7 +131,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                if (Model.PinnedNode==null)
+                if (Model.PinnedNode == null)
                 {
                     return null;
                 }
@@ -149,7 +149,7 @@ namespace Dynamo.ViewModels
             this.WorkspaceViewModel = workspaceViewModel;
             _model = model;
             model.PropertyChanged += note_PropertyChanged;
-            model.UndoRedoRequest += note_PinUnpinToNode;
+            model.UndoRequest += note_PinUnpinToNode;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
             ZIndex = ++StaticZIndex; // places the note on top of all nodes/notes
 
@@ -160,17 +160,28 @@ namespace Dynamo.ViewModels
             IsOnEditMode = false;
         }
 
-        private void note_PinUnpinToNode(ModelBase obj, string context, Guid nodeGuid)
+        public override void Dispose()
         {
-            if (context.Equals("Unpin"))
+            if (Model.PinnedNode != null)
+            {
+                UnsuscribeFromPinnedNode();
+            }
+            _model.PropertyChanged -= note_PropertyChanged;
+            _model.UndoRequest -= note_PinUnpinToNode;
+            DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;
+        }
+
+        private void note_PinUnpinToNode(ModelBase obj)
+        {
+            if (Model.UndoRedoAction.Equals(NoteModel.UndoAction.Unpin))
             {
                 UnpinFromNode(obj);
                 return;
             }
-            if (context.Equals("Pin"))
+            if (Model.UndoRedoAction.Equals(NoteModel.UndoAction.Pin))
             {
                 NodeModel node = WorkspaceViewModel.Model.Nodes
-                    .Where(x => x.GUID.Equals(nodeGuid))
+                    .Where(x => x.GUID.Equals(Model.PinnedNodeGuid))
                     .FirstOrDefault();
 
                 if (node == null) return;
@@ -185,16 +196,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-        public override void Dispose()
-        {
-            if (Model.PinnedNode != null)
-            {
-                UnsuscribeFromPinnedNode();
-            }
-            _model.PropertyChanged -= note_PropertyChanged;
-            _model.UndoRedoRequest -= note_PinUnpinToNode;
-            DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;
-        }
 
         private void SelectionOnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
@@ -211,7 +212,7 @@ namespace Dynamo.ViewModels
 
         public void UpdateSizeFromView(double w, double h)
         {
-            this._model.SetSize(w,h);
+            this._model.SetSize(w, h);
             MoveNoteAbovePinnedNode();
         }
 
@@ -353,7 +354,7 @@ namespace Dynamo.ViewModels
             var noteSelection = DynamoSelection.Instance.Selection
                     .OfType<NoteModel>();
 
-            if (nodeSelection == null || noteSelection == null || 
+            if (nodeSelection == null || noteSelection == null ||
                 nodeSelection.Count() != 1 || noteSelection.Count() != 1)
                 return false;
 


### PR DESCRIPTION
### Purpose

This is a minor Bug fix. The ability to Redo after a Note has been Pinned to a Node and Undo is triggered.

Task: https://jira.autodesk.com/browse/DYN-4828

![redo-pin-note](https://user-images.githubusercontent.com/5354594/169784169-91a13ac5-8f1b-47a7-a30b-aa5a2134cd12.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- NodeModel.cs - new Action that is triggered on Undo/Redo
- NoteViewModel.cs - new logic that handles both Pin/Unpin scenarios when performing Undo/Redo

### Reviewers

@reddyashish 

### FYIs
@mjkkirschner
@Amoursol 

