### PR TITLE
[DYN-5013] Trust location added in Prefrences Panel to take effect immediately

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1621,7 +1621,7 @@ namespace Dynamo.ViewModels
                     // Skip these when opening dyf
                     FileTrustViewModel.DynFileDirectoryName = directoryName;
                     FileTrustViewModel.ShowWarningPopup = true;
-                    FileTrustViewModel.AllowOneTimeTrust = false; ;
+                    FileTrustViewModel.AllowOneTimeTrust = false;
                 }
                 (HomeSpaceViewModel as HomeWorkspaceViewModel).UpdateRunStatusMsgBasedOnStates();
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2869,7 +2869,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void ShowHideFileTrustWarningIfCurrentWorkspaceTrusted()
         {
-            if (FileTrustViewModel == null) return;
+            if (FileTrustViewModel == null || DynamoModel.IsTestMode) return;
             if ((FileTrustViewModel.ShowWarningPopup
                 && model.PreferenceSettings.IsTrustedLocation(FileTrustViewModel.DynFileDirectoryName))
                 || model.PreferenceSettings.DisableTrustWarnings)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1621,6 +1621,7 @@ namespace Dynamo.ViewModels
                     // Skip these when opening dyf
                     FileTrustViewModel.DynFileDirectoryName = directoryName;
                     FileTrustViewModel.ShowWarningPopup = true;
+                    FileTrustViewModel.AllowOneTimeTrust = false; ;
                 }
                 (HomeSpaceViewModel as HomeWorkspaceViewModel).UpdateRunStatusMsgBasedOnStates();
             }
@@ -2860,6 +2861,33 @@ namespace Dynamo.ViewModels
                 BackgroundPreviewViewModel.ExportToSTL(_fileDialog.FileName, HomeSpace.Name);
 
                 Dynamo.Logging.Analytics.TrackCommandEvent("ExportToSTL");
