### PR TITLE
[DYN-5036] Update error message when adding directory to trusted locations is not accessible.

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7854,6 +7854,16 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A problem occurred when trying to access the location. Dynamo is unable to obtain read/write access to
+        ///{0}.
+        /// </summary>
+        public static string TrustedLocationNotAccessible {
+            get {
+                return ResourceManager.GetString("TrustedLocationNotAccessible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Trusted location.
         /// </summary>
         public static string TrustedPathsExpanderName {
@@ -7887,6 +7897,15 @@ namespace Dynamo.Wpf.Properties {
         public static string UnableToAccessPackageDirectory {
             get {
                 return ResourceManager.GetString("UnableToAccessPackageDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable To Access Directory.
+        /// </summary>
+        public static string UnableToAccessTrustedDirectory {
+            get {
+                return ResourceManager.GetString("UnableToAccessTrustedDirectory", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3245,4 +3245,11 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="TitlePackageTargetOtherHost" xml:space="preserve">
     <value>Package Host Error</value>
   </data>
+  <data name="TrustedLocationNotAccessible" xml:space="preserve">
+    <value>A problem occurred when trying to access the trusted location. Dynamo is unable to obtain read/write access to
+{0}</value>
+  </data>
+  <data name="UnableToAccessTrustedDirectory" xml:space="preserve">
+    <value>Unable To Access Trusted Directory</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3232,4 +3232,11 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="TitlePackageTargetOtherHost" xml:space="preserve">
     <value>Package Host Error</value>
   </data>
+  <data name="TrustedLocationNotAccessible" xml:space="preserve">
+    <value>A problem occurred when trying to access the location. Dynamo is unable to obtain read/write access to
+{0}</value>
+  </data>
+  <data name="UnableToAccessTrustedDirectory" xml:space="preserve">
+    <value>Unable To Access Directory</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/TrustedPathViewModel.cs
@@ -114,8 +114,8 @@ namespace Dynamo.ViewModels
                     this.logger?.LogError($"Failed to add trusted location ${args.Path} due to the following error: {ex.Message}");
                 }
 
-                string errorMessage = string.Format(Resources.PackageFolderNotAccessible, args.Path);
-                MessageBoxService.Show(errorMessage, Resources.UnableToAccessPackageDirectory, MessageBoxButton.OK, MessageBoxImage.Error);
+                string errorMessage = string.Format(Resources.TrustedLocationNotAccessible, args.Path);
+                MessageBoxService.Show(errorMessage, Resources.UnableToAccessTrustedDirectory, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
             


### PR DESCRIPTION
### Purpose

When adding an in-accessible folder to trusted locations now appropriate warning message will be displayed.

![DynamoSandbox_znyAf9dxZZ](https://user-images.githubusercontent.com/32665108/174325664-ab29253a-83be-4bc2-97ab-20178c6d7fd7.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Update error message when adding directory to trusted locations is not accessible.


### Reviewers

@QilongTang 
