### PR TITLE
Remove the node label for object type and differentiate using the color

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3283,6 +3283,41 @@ namespace Dynamo.Controls
     }
 
     /// <summary>
+    /// Converts the object type to forground color for the object.
+    /// </summary>
+    public class ObjectTypeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
+
+            if (value != null)
+            {
+                switch (value)
+                {
+                    case WatchViewModel.objectType:
+                        return resourceDictionary["objectLabelBackground"] as SolidColorBrush;
+                    case WatchViewModel.doubleType:
+                        return resourceDictionary["numberLabelBackground"] as SolidColorBrush;
+                    case WatchViewModel.intType:
+                        return resourceDictionary["numberLabelBackground"] as SolidColorBrush;
+                    case WatchViewModel.stringType:
+                        return resourceDictionary["stringLabelBackground"] as SolidColorBrush;
+                    case WatchViewModel.boolType:
+                        return resourceDictionary["boolLabelBackground"] as SolidColorBrush;
+                    default:
+                        return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+                };
+            }
+            return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
     /// Receives an string containing a hexadecimal color value and returs a Brush color corresponding to the string value
     /// </summary>
     public class StringToBrushColorConverter : IValueConverter

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -182,4 +182,5 @@
     <controls:NestedGroupsLabelConverter x:Key="NestedGroupsLabelConverter" />
     <controls:CollectionHasMoreThanNItemsToBoolConverter x:Key="CollectionHasMoreThanNItemsToBoolConverter" />
     <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
+    <controls:ObjectTypeConverter x:Key="ObjectTypeConverter" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -18,11 +18,11 @@ namespace Dynamo.ViewModels
         // For more info: https://msdn.microsoft.com/en-us/library/kfsatb94(v=vs.110).aspx
         private const string numberFormat = "g";
 
-        private static readonly string doubleType = "double";
-        private static readonly string boolType = "bool";
-        private static readonly string intType = "int";
-        private static readonly string objectType = "object";
-        private static readonly string stringType = "string";
+        internal const string doubleType = "double";
+        internal const string boolType = "bool";
+        internal const string intType = "int";
+        internal const string objectType = "object";
+        internal const string stringType = "string";
 
         #region Events
 

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -349,54 +349,15 @@
                                 </Style>
                             </TextBlock.Style>
                         </TextBlock>
+
                         <TextBlock Width="Auto"
                                    Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
                                    VerticalAlignment="Center"
-                                   Foreground="{StaticResource PrimaryCharcoal200Brush}"
+                                   Foreground="{Binding Path=ValueType, Converter={StaticResource ObjectTypeConverter}}"
                                    FontFamily="{StaticResource SourceCodePro}"
                                    Text="{Binding Path=NodeLabel}"
                                    Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
 
-                        <Grid Margin="4 0 0 0">
-                            <Border CornerRadius="3,3,3,3">
-                                <Border.Style>
-                                    <Style>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding ValueType}" Value="string">
-                                                <Setter Property="Border.Background"
-                                                        Value="{DynamicResource stringLabelBackground}"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding ValueType}" Value="int">
-                                                <Setter Property="Border.Background"
-                                                        Value="{DynamicResource numberLabelBackground}"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding ValueType}" Value="double">
-                                                <Setter Property="Border.Background"
-                                                        Value="{DynamicResource numberLabelBackground}"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding ValueType}" Value="object">
-                                                <Setter Property="Border.Background"
-                                                        Value="{DynamicResource objectLabelBackground}"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding ValueType}"
-                                                         Value="bool">
-                                                <Setter Property="Border.Background"
-                                                        Value="{DynamicResource boolLabelBackground}" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Border.Style>
-                            </Border>
-                            <TextBlock Text="{Binding ValueType}"
-                                       FontStyle="Italic"
-                                       FontSize="8"
-                                       VerticalAlignment="Center"
-                                       Width="Auto"
-                                       FontFamily="Consolas"
-                                       Margin="2 0 2 0">
-                            </TextBlock>
-                        </Grid>
-                        
                         <Button Margin="10,2,2,2"
                                 Padding="4,0,4,0"
                                 VerticalAlignment="Center"

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -299,7 +299,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, tree.Count());
 
             var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(12, items.Count());
+            Assert.AreEqual(8, items.Count());
         }
 
         [Test, Category("DisplayHardwareDependent")]
@@ -443,7 +443,7 @@ namespace DynamoCoreWpfTests
 
             var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
             // watch is computed with cbn and has its value
-            Assert.AreEqual(12, items.Count());
+            Assert.AreEqual(8, items.Count());
 
             // disconnect watch
             Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
@@ -471,7 +471,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
             tree = nodeView.ChildrenOfType<WatchTree>();
             items = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(12, items.Count());
+            Assert.AreEqual(8, items.Count());
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This is a followup to the previous PR: https://github.com/DynamoDS/Dynamo/pull/12950

Removing the node label for object type and using background color to identify the object type. Data in preview bubble and watch node match DesignScript color for the following types: Int(int32 and int 64), Float, String, Boolean, Object, null. 

<img width="1202" alt="Screen Shot 2022-06-06 at 7 07 49 PM" src="https://user-images.githubusercontent.com/43763136/172264637-b97e13dd-37a0-479d-aab2-b60914f943b7.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Type Identifiers in preview bubble and watch node.

### Reviewers
@QilongTang @zeusongit @RobertGlobant20 

