### PR TITLE
GraphicDataProvider Fix: Regression for pointer referencing non-clr objects

### DIFF
--- a/src/Engine/ProtoCore/ClassTable.cs
+++ b/src/Engine/ProtoCore/ClassTable.cs
@@ -494,9 +494,14 @@ namespace ProtoCore.DSASM
             symbol.Id = index;
         }
 
+        /// <summary>
+        /// Retreive the ClassNode at the index.  
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns>ClassNode if found, else null value</returns>
         internal ClassNode GetClassNodeAtIndex(int index)
         {
-            return index < classNodes.Count ? classNodes[index] : null;
+            return index >= 0 && index < classNodes.Count ? classNodes[index] : null;
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/ClassTable.cs
+++ b/src/Engine/ProtoCore/ClassTable.cs
@@ -494,6 +494,11 @@ namespace ProtoCore.DSASM
             symbol.Id = index;
         }
 
+        internal ClassNode GetClassNodeAtIndex(int index)
+        {
+            return index < classNodes.Count ? classNodes[index] : null;
+        }
+
         /// <summary>
         /// Find a matching class for given partial class name.
         /// </summary>

--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -147,21 +147,24 @@ namespace ProtoCore.Mirror
         
         internal object GetCLRObject(StackValue svData, RuntimeCore runtimeCore)
         {
+            if (null == runtimeCore.DSExecutable.classTable)
+                return null;
+
+            //The GetCLRObject function is typically utilized retrieve a clrObject from a StackValue of type pointer.
+            //There is an edge cases for pointers where the pointer references an  a non CLR object.  This code
+            //checks for this edge case by verifying that the requested StackValue pointer is associated with an
+            //imported library.  An example is the "Function" pointer which does not have an associated CLRObject.
+            //In that case, the return value should be null.
+            var classNode = runtimeCore.DSExecutable.classTable.GetClassNodeAtIndex(svData.metaData.type);
+            if (classNode != null  && !classNode.IsImportedClass)
+            {
+                return null;
+            }
+
             if (marshaler != null)
             {
                 return marshaler.UnMarshal(svData, null, interpreter, typeof(object));
             }
-            
-            if (null == runtimeCore.DSExecutable.classTable)
-                return null;
-
-            IList<ClassNode> classNodes = runtimeCore.DSExecutable.classTable.ClassNodes;
-            if (null == classNodes || (classNodes.Count <= 0))
-                return null;
-
-            ClassNode classnode = runtimeCore.DSExecutable.classTable.ClassNodes[svData.metaData.type];
-            if (!classnode.IsImportedClass) //TODO: look at properties to see if it contains any FFI objects.
-                return null;
 
             try
             {

--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -150,8 +150,8 @@ namespace ProtoCore.Mirror
             if (null == runtimeCore.DSExecutable.classTable)
                 return null;
 
-            //The GetCLRObject function is typically utilized retrieve a clrObject from a StackValue of type pointer.
-            //There is an edge cases for pointers where the pointer references an  a non CLR object.  This code
+            //The GetCLRObject function is typically utilized to retrieve a ClrObject from a StackValue of type pointer.
+            //There is an edge cases for pointers where the pointer references a non CLR object.  This code
             //checks for this edge case by verifying that the requested StackValue pointer is associated with an
             //imported library.  An example is the "Function" pointer which does not have an associated CLRObject.
             //In that case, the return value should be null.

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -665,6 +665,19 @@ namespace Dynamo.Tests
 		}
 
         [Test]
+        public void SortBy_PreviewValueIsCorrectForFunction()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\list\SortBy_SimpleTest.dyn");
+            RunModel(openPath);
+
+            var preview = GetPreviewValueInString("42ac0cec-442f-4e4a-b629-1260f6db3d86");
+            Assert.AreEqual("Function()", preview);
+            
+            var value = GetPreviewValue("42ac0cec-442f-4e4a-b629-1260f6db3d86");
+            Assert.Null(value);
+        }
+
+		[Test]
         public void SortByKey_SimpleTest()
         {
             string openPath = Path.Combine(TestDirectory, @"core\list\ListSortByKey.dyn");


### PR DESCRIPTION
### Purpose

This PR fixes a regression associated with task https://jira.autodesk.com/browse/DYN-4229 and the https://github.com/DynamoDS/Dynamo/pull/11920.  This adds back the check for edge cases where some Pointers are not associated with CLR Objects.  That is determined by checking the associated Class within the VM ClassTable is an external library.  

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@sm6srw @aparajit-pratap 

### FYIs

@QilongTang @Amoursol 
