### PR TITLE
add more logging to trust tests

### DIFF
--- a/test/DynamoCoreTests/TrustLocationsTests.cs
+++ b/test/DynamoCoreTests/TrustLocationsTests.cs
@@ -90,7 +90,7 @@ namespace Dynamo.Tests
             Assert.IsTrue(settings.AddTrustedLocation(rootDir), $"adding {rootDir} (root dir of this machine) should succeed");
             Assert.IsFalse(settings.AddTrustedLocation($"{rootDir}users"), "adding a subdirectory of already trusted path should fail.");
             Assert.IsFalse(settings.AddTrustedLocation($"{rootDir}Users\\pinzart\\AppData\\Local\\Temp\\1"), "adding path that does not exist should fail. ");
-            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()), "root volume should be trusted, so all sub folders should be trusted.");
+            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()), $"root volume should be trusted, so all sub folders should be trusted.root was{rootDir}, temppath was {Path.GetTempPath()}");
         }
 
         [Test]

--- a/test/DynamoCoreTests/TrustLocationsTests.cs
+++ b/test/DynamoCoreTests/TrustLocationsTests.cs
@@ -24,71 +24,72 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("UnitTests"), Category("Failure")]
+        [Category("UnitTests")]
         public void TestTrustLocationManagerAPIs()
         {
-            Assert.AreEqual(settings.TrustedLocations.Count, 2);
+            Assert.AreEqual(settings.TrustedLocations.Count, 2, "trust location count is incorrect");
 
-            Assert.IsFalse(settings.IsTrustedLocation(".//Test"));
+            Assert.IsFalse(settings.IsTrustedLocation(".//Test"), "relative path should not be trusted");
 
-            Assert.IsFalse(settings.IsTrustedLocation(null));
+            Assert.IsFalse(settings.IsTrustedLocation(null), "null should not be trusted");
 
-            Assert.IsFalse(settings.IsTrustedLocation(""));
+            Assert.IsFalse(settings.IsTrustedLocation(""), "empty should not be trusted");
 
-            Assert.IsFalse(settings.IsTrustedLocation(Path.GetTempPath()));
+            Assert.IsFalse(settings.IsTrustedLocation(Path.GetTempPath()), "temp should not be trusted by default");
 
-            Assert.IsTrue(settings.AddTrustedLocation(Path.GetTempPath()));
+            Assert.IsTrue(settings.AddTrustedLocation(Path.GetTempPath()), "temp should be added to trusted paths successfully");
 
-            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()));
+            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()), "temp should now be trusted");
 
             var tempWithSuffix = Path.GetTempPath() + "2222";
-            Assert.IsFalse(settings.TrustedLocations.Contains(tempWithSuffix));
-            Assert.IsFalse(settings.IsTrustedLocation(tempWithSuffix));
+            Assert.IsFalse(settings.TrustedLocations.Contains(tempWithSuffix), "temp with suffix should not be in list of paths");
+            Assert.IsFalse(settings.IsTrustedLocation(tempWithSuffix), "temp with suffix should not be trusted");
 
-            Assert.IsFalse(settings.IsTrustedLocation(Path.Combine(TestDirectory, ":")));
+            Assert.IsFalse(settings.IsTrustedLocation(Path.Combine(TestDirectory, ":")), "sibling path should not be trusted");
 
             var doesNotExist = settings.TrustedLocations[0];
-            Assert.IsFalse(settings.IsTrustedLocation(doesNotExist));
+            Assert.IsFalse(settings.IsTrustedLocation(doesNotExist), "trusted location must exist");
 
             var notTrusted = Directory.GetParent(doesNotExist).FullName;
-            Assert.IsFalse(settings.IsTrustedLocation(notTrusted));
+            Assert.IsFalse(settings.IsTrustedLocation(notTrusted), "Parent of trusted should not be trusted.");
 
             var trusted = settings.TrustedLocations[1];
-            Assert.IsTrue(settings.IsTrustedLocation(trusted));
+            Assert.IsTrue(settings.IsTrustedLocation(trusted), "executing dir should be trusted");
 
-            Assert.IsFalse(settings.AddTrustedLocation(ExecutingDirectory));
-            Assert.IsTrue(settings.AddTrustedLocation(Path.Combine(TestDirectory, "pkgs")));
+            Assert.IsFalse(settings.AddTrustedLocation(ExecutingDirectory), "should not be able to add path twice");
+            Assert.IsTrue(settings.AddTrustedLocation(Path.Combine(TestDirectory, "pkgs")), "add test package dir to trust successfully");
 
