### PR TITLE
DYN-4973-Popups-NotAttached

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -9,7 +9,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
     public delegate void UpdateLibraryInteractionsEventHandler();
     public delegate void GuidedTourStartEventHandler(GuidedTourStateEventArgs args);
     public delegate void GuidedTourFinishEventHandler(GuidedTourStateEventArgs args);
-    public delegate void GuidedTourFinishedEventHandler(GuidedTourStateEventArgs args);
+    public delegate void GuidedTourExitedEventHandler(GuidedTourStateEventArgs args);
 
     /// <summary>
     /// This static class will be used to raise events when the tooltip, welcome and survey popup buttons are clicked.
@@ -19,7 +19,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         //Event that will be raised when the Popup Next button is pressed, the value passed as parameter is the current Step Sequence
         public static event GuidedTourNextEventHandler GuidedTourNextStep;
         private static bool isAnyGuideActive { get; set; } = false;
-        private static bool isGuideFinished { get; set; } = false;
+        private static bool isGuideExited { get; set; } = false;
         public static void OnGuidedTourNext()
         {
             if (GuidedTourNextStep != null)
@@ -41,7 +41,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if (GuidedTourStart != null)
             {
                 isAnyGuideActive = true;
-                isGuideFinished = false;
+                isGuideExited = false;
                 GuidedTourStart(new GuidedTourStateEventArgs(name));
             }              
         }
@@ -58,13 +58,13 @@ namespace Dynamo.Wpf.UI.GuidedTour
         }
 
         //Event that will be raised when the Guide is completely closed (this is specific for the Packages guide that allows the user to continue or exit the guide)
-        public static event GuidedTourFinishedEventHandler GuidedTourFinished;
-        internal static void OnGuidedTourFinished(string name)
+        public static event GuidedTourExitedEventHandler GuidedTourExited;
+        internal static void OnGuidedTourExited(string name)
         {
-            if (GuidedTourFinished != null)
+            if (GuidedTourExited != null)
             {
-                isGuideFinished = true;
-                GuidedTourFinished(new GuidedTourStateEventArgs(name));
+                isGuideExited = true;
+                GuidedTourExited(new GuidedTourStateEventArgs(name));
             }
         }
 
@@ -98,8 +98,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         public static bool IsGuideClosed
         {
-            get { return isGuideFinished; }
-            set { isGuideFinished = value; }
+            get { return isGuideExited; }
+            set { isGuideExited = value; }
         }
     }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -92,7 +92,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This property will return a value that says if the tour has been completely closed or not
         /// </summary>
-        public static bool IsGuideClosed
+        public static bool IsGuideExited
         {
             get { return isGuideExited; }
             set { isGuideExited = value; }

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -61,11 +61,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         public static event GuidedTourExitedEventHandler GuidedTourExited;
         internal static void OnGuidedTourExited(string name)
         {
-            if (GuidedTourExited != null)
-            {
-                isGuideExited = true;
-                GuidedTourExited(new GuidedTourStateEventArgs(name));
-            }
+            isGuideExited = true;
         }
 
         //Event that will be raised when we want to update the Popup location of the current step being executed

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -9,6 +9,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
     public delegate void UpdateLibraryInteractionsEventHandler();
     public delegate void GuidedTourStartEventHandler(GuidedTourStateEventArgs args);
     public delegate void GuidedTourFinishEventHandler(GuidedTourStateEventArgs args);
+    public delegate void GuidedTourClosedEventHandler(GuidedTourStateEventArgs args);
 
     /// <summary>
     /// This static class will be used to raise events when the tooltip, welcome and survey popup buttons are clicked.
@@ -18,6 +19,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         //Event that will be raised when the Popup Next button is pressed, the value passed as parameter is the current Step Sequence
         public static event GuidedTourNextEventHandler GuidedTourNextStep;
         private static bool isAnyGuideActive { get; set; } = false;
+        private static bool isGuideClosed { get; set; } = false;
         public static void OnGuidedTourNext()
         {
             if (GuidedTourNextStep != null)
@@ -39,6 +41,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if (GuidedTourStart != null)
             {
                 isAnyGuideActive = true;
+                isGuideClosed = false;
                 GuidedTourStart(new GuidedTourStateEventArgs(name));
             }              
         }
@@ -51,6 +54,17 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 isAnyGuideActive = false;
                 GuidedTourFinish(new GuidedTourStateEventArgs(name));
+            }
+        }
+
+        //Event that will be raised when the Guide is completely closed (this is specific for the Packages guide that allows the user to continue or exit the guide)
+        public static event GuidedTourClosedEventHandler GuidedTourClosed;
+        internal static void OnGuidedTourClosed(string name)
+        {
+            if (GuidedTourClosed != null)
+            {
+                isGuideClosed = true;
+                GuidedTourClosed(new GuidedTourStateEventArgs(name));
             }
         }
 
