### PR TITLE
Dyn 5008 watch node height 4 dictionary

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -34,6 +34,7 @@ namespace Dynamo.Controls
         internal double ExtratWidthSize { get { return extraWidthSize; } }
         internal double WidthPerCharacter { get { return widthPerCharacter; } }
         internal double MaxWidthSize { get { return defaultWidthSize * 2; } }
+        internal string NodeLabel { get { return _vm.Children[0].NodeLabel; } }
 
         private void WatchTree_Unloaded(object sender, RoutedEventArgs e)
         {
@@ -59,7 +60,7 @@ namespace Dynamo.Controls
                     this.Height = minHeightSize;
                     if (_vm.Children.Count !=0)
                     {
-                        if (_vm.Children[0].NodeLabel.Contains(Environment.NewLine))
+                        if (_vm.Children[0].NodeLabel.Contains(Environment.NewLine) || _vm.Children[0].NodeLabel.ToUpper() == nameof(WatchViewModel.DICTIONARY))
                         {
                             this.Height = defaultHeightSize;
                         }

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -60,7 +60,7 @@ namespace Dynamo.Controls
                     this.Height = minHeightSize;
                     if (_vm.Children.Count !=0)
                     {
-                        if (_vm.Children[0].NodeLabel.Contains(Environment.NewLine) || _vm.Children[0].NodeLabel.ToUpper() == nameof(WatchViewModel.DICTIONARY))
+                        if (NodeLabel.Contains(Environment.NewLine) || NodeLabel.ToUpper() == nameof(WatchViewModel.DICTIONARY))
                         {
                             this.Height = defaultHeightSize;
                         }
@@ -80,7 +80,7 @@ namespace Dynamo.Controls
                     {
                         // We will use 7.5 as width factor for each character.
 
-                        double requiredWidth = (_vm.Children[0].NodeLabel.Length * widthPerCharacter);
+                        double requiredWidth = (NodeLabel.Length * widthPerCharacter);
                         if (requiredWidth > (MaxWidthSize))
                         {
                             requiredWidth = MaxWidthSize;

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -448,6 +448,32 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(rawMultiLineStringtWatchNode.DefaultHeightSize, rawMultiLineStringtWatchNode.Height);
         }
 
+        [Test]
+        public void Watch_Dictionary()
+        {
+            OpenAndRun(@"core\WatchTree.dyn");
+
+            string watchNodeGuid = "a3b57ebd-5fff-413d-a6c5-ecee20e80e4e";
+            var dictionaryWatchNode = NodeViewWithGuid(watchNodeGuid);
+            WatchTree rawDictionaryWatchNode = dictionaryWatchNode.ChildOfType<WatchTree>();
+
+            bool isDictionary = rawDictionaryWatchNode.NodeLabel.ToUpper() == nameof(Dynamo.ViewModels.WatchViewModel.DICTIONARY);
+
+            // Fire transition on dynamo main ui thread.
+            View.Dispatcher.Invoke(() =>
+            {
+                dictionaryWatchNode.PreviewControl.BindToDataSource();
+                dictionaryWatchNode.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
+                dictionaryWatchNode.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Expanded);
+            });
+
+            DispatcherUtil.DoEvents();
+
+            Assert.NotNull(dictionaryWatchNode);
+            Assert.IsTrue(isDictionary);
+            Assert.AreEqual(rawDictionaryWatchNode.DefaultHeightSize, rawDictionaryWatchNode.Height);
+        }
+
         #endregion
 
         [Test]

--- a/test/core/WatchTree.dyn
+++ b/test/core/WatchTree.dyn
@@ -12,6 +12,10 @@
       "Point": {
         "Key": "Autodesk.DesignScript.Geometry.Point",
         "Value": "ProtoGeometry.dll"
+      },
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
       }
     }
   },
@@ -309,6 +313,55 @@
       ],
       "Replication": "Disabled",
       "Description": "Visualize the node's output"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{\"id\":7888,\"uid\":\"095a8563-6b2f-4961-b5d0-51d224508ff7\",\"brand\":\"Budweiser\",\"name\":\"Westmalle Trappist Tripel\",\"style\":\"Stout\",\"hop\":\"Willamette\",\"yeast\":\"1099 - Whitbread Ale\",\"malts\":\"Vienna\",\"ibu\":\"45 IBU\",\"alcohol\":\"9.6%\",\"blg\":\"11.7°Blg\"};",
+      "Id": "4dbf32f1be71457a8a207d659896d274",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "97450167f6e844f38de8e1204b9cf543",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "a3b57ebd5fff413da6c5ecee20e80e4e",
+      "Inputs": [
+        {
+          "Id": "9bc1396dc4e642e787f1c273ad7e1c1f",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bc02de04f1fc41f485188d443b311d5d",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the node's output"
     }
   ],
   "Connectors": [
@@ -341,6 +394,12 @@
       "End": "79a2a477a7144cf4aa1888f35080c103",
       "Id": "a8636b0b2b1e4c9ba0088c5de773290b",
       "IsHidden": "False"
+    },
+    {
+      "Start": "97450167f6e844f38de8e1204b9cf543",
+      "End": "9bc1396dc4e642e787f1c273ad7e1c1f",
+      "Id": "9850c23ac51f46849692bb191274a853",
+      "IsHidden": "False"
     }
   ],
   "Dependencies": [],
@@ -368,7 +427,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.15.0.5047",
+      "Version": "2.15.0.5252",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -495,6 +554,26 @@
         "Excluded": false,
         "X": 841.30826466519318,
         "Y": 973.22971481997047
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "4dbf32f1be71457a8a207d659896d274",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1053.2918870047356,
+        "Y": 261.47013517660719
+      },
+      {
+        "Name": "Watch",
+        "ShowGeometry": true,
+        "Id": "a3b57ebd5fff413da6c5ecee20e80e4e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1516.5673530447943,
+        "Y": 417.29915557189958
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose
WatchNode height 4 a Dictionary
https://jira.autodesk.com/browse/DYN-5008

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

###Reviewers  
[@QilongTang](https://github.com/QilongTang)

###FYIs  
[@RobertGlobant20](https://github.com/RobertGlobant20) [@filipeotero](https://github.com/filipeotero)
Show less
