### PR TITLE
DYN-4903 Wrong dialog step 4 of packages tour

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -74,9 +74,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         internal static void ExecuteTermsOfServiceFlow(Step stepInfo, StepUIAutomation uiAutomationData, bool enableFunction, GuideFlow currentFlow)
         {
             CurrentExecutingStep = stepInfo;
-
-            if (stepInfo.ExitGuide != null)
-                exitGuide = stepInfo.ExitGuide;
+            exitGuide = stepInfo.ExitGuide;
 
             //When enableFunction = true, means we want to show the TermsOfUse Window (this is executed in the UIAutomation step in the Show() method)
             if (enableFunction)
@@ -146,9 +144,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if (enableFunction)
             {
                 CurrentExecutingStep = stepInfo;
-
-                if (stepInfo.ExitGuide != null)
-                    exitGuide = stepInfo.ExitGuide;
+                exitGuide = stepInfo.ExitGuide;
 
                 Window ownedWindow = GuideUtilities.FindWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window);
 
@@ -156,8 +152,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 {
                     if (ownedWindow == null) return;
 
-                    CloseButtonSearchPackages = GuideUtilities.FindChild(ownedWindow, handler.HandlerElement) as Button;
-                    CloseButtonSearchPackages.Click += CloseButton_Click;
+                    if(CloseButtonSearchPackages == null)
+                    {
+                        CloseButtonSearchPackages = GuideUtilities.FindChild(ownedWindow, handler.HandlerElement) as Button;
+                        CloseButtonSearchPackages.Click += CloseButton_Click;
+                    }
                 }
             }
             else
@@ -291,6 +290,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <param name="e"></param>
         internal static void CloseButton_Click(object sender, RoutedEventArgs e)
         {
+            CloseButtonSearchPackages = null;
             CloseTour();
         }
 
@@ -310,6 +310,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         internal static void ExecutePackageSearch(Step stepInfo, StepUIAutomation uiAutomationData, bool enableFunction, GuideFlow currentFlow)
         {
             CurrentExecutingStep = stepInfo;
+            exitGuide = stepInfo.ExitGuide;
             //We try to find the PackageManagerSearchView window
             Window ownedWindow = GuideUtilities.FindWindowOwned(stepInfo.HostPopupInfo.WindowName, stepInfo.MainWindow as Window);
             if (enableFunction)


### PR DESCRIPTION
### Purpose

This PR includes the fix for a bug related to the exit popup when in step 4.

![ExitPopupWrong](https://user-images.githubusercontent.com/89042471/171275869-4e79c852-c693-4fb0-b597-afda71c424de.gif)


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
