### PR TITLE
Return correct type indices for primitive types referred to by their CLR type names

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -463,10 +463,10 @@ namespace ProtoCore.Lang
                     }
                 case BuiltInMethods.MethodID.Evaluate:
                     ret = ArrayUtilsForBuiltIns.Evaluate(
-                        formalParameters[0],
-                        formalParameters[1],
+                        formalParameters[0], 
+                        formalParameters[1], 
                         formalParameters[2],
-                        interpreter,
+                        interpreter, 
                         stackFrame);
                     break;
                 case BuiltInMethods.MethodID.NodeAstFailed:
@@ -545,7 +545,7 @@ namespace ProtoCore.Lang
 
 
             blockCaller = runtimeCore.DebugProps.CurrentBlockId;
-            StackFrame bounceStackFrame = new StackFrame(svThisPtr, ci, fi, returnAddr, blockDecl, blockCaller, callerType, type,
+            StackFrame bounceStackFrame = new StackFrame(svThisPtr, ci, fi, returnAddr, blockDecl, blockCaller, callerType, type, 
                 depth, framePointer, 0, interpreter.runtime.GetRegisters(), 0);
 
             StackValue ret = interpreter.runtime.Bounce(blockId, 0, bounceStackFrame, 0, false, runtimeCore.CurrentExecutive.CurrentDSASMExec, runtimeCore.Breakpoints);
@@ -684,21 +684,21 @@ namespace ProtoCore.Lang
             }
 
             // Build the stackframe
-            var newStackFrame = new StackFrame(thisObject,
-                                               stackFrame.ClassScope,
-                                               procNode == null ? procIndex : procNode.ID,
-                                               stackFrame.ReturnPC,
-                                               stackFrame.FunctionBlock,
-                                               stackFrame.FunctionCallerBlock,
+            var newStackFrame = new StackFrame(thisObject, 
+                                               stackFrame.ClassScope, 
+                                               procNode == null ? procIndex : procNode.ID, 
+                                               stackFrame.ReturnPC, 
+                                               stackFrame.FunctionBlock, 
+                                               stackFrame.FunctionCallerBlock, 
                                                stackFrame.StackFrameType,
-                                               StackFrameType.Function,
+                                               StackFrameType.Function, 
                                                0,
-                                               rmem.FramePointer,
+                                               rmem.FramePointer, 
                                                0,
-                                               stackFrame.GetRegisters(),
+                                               stackFrame.GetRegisters(), 
                                                0);
 
-            ProtoCore.CallSite callsite = runtimeData.GetCallSite(thisObjectType, functionName, runtime.exe, runtimeCore);
+            ProtoCore.CallSite callsite = runtimeData.GetCallSite( thisObjectType, functionName, runtime.exe, runtimeCore);
             Validity.Assert(null != callsite);
 
             // TODO: Disabling support for stepping into replicated function calls temporarily - pratapa
@@ -826,7 +826,7 @@ namespace ProtoCore.Lang
             {
                 if (instructions[pc].debug != null)
                 {
-                    if (!runtimeCore.Breakpoints.Contains(instructions[pc]))
+                    if(!runtimeCore.Breakpoints.Contains(instructions[pc]))
                         runtimeCore.Breakpoints.Add(instructions[pc]);
                     break;
                 }
@@ -848,7 +848,7 @@ namespace ProtoCore.Lang
         internal static string ConvertToString(StackValue st, ProtoCore.DSASM.Interpreter runtime)
         {
             string result = "";
-            if (!st.IsString)
+            if (!st.IsString) 
                 return result;
 
             result = runtime.runtime.rmem.Heap.ToHeapObject<DSString>(st).Value;
@@ -874,7 +874,7 @@ namespace ProtoCore.Lang
             string filename = ConvertToString(fn, runtime);
             string path = FileUtils.GetDSFullPathName(filename, runtime.runtime.RuntimeCore.Options);
             // File not existing.
-            if (null == path || !File.Exists(path))
+            if(null==path || !File.Exists(path))
             {
                 string message = String.Format(Resources.kFileNotFound, path);
                 runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.FileNotExist, message);
@@ -902,7 +902,7 @@ namespace ProtoCore.Lang
                                 line[count] = Double.Parse(elementStr);
                             else line[count] = Int32.Parse(elementStr);
                         }
-                        catch (Exception)
+                        catch(Exception)
                         {
                             line[count] = elementStr;
                         }
@@ -981,7 +981,7 @@ namespace ProtoCore.Lang
             ProtoCore.DSASM.Mirror.ExecutionMirror mirror = new DSASM.Mirror.ExecutionMirror(runtime.runtime, runtime.runtime.RuntimeCore);
             string result = mirror.GetStringValue(msg, runtime.runtime.rmem.Heap, 0, true);
 #if DEBUG
-
+            
             //For Console output
             Console.WriteLine(result);
 #endif
@@ -998,13 +998,13 @@ namespace ProtoCore.Lang
         }
     }
 