@@ -71,12 +85,21 @@ namespace Dynamo.Wpf.UI.GuidedTour
         }
 
         /// <summary>
-        /// This property will returm if the a guide is being executed or not. 
+        /// This property will return if the a guide is being executed or not. 
         /// </summary>
         public static bool IsAnyGuideActive
         {
             get { return isAnyGuideActive; }
             set { isAnyGuideActive = value; }
+        }
+
+        /// <summary>
+        /// This property will return a value that says if the tour has been completely closed or not
+        /// </summary>
+        public static bool IsGuideClosed
+        {
+            get { return isGuideClosed; }
+            set { isGuideClosed = value; }
         }
     }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuideFlowEvents.cs
@@ -9,7 +9,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
     public delegate void UpdateLibraryInteractionsEventHandler();
     public delegate void GuidedTourStartEventHandler(GuidedTourStateEventArgs args);
     public delegate void GuidedTourFinishEventHandler(GuidedTourStateEventArgs args);
-    public delegate void GuidedTourClosedEventHandler(GuidedTourStateEventArgs args);
+    public delegate void GuidedTourFinishedEventHandler(GuidedTourStateEventArgs args);
 
     /// <summary>
     /// This static class will be used to raise events when the tooltip, welcome and survey popup buttons are clicked.
@@ -19,7 +19,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         //Event that will be raised when the Popup Next button is pressed, the value passed as parameter is the current Step Sequence
         public static event GuidedTourNextEventHandler GuidedTourNextStep;
         private static bool isAnyGuideActive { get; set; } = false;
-        private static bool isGuideClosed { get; set; } = false;
+        private static bool isGuideFinished { get; set; } = false;
         public static void OnGuidedTourNext()
         {
             if (GuidedTourNextStep != null)
@@ -41,7 +41,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if (GuidedTourStart != null)
             {
                 isAnyGuideActive = true;
-                isGuideClosed = false;
+                isGuideFinished = false;
                 GuidedTourStart(new GuidedTourStateEventArgs(name));
             }              
         }
@@ -58,13 +58,13 @@ namespace Dynamo.Wpf.UI.GuidedTour
         }
 
         //Event that will be raised when the Guide is completely closed (this is specific for the Packages guide that allows the user to continue or exit the guide)
-        public static event GuidedTourClosedEventHandler GuidedTourClosed;
-        internal static void OnGuidedTourClosed(string name)
+        public static event GuidedTourFinishedEventHandler GuidedTourFinished;
+        internal static void OnGuidedTourFinished(string name)
         {
-            if (GuidedTourClosed != null)
+            if (GuidedTourFinished != null)
             {
-                isGuideClosed = true;
-                GuidedTourClosed(new GuidedTourStateEventArgs(name));
+                isGuideFinished = true;
+                GuidedTourFinished(new GuidedTourStateEventArgs(name));
             }
         }
 
@@ -98,8 +98,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         public static bool IsGuideClosed
         {
-            get { return isGuideClosed; }
-            set { isGuideClosed = value; }
+            get { return isGuideFinished; }
+            set { isGuideFinished = value; }
         }
     }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -210,7 +210,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             currentGuide = (from guide in Guides where guide.Name.Equals(args.GuideName) select guide).FirstOrDefault();
 
             //Check if it's packages guide to open the exit modal 
