### PR TITLE
Fix Publish package remove item bug

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1335,15 +1335,28 @@ namespace Dynamo.PackageManager
         {
             if (!(parameter is PackageItemRootViewModel packageItemRootViewModel)) return;
 
-            if (packageItemRootViewModel.FileInfo == null || packageItemRootViewModel.FileInfo == null)
-            {
-                PackageContents.Remove(PackageContents
-                    .First(x => x.Name == packageItemRootViewModel.Name));
-                return;
-            }
+            string fileName = packageItemRootViewModel.FileInfo == null ? packageItemRootViewModel.Name : packageItemRootViewModel.FileInfo.FullName;
+            string fileType = packageItemRootViewModel.DependencyType.ToString();
 
-            PackageContents.Remove(PackageContents
-                .First(x => x.FileInfo?.FullName == packageItemRootViewModel.FileInfo.FullName));
+            if (fileName.ToLower().EndsWith(".dll") || fileType.Equals("Assembly"))
+            {
+                Assemblies.Remove(Assemblies
+                    .First(x => x.Name == Path.GetFileNameWithoutExtension(fileName)));
+            }
+            else if (fileType.Equals("CustomNode"))
+            {
+                CustomNodeDefinitions.Remove(CustomNodeDefinitions
+                    .First(x => x.DisplayName == fileName));
+            }
+            else
+            {
+                AdditionalFiles.Remove(AdditionalFiles
+                    .First(x => x == fileName));
+            }
+                        
+            RefreshPackageContents();
+            return;
+
         }
 
         private bool CanShowAddFileDialogAndAdd()

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1338,12 +1338,12 @@ namespace Dynamo.PackageManager
             string fileName = packageItemRootViewModel.FileInfo == null ? packageItemRootViewModel.Name : packageItemRootViewModel.FileInfo.FullName;
             string fileType = packageItemRootViewModel.DependencyType.ToString();
 
-            if (fileName.ToLower().EndsWith(".dll") || fileType.Equals("Assembly"))
+            if (fileName.ToLower().EndsWith(".dll") || fileType.Equals(DependencyType.Assembly))
             {
                 Assemblies.Remove(Assemblies
                     .First(x => x.Name == Path.GetFileNameWithoutExtension(fileName)));
             }
-            else if (fileType.Equals("CustomNode"))
+            else if (fileType.Equals(DependencyType.CustomNode))
             {
                 CustomNodeDefinitions.Remove(CustomNodeDefinitions
                     .First(x => x.DisplayName == fileName));

--- a/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
@@ -9,6 +9,7 @@ using Dynamo.PackageManager;
 using Dynamo.Tests;
 using NUnit.Framework;
 using Moq;
+using Dynamo.PackageManager.UI;
 
 namespace DynamoCoreWpfTests
 {
@@ -120,6 +121,36 @@ namespace DynamoCoreWpfTests
             });
 
             Assert.AreEqual(PackageUploadHandle.State.Error, vm.UploadState);
+        }
+
+        [Test]
+        public void NewPackageVersionUpload_CanAddAndRemoveFiles()
+        {
+            string packagesDirectory = Path.Combine(TestDirectory, "pkgs");
+            string addFilePath = Path.Combine(packagesDirectory, "testFile.txt");
+            PackageItemRootViewModel pkgItem = new PackageItemRootViewModel(new FileInfo(addFilePath));
+
+            var pathManager = new Mock<Dynamo.Interfaces.IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { packagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            loader.LoadAll(new LoadPackageParams
+            {
+                Preferences = ViewModel.Model.PreferenceSettings
+            });
+
+            PublishPackageViewModel vm = null;
+            var package = loader.LocalPackages.FirstOrDefault(x => x.Name == "Custom Rounding");
+            Assert.DoesNotThrow(() =>
+            {
+                vm = PublishPackageViewModel.FromLocalPackage(ViewModel, package);
+            });
+
+            vm.AddFile(addFilePath);
+            Assert.AreEqual(1, vm.AdditionalFiles.Count);
+
+            vm.RemoveItemCommand.Execute(pkgItem);
+            Assert.AreEqual(0, vm.AdditionalFiles.Count);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Fix a bug in Dynamo Publish Package window, where user was unable to remove an item after publishing it it the next version. The problem was that the PackageContent list was being refreshed, bringing all the concatenated files back, including the deleted ones, therefore now we are updating each separate file list as well, so that a PackageContent refresh won't affect the delete action.

![Revit_Pl22aPmiz0](https://user-images.githubusercontent.com/32665108/170788361-a29b48a6-4cde-4212-b944-a27a94d794fd.gif)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
