### PR TITLE
Validate the resizing based on the Control role

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -54,25 +54,29 @@ namespace Dynamo.Controls
         {
             if (e.PropertyName == nameof(WatchViewModel.IsCollection))
             {
-                if (_vm.IsCollection)
+                // // The WatchTree controll will resize only if its role is a WatchNode (starts with an specific height), otherwise it won't resize (Bubble role).
+                if (!Double.IsNaN(this.Height))
                 {
-                    this.Height = defaultHeightSize;
-                }
-                else
-                {
-                    this.Height = minHeightSize;
-                    if (_vm.Children.Count !=0)
+                    if (_vm.IsCollection)
                     {
-                        if (NodeLabel.Contains(Environment.NewLine) || NodeLabel.ToUpper() == nameof(WatchViewModel.DICTIONARY))
+                        this.Height = defaultHeightSize;
+                    }
+                    else
+                    {
+                        this.Height = minHeightSize;
+                        if (_vm.Children.Count != 0)
                         {
-                            this.Height = defaultHeightSize;
+                            if (NodeLabel.Contains(Environment.NewLine) || NodeLabel.ToUpper() == nameof(WatchViewModel.DICTIONARY))
+                            {
+                                this.Height = defaultHeightSize;
+                            }
                         }
-                    }                    
-                }
-                // When it doesn't have any element, it should be set back the width to the default.
-                if (_vm.Children != null && _vm.Children.Count == 0)
-                {
-                    this.Width = defaultWidthSize;
+                    }
+                    // When it doesn't have any element, it should be set back the width to the default.
+                    if (_vm.Children != null && _vm.Children.Count == 0)
+                    {
+                        this.Width = defaultWidthSize;
+                    }
                 }
             }
             else if (e.PropertyName == nameof(WatchViewModel.Children))
@@ -89,7 +93,7 @@ namespace Dynamo.Controls
                             requiredWidth = MaxWidthSize;
                         }
                         requiredWidth += extraWidthSize;
-                        this.Width = requiredWidth;                        
+                        this.Width = requiredWidth;
                     }
                     else
                     {


### PR DESCRIPTION
### Purpose

Restricting the resize of the control only in a WatchNode role, it won't resize if its playing a Bubble role
https://jira.autodesk.com/browse/DYN-5020

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