-            if (args.GuideName == "Packages" && currentGuide.CurrentStep.StepType != Step.StepTypes.SURVEY)
+            if (args.GuideName == GuidesManager.PackagesGuideName && currentGuide.CurrentStep.StepType != Step.StepTypes.SURVEY)
             {
                 guideBackgroundElement.ClearHighlightSection();
                 guideBackgroundElement.ClearCutOffSection();
@@ -298,7 +298,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             }
             else if (GuideFlowEvents.IsAnyGuideActive == false && GuideFlowEvents.IsGuideClosed == false)
             {
-                if(exitGuideWindow != null && currentGuide.Name.Equals("Packages"))
+                if(exitGuideWindow != null && currentGuide.Name.Equals(GuidesManager.PackagesGuideName))
                     exitGuideWindow.IsOpen = isActive;
             }
         }

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -106,7 +106,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;
             GuideFlowEvents.GuidedTourFinish += TourFinished;
-            GuideFlowEvents.GuidedTourExited += TourClosed;
+            GuideFlowEvents.GuidedTourExited += TourExited;
 
             Guides = new List<Guide>();
 
@@ -222,7 +222,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             }
         }
 
-        private void TourClosed(GuidedTourStateEventArgs args)
+        private void TourExited(GuidedTourStateEventArgs args)
         {
 
         }
@@ -254,7 +254,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;
-                GuideFlowEvents.GuidedTourExited -= TourClosed;
+                GuideFlowEvents.GuidedTourExited -= TourExited;
 
                 if (exitGuideWindow != null)
                 {

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -289,7 +289,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 if (currentGuide.CurrentStep.stepUIPopup.IsOpen == !isActive)
                     currentGuide.CurrentStep.stepUIPopup.IsOpen = isActive;
             }