-            Assert.IsFalse(settings.AddTrustedLocation(Path.GetTempPath()));
+            Assert.IsFalse(settings.AddTrustedLocation(Path.GetTempPath()), "cannot add tempt path twice to trusted paths");
 
-            Assert.AreEqual(4, settings.TrustedLocations.Count);
-            Assert.IsTrue(settings.RemoveTrustedLocation(ExecutingDirectory));
-            Assert.AreEqual(3, settings.TrustedLocations.Count);
+            Assert.AreEqual(4, settings.TrustedLocations.Count, "should be 4 trusted paths");
+            Assert.IsTrue(settings.RemoveTrustedLocation(ExecutingDirectory), "can remove executing dir from trust paths - loc 1");
+            Assert.AreEqual(3, settings.TrustedLocations.Count, "3 paths remain");
 
-            Assert.IsTrue(settings.RemoveTrustedLocation(Path.GetTempPath()));
+            Assert.IsTrue(settings.RemoveTrustedLocation(Path.GetTempPath()), $"can remove temp path");
 
-            Assert.IsTrue(settings.RemoveTrustedLocation(Path.Combine(TestDirectory, "pkgs")));
-            Assert.AreEqual(1, settings.TrustedLocations.Count);
+            Assert.IsTrue(settings.RemoveTrustedLocation(Path.Combine(TestDirectory, "pkgs")), "can remove test pkg dir");
+            Assert.AreEqual(1, settings.TrustedLocations.Count, "1 path remains");
 
             // Test that TrustedLocations (in preferenceSettings) are immutable.
             settings.TrustedLocations.Clear();
-            Assert.AreEqual(1, settings.TrustedLocations.Count);
+            Assert.AreEqual(1, settings.TrustedLocations.Count, "clearing external list copy does not modify property");
 
-            Assert.IsFalse(settings.AddTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd", "pkg.json")));
-            Assert.IsFalse(settings.IsTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd")));
+            Assert.IsFalse(settings.AddTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd", "pkg.json")), "cannot add file as path");
+            Assert.IsFalse(settings.IsTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd")), "parent of file is not trusted");
 
-            Assert.IsTrue(settings.AddTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd")));
-            Assert.IsTrue(settings.IsTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd")));
+            Assert.IsTrue(settings.AddTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd")), "can add package folder as trusted path");
+            Assert.IsTrue(settings.IsTrustedLocation(Path.Combine(TestDirectory, "pkgs", "EvenOdd")), "package folder is trusted after adding.");
 
             settings.SetTrustedLocations(new List<string>() { TestDirectory });
 
-            Assert.IsTrue(settings.IsTrustedLocation(TestDirectory));
-            Assert.AreEqual(1, settings.TrustedLocations.Count);
+            Assert.IsTrue(settings.IsTrustedLocation(TestDirectory), "test dir should have been set as trusted");
+            Assert.AreEqual(1, settings.TrustedLocations.Count, "set trusted should have set only 1 path");
 
-            Assert.IsTrue(settings.AddTrustedLocation(@"C:\"));
-            Assert.IsFalse(settings.AddTrustedLocation(@"C:\users"));
-            Assert.IsFalse(settings.AddTrustedLocation(@"C:\Users\pinzart\AppData\Local\Temp\1"));
-            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()));
+            var rootDir = Path.GetPathRoot(System.Environment.SystemDirectory);
+            Assert.IsTrue(settings.AddTrustedLocation(rootDir), $"adding {rootDir} (root dir of this machine) should succeed");
+            Assert.IsFalse(settings.AddTrustedLocation($"{rootDir}users"), "adding a subdirectory of already trusted path should fail.");
+            Assert.IsFalse(settings.AddTrustedLocation($"{rootDir}Users\\pinzart\\AppData\\Local\\Temp\\1"), "adding path that does not exist should fail. ");
+            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()), "root volume should be trusted, so all sub folders should be trusted.");
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

add more logging to trust tests
-  I assume a failure because temp path is somehow not under root dir on this machine - temp path can be overrriden by a local env var in windows but I want to confirm this before changing the test.


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
