### PR TITLE
Update TrustLocationsTests.cs to test sub directory we know exists

### DIFF
--- a/test/DynamoCoreTests/TrustLocationsTests.cs
+++ b/test/DynamoCoreTests/TrustLocationsTests.cs
@@ -90,7 +90,7 @@ namespace Dynamo.Tests
             Assert.IsTrue(settings.AddTrustedLocation(rootDir), $"adding {rootDir} (root dir of this machine) should succeed");
             Assert.IsFalse(settings.AddTrustedLocation($"{rootDir}users"), "adding a subdirectory of already trusted path should fail.");
             Assert.IsFalse(settings.AddTrustedLocation($"{rootDir}Users\\pinzart\\AppData\\Local\\Temp\\1"), "adding path that does not exist should fail. ");
-            Assert.IsTrue(settings.IsTrustedLocation(Path.GetTempPath()), $"root volume should be trusted, so all sub folders should be trusted.root was{rootDir}, temppath was {Path.GetTempPath()}");
+            Assert.IsTrue(settings.IsTrustedLocation(System.Environment.SystemDirectory), $"root volume should be trusted, so all sub folders should be trusted.root was{rootDir}, sub dir was {System.Environment.SystemDirectory}");
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

instead of trying to test nested directory functionality with  `TempPath` (which can be overridden by env vars) let's use a directory we know that will be under the root volume, like `C:\WINDOWS\System32` - whatever this returns, it should work given that we have built the root directory from this path initially, even if it's not what we expect.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

NA

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
