### PR TITLE
DYN-5018 Collapsed group moving fix

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -23,6 +23,8 @@ namespace Dynamo.Graph.Annotations
         private const double ExtendSize = 10.0;
         private const double ExtendYHeight = 5.0;
 
+        double lastExpandedWidth = 0;
+
         #region Properties
 
         /// <summary>
@@ -498,9 +500,19 @@ namespace Dynamo.Graph.Annotations
 
                 this.X = region.X;              
                 this.Y = region.Y;
-                this.Width = Math.Max(region.Width, TextMaxWidth + ExtendSize);
                 this.ModelAreaHeight = IsExpanded ? region.Height : ModelAreaHeight;
-                this.Height = this.ModelAreaHeight + TextBlockHeight;
+                Height = this.ModelAreaHeight + TextBlockHeight;
+
+                if (IsExpanded)
+                {
+                    Width = Math.Max(region.Width, TextMaxWidth + ExtendSize);                    
+                    lastExpandedWidth = Width;
+                }
+                else
+                {
+                    //If the annotation is not expanded, than it will remain the same width of the last time it was expanded
+                    Width = lastExpandedWidth;
+                }
 
                 //Initial Height is to store the Actual height of the group.
                 //that is the height should be the initial height without the textblock height.

--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -510,7 +510,7 @@ namespace Dynamo.Graph.Annotations
                 }
                 else
                 {
-                    //If the annotation is not expanded, than it will remain the same width of the last time it was expanded
+                    //If the annotation is not expanded, then it will remain the same width of the last time it was expanded
                     Width = lastExpandedWidth;
                 }
 


### PR DESCRIPTION
### Purpose

This PR is to fix the bug when the user moves a collapsed group horizontally.
The issue was occurring because of an unusual change in the width value. To fix that was created a variable to keep the previous value of the group's width when collapsed.

![wirebug](https://user-images.githubusercontent.com/89042471/176334386-5c0903c6-6135-4c2f-8423-c4b0296e30fb.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang @pinzart 