-
-
+         
+        
     internal class MapBuiltIns
     {
         internal static double Map(double rangeMin, double rangeMax, double inputValue)
         {
-            double result = (inputValue - rangeMin) / (rangeMax - rangeMin);
+            double result =  (inputValue - rangeMin) / (rangeMax - rangeMin);
             if (result < 0)
             {
                 return 0.0;
@@ -1024,9 +1024,9 @@ namespace ProtoCore.Lang
             double rangeMax,
             double inputValue,
             double targetRangeMin,
-            double targetRangeMax)
+            double targetRangeMax) 
         {
-            double percent = Map(rangeMin, rangeMax, inputValue);
+            double percent = Map(rangeMin, rangeMax, inputValue); 
             return targetRangeMin + (targetRangeMax - targetRangeMin) * percent;
         }
     }
@@ -1185,7 +1185,7 @@ namespace ProtoCore.Lang
                             decimal stepsize = (start > end) ? -1 : 1;
                             if (hasStep)
                             {
-                                stepsize = new decimal(svStep.IsDouble ? svStep.DoubleValue : svStep.IntegerValue);
+                                stepsize = new decimal(svStep.IsDouble ? svStep.DoubleValue: svStep.IntegerValue);
                                 isIntRange = isIntRange && (svStep.IsInteger);
                             }
 
