### PR TITLE
Grey output bar updated

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -921,6 +921,15 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        ///     Are all the inputs of this node disconnected?
+        /// </summary>
+        [JsonIgnore]
+        public bool AreAllInputsDisconnected
+        {
+            get { return inPorts.All(p => !p.IsConnected); }
+        }
+
+        /// <summary>
         ///     Returns the description from type information
         /// </summary>
         /// <returns>The value or "No description provided"</returns>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -101,7 +101,7 @@
                        Grid.Column="1"
                        Height="27px"
                        VerticalAlignment="Center"
-                       Fill="{Binding PortValueMarkerColor, UpdateSourceTrigger=PropertyChanged}"
+                       Fill="#999999"
                        IsHitTestVisible="False"
                        Visibility="{Binding PortDefaultValueMarkerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
                        SnapsToDevicePixels="True" />

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -192,7 +192,6 @@ namespace Dynamo.ViewModels
                 case nameof(UsingDefaultValue):
                     RaisePropertyChanged(nameof(UsingDefaultValue));
                     RefreshPortDefaultValueMarkerVisible();
-                    RefreshPortColors();
                     break;
                 case nameof(DefaultValueEnabled):
                     RefreshPortDefaultValueMarkerVisible();
@@ -205,12 +204,25 @@ namespace Dynamo.ViewModels
                     break;
                 case nameof(KeepListStructure):
                     RaisePropertyChanged(nameof(ShouldKeepListStructure));
-                    RefreshPortColors();
                     break;
                 case nameof(IsConnected):
-                    RefreshPortColors();
+                    RaisePropertyChanged(nameof(IsConnected));
+                    RefreshAllPortColors();
                     break;
             }
+        }
+
+        private void RefreshAllPortColors()
+        {
+            foreach (InPortViewModel port in node.InPorts)
+            {
+                port.RefreshInputColors();
+            }
+        }
+
+        internal void RefreshInputColors()
+        {
+            RefreshPortColors();
         }
 
         /// <summary>
@@ -298,7 +310,7 @@ namespace Dynamo.ViewModels
 
             if (isFunctionNode)
             {
-                if (node.NodeModel.AreAllOutputsConnected)
+                if (node.NodeModel.AreAllOutputsConnected && node.NodeModel.AreAllInputsDisconnected)
                 {
                     PortValueMarkerColor = PortValueMarkerGrey;
                     PortBackgroundColor = PortBackgroundColorDefault;
@@ -317,16 +329,13 @@ namespace Dynamo.ViewModels
 
         internal void RefreshInputPortsByOutputConnectionChanged(bool isOutputConnected)
         {
-            if (node.NodeModel.IsPartiallyApplied)
+            if (node.NodeModel.AreAllInputsDisconnected && isOutputConnected)
             {
-                if (isOutputConnected)
-                {
-                    PortValueMarkerColor = PortValueMarkerGrey;
-                }
-                else
-                {
-                    SetupDefaultPortColorValues();
-                }
+                PortValueMarkerColor = PortValueMarkerGrey;
+            }
+            else
+            {
+                SetupDefaultPortColorValues();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -309,17 +309,13 @@ namespace Dynamo.ViewModels
 
         protected override void RefreshPortColors()
         {
-            //This variable checks if the node is a function class
             var isCachedValueNull = node.NodeModel.CachedValue == null || node.NodeModel.CachedValue.Data == null;
-            var isFunctionNode = isCachedValueNull && node.NodeModel.IsPartiallyApplied
-                || !isCachedValueNull && node.NodeModel.CachedValue.IsFunction;
 
-            if (isFunctionNode)
+            if (node.NodeModel.CachedValue != null  && node.NodeModel.CachedValue.IsFunction)
             {
                 PortDefaultValueMarkerVisible = true;
-                portValueMarkerColor = PortValueMarkerGrey;
             }
-            else
+            else if (isCachedValueNull)
             {
                 PortDefaultValueMarkerVisible = false;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -379,7 +379,6 @@ namespace Dynamo.ViewModels
             {
                 case "ActiveConnector":
                     RaisePropertyChanged(nameof(IsHitTestVisible));
-                    RefreshPortColors();
                     break;
                 default:
                     break;
@@ -401,6 +400,9 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged(nameof(ToolTipContent));
                     break;
                 case nameof(node.IsVisible):
+                    RefreshPortColors();
+                    break;
+                case nameof(node.NodeModel.CachedValue):
                     RefreshPortColors();
                     break;
             }
@@ -431,6 +433,9 @@ namespace Dynamo.ViewModels
                     break;
                 case nameof(MarginThickness):
                     RaisePropertyChanged(nameof(MarginThickness));
+                    break;
+                case nameof(UsingDefaultValue):
+                    RefreshPortColors();
                     break;
             }
         }


### PR DESCRIPTION
### Purpose

Grey bar on output ports = Exists whenever a function is returned from the node, in any scenario.

![image](https://user-images.githubusercontent.com/89042471/170718460-611d8391-c446-4d53-91ef-ff247a3fff1a.png)

Grey bar's should not exist in a node's pre-run state as the output is not there and the node will show a null value.

![image](https://user-images.githubusercontent.com/89042471/170718603-86757524-1417-4b9c-98f8-7a74401e401c.png)

Grey bar's on input ports = Should only exist in a function passing state, when there is nothing connected to any input port, and the output port is connected.

![ExampleGreyBar](https://user-images.githubusercontent.com/89042471/170744517-4141f8ba-0e60-4085-a6fc-ffd85221f960.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
