### PR TITLE
DYN-4999-YesButton-RunGraph

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -673,7 +673,7 @@ namespace Dynamo.Graph.Workspaces
                 MarkNodesAsModifiedAndRequestRun(Nodes);
             }
 
-            if (RunSettings.RunEnabled && RunSettings.RunType == RunType.Automatic && !RunSettings.ForceBlockRun)
+            if (RunSettings.RunEnabled && RunSettings.RunType == RunType.Automatic)
                 Run();
         }
 
@@ -804,6 +804,8 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public void Run()
         {
+            if (RunSettings.ForceBlockRun) return;
+
             graphExecuted = true;
 
             // When Dynamo is shut down, the workspace is cleared, which results

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -97,10 +97,7 @@ namespace Dynamo.Wpf.Views.FileTrust
         private void EnableRunInteractivity()
         {
             dynViewModel.HomeSpace.RunSettings.RunEnabled = true;
-            if (FileTrustWarningCheckBox.IsChecked.Value == true)
-            {
-                dynViewModel.HomeSpace.RunSettings.RunTypesEnabled = true;
-            }
+            dynViewModel.HomeSpace.RunSettings.RunTypesEnabled = true;
         }
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
@@ -120,12 +117,14 @@ namespace Dynamo.Wpf.Views.FileTrust
         private void YesButton_Click(object sender, RoutedEventArgs e)
         {
             fileTrustWarningViewModel.ShowWarningPopup = false;
-            if(FileTrustWarningCheckBox.IsChecked.Value == true)
+            RunSettings.ForceBlockRun = false;
+            if (FileTrustWarningCheckBox.IsChecked.Value == true)
             {
                 if (string.IsNullOrEmpty(fileTrustWarningViewModel.DynFileDirectoryName)) return;
                 if (dynViewModel.PreferenceSettings.TrustedLocations.Contains(fileTrustWarningViewModel.DynFileDirectoryName)) return;
                 dynViewModel.PreferenceSettings.AddTrustedLocation(fileTrustWarningViewModel.DynFileDirectoryName);
             }
+            dynViewModel.Model.CurrentWorkspace.RequestRun();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Adding missing functionality for the Yes button located in the FileTrust Warning.
With this changes the Run button and RunTypes ComboBox will be enabled after pressing the Yes button in the FileTrust Warning (no matter the status of the checkbox), by consequence of this change the  ComboBox tooltip will be disabled(due that it's Visibility is binded to the RunTypesEnabled property).
Also when the Yes button is pressed (no matter the RunTypes ComboBox) a run will be executed.

Also for dyn files with RunMode = Periodic the RunTypes ComboBox will be disabled and will be enabled once we press Yes button and also a run will be executed.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Adding missing functionality for the Yes button located in the FileTrust Warning.

### Reviewers

@QilongTang 

### FYIs

@zeusongit 
