### PR TITLE
DYN-4731-Ghost-Warning

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1199,7 +1199,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void BuildErrorBubble()
         {
-            if (ErrorBubble == null) ErrorBubble = new InfoBubbleViewModel(DynamoViewModel)
+            if (ErrorBubble == null) ErrorBubble = new InfoBubbleViewModel(DynamoViewModel, this)
             {
                 IsCollapsed = this.IsCollapsed
             };
@@ -1971,12 +1971,12 @@ namespace Dynamo.ViewModels
         }
         
         #region Private Helper Methods
-        private Point GetTopLeft()
+        internal Point GetTopLeft()
         {
             return new Point(NodeModel.X, NodeModel.Y);
         }
 
-        private Point GetBotRight()
+        internal Point GetBotRight()
         {
             return new Point(NodeModel.X + NodeModel.Width, NodeModel.Y + NodeModel.Height);
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1199,7 +1199,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void BuildErrorBubble()
         {
-            if (ErrorBubble == null) ErrorBubble = new InfoBubbleViewModel(DynamoViewModel, this)
+            if (ErrorBubble == null) ErrorBubble = new InfoBubbleViewModel(this)
             {
                 IsCollapsed = this.IsCollapsed
             };

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -466,6 +466,32 @@ namespace Dynamo.ViewModels
         /// <param name="dynamoViewModel"></param>
         public InfoBubbleViewModel(DynamoViewModel dynamoViewModel)
         {
+            InitializeInfoBubble(dynamoViewModel);
+        }
+
+        /// <summary>
+        /// This constructor will update the TopBottom and BottomRight positions of the warnings since the beginning.
+        /// </summary>
+        /// <param name="dynamoViewModel"></param>
+        /// <param name="nodeViewModel">This parameter will be used to get the TopBottom and BottomRight positions of the NodeModel</param>
+        public InfoBubbleViewModel(DynamoViewModel dynamoViewModel, NodeViewModel nodeViewModel)
+        {
+
+            InitializeInfoBubble(dynamoViewModel);
+
+            if (nodeViewModel != null)
+            {
+                var data = new InfoBubbleDataPacket
+                {
+                    TopLeft = nodeViewModel.GetTopLeft(),
+                    BotRight = nodeViewModel.GetBotRight()
+                };
+                UpdatePosition(data);
+            }
+        }
+
+        private void InitializeInfoBubble(DynamoViewModel dynamoViewModel)
+        {
             this.DynamoViewModel = dynamoViewModel;
 
             // Default values
@@ -477,7 +503,7 @@ namespace Dynamo.ViewModels
             InfoBubbleState = State.Minimized;
 
             NodeMessages.CollectionChanged += NodeInformation_CollectionChanged;
-            
+
             RefreshNodeInformationalStateDisplay();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -476,11 +476,11 @@ namespace Dynamo.ViewModels
         /// <param name="nodeViewModel">This parameter will be used to get the TopBottom and BottomRight positions of the NodeModel</param>
         public InfoBubbleViewModel(NodeViewModel nodeViewModel)
         {
-
-            InitializeInfoBubble(nodeViewModel.DynamoViewModel);
-
             if (nodeViewModel != null)
             {
+                InitializeInfoBubble(nodeViewModel.DynamoViewModel);
+
+            
                 var data = new InfoBubbleDataPacket
                 {
                     TopLeft = nodeViewModel.GetTopLeft(),

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -474,10 +474,10 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="dynamoViewModel"></param>
         /// <param name="nodeViewModel">This parameter will be used to get the TopBottom and BottomRight positions of the NodeModel</param>
-        public InfoBubbleViewModel(DynamoViewModel dynamoViewModel, NodeViewModel nodeViewModel)
+        public InfoBubbleViewModel(NodeViewModel nodeViewModel)
         {
 
-            InitializeInfoBubble(dynamoViewModel);
+            InitializeInfoBubble(nodeViewModel.DynamoViewModel);
 
             if (nodeViewModel != null)
             {


### PR DESCRIPTION
### Purpose

Fix the ghost warnings appearing when opening graphs.
I added a new constructor for the InfoBubbleViewModel class so we can pass the NodeViewModel and set the TopBottom and BottomRight positions of the warnings.
Also I changed to internal the methods NodeViewModel.GetTopLeft() and NodeViewModel.GetBotRight() so we have access to them in the InfoBubbleViewModel.


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix the ghost warnings appearing when opening graphs.


### Reviewers

@QilongTang 

### FYIs