+            }
+        }
+
+        /// <summary>
+        /// Hide file trust warning popup if current workspace is in a trusted location
+        /// </summary>
+        internal void ShowHideFileTrustWarningIfCurrentWorkspaceTrusted()
+        {
+            if (FileTrustViewModel == null) return;
+            if ((FileTrustViewModel.ShowWarningPopup == true 
+                && model.PreferenceSettings.IsTrustedLocation(FileTrustViewModel.DynFileDirectoryName))
+                || model.PreferenceSettings.DisableTrustWarnings)
+            {
+                FileTrustViewModel.ShowWarningPopup = false;
+                RunSettings.ForceBlockRun = false;
+                Model.CurrentWorkspace.RequestRun();
+                return;
+            }
+            if (FileTrustViewModel.ShowWarningPopup == false
+                && !model.PreferenceSettings.IsTrustedLocation(FileTrustViewModel.DynFileDirectoryName)
+                && (currentWorkspaceViewModel?.IsHomeSpace ?? false)
+                && FileTrustViewModel.AllowOneTimeTrust == false
+                && !model.PreferenceSettings.DisableTrustWarnings)
+            {
+                FileTrustViewModel.ShowWarningPopup = true;
+                RunSettings.ForceBlockRun = true;
+                (HomeSpaceViewModel as HomeWorkspaceViewModel).UpdateRunStatusMsgBasedOnStates();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2865,12 +2865,12 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Hide file trust warning popup if current workspace is in a trusted location
+        /// Hide or show file trust warning popup for the current workspace when preference settings are updated.
         /// </summary>
         internal void ShowHideFileTrustWarningIfCurrentWorkspaceTrusted()
         {
             if (FileTrustViewModel == null) return;
-            if ((FileTrustViewModel.ShowWarningPopup == true 
+            if ((FileTrustViewModel.ShowWarningPopup
                 && model.PreferenceSettings.IsTrustedLocation(FileTrustViewModel.DynFileDirectoryName))
                 || model.PreferenceSettings.DisableTrustWarnings)
             {
@@ -2879,10 +2879,10 @@ namespace Dynamo.ViewModels
                 Model.CurrentWorkspace.RequestRun();
                 return;
             }
-            if (FileTrustViewModel.ShowWarningPopup == false
+            if (!FileTrustViewModel.ShowWarningPopup
                 && !model.PreferenceSettings.IsTrustedLocation(FileTrustViewModel.DynFileDirectoryName)
-                && (currentWorkspaceViewModel?.IsHomeSpace ?? false)
-                && FileTrustViewModel.AllowOneTimeTrust == false
+                && (currentWorkspaceViewModel?.IsHomeSpace ?? false) && !ShowStartPage
+                && !FileTrustViewModel.AllowOneTimeTrust
                 && !model.PreferenceSettings.DisableTrustWarnings)
             {
                 FileTrustViewModel.ShowWarningPopup = true;

--- a/src/DynamoCoreWpf/ViewModels/FileTrust/FileTrustWarningViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/FileTrust/FileTrustWarningViewModel.cs
@@ -56,7 +56,7 @@ namespace Dynamo.Wpf.ViewModels.FileTrust
         }
 
         /// <summary>
-        /// This property indicates if the Popup has been dismissed once temporarily ignoring the trust warning
+        /// This property indicates if the Popup has been dismissed once, temporarily ignoring the trust warning
         /// </summary>
         public bool AllowOneTimeTrust
         {

--- a/src/DynamoCoreWpf/ViewModels/FileTrust/FileTrustWarningViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/FileTrust/FileTrustWarningViewModel.cs
@@ -10,6 +10,7 @@ namespace Dynamo.Wpf.ViewModels.FileTrust
     public class FileTrustWarningViewModel : ViewModelBase
     {
         private bool showWarningPopup;
+        private bool allowOneTimeTrust;
 
         /// <summary>
         /// This offset is set to make the popup pointer point at the middle of the RunMode combo box
@@ -55,6 +56,21 @@ namespace Dynamo.Wpf.ViewModels.FileTrust
         }
 
         /// <summary>
+        /// This property indicates if the Popup has been dismissed once temporarily ignoring the trust warning
+        /// </summary>
+        public bool AllowOneTimeTrust
+        {
+            get
+            {
+                return allowOneTimeTrust;
+            }
+            set
+            {
+                allowOneTimeTrust = value;
+            }
+        }
+
+        /// <summary>
         /// This property will contain the full path of the file to be opened and is used to check if already exists in the Trusted Paths 
         /// </summary>
         public string DynFileDirectoryName { get; set; }
@@ -82,6 +98,7 @@ namespace Dynamo.Wpf.ViewModels.FileTrust
                                                                new Point(pointX3, pointY3)});
 
             showWarningPopup = false;
+            allowOneTimeTrust = false;
         }
 
     }

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -123,6 +123,7 @@ namespace Dynamo.Wpf.Views.FileTrust
 
         private void YesButton_Click(object sender, RoutedEventArgs e)
         {
+            fileTrustWarningViewModel.AllowOneTimeTrust = true;
             fileTrustWarningViewModel.ShowWarningPopup = false;
             RunSettings.ForceBlockRun = false;
             if (FileTrustWarningCheckBox.IsChecked.Value == true)

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -104,6 +104,8 @@ namespace Dynamo.Wpf.Views
             Analytics.TrackEvent(Actions.Close, Categories.Preferences);
             viewModel.PackagePathsViewModel.SaveSettingCommand.Execute(null);
             viewModel.TrustedPathsViewModel?.SaveSettingCommand?.Execute(null);
+            dynViewModel.ShowHideFileTrustWarningIfCurrentWorkspaceTrusted();
+
             viewModel.CommitPackagePathsForInstall();
             PackagePathView.Dispose();
             TrustedPathView.Dispose();

--- a/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
@@ -7,7 +7,6 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Wpf.Views;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
-using Dynamo.Models;
 
 namespace DynamoCoreWpfTests
 {

--- a/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesGeometryScalingTests.cs
@@ -7,6 +7,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Wpf.Views;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
+using Dynamo.Models;
 
 namespace DynamoCoreWpfTests
 {


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-5013
this update will show and hide file trust warning when as it is added to the trusted locations and preference panel is closed to save settings.

![DynamoSandbox_SxptJ5GDsX](https://user-images.githubusercontent.com/32665108/172735937-2e48e579-5f2b-4046-b020-9a6747974a9e.gif)


![DynamoSandbox_kUns6Qfij0](https://user-images.githubusercontent.com/32665108/172734839-d5449fb0-5990-48e7-a001-7bc7f85fc660.gif)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Trust location added in Prefrences Panel to take effect immediately


### Reviewers

@DynamoDS/dynamo 
