### PR TITLE
DYN-4759-RunAutomatic-Bug

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1960,6 +1960,16 @@ namespace Dynamo.Models
                 CustomNodeManager,
                 this.LinterManager);
 
+            var directoryName = Path.GetDirectoryName(filePath);
+            if (!PreferenceSettings.TrustedLocations.Contains(directoryName) && DynamoModel.IsTestMode == false)
+            {
+                RunSettings.ForceAutomaticWithoutRun = true;
+            }
+            else
+            {
+                RunSettings.ForceAutomaticWithoutRun = false;
+            }
+
             workspace.FileName = string.IsNullOrEmpty(filePath) ? "" : filePath;
             workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
 

--- a/src/DynamoCore/Models/RunSettings.cs
+++ b/src/DynamoCore/Models/RunSettings.cs
@@ -22,7 +22,10 @@ namespace Dynamo.Models
         private bool runTypesEnabled;
         private bool runTypesComboBoxToolTipIsEnabled;
 
-        internal bool ForceAutomaticWithoutRun { get; set; } = false;
+        /// <summary>
+        /// This static property with true value will be used when opening a dyn file with RunMode = Automatic and we don't want to execute the graph
+        /// </summary>
+        internal static bool ForceAutomaticWithoutRun { get; set; } = false;
 
         /// <summary>
         /// Default milliseconds number for the period in periodic run.

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1609,7 +1609,7 @@ namespace Dynamo.ViewModels
                 bool bShowFileTrustWarning = false;
                 if(!PreferenceSettings.TrustedLocations.Contains(directoryName) && DynamoModel.IsTestMode == false)
                 {
-                    HomeSpace.RunSettings.ForceAutomaticWithoutRun = true;
+                    RunSettings.ForceAutomaticWithoutRun = true;
                     bShowFileTrustWarning = true;
                 }
                 ExecuteCommand(new DynamoModel.OpenFileCommand(filePath, forceManualMode));
@@ -2345,8 +2345,7 @@ namespace Dynamo.ViewModels
                 // If after closing the HOME workspace, and there are no other custom 
                 // workspaces opened at the time, then we should show the start page.
                 this.ShowStartPage = (Model.Workspaces.Count() <= 1);
-                if (HomeSpace.RunSettings != null)
-                    HomeSpace.RunSettings.ForceAutomaticWithoutRun = false;
+                RunSettings.ForceAutomaticWithoutRun = false;
             }
         }
 


### PR DESCRIPTION
### Purpose

A bug was reported during testing due that when opening a dyn file with RunMode=Automatic the graph was executed even when showing the file trust warning.
The property ForceAutomaticWithoutRun was converted to be static due that is used in several places and we need to use it before and after executing the OpenFileCommand, due that the call for opening the file is async and the RunSettings instance is created two times one when we open a dyn file and the other one when dynamo is opened then this property needs to be static.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing bug reported during testing due that when opening a dyn file with RunMode=Automatic the graph was executed even when showing the file trust warning.

### Reviewers

@QilongTang 

### FYIs