-            else if (GuideFlowEvents.IsAnyGuideActive == false && GuideFlowEvents.IsGuideClosed == false)
+            else if (GuideFlowEvents.IsAnyGuideActive == false && GuideFlowEvents.IsGuideExited == false)
             {
                 if(exitGuideWindow != null && currentGuide.Name.Equals(GuidesManager.PackagesGuideName))
                     exitGuideWindow.IsOpen = isActive;

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -106,7 +106,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;
             GuideFlowEvents.GuidedTourFinish += TourFinished;
-            GuideFlowEvents.GuidedTourFinished += TourClosed;
+            GuideFlowEvents.GuidedTourExited += TourClosed;
 
             Guides = new List<Guide>();
 
@@ -254,7 +254,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;
-                GuideFlowEvents.GuidedTourFinished -= TourClosed;
+                GuideFlowEvents.GuidedTourExited -= TourClosed;
 
                 if (exitGuideWindow != null)
                 {
@@ -316,7 +316,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private void ExitTourButton_Click(object sender, RoutedEventArgs e)
         {
             exitGuideWindow.IsOpen = false;
-            GuideFlowEvents.OnGuidedTourFinished(currentGuide.Name);
+            GuideFlowEvents.OnGuidedTourExited(currentGuide.Name);
             ExitTour();
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -106,7 +106,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;
             GuideFlowEvents.GuidedTourFinish += TourFinished;
-            GuideFlowEvents.GuidedTourExited += TourExited;
 
             Guides = new List<Guide>();
 
@@ -222,11 +221,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
             }
         }
 
-        private void TourExited(GuidedTourStateEventArgs args)
-        {
-
-        }
-
         /// <summary>
         /// This method exits from tour 
         /// </summary>
@@ -254,7 +248,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;
-                GuideFlowEvents.GuidedTourExited -= TourExited;
 
                 if (exitGuideWindow != null)
                 {

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -106,7 +106,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             //Subscribe the handlers when the Tour is started and finished, the handlers are unsubscribed in the method TourFinished()
             GuideFlowEvents.GuidedTourStart += TourStarted;
             GuideFlowEvents.GuidedTourFinish += TourFinished;
-            GuideFlowEvents.GuidedTourClosed += TourClosed;
+            GuideFlowEvents.GuidedTourFinished += TourClosed;
 
             Guides = new List<Guide>();
 
@@ -254,7 +254,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 currentGuide.ClearGuide();
                 GuideFlowEvents.GuidedTourStart -= TourStarted;
                 GuideFlowEvents.GuidedTourFinish -= TourFinished;
-                GuideFlowEvents.GuidedTourClosed -= TourClosed;
+                GuideFlowEvents.GuidedTourFinished -= TourClosed;
 
                 if (exitGuideWindow != null)
                 {
@@ -316,7 +316,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private void ExitTourButton_Click(object sender, RoutedEventArgs e)
         {
             exitGuideWindow.IsOpen = false;
-            GuideFlowEvents.OnGuidedTourClosed(currentGuide.Name);
+            GuideFlowEvents.OnGuidedTourFinished(currentGuide.Name);
             ExitTour();
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -179,7 +179,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         #endregion
 
         #region Protected Properties
-        protected Popup stepUIPopup;
+        internal Popup stepUIPopup;
         protected Func<bool, bool> validator;
         /// <summary>
         /// This property describe which will be the pointing direction of the tooltip (if is a Welcome or Survey popup then is not used)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -30,6 +30,8 @@
         SnapsToDevicePixels="True"
         ResizeMode="CanResizeWithGrip"
         UseLayoutRounding="True"
+        Activated="DynamoView_Activated"
+        Deactivated="DynamoView_Deactivated"
         Style="{DynamicResource DynamoWindowStyle}">
 
     <Window.Resources>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -93,7 +93,7 @@ namespace Dynamo.Controls
         internal ViewExtensionManager viewExtensionManager;
         internal Watch3DView BackgroundPreview { get; private set; }
 
-        private FileTrustWarning warningPopup = null;
+        private FileTrustWarning fileTrustWarningPopup = null;
 
         /// <summary>
         /// Constructor
@@ -219,8 +219,8 @@ namespace Dynamo.Controls
             this.dynamoViewModel.Model.WorkspaceOpened += OnWorkspaceOpened;
             FocusableGrid.InputBindings.Clear();
             
-            if(warningPopup == null)
-                warningPopup = new FileTrustWarning(this);
+            if(fileTrustWarningPopup == null)
+                fileTrustWarningPopup = new FileTrustWarning(this);
         }
         private void OnWorkspaceOpened(WorkspaceModel workspace)
         {
@@ -745,8 +745,8 @@ namespace Dynamo.Controls
             if(dynamoViewModel.MainGuideManager != null)
                 dynamoViewModel.MainGuideManager.UpdateGuideStepsLocation();
 
-            if (warningPopup != null && warningPopup.IsOpen)
-                warningPopup.UpdatePopupLocation();
+            if (fileTrustWarningPopup != null && fileTrustWarningPopup.IsOpen)
+                fileTrustWarningPopup.UpdatePopupLocation();
         }
 
         private void DynamoView_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -758,8 +758,8 @@ namespace Dynamo.Controls
             if (dynamoViewModel.MainGuideManager != null)
                 dynamoViewModel.MainGuideManager.UpdateGuideStepsLocation();
 
-            if (warningPopup != null && warningPopup.IsOpen)
-                warningPopup.UpdatePopupLocation();
+            if (fileTrustWarningPopup != null && fileTrustWarningPopup.IsOpen)
+                fileTrustWarningPopup.UpdatePopupLocation();
         }
 
         private void InitializeLogin()
@@ -2484,8 +2484,8 @@ namespace Dynamo.Controls
             }
                
 
-            if (warningPopup != null)
-                warningPopup.ManagePopupActivation(true);
+            if (fileTrustWarningPopup != null)
+                fileTrustWarningPopup.ManagePopupActivation(true);
         }
 
         private void DynamoView_Deactivated(object sender, EventArgs e)
@@ -2493,8 +2493,8 @@ namespace Dynamo.Controls
             if (dynamoViewModel.MainGuideManager != null && dynamoViewModel.MainGuideManager.currentGuide != null)
                 dynamoViewModel.MainGuideManager.ManagePopupActivation(false);
 
-            if(warningPopup != null)
-                warningPopup.ManagePopupActivation(false);
+            if(fileTrustWarningPopup != null)
+                fileTrustWarningPopup.ManagePopupActivation(false);
         }
 
         public void Dispose()
@@ -2508,8 +2508,8 @@ namespace Dynamo.Controls
             // Removing the tab items list handler
             ExtensionTabItems.CollectionChanged -= this.OnCollectionChanged;
 
