### PR TITLE
DYN-5018 wires disappear when moving group

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -594,13 +594,14 @@ namespace Dynamo.ViewModels
             LoadGroupStylesFromPreferences(preferenceSettings.GroupStyleItemsList);
         }
 
-        
+
         /// <summary>
-            /// Creates input ports for the group based on its Nodes.
-            /// Input ports that either is connected to a Node outside of the
-            /// group, or has a port that is not connected will be used for the group.
-            /// </summary>
-        internal void SetGroupInputPorts()
+        /// Creates input ports for the group based on its Nodes.
+        /// Input ports that either is connected to a Node outside of the
+        /// group, or has a port that is not connected will be used for the group.
+        /// This function appends to the inputs
+        /// </summary>
+        private void SetGroupInputPorts()
         {
             List<PortViewModel> newPortViewModels;
 
@@ -635,8 +636,9 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Creates output ports for the group based on its Nodes.
         /// Output ports that are not connected will be used for the group.
+        /// This function appends to the outports
         /// </summary>
-        internal void SetGroupOutPorts()
+        private void SetGroupOutPorts()
         {
             List<PortViewModel> newPortViewModels;
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -915,7 +915,6 @@ namespace Dynamo.ViewModels
 
             foreach (var connector in allNodes.SelectMany(x=>x.AllConnectors))
             {
-
                 var connectorViewModel = WorkspaceViewModel
                     .Connectors
                     .Where(x => connector.GUID == x.ConnectorModel.GUID)
@@ -1098,10 +1097,12 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged("Width");
                     RaisePropertyChanged(nameof(ModelAreaRect));
                     UpdateAllGroupedGroups();
+                    UpdateProxyPortsPosition();
                     break;
                 case "Height":
                     RaisePropertyChanged("Height");
                     UpdateAllGroupedGroups();
+                    UpdateProxyPortsPosition();
                     break;
                 case nameof(AnnotationDescriptionText):
                     RaisePropertyChanged(nameof(AnnotationDescriptionText));

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -245,6 +245,8 @@ namespace Dynamo.ViewModels
             set
             {
                 annotationModel.IsExpanded = value;
+                InPorts.Clear();
+                OutPorts.Clear();
                 if (value)
                 {
                     this.ShowGroupContents();
@@ -259,6 +261,15 @@ namespace Dynamo.ViewModels
                 WorkspaceViewModel.HasUnsavedChanges = true;
                 AddGroupToGroupCommand.RaiseCanExecuteChanged();
                 RaisePropertyChanged(nameof(IsExpanded));
+                ReportNodesPosition();
+            }
+        }
+
+        private void ReportNodesPosition()
+        {
+            foreach (var node in Nodes)
+            {
+                node.ReportPosition();
             }
         }
 
@@ -587,7 +598,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void SetGroupInputPorts()
         {
-            InPorts.Clear();
             List<PortViewModel> newPortViewModels;
 
             // we need to store the original ports here
@@ -624,7 +634,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void SetGroupOutPorts()
         {
-            OutPorts.Clear();
             List<PortViewModel> newPortViewModels;
 
             // we need to store the original ports here

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -547,14 +547,12 @@ namespace Dynamo.ViewModels
         public AnnotationViewModel(WorkspaceViewModel workspaceViewModel, AnnotationModel model)
         {
             annotationModel = model;
-            var modelBase = (ModelBase)model;
 
             this.WorkspaceViewModel = workspaceViewModel;
             this.preferenceSettings = WorkspaceViewModel.DynamoViewModel.PreferenceSettings;
             model.PropertyChanged += model_PropertyChanged;
             model.RemovedFromGroup += OnModelRemovedFromGroup;
             model.AddedToGroup += OnModelAddedToGroup;
-            modelBase.PropertyChanged += ModelBase_PropertyChanged;
 
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
 
@@ -596,15 +594,6 @@ namespace Dynamo.ViewModels
             LoadGroupStylesFromPreferences(preferenceSettings.GroupStyleItemsList);
         }
 
-        private void ModelBase_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            switch (e.PropertyName)
-            {
-                case nameof(annotationModel.Position):
-                    UpdateProxyPortsPosition();
-                    break;
-            }
-        }
         
         /// <summary>
             /// Creates input ports for the group based on its Nodes.

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -254,6 +254,8 @@ namespace Dynamo.Nodes
                 SetTextMaxWidth();
                 SetTextHeight();
             }
+
+            ViewModel.UpdateProxyPortsPosition();
         }
 
 


### PR DESCRIPTION
### Purpose

In this PR, the position of the wires is calculated based on the height of the port that is created after the group is collapsed.
Previously, we were assuming that all the ports have the same height, causing a mispositioning of the wires. 

![image](https://user-images.githubusercontent.com/89042471/173596539-faa5afda-1640-4215-a983-205092f4c405.png)

![image](https://user-images.githubusercontent.com/89042471/173596602-37af7309-59ad-4847-bfda-7ba376dddaf3.png)

![Positionwires](https://user-images.githubusercontent.com/89042471/173600141-f7a4dcd0-2f0a-469c-8e49-9e797f8b3d07.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @pinzart @reddyashish 