### PR TITLE
DYN-4975-FileTrustUI-PreferencesSettings

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -142,17 +142,6 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Returns the state of the Preferences Window Debug Mode
-        /// </summary>
-        public bool PreferencesDebugMode
-        {
-            get
-            {
-                return DebugModes.IsEnabled("DynamoPreferencesMenuDebugMode");
-            }
-        }
-
-        /// <summary>
         /// Returns all installed packages
         /// </summary>
         public ObservableCollection<PackageViewModel> LocalPackages => installedPackagesViewModel.LocalPackages;

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -7,7 +7,6 @@ using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Models;
 using Dynamo.ViewModels;
-using Dynamo.Wpf.Controls;
 using Dynamo.Wpf.ViewModels;
 using Dynamo.Wpf.ViewModels.FileTrust;
 
@@ -107,7 +106,23 @@ namespace Dynamo.Wpf.Views.FileTrust
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
-            //Launch the Preference panel in the Security tab
+            const string securityTabName = "Security";
+            const string trustedTabExpanderName = "TrustedPathsExpander";
+
+            var preferencesWindow = new PreferencesView(mainWindow as DynamoView);
+            var tabControl = preferencesWindow.preferencesTabControl;
+            if (tabControl == null) return;
+            var securityTab = (from TabItem tabItem in tabControl.Items
+                               where tabItem.Header.ToString().Equals(securityTabName)
+                               select tabItem).FirstOrDefault();
+            if (securityTab == null) return;
+            tabControl.SelectedItem = securityTab;
+            var trustedPathExpander = securityTab.FindName(trustedTabExpanderName) as Expander;
+            if (trustedPathExpander == null) return;
+            trustedPathExpander.IsExpanded = true;
+
+            preferencesWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            preferencesWindow.ShowDialog();
         }
 
         private void CloseFileButton_Click(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -158,7 +158,8 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <TabControl TabStripPlacement="Left" 
+                <TabControl x:Name="preferencesTabControl"
+                            TabStripPlacement="Left" 
                             Background="{StaticResource PreferencesWindowBackgroundColor}">
                     
                     <!--General Tab-->
@@ -859,8 +860,7 @@
                     
                     <!--Security Settings Tab-->
                     <TabItem Header="{x:Static p:Resources.PreferencesSecuritySettingsTab}"
-                             Style="{StaticResource LeftTab}"
-                             Visibility="{Binding PreferencesDebugMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                             Style="{StaticResource LeftTab}">
                         <!--This Grid contains the package manager settings tab-->
                         <Grid x:Name="SecurityTab" 
                               Margin="1"

--- a/src/DynamoUtilities/DebugModes.cs
+++ b/src/DynamoUtilities/DebugModes.cs
@@ -54,8 +54,6 @@ namespace Dynamo.Utilities
         {
             // Register app wide new debug modes here.
             AddDebugMode("DumpByteCode", "Dumps bytecode to a log file in a folder called ByteCodeLogs located in the current working dirrectory.", false);
-
-            AddDebugMode("DynamoPreferencesMenuDebugMode", "Enable/Disable the Preferences Panel new features in the Dynamo menu.", false);
         }
 
         internal static void LoadDebugModesStatusFromConfig(string configPath)


### PR DESCRIPTION
### Purpose

Connecting the FileTrustUI Settings button with opening the Preferences panel.
I've removed the Debug mode for Preferences settings and also I've added the needed code for execute the Preferences panel in the Security tab and expand the TrustedPaths section.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Connecting the FileTrustUI Settings button with opening the Preferences panel.


### Reviewers

@QilongTang 

### FYIs
