### PR TITLE
DYN-4880: Dynamo crash upon clicking Packages > Arkance Systems Settings

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3904,6 +3904,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package or one of its dependencies targets a different environment, such as Revit, Civil 3D, Advance Steel, Alias or FormIt. This can cause instability and unexpected problems. Do you want to continue?.
+        /// </summary>
+        public static string MessagePackageTargetOtherHosts {
+            get {
+                return ResourceManager.GetString("MessagePackageTargetOtherHosts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Version {0} of {1} could not be found..
         /// </summary>
         public static string MessagePackageVersionNotFound {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3156,4 +3156,7 @@ To install the latest version of a package, click Install. \n
   <data name="OnboardingSuccessTitle" xml:space="preserve">
     <value>Success</value>
   </data>
+  <data name="MessagePackageTargetOtherHosts" xml:space="preserve">
+    <value>The package or one of its dependencies targets a different environment, such as Revit, Civil 3D, Advance Steel, Alias or FormIt. This can cause instability and unexpected problems. Do you want to continue?</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3143,4 +3143,7 @@ To install the latest version of a package, click Install. \n
   <data name="OnboardingSuccessTitle" xml:space="preserve">
     <value>Success</value>
   </data>
+  <data name="MessagePackageTargetOtherHosts" xml:space="preserve">
+    <value>The package or one of its dependencies targets a different environment, such as Revit, Civil 3D, Advance Steel, Alias or FormIt. This can cause instability and unexpected problems. Do you want to continue?</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -673,6 +673,9 @@ namespace Dynamo.ViewModels
             return true;
         }
 
+        // Current host, empty if sandbox, null when running tests
+        internal virtual string Host => DynamoViewModel.Model.HostAnalyticsInfo.HostName;
+
         internal async void ExecutePackageDownload(string name, PackageVersion package, string installPath)
         {
             string msg = String.IsNullOrEmpty(installPath) ?
@@ -809,14 +812,12 @@ namespace Dynamo.ViewModels
                 // determinate if any of the packages are targeting other hosts
                 var containsPackagesThatTargetOtherHosts = false;
 
-                // Current host, empty if sandbox
-                var host = DynamoViewModel.Model.HostAnalyticsInfo.HostName;
 
                 // Known hosts
                 var knownHosts = Model.GetKnownHosts();
 
                 // Sandbox, special case: Warn if any package targets only one known host
-                if (String.IsNullOrEmpty(host))
+                if (String.IsNullOrEmpty(Host))
                 {
                     containsPackagesThatTargetOtherHosts =
                         newPackageHeaders.Any(y => y.host_dependencies != null && y.host_dependencies.Intersect(knownHosts).Count() == 1);
@@ -824,12 +825,12 @@ namespace Dynamo.ViewModels
                 else
                 {
                     // Warn if there are packages targeting other hosts but not our host
-                    var otherHosts = knownHosts.Except(new List<string>() {host});
+                    var otherHosts = knownHosts.Except(new List<string>() {Host});
                     containsPackagesThatTargetOtherHosts = newPackageHeaders.Any(x =>
                     {
                         // Is our host in the list?
                         // If not, is any other host in the list?
-                        return x.host_dependencies != null && !x.host_dependencies.Contains(host) && otherHosts.Any(y => x.host_dependencies != null && x.host_dependencies.Contains(y));
+                        return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && otherHosts.Any(y => x.host_dependencies != null && x.host_dependencies.Contains(y));
                     });
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -815,11 +815,11 @@ namespace Dynamo.ViewModels
                 // Known hosts
                 var knownHosts = Model.GetKnownHosts();
 
-                // Sandbox, special case: Warn if any package targets any known host
+                // Sandbox, special case: Warn if any package targets only one known host
                 if (String.IsNullOrEmpty(host))
                 {
                     containsPackagesThatTargetOtherHosts =
-                        knownHosts.Any(x => newPackageHeaders.Any(y => y.host_dependencies != null && y.host_dependencies.Contains(x)));
+                        newPackageHeaders.Any(y => y.host_dependencies != null && y.host_dependencies.Intersect(knownHosts).Count() == 1);
                 }
                 else
                 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -811,7 +810,6 @@ namespace Dynamo.ViewModels
 
                 // determinate if any of the packages are targeting other hosts
                 var containsPackagesThatTargetOtherHosts = false;
-
 
                 // Known hosts
                 var knownHosts = Model.GetKnownHosts();

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -135,7 +135,7 @@ namespace Dynamo.PackageManager
         /// Make a call to Package Manager to get the known
         /// supported hosts for package publishing and filtering
         /// </summary>
-        internal IEnumerable<string> GetKnownHosts()
+        internal virtual IEnumerable<string> GetKnownHosts()
         {
             return FailFunc.TryExecute(() =>
             {

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -1154,6 +1154,110 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        [Description("User tries to download a package that target a different host.")]
+        public void PackageManagerWarnWhenInstallingPackageTargetingOtherHost()
+        {
+
+            var mockGreg = new Mock<IGregClient>();
+
+            var clientmock = new Mock<Dynamo.PackageManager.PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
+            var pmVmMock = new Mock<PackageManagerClientViewModel>(ViewModel, clientmock.Object);
+
+            //when we attempt a download - it returns a valid download path
+            pmVmMock.Setup(x => x.Download(It.IsAny<PackageDownloadHandle>())).
+                Returns<PackageDownloadHandle>(h => Task.Factory.StartNew(() => (h, h.Name)));
+
+            //these are our fake packages
+            var dep_name = "Dep123";
+            var dep_version = "0.0.1";
+            var dep_id = "Dep123";
+            var dep_deps = new List<Dependency>() { new Dependency() { _id = dep_id, name = dep_name } };
+            var dep_depVers = new List<string>() { dep_version };
+            var host_dependencies = new List<string>() { "Revit" };
+
+            var dep_pkgVer = new PackageVersion()
+            {
+                version = dep_version,
+                engine_version = "2.1.1",
+                name = dep_name,
+                id = dep_id,
+                full_dependency_ids = dep_deps,
+                full_dependency_versions = dep_depVers,
+                host_dependencies = host_dependencies
+            };
+
+            var name = "PackageWithDep123";
+            var version = "0.0.1";
+            var id = "PackageWithDep123";
+            var deps = new List<Dependency>() { new Dependency() { _id = id, name = name }, new Dependency() { _id = dep_id, name = dep_name } };
+            var depVers = new List<string>() { version, dep_version };
+
+            var pkgVer = new PackageVersion()
+            {
+                version = version,
+                engine_version = "2.1.1",
+                name = name,
+                id = id,
+                full_dependency_ids = deps,
+                full_dependency_versions = depVers
+            };
+
+            //when headers are retrieved for dependencies return the correct header
+            clientmock.Setup(x => x.GetPackageVersionHeader(It.IsAny<string>(), It.IsAny<string>())).Returns<string, string>((i, v) =>
+            {
+                switch (i)
+                {
+                    case "PackageWithDep123":
+                        return pkgVer;
+
+                    case "Dep123":
+                        return dep_pkgVer;
+                    default:
+                        return null;
+                }
+            });
+
+            pmVmMock.Setup(x =>
+                x.InstallPackage(It.IsAny<PackageDownloadHandle>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+
+            //click ok during download.
+            dlgMock.Setup(m => m.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(), It.Is<MessageBoxButton>(x => x == MessageBoxButton.OKCancel || x == MessageBoxButton.OK), It.IsAny<MessageBoxImage>()))
+                .Returns(MessageBoxResult.OK);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            clientmock.Setup(x => x.GetKnownHosts()).Returns(new List<string>() { "Revit", "Civil 3D", "FormIt" });
+
+            // Host is Sandbox, empty string
+            // This will produce a warning dialog
+            pmVmMock.Setup(x => x.Host).Returns("");
+
+            
+            //actually perform the download & install operations
+            pmVmMock.Object.ExecutePackageDownload(id, pkgVer, "");
+
+            // Host is Revit
+            // This will not produce a warning dialog
+            pmVmMock.Setup(x => x.Host).Returns("Revit");
+
+            //actually perform the download & install operations
+            pmVmMock.Object.ExecutePackageDownload(id, pkgVer, "");
+
+            // Host is Civil 3D
+            // This will produce a warning dialog
+            pmVmMock.Setup(x => x.Host).Returns("Civil 3D");
+
+            //actually perform the download & install operations
+            pmVmMock.Object.ExecutePackageDownload(id, pkgVer, "");
+
+            // We should now have showed the warning dialog twice
+            dlgMock.Verify(x => x.Show(It.IsAny<Window>(), Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHosts,
+                Dynamo.Wpf.Properties.Resources.PackageDownloadMessageBoxTitle,
+                MessageBoxButton.OKCancel, MessageBoxImage.Exclamation), Times.Exactly(2));
+        }
+
+        [Test]
         [Description("User tries to download a package with dependencies on other packages but some fail to download.")]
         public void InstallsPackagesEvenIfSomeFailToDownloadShouldNotThrow()
         {


### PR DESCRIPTION
### Purpose

We can't prevent the crash in DYN-4880 but we can improve our messaging when users install packages that targets other hosts.

![image](https://user-images.githubusercontent.com/7033002/171187260-d405543b-5658-492c-bc29-5a7c6a061018.png)

Normal case: Warn if a package target other hosts but not the current host
Special case: Sandbox, warn if a package target only one known host (a conservative way to not warn for packages that works for all hosts). 

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Improves messaging when a user install a package that target a different environment.


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
