### PR TITLE
DYN-5050-Bug-AddingTrustedPath

### DIFF
--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -126,7 +126,7 @@ namespace Dynamo.Wpf.Views.FileTrust
         {
             fileTrustWarningViewModel.AllowOneTimeTrust = true;
             fileTrustWarningViewModel.ShowWarningPopup = false;
-            fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
+            
             RunSettings.ForceBlockRun = false;
             if (FileTrustWarningCheckBox.IsChecked.Value == true)
             {
@@ -142,6 +142,8 @@ namespace Dynamo.Wpf.Views.FileTrust
                 (dynViewModel.HomeSpaceViewModel as HomeWorkspaceViewModel).CurrentNotificationMessage = Properties.Resources.RunReady;
                 (dynViewModel.HomeSpaceViewModel as HomeWorkspaceViewModel).CurrentNotificationLevel = NotificationLevel.Mild;
             }
+
+            fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

After the changes done in the next PR: https://github.com/DynamoDS/Dynamo/pull/13002 I introduced a bug that was not allowing to save the path added in trusted locations, then with this fix is saving again the trusted locations.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

 I introduced a bug that was not allowing to save the path added in trusted locations, then with this fix is saving again the trusted locations.


### Reviewers

@QilongTang 

### FYIs

