### PR TITLE
Workspace_ContextMenuPopup_Bug

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -369,7 +369,7 @@
                AllowsTransparency="True"
                Opened="OnContextMenuOpened"
                Placement="MousePoint"
-               StaysOpen="False"
+               StaysOpen="True"
                Style="{StaticResource WorkspaceContextMenuStylePopup}">
             <Popup.Resources>
                 <Style TargetType="{x:Type MenuItem}">


### PR DESCRIPTION
### Purpose

Reverting fix in WorkspaceView
Due to my change in putting StaysOpen = False ( https://github.com/DynamoDS/Dynamo/pull/13002 ) the WorkspaceView ContextMenu doesn't work any more because the Commands are not executed, then I'm reverting this change until I find a fix for this.


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Reverting fix in WorkspaceView


### Reviewers

@QilongTang

### FYIs

@aparajit-pratap 
