### PR TITLE
Fix the crash and open the onboarding dyn correctly before launching the tour.

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -669,8 +669,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
             //Inside the NodeView try to find the ItemsControl that contains Input ports or Output ports
             var itemsControlPort = GuideUtilities.FindChild(byOriginNode, portHighlighted) as ItemsControl;
-            var inPorts = itemsControlPort.Items.Cast<PortViewModel>().ToList();
+
             if (itemsControlPort == null) return;
+
+            var inPorts = itemsControlPort.Items.Cast<PortViewModel>().ToList();
 
             //Once we have the ItemsControl we get the ContentPresenter
             var inputViewModel = inPorts.FirstOrDefault(x => x.PortName == (string)uiAutomationData.Parameters[3]);

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1657,7 +1657,7 @@ namespace Dynamo.ViewModels
 
         internal void OpenOnboardingGuideFile()
         {  
-            var jsonDynFile = ResourceUtilities.LoadContentFromResources(GuidesManager.OnboardingGuideWorkspaceEmbeededResource, GetType().Assembly, false, false);
+            var jsonDynFile = ResourceUtilities.LoadContentFromResources(GuidesManager.OnboardingGuideWorkspaceEmbeededResource, Assembly.GetExecutingAssembly(), false, false);
             OpenFromJson(new Tuple<string, bool>(jsonDynFile, true));
         }
 

--- a/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
+++ b/src/LibraryViewExtensionMSWebBrowser/LibraryViewController.cs
@@ -97,6 +97,7 @@ namespace Dynamo.LibraryViewExtensionMSWebBrowser
                 {
                     var data = simpleRPCPayload["data"] as string;
                     controller.CreateNode(data);
+                    controller.CloseNodeTooltip(true);
                 }
                 else if (funcName == "showNodeTooltip")
                 {


### PR DESCRIPTION
### Purpose

Fixes the crash described here: https://jira.autodesk.com/browse/DYN-5001

The onboarding DYN was not able to load as the code was pointing to the wrong assembly when Dynamo was being used inside Revit. It should be the DynamoCoreWPF assembly where it needs to get the resource.

Also fixes https://jira.autodesk.com/browse/DYN-4980.

The issue here was that when a node is placed in the workspace, the node tooltip doesn't close until the user clicks on something else in the window. So in the guided tour, after the node is placed, the library is disabled and the tooltip persisted throughout the tour. We can just close the node library tooltip instead, after the node is placed in the workspace.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix the crash and open the onboarding dyn correctly before launching the tour.
Close the node library tooltip after a node is placed in the workspace. 

### Reviewers

@QilongTang @RobertGlobant20  


