### PR TITLE
DYN-4840 Avoid duplicated terms of use if the menu item is clicked

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -47,6 +47,8 @@ namespace Dynamo.ViewModels
         private readonly PackageManagerClient packageManagerClient;
         private readonly AuthenticationManager authenticationManager;
 
+        private static TermsOfUseView termsOfUseView;
+
         public TermsOfUseHelper(TermsOfUseHelperParams touParams)
         {
             if (touParams == null)
@@ -116,11 +118,15 @@ namespace Dynamo.ViewModels
 
         internal static bool ShowTermsOfUseDialog(bool forPublishing, string additionalTerms, Window parent = null)
         {
+            if (termsOfUseView != null) return false;
+
             var executingAssemblyPathName = Assembly.GetExecutingAssembly().Location;
             var rootModuleDirectory = Path.GetDirectoryName(executingAssemblyPathName);
             var touFilePath = Path.Combine(rootModuleDirectory, "TermsOfUse.rtf");
+            
+            termsOfUseView = new TermsOfUseView(touFilePath);
+            termsOfUseView.Closed += TermsOfUseView_Closed;
 
-            var termsOfUseView = new TermsOfUseView(touFilePath);
             if (parent == null)
                 termsOfUseView.ShowDialog();
             else
@@ -129,6 +135,7 @@ namespace Dynamo.ViewModels
                 termsOfUseView.Owner = parent;
                 termsOfUseView.Show();
             }
+
             if (!termsOfUseView.AcceptedTermsOfUse)
                 return false; // User rejected the terms, go no further.
 
@@ -152,6 +159,12 @@ namespace Dynamo.ViewModels
                 additionalTermsView.Show();
             }
             return additionalTermsView.AcceptedTermsOfUse;
+        }
+
+        private static void TermsOfUseView_Closed(object sender, EventArgs e)
+        {
+            termsOfUseView.Closed -= TermsOfUseView_Closed;
+            termsOfUseView = null;
         }
 
         private void ShowTermsOfUseForPublishing()

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -47,7 +47,7 @@ namespace Dynamo.ViewModels
         private readonly PackageManagerClient packageManagerClient;
         private readonly AuthenticationManager authenticationManager;
 
-        private static TermsOfUseView termsOfUseView;
+        private static bool isTermsOfUseCreated;
 
         public TermsOfUseHelper(TermsOfUseHelperParams touParams)
         {
@@ -118,14 +118,15 @@ namespace Dynamo.ViewModels
 
         internal static bool ShowTermsOfUseDialog(bool forPublishing, string additionalTerms, Window parent = null)
         {
-            if (termsOfUseView != null) return false;
+            if (isTermsOfUseCreated) return false;
 
             var executingAssemblyPathName = Assembly.GetExecutingAssembly().Location;
             var rootModuleDirectory = Path.GetDirectoryName(executingAssemblyPathName);
             var touFilePath = Path.Combine(rootModuleDirectory, "TermsOfUse.rtf");
             
-            termsOfUseView = new TermsOfUseView(touFilePath);
+            var termsOfUseView = new TermsOfUseView(touFilePath);
             termsOfUseView.Closed += TermsOfUseView_Closed;
+            isTermsOfUseCreated = true;
 
             if (parent == null)
                 termsOfUseView.ShowDialog();
@@ -163,8 +164,7 @@ namespace Dynamo.ViewModels
 
         private static void TermsOfUseView_Closed(object sender, EventArgs e)
         {
-            termsOfUseView.Closed -= TermsOfUseView_Closed;
-            termsOfUseView = null;
+            isTermsOfUseCreated = false;
         }
 
         private void ShowTermsOfUseForPublishing()


### PR DESCRIPTION
### Purpose

This PR fixes duplicated terms of use if the _packages_ menu item is clicked by verifying if it has already been opened.
Related to the task DYN-4840.

![TermsOfUseDuplicatedBugFix](https://user-images.githubusercontent.com/89042471/170381980-0ab44a31-91bb-42a2-92a1-550a060f8b87.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 