### PR TITLE
Bugfix Vertical Margin of Note in Group

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -22,6 +22,7 @@ namespace Dynamo.Graph.Annotations
         private const double MinTextHeight = 20.0;
         private const double ExtendSize = 10.0;
         private const double ExtendYHeight = 5.0;
+        private const double NoteYAdjustment = 8.0;
 
         #region Properties
 
@@ -475,15 +476,15 @@ namespace Dynamo.Graph.Annotations
                 var regionX = groupModels.Min(x => x.X) - ExtendSize;
                 //Increase the Y value by 10. This provides the extra space between
                 // a model and textbox. Otherwise there will be some overlap
-                var regionY = groupModels.Min(y => y.Y) -
+                var regionY = groupModels.Min(y => (y as NoteModel) == null ? (y.Y) : (y.Y - NoteYAdjustment)) -
                     ExtendSize - (TextBlockHeight == 0.0 ? MinTextHeight : TextBlockHeight);
 
                 //calculates the distance between the nodes
                 var xDistance = groupModels.Max(x => (x.X + x.Width)) - regionX;
-                var yDistance = groupModels.Max(x => (x.Y + x.Height)) - regionY;
-
+                var yDistance = groupModels.Max(y => (y as NoteModel) == null ? (y.Y + y.Height) : (y.Y + y.Height - NoteYAdjustment)) - regionY;
+                
                 // InitialTop is to store the Y value without the Textblock height
-                this.InitialTop = groupModels.Min(y => y.Y);
+                this.InitialTop = groupModels.Min(y => (y as NoteModel) == null ? (y.Y) : (y.Y - NoteYAdjustment));
 
 
                 var region = new Rect2D
@@ -515,7 +516,7 @@ namespace Dynamo.Graph.Annotations
             else
             {
                 this.Width = 0;
-                this.height = 0;               
+                this.Height = 0;               
             }
         }
 


### PR DESCRIPTION
### Purpose

A but-fix affecting Notes inside Groups. Notes display a consistent vertical offset, which has been addressed with this PR.


**Before**

![before](https://user-images.githubusercontent.com/5354594/176181524-6f986ed1-9b3a-4835-9e90-2604e0d6cd13.gif)

**After**

![after](https://user-images.githubusercontent.com/5354594/176181582-c6ac2f91-c14a-48e8-b723-e929758463d9.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- fixed an issue where Notes in Groups display a skewed vertical margin causing the Note to overlap when in the top position or push the boundary unrealistically when in the bottom position inside the Group


### Reviewers

@reddyashish 
@mjkkirschner 

### FYIs

@Amoursol 

