### PR TITLE
[DNM] Align node previews with number format selected in preferences

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1574,7 +1574,7 @@ namespace Dynamo.Models
 
         private static void InitializePreferences(IPreferences preferences)
         {
-            DynamoUnits.Display.PrecisionFormat = preferences.NumberFormat;
+            ProtoCore.Mirror.MirrorData.PrecisionFormat = DynamoUnits.Display.PrecisionFormat = preferences.NumberFormat;
 
             var settings = preferences as PreferenceSettings;
             if (settings != null)
@@ -1594,8 +1594,8 @@ namespace Dynamo.Models
         {
             switch (e.PropertyName)
             {
-                case "NumberFormat":
-                    DynamoUnits.Display.PrecisionFormat = PreferenceSettings.NumberFormat;
+                case nameof(PreferenceSettings.NumberFormat):
+                    ProtoCore.Mirror.MirrorData.PrecisionFormat = DynamoUnits.Display.PrecisionFormat = PreferenceSettings.NumberFormat;
                     break;
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -255,7 +255,7 @@ namespace Dynamo.ViewModels
                 case TypeCode.Boolean:
                     return ObjectToLabelString(obj);
                 case TypeCode.Double:
-                    return ((double)obj).ToString(numberFormat, CultureInfo.InvariantCulture);
+                    return ((double)obj).ToString(ProtoCore.Mirror.MirrorData.PrecisionFormat, CultureInfo.InvariantCulture);
                 case TypeCode.Int32:
                     return ((int)obj).ToString(CultureInfo.InvariantCulture);
                 case TypeCode.Int64:

--- a/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
+++ b/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ProtoTest")]
 [assembly: InternalsVisibleTo("ProtoTestFx")]
 [assembly:InternalsVisibleTo("DynamoCore")]
+[assembly:InternalsVisibleTo("DynamoCoreWpf")]
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
 [assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
 [assembly: InternalsVisibleTo("ProtoImperative")]

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -208,6 +208,8 @@ namespace ProtoCore
                 return null;
             }
 
+            internal static string PrecisionFormat { get; set; } = "f3";
+
             /// <summary>
             /// Returns string representation of data
             /// </summary>
@@ -230,7 +232,11 @@ namespace ProtoCore
                         // https://msdn.microsoft.com/en-us/library/3hfd35ad(v=vs.110).aspx
                         // We should always use invariant culture format for formattable 
                         // object.
-                        return (Data as IFormattable).ToString(null, CultureInfo.InvariantCulture);
+                        if (Data is double)
+                        {
+                            return (Data as IFormattable).ToString(PrecisionFormat, CultureInfo.InvariantCulture);
+                        }
+                        else return (Data as IFormattable).ToString(null, CultureInfo.InvariantCulture);
                     }
                     else
                     {


### PR DESCRIPTION
### Purpose

See [slack thread](https://autodesk.slack.com/archives/C01C8GGT9EY/p1656409906857579).

![image](https://user-images.githubusercontent.com/5710686/176542474-1b721764-f45c-4f0a-9aa9-2ff33a249ebf.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 

### FYIs

@Amoursol 
