### PR TITLE
Replace xcopy with robocopy and exclude certain folders from being copied

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/DynamoPerformanceTests.csproj
+++ b/tools/Performance/DynamoPerformanceTests/DynamoPerformanceTests.csproj
@@ -253,6 +253,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>xcopy ..\..\..\..\..\..\bin\AnyCPU\$(Configuration)\* . /s /y /i</PreBuildEvent>
+    <PreBuildEvent>robocopy ..\..\..\..\..\..\bin\AnyCPU\$(Configuration)\ . /s /xd fallback_docs
+if %25ERRORLEVEL%25 GTR 3 ( exit 1 ) else ( exit 0 )</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Purpose

Replace `xcopy `with `robocopy` and exclude certain folders from being copied to prevent build failures with long file names.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 



### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
