### PR TITLE
Add commits to the Add, Update, Remove logic for trusted workflows

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
@@ -120,7 +120,7 @@ namespace Dynamo.ViewModels
             }
             
             TrustedLocations.Insert(TrustedLocations.Count, args.Path);
-            settings?.SetTrustedLocations(TrustedLocations);
+            CommitChanges(null);
             RaiseCanExecuteChanged();
         }
 
@@ -145,13 +145,13 @@ namespace Dynamo.ViewModels
                 return;
 
             TrustedLocations[index] = args.Path;
-            settings?.SetTrustedLocations(TrustedLocations);
+            CommitChanges(null);
         }
 
         private void RemovePathAt(int index)
         {
             TrustedLocations.RemoveAt(index);
-            settings?.SetTrustedLocations(TrustedLocations);
+            CommitChanges(null);
             RaiseCanExecuteChanged();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
@@ -120,6 +120,7 @@ namespace Dynamo.ViewModels
             }
             
             TrustedLocations.Insert(TrustedLocations.Count, args.Path);
+            settings?.SetTrustedLocations(TrustedLocations);
             RaiseCanExecuteChanged();
         }
 
@@ -144,11 +145,13 @@ namespace Dynamo.ViewModels
                 return;
 
             TrustedLocations[index] = args.Path;
+            settings?.SetTrustedLocations(TrustedLocations);
         }
 
         private void RemovePathAt(int index)
         {
             TrustedLocations.RemoveAt(index);
+            settings?.SetTrustedLocations(TrustedLocations);
             RaiseCanExecuteChanged();
         }
 


### PR DESCRIPTION
### Purpose

This PR adds a commit behavior to user actions within the preference dialog view for adding, updating and removing a Trusted Path.  Previous behavior was that these changes to trusted paths were not added to the backing collection until the user closed the preferences dialog.  This change allows those updates to be committed immediately so that workflows that synchronize with the with Trusted Locations APIs will have access the changes as users make them.

Note: this implementation leaves in place the commit associated with the preference dialog close so that the view state of the preferences dialog for trusted paths is still the governing state at close.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@BogdanZavu @deepakanand 
