### PR TITLE
Re-add allowrankreduction attribute to Dictionary.Values

### DIFF
--- a/src/Libraries/DesignScriptBuiltin/Dictionary.cs
+++ b/src/Libraries/DesignScriptBuiltin/Dictionary.cs
@@ -59,8 +59,7 @@ namespace DesignScript
             ///     Produces the values in a Dictionary.
             /// </summary>
             /// <returns name="values">Values of the dictionary</returns>
-            // [AllowRankReduction]
-            // TODO: Consider adding this attribute in 3.0 (DYN-1697)
+            [AllowRankReduction]
             public IEnumerable<object> Values => D.Values;
 
             /// <summary>


### PR DESCRIPTION
### Purpose

Fixes a case like this that would fail. It now works as expected.
![image](https://user-images.githubusercontent.com/5710686/174910225-07c1e87b-99b7-4af1-8dfe-768d4031f322.png)


### Declarations

This introduces an API break but I think it's a necessary fix. Alternatively, we can add a new property with a different but similar name to `Values` and deprecate `Values`.

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@saintentropy 

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

@Amoursol what do you think?