-            if (warningPopup != null)
-                warningPopup.CleanPopup();
+            if (fileTrustWarningPopup != null)
+                fileTrustWarningPopup.CleanPopup();
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -42,6 +42,7 @@ using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.UI.GuidedTour;
 using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels.Core;
+using Dynamo.Wpf.ViewModels.FileTrust;
 using Dynamo.Wpf.Views;
 using Dynamo.Wpf.Views.Debug;
 using Dynamo.Wpf.Views.FileTrust;
@@ -2473,6 +2474,27 @@ namespace Dynamo.Controls
             var dynViewModel = DataContext as DynamoViewModel;
             if (dynViewModel.FileTrustViewModel == null) return;
             dynViewModel.FileTrustViewModel.ShowWarningPopup = true;
+        }
+
+        private void DynamoView_Activated(object sender, EventArgs e)
+        {
+            if (dynamoViewModel.MainGuideManager != null && dynamoViewModel.MainGuideManager.currentGuide != null)
+            {
+                dynamoViewModel.MainGuideManager.ManagePopupActivation(true);
+            }
+               
+
+            if (warningPopup != null)
+                warningPopup.ManagePopupActivation(true);
+        }
+
+        private void DynamoView_Deactivated(object sender, EventArgs e)
+        {
+            if (dynamoViewModel.MainGuideManager != null && dynamoViewModel.MainGuideManager.currentGuide != null)
+                dynamoViewModel.MainGuideManager.ManagePopupActivation(false);
+
+            if(warningPopup != null)
+                warningPopup.ManagePopupActivation(false);
         }
 
         public void Dispose()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -369,7 +369,7 @@
                AllowsTransparency="True"
                Opened="OnContextMenuOpened"
                Placement="MousePoint"
-               StaysOpen="True"
+               StaysOpen="False"
                Style="{StaticResource WorkspaceContextMenuStylePopup}">
             <Popup.Resources>
                 <Style TargetType="{x:Type MenuItem}">

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -111,6 +111,7 @@ namespace Dynamo.Wpf.Views.FileTrust
         private void CloseFileButton_Click(object sender, RoutedEventArgs e)
         {
             fileTrustWarningViewModel.ShowWarningPopup = false;
+            fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
             if (dynViewModel.CloseHomeWorkspaceCommand.CanExecute(null))
             {
                 dynViewModel.CloseHomeWorkspaceCommand.Execute(null);
@@ -125,6 +126,7 @@ namespace Dynamo.Wpf.Views.FileTrust
         {
             fileTrustWarningViewModel.AllowOneTimeTrust = true;
             fileTrustWarningViewModel.ShowWarningPopup = false;
+            fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
             RunSettings.ForceBlockRun = false;
             if (FileTrustWarningCheckBox.IsChecked.Value == true)
             {
@@ -162,6 +164,17 @@ namespace Dynamo.Wpf.Views.FileTrust
                 fileTrustWarningViewModel.PropertyChanged -= ViewModel_PropertyChanged;
                 fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
             }
+        }
+
+        /// <summary>
+        /// This method will show/hide the Popup when the main window is Activated or Deactivated
+        /// </summary>
+        internal void ManagePopupActivation(bool activate)
+        {
+            if (dynViewModel.FileTrustViewModel.ShowWarningPopup == !activate &&
+               !string.IsNullOrEmpty(dynViewModel.FileTrustViewModel.DynFileDirectoryName) &&
+               RunSettings.ForceBlockRun == true)
+                IsOpen = activate;
         }
 
         private void SetUpPopup()


### PR DESCRIPTION
### Purpose

I implemented the functionality of  hiding/showing the FileTrustUI and GuidedTours popups when the Dynamo window is inactive (in background).
I've tested the functionality for the User Interface tour and Packages tour and for the exitwindow that appear in the Packages tour.
For the other tours the RealTimeWindow (that appear when exiting the Guide) wont' have this functionality implemented.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

I implemented the functionality of  hiding/showing the FileTrustUI and GuidedTours popups when the Dynamo window is inactive.

### Reviewers

@QilongTang 

### FYIs


