### PR TITLE
Update the type identifier colors to match DS color mapping.

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3309,7 +3309,7 @@ namespace Dynamo.Controls
                         return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
                 };
             }
-            return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+            return resourceDictionary["boolLabelBackground"] as SolidColorBrush;
         }
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -93,13 +93,13 @@
 
     <!-- NodeLabel colors -->
     <SolidColorBrush x:Key="stringLabelBackground"
-                     Color="#c3ae9d" />
+                     Color="#E0A86F" />
     <SolidColorBrush x:Key="numberLabelBackground"
-                     Color="#91c2f2" />
+                     Color="#6AC0E7" />
     <SolidColorBrush x:Key="objectLabelBackground"
-                     Color="#a1a1a1" />
+                     Color="#B7D78C" />
     <SolidColorBrush x:Key="boolLabelBackground"
-                     Color="#c6afd5" />
+                     Color="#F9F9A5" />
 
     <!-- Node Autocomplete -->
     <SolidColorBrush x:Key="autocompletionWindow" Color="#535353" />


### PR DESCRIPTION
### Purpose

The type identifier colors have been changed to match the DS look.

<img width="1332" alt="Screen Shot 2022-06-07 at 5 13 19 PM" src="https://user-images.githubusercontent.com/43763136/172484287-ff53225d-b057-44db-a353-16b6f1753295.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Update the type identifier colors to match DS color mapping.

### Reviewers
@QilongTang @Amoursol 
