### PR TITLE
DYN-5007 Group Collapsed Hiding Wires

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -257,6 +257,7 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged(nameof(NodeContentCount));
                 }
                 WorkspaceViewModel.HasUnsavedChanges = true;
+                UpdateProxyPortsPosition();
                 AddGroupToGroupCommand.RaiseCanExecuteChanged();
                 RaisePropertyChanged(nameof(IsExpanded));
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -257,9 +257,9 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged(nameof(NodeContentCount));
                 }
                 WorkspaceViewModel.HasUnsavedChanges = true;
-                UpdateProxyPortsPosition();
                 AddGroupToGroupCommand.RaiseCanExecuteChanged();
                 RaisePropertyChanged(nameof(IsExpanded));
+                RedrawConnectors();
             }
         }
 
@@ -886,6 +886,24 @@ namespace Dynamo.ViewModels
                     .FirstOrDefault();
 
                 connectorViewModel.IsCollapsed = true;
+            }
+        }
+
+        private void RedrawConnectors()
+        {
+            var allNodes = this.Nodes
+                .OfType<AnnotationModel>()
+                .SelectMany(x => x.Nodes.OfType<NodeModel>())
+                .Concat(this.Nodes.OfType<NodeModel>());
+
+            foreach (var connector in allNodes.SelectMany(x=>x.AllConnectors))
+            {
+                var connectorViewModel = WorkspaceViewModel
+                    .Connectors
+                    .Where(x => connector.GUID == x.ConnectorModel.GUID)
+                    .FirstOrDefault();
+
+                connectorViewModel.Redraw();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -694,10 +694,7 @@ namespace Dynamo.ViewModels
                 return ownerNodes
                     .SelectMany(x => x.OutPorts
                         .Where(p => !p.IsConnected ||
-                                    !p.Connectors.Any(c => ownerNodes.Contains(c.End.Owner)) ||
-                                    // If the port is connected to any of the groups inports
-                                    // we need to return it as well
-                                    p.Connectors.Any(c => inPorts.Select(m => m.PortModel).Contains(c.End)))
+                                    !p.Connectors.All(c => ownerNodes.Contains(c.End.Owner)))
                     );
             }
 
@@ -707,10 +704,7 @@ namespace Dynamo.ViewModels
             return Nodes.OfType<NodeModel>()
                 .SelectMany(x => x.OutPorts
                     .Where(p => !p.IsConnected ||
-                                !p.Connectors.Any(c => Nodes.Contains(c.End.Owner)) ||
-                                // If the port is connected to any of the groups inports
-                                // we need to return it as well
-                                p.Connectors.Any(c => inPorts.Select(m => m.PortModel).Contains(c.End)))
+                                !p.Connectors.All(c => Nodes.Contains(c.End.Owner)))
                 );
         }
 
@@ -864,18 +858,24 @@ namespace Dynamo.ViewModels
                 return;
             }
 
-            var excludedPorts = originalInPorts.Concat(originalOutPorts);
-
             var allNodes = this.Nodes
                 .OfType<AnnotationModel>()
                 .SelectMany(x => x.Nodes.OfType<NodeModel>())
                 .Concat(this.Nodes.OfType<NodeModel>());
 
-            var connectorsToHide = allNodes
-                .SelectMany(x => x.InPorts.Concat(x.OutPorts))
-                .Except(excludedPorts)
+            var inportsToHide = allNodes
+                .SelectMany(x => x.InPorts)
+                .Except(originalInPorts)
                 .SelectMany(x => x.Connectors)
                 .Distinct();
+
+            var outportsToHide = allNodes
+                .SelectMany(x => x.OutPorts)
+                .SelectMany(x => x.Connectors)
+                .Distinct()
+                .Where(x => Nodes.Contains(x.End.Owner));
+
+            var connectorsToHide = inportsToHide.Concat(outportsToHide);
 
             foreach (var connector in connectorsToHide)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -898,12 +898,14 @@ namespace Dynamo.ViewModels
 
             foreach (var connector in allNodes.SelectMany(x=>x.AllConnectors))
             {
+
                 var connectorViewModel = WorkspaceViewModel
                     .Connectors
                     .Where(x => connector.GUID == x.ConnectorModel.GUID)
                     .FirstOrDefault();
 
                 connectorViewModel.Redraw();
+                connector.Start.Owner.ReportPosition();
             }
         }
 


### PR DESCRIPTION
### Purpose

It's included in this PR the fix for the bug that the output wires are disappearing when the group is collapsed.
The conditions to get the ports and wires to be shown after the group collapsed were adapted for the situation when there are two connections going out from the same outport. One wire is connected inside the group and the other outside.

![showhire](https://user-images.githubusercontent.com/89042471/172460974-1fe3de01-6102-4e56-aa5a-8f618dc07f56.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### Reviewers

@QilongTang @zeusongit @reddyashish 