### PR TITLE
Dyn 4977 crash during installation

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -78,7 +78,7 @@ namespace Dynamo.PackageManager
             return FailFunc.TryExecute(() => {
                 var nv = HeaderCollectionDownload.ByEngine("dynamo");
                 var pkgResponse = this.client.ExecuteAndDeserializeWithContent<List<PackageHeader>>(nv);                
-                CleanPackageWithWrongVersions(pkgResponse.content);
+                CleanPackagesWithWrongVersions(pkgResponse.content);
                 return pkgResponse.content;
             }, new List<PackageHeader>());
         }
@@ -87,7 +87,7 @@ namespace Dynamo.PackageManager
         /// For every package Checks its versions and exclude the ones with errors
         /// </summary>
         /// <param name="packages"></param>
-        void CleanPackageWithWrongVersions(List<PackageHeader> packages)
+        void CleanPackagesWithWrongVersions(List<PackageHeader> packages)
         {
             foreach (var package in packages)
             {

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -91,12 +91,12 @@ namespace Dynamo.PackageManager
         {
             foreach (var package in packages)
             {
-                bool packageHasWrongVersion = package.versions.Count(v => v.full_dependency_versions == null) > 0;
+                bool packageHasWrongVersion = package.versions.Count(v => v.url == null) > 0;
 
                 if (packageHasWrongVersion)
                 {
                     List<PackageVersion> cleanVersions = new List<PackageVersion>();
-                    cleanVersions.AddRange(package.versions.Where(v => v.full_dependency_versions != null));
+                    cleanVersions.AddRange(package.versions.Where(v => v.url != null));
                     package.versions = cleanVersions;
                 }
             }

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -77,9 +77,29 @@ namespace Dynamo.PackageManager
         {
             return FailFunc.TryExecute(() => {
                 var nv = HeaderCollectionDownload.ByEngine("dynamo");
-                var pkgResponse = this.client.ExecuteAndDeserializeWithContent<List<PackageHeader>>(nv);
+                var pkgResponse = this.client.ExecuteAndDeserializeWithContent<List<PackageHeader>>(nv);                
+                CleanPackageWithWrongVersions(pkgResponse.content);
                 return pkgResponse.content;
             }, new List<PackageHeader>());
+        }
+
+        /// <summary>
+        /// For every package Checks its versions and exclude the ones with errors
+        /// </summary>
+        /// <param name="packages"></param>
+        void CleanPackageWithWrongVersions(List<PackageHeader> packages)
+        {
+            foreach (var package in packages)
+            {
+                bool packageHasWrongVersion = package.versions.Count(v => v.full_dependency_versions == null) > 0;
+
+                if (packageHasWrongVersion)
+                {
+                    List<PackageVersion> cleanVersions = new List<PackageVersion>();
+                    cleanVersions.AddRange(package.versions.Where(v => v.full_dependency_versions != null));
+                    package.versions = cleanVersions;
+                }
+            }
         }
 
         /// <summary>

--- a/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
@@ -23,7 +23,13 @@ namespace Dynamo.PackageManager.Tests
             {
                 content = new List<PackageHeader>()
                 {
-                    new PackageHeader()
+                    new PackageHeader(){
+                        versions = new List<PackageVersion>(){
+                            new PackageVersion(){
+                                url="test.zip"
+                            }
+                        }
+                    }
                 },
                 success = true
             };


### PR DESCRIPTION
### Purpose

Excluding wrong package versions in order to prevent  Dynamo from Crash
https://jira.autodesk.com/browse/DYN-4977

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

###Reviewers
@QilongTang

###FYIs
@RobertGlobant20 @filipeotero