### PR TITLE
Type Identifiers in preview bubble and watch node.

### DIFF
--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -119,22 +119,22 @@ namespace Dynamo.Interfaces
                 return new WatchViewModel(((Enum)value).GetDescription(), tag, RequestSelectGeometry);
             }
 
-            return new WatchViewModel(ToString(value), tag, RequestSelectGeometry);
+            return new WatchViewModel(value, tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(double value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
+            return new WatchViewModel(value, tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(System.DateTime value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
+            return new WatchViewModel(value, tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(long value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
+            return new WatchViewModel(value, tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(string value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -91,6 +91,16 @@
     <!--  Node colors in selected state  -->
     <SolidColorBrush x:Key="outerBorderSelection" Color="#4192d9" />
 
+    <!-- NodeLabel colors -->
+    <SolidColorBrush x:Key="stringLabelBackground"
+                     Color="#c3ae9d" />
+    <SolidColorBrush x:Key="numberLabelBackground"
+                     Color="#91c2f2" />
+    <SolidColorBrush x:Key="objectLabelBackground"
+                     Color="#a1a1a1" />
+    <SolidColorBrush x:Key="boolLabelBackground"
+                     Color="#c6afd5" />
+
     <!-- Node Autocomplete -->
     <SolidColorBrush x:Key="autocompletionWindow" Color="#535353" />
     <SolidColorBrush x:Key="AutocompletionWindowFontColor" Color="#F5F5F5" />

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -248,6 +248,9 @@ namespace Dynamo.ViewModels
                 case TypeCode.Double:
                     return ((double)obj).ToString(numberFormat, CultureInfo.InvariantCulture);
 
+                case TypeCode.Int32:
+                    return ((int)obj).ToString(CultureInfo.InvariantCulture);
+
                 case TypeCode.Int64:
                     return ((long)obj).ToString(CultureInfo.InvariantCulture);
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -18,6 +18,12 @@ namespace Dynamo.ViewModels
         // For more info: https://msdn.microsoft.com/en-us/library/kfsatb94(v=vs.110).aspx
         private const string numberFormat = "g";
 
+        private static readonly string doubleType = "double";
+        private static readonly string boolType = "bool";
+        private static readonly string intType = "int";
+        private static readonly string objectType = "object";
+        private static readonly string stringType = "string";
+
         #region Events
 
         public event Action Clicked;
@@ -220,6 +226,10 @@ namespace Dynamo.ViewModels
 
         public WatchViewModel(Action<string> tagGeometry) : this(null, null, tagGeometry, true) { }
 
+        /// <summary>
+        /// This is added to set the Type identifier for the watch data. 
+        /// It calls the base constructor internally.
+        /// </summary> 
         public WatchViewModel(object obj, string path, Action<string> tagGeometry, bool expanded = false) : this(GetStringFromObject(obj), path, tagGeometry, expanded)
         {
             ValueType = GetDisplayType(obj);
@@ -244,22 +254,16 @@ namespace Dynamo.ViewModels
             {
                 case TypeCode.Boolean:
                     return ObjectToLabelString(obj);
-
                 case TypeCode.Double:
                     return ((double)obj).ToString(numberFormat, CultureInfo.InvariantCulture);
-
                 case TypeCode.Int32:
                     return ((int)obj).ToString(CultureInfo.InvariantCulture);
-
                 case TypeCode.Int64:
                     return ((long)obj).ToString(CultureInfo.InvariantCulture);
-
                 case TypeCode.DateTime:
                     return ((DateTime)obj).ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture);
-
                 case TypeCode.Object:
                     return ObjectToLabelString(obj);
-
                 default:
                     return (string)obj;
             };
@@ -286,21 +290,21 @@ namespace Dynamo.ViewModels
             switch (typeCode)
             {
                 case TypeCode.Boolean:
-                    return "bool";
+                    return boolType;
                 case TypeCode.Double:
-                    return "double";
+                    return doubleType;
                 case TypeCode.Int64:
-                    return "int";
+                    return intType;
                 case TypeCode.Int32:
-                    return "int";
+                    return intType;
                 case TypeCode.Object:
-                    return "object";
+                    return objectType;
                 case TypeCode.String:
-                    return "string";
+                    return stringType;
                 case TypeCode.Empty:
-                    return "";
+                    return String.Empty;
                 default:
-                    return "";
+                    return String.Empty;
             }
         }
         private bool CanFindNodeForPath(object obj)

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -356,6 +356,47 @@
                                    FontFamily="{StaticResource SourceCodePro}"
                                    Text="{Binding Path=NodeLabel}"
                                    Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
+
+                        <Grid Margin="4 0 0 0">
+                            <Border CornerRadius="3,3,3,3">
+                                <Border.Style>
+                                    <Style>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="string">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource stringLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="int">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource numberLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="double">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource numberLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}" Value="object">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource objectLabelBackground}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ValueType}"
+                                                         Value="bool">
+                                                <Setter Property="Border.Background"
+                                                        Value="{DynamicResource boolLabelBackground}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
+                            <TextBlock Text="{Binding ValueType}"
+                                       FontStyle="Italic"
+                                       FontSize="8"
+                                       VerticalAlignment="Center"
+                                       Width="Auto"
+                                       FontFamily="Consolas"
+                                       Margin="2 0 2 0">
+                            </TextBlock>
+                        </Grid>
+                        
                         <Button Margin="10,2,2,2"
                                 Padding="4,0,4,0"
                                 VerticalAlignment="Center"

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -443,7 +443,7 @@ namespace DynamoCoreWpfTests
 
             var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
             // watch is computed with cbn and has its value
-            Assert.AreEqual(8, items.Count());
+            Assert.AreEqual(12, items.Count());
 
             // disconnect watch
             Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -299,7 +299,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, tree.Count());
 
             var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(8, items.Count());
+            Assert.AreEqual(12, items.Count());
         }
 
         [Test, Category("DisplayHardwareDependent")]
@@ -471,7 +471,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
             tree = nodeView.ChildrenOfType<WatchTree>();
             items = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(8, items.Count());
+            Assert.AreEqual(12, items.Count());
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This PR is to implement type identifiers for the data in preview bubble and watch node. 

Task: https://jira.autodesk.com/browse/DYN-3416

<img width="953" alt="Screen Shot 2022-06-06 at 9 40 27 AM" src="https://user-images.githubusercontent.com/43763136/172172157-d398301d-e1aa-4b4f-be2c-a8c17336d615.png">

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers
@QilongTang @zeusongit 