@@ -1212,7 +1212,7 @@ namespace ProtoCore.Lang
                         }
                     case (int)RangeStepOperator.Number:
                         {
-                            decimal stepnum = new decimal(Math.Round(svStep.IsDouble ? svStep.DoubleValue : svStep.IntegerValue));
+                            decimal stepnum = new decimal(Math.Round(svStep.IsDouble ? svStep.DoubleValue: svStep.IntegerValue));
                             if (stepnum <= 0)
                             {
                                 return null;
@@ -1312,11 +1312,11 @@ namespace ProtoCore.Lang
             int stepnum = (int)Math.Abs(Math.Truncate((endLetter - startLetter) / (double)step)) + 1;
 
             letters = Enumerable.Range(1, stepnum)
-                 // Generate arithmetic progression.
+                // Generate arithmetic progression.
                  .Select(x => startLetter + (x - 1) * step * stepOffset)
-                 // Take just letters.
+                // Take just letters.
                  .Where(x => Char.IsLetter((char)x))
-                 // Create stack values.
+                // Create stack values.
                  .Select(x => StackValue.BuildString(Char.ToString((char)x), runtimeCore.Heap))
                  .ToArray();
 

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -463,10 +463,10 @@ namespace ProtoCore.Lang
                     }
                 case BuiltInMethods.MethodID.Evaluate:
                     ret = ArrayUtilsForBuiltIns.Evaluate(
-                        formalParameters[0], 
-                        formalParameters[1], 
+                        formalParameters[0],
+                        formalParameters[1],
                         formalParameters[2],
-                        interpreter, 
+                        interpreter,
                         stackFrame);
                     break;
                 case BuiltInMethods.MethodID.NodeAstFailed:
@@ -545,7 +545,7 @@ namespace ProtoCore.Lang
 
 
             blockCaller = runtimeCore.DebugProps.CurrentBlockId;
-            StackFrame bounceStackFrame = new StackFrame(svThisPtr, ci, fi, returnAddr, blockDecl, blockCaller, callerType, type, 
+            StackFrame bounceStackFrame = new StackFrame(svThisPtr, ci, fi, returnAddr, blockDecl, blockCaller, callerType, type,
                 depth, framePointer, 0, interpreter.runtime.GetRegisters(), 0);
 
             StackValue ret = interpreter.runtime.Bounce(blockId, 0, bounceStackFrame, 0, false, runtimeCore.CurrentExecutive.CurrentDSASMExec, runtimeCore.Breakpoints);
@@ -684,21 +684,21 @@ namespace ProtoCore.Lang
             }
 
             // Build the stackframe
-            var newStackFrame = new StackFrame(thisObject, 
-                                               stackFrame.ClassScope, 
-                                               procNode == null ? procIndex : procNode.ID, 
-                                               stackFrame.ReturnPC, 
-                                               stackFrame.FunctionBlock, 
-                                               stackFrame.FunctionCallerBlock, 
+            var newStackFrame = new StackFrame(thisObject,
+                                               stackFrame.ClassScope,
+                                               procNode == null ? procIndex : procNode.ID,
+                                               stackFrame.ReturnPC,
+                                               stackFrame.FunctionBlock,
+                                               stackFrame.FunctionCallerBlock,
                                                stackFrame.StackFrameType,
-                                               StackFrameType.Function, 
+                                               StackFrameType.Function,
                                                0,
-                                               rmem.FramePointer, 
+                                               rmem.FramePointer,
                                                0,
-                                               stackFrame.GetRegisters(), 
+                                               stackFrame.GetRegisters(),
                                                0);
 
-            ProtoCore.CallSite callsite = runtimeData.GetCallSite( thisObjectType, functionName, runtime.exe, runtimeCore);
+            ProtoCore.CallSite callsite = runtimeData.GetCallSite(thisObjectType, functionName, runtime.exe, runtimeCore);
             Validity.Assert(null != callsite);
 
             // TODO: Disabling support for stepping into replicated function calls temporarily - pratapa
@@ -826,7 +826,7 @@ namespace ProtoCore.Lang
             {
                 if (instructions[pc].debug != null)
                 {
-                    if(!runtimeCore.Breakpoints.Contains(instructions[pc]))
+                    if (!runtimeCore.Breakpoints.Contains(instructions[pc]))
                         runtimeCore.Breakpoints.Add(instructions[pc]);
                     break;
                 }
@@ -848,7 +848,7 @@ namespace ProtoCore.Lang
         internal static string ConvertToString(StackValue st, ProtoCore.DSASM.Interpreter runtime)
         {
             string result = "";
-            if (!st.IsString) 
+            if (!st.IsString)
                 return result;
 
             result = runtime.runtime.rmem.Heap.ToHeapObject<DSString>(st).Value;
@@ -874,7 +874,7 @@ namespace ProtoCore.Lang
             string filename = ConvertToString(fn, runtime);
             string path = FileUtils.GetDSFullPathName(filename, runtime.runtime.RuntimeCore.Options);
             // File not existing.
-            if(null==path || !File.Exists(path))
+            if (null == path || !File.Exists(path))
             {
                 string message = String.Format(Resources.kFileNotFound, path);
                 runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.FileNotExist, message);
@@ -902,7 +902,7 @@ namespace ProtoCore.Lang
                                 line[count] = Double.Parse(elementStr);
                             else line[count] = Int32.Parse(elementStr);
                         }
-                        catch(Exception)
+                        catch (Exception)
                         {
                             line[count] = elementStr;
                         }
@@ -981,7 +981,7 @@ namespace ProtoCore.Lang
             ProtoCore.DSASM.Mirror.ExecutionMirror mirror = new DSASM.Mirror.ExecutionMirror(runtime.runtime, runtime.runtime.RuntimeCore);
             string result = mirror.GetStringValue(msg, runtime.runtime.rmem.Heap, 0, true);
 #if DEBUG
-            
+
             //For Console output
             Console.WriteLine(result);
 #endif
@@ -998,13 +998,13 @@ namespace ProtoCore.Lang
         }
     }
 
-         
-        
+
+
     internal class MapBuiltIns
     {
         internal static double Map(double rangeMin, double rangeMax, double inputValue)
         {
-            double result =  (inputValue - rangeMin) / (rangeMax - rangeMin);
+            double result = (inputValue - rangeMin) / (rangeMax - rangeMin);
             if (result < 0)
             {
                 return 0.0;
@@ -1024,9 +1024,9 @@ namespace ProtoCore.Lang
             double rangeMax,
             double inputValue,
             double targetRangeMin,
-            double targetRangeMax) 
+            double targetRangeMax)
         {
-            double percent = Map(rangeMin, rangeMax, inputValue); 
+            double percent = Map(rangeMin, rangeMax, inputValue);
             return targetRangeMin + (targetRangeMax - targetRangeMin) * percent;
         }
     }
@@ -1185,7 +1185,7 @@ namespace ProtoCore.Lang
                             decimal stepsize = (start > end) ? -1 : 1;
                             if (hasStep)
                             {
-                                stepsize = new decimal(svStep.IsDouble ? svStep.DoubleValue: svStep.IntegerValue);
+                                stepsize = new decimal(svStep.IsDouble ? svStep.DoubleValue : svStep.IntegerValue);
                                 isIntRange = isIntRange && (svStep.IsInteger);
                             }
 
@@ -1212,7 +1212,7 @@ namespace ProtoCore.Lang
                         }
                     case (int)RangeStepOperator.Number:
                         {
-                            decimal stepnum = new decimal(Math.Round(svStep.IsDouble ? svStep.DoubleValue: svStep.IntegerValue));
+                            decimal stepnum = new decimal(Math.Round(svStep.IsDouble ? svStep.DoubleValue : svStep.IntegerValue));
                             if (stepnum <= 0)
                             {
                                 return null;
@@ -1312,11 +1312,11 @@ namespace ProtoCore.Lang
             int stepnum = (int)Math.Abs(Math.Truncate((endLetter - startLetter) / (double)step)) + 1;
 
             letters = Enumerable.Range(1, stepnum)
-                // Generate arithmetic progression.
+                 // Generate arithmetic progression.
                  .Select(x => startLetter + (x - 1) * step * stepOffset)
-                // Take just letters.
+                 // Take just letters.
                  .Where(x => Char.IsLetter((char)x))
-                // Create stack values.
+                 // Create stack values.
                  .Select(x => StackValue.BuildString(Char.ToString((char)x), runtimeCore.Heap))
                  .ToArray();
 

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -121,6 +121,16 @@ namespace ProtoCore
         public Dictionary<ProtoCore.DSASM.AddressType, int> addressTypeClassMap { get; set; }
         private static Dictionary<PrimitiveType, string> primitiveTypeNames;
 
+        private static readonly Dictionary<string, string> clrToDSTypeMap = new Dictionary<string, string>
+        {
+            { $"{nameof(System)}.{nameof(String)}", "string" },
+            { "long", "int" },
+            { $"{nameof(System)}.{nameof(Int64)}", "int" },
+            { $"{nameof(System)}.{nameof(Double)}", "double" },
+            { $"{nameof(System)}.{nameof(Boolean)}", "bool" },
+            { $"{nameof(System)}.{nameof(Char)}", "char" }
+        };
+
         public TypeSystem()
         {
             SetTypeSystem();
@@ -314,7 +324,13 @@ namespace ProtoCore
         public int GetType(string ident)
         {
             Validity.Assert(null != classTable);
-            return classTable.IndexOf(ident);
+            var index = classTable.IndexOf(ident);
+            if (index != Constants.kInvalidIndex) return index;
+
+            if(clrToDSTypeMap.TryGetValue(ident, out string dsType))
+                return classTable.IndexOf(dsType);
+
+            return Constants.kInvalidIndex;
         }
 
         public int GetType(StackValue sv)

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -123,12 +123,11 @@ namespace ProtoCore
 
         private static readonly Dictionary<string, string> clrToDSTypeMap = new Dictionary<string, string>
         {
-            { $"{nameof(System)}.{nameof(String)}", "string" },
-            { "long", "int" },
-            { $"{nameof(System)}.{nameof(Int64)}", "int" },
-            { $"{nameof(System)}.{nameof(Double)}", "double" },
-            { $"{nameof(System)}.{nameof(Boolean)}", "bool" },
-            { $"{nameof(System)}.{nameof(Char)}", "char" }
+            { typeof(string).FullName, "string" },
+            { typeof(long).FullName, "int" },
+            { typeof(double).FullName, "double" },
+            { typeof(bool).FullName, "bool" },
+            { typeof(char).FullName, "char" }
         };
 
         public TypeSystem()

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -226,6 +226,27 @@ t = e[0][0];
         }
 
         [Test]
+        //Test "RemoveIfNot()"
+        public void List_RemoveIfNot_CLRType()
+        {
+            String code =
+@"import(""BuiltIn.ds"");
+a = [""This is "",""a very complex "",""array"",1,2.0,3,false,4.0,5,6.0,true,[2,3.1415926],null,false,'c'];
+b = List.RemoveIfNot(a, ""System.Int64"");
+c = List.RemoveIfNot(a, ""System.Double"");
+d = List.RemoveIfNot(a, ""System.Boolean"");
+e = List.RemoveIfNot(a, ""System.Char"");
+f = List.RemoveIfNot(a, ""System.String"");
+";
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("b", new int[] { 1, 3, 5 });
+            thisTest.Verify("c", new double[] { 2.0, 4.0, 6.0 });
+            thisTest.Verify("d", new bool[] { false, true, false });
+            thisTest.Verify("e", new char[] { 'c' });
+            thisTest.Verify("f", new string[] { "This is ", "a very complex ", "array" });
+        }
+
+        [Test]
         //Test "Reverse()"
         public void BIM11_Reverse()
         {


### PR DESCRIPTION
### Purpose

Return correct type indices for primitive types referred to by their CLR type names - this permits a node like `List.RemoveIfNot` to work with not just the DS types passed as input, but also the C# type. For e.g. it now works for both the DS type `int` but also the equivalent C# type, `System.Int64` type.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
