### PR TITLE
Workspace References refactoring

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -935,6 +935,9 @@ namespace Dynamo.Graph.Workspaces
             return externalFiles.Values.ToList<INodeLibraryDependencyInfo>();
         }
 
+        /// <summary>
+        /// This flag will indicate if the workspace references should be computed again.
+        /// </summary>
         internal bool ForceComputeWorkspaceReferences
         {
             get { return forceComputeWorkspaceReferences; }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -238,8 +238,16 @@ namespace Dynamo.Graph.Workspaces
         private bool hasNodeInSyncWithDefinition;
         protected Guid guid;
         private HashSet<Guid> dependencies = new HashSet<Guid>();
-
         private int delayGraphExecutionCounter = 0;
+
+        // For workspace references view extension.
+        private bool forceComputeWorkspaceReferences;
+        private List<INodeLibraryDependencyInfo> nodeLibraryDependencies;
+        private List<INodeLibraryDependencyInfo> nodeLocalDefinitions;
+        private List<INodeLibraryDependencyInfo> externalFileReferences;
+        private Dictionary<Guid, PackageInfo> nodePackageDictionary = new Dictionary<Guid, PackageInfo>();
+        private Dictionary<Guid, DependencyInfo> localDefinitionsDictionary = new Dictionary<Guid, DependencyInfo>();
+        private Dictionary<Guid, DependencyInfo> externalFilesDictionary = new Dictionary<Guid, DependencyInfo>();
         private readonly string customNodeExtension = ".dyf";
 
         /// <summary>
@@ -641,65 +649,15 @@ namespace Dynamo.Graph.Workspaces
         {
             get
             {
-                var packageDependencies = new Dictionary<PackageInfo, PackageDependencyInfo>();
-                foreach (var node in Nodes)
+                if (HasUnsavedChanges || ForceComputeWorkspaceReferences)
                 {
-                    var collected = GetNodePackage(node);
-                    if (nodePackageDictionary.ContainsKey(node.GUID))
-                    {
-                        var saved = nodePackageDictionary[node.GUID];
-                        if (!packageDependencies.ContainsKey(saved))
-                        {
-                            packageDependencies[saved] = new PackageDependencyInfo(saved);
-                        }
-                        packageDependencies[saved].AddDependent(node.GUID);
-
-                        // if the package is not installed.
-                        if (collected == null)
-                        {
-                            packageDependencies[saved].State = PackageDependencyState.Missing;
-                        }
-                        // If the state is Missing for at least one of the nodes,
-                        // we set the state of the whole package dependency to Missing.
-                        // Set other states accordingly, only if the PackageDependencyState(for that package)
-                        // is not set to Missing by any of the other nodes. 
-                        else if (packageDependencies[saved].State != PackageDependencyState.Missing)
-                        {
-                            if (saved.Name == collected.Name)
-                            {
-                                // if the correct version of package is installed.
-                                if (saved.Version == collected.Version)
-                                {
-                                    packageDependencies[saved].State = PackageDependencyState.Loaded;
-                                }
-                                // If incorrect version of package is installed and not marked for uninstall,
-                                // set the state. Otherwise, keep the RequiresRestart state away from overwritten.
-                                else if (packageDependencies[saved].State != PackageDependencyState.RequiresRestart)
-                                {
-                                    packageDependencies[saved].State = PackageDependencyState.IncorrectVersion;
-                                }
-                            }
-                            // if the package is not installed, but the nodes are resolved by a different package.
-                            else
-                            {
-                                packageDependencies[saved].State = PackageDependencyState.Warning;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (collected != null)
-                        {
-                            if (!packageDependencies.ContainsKey(collected))
-                            {
-                                packageDependencies[collected] = new PackageDependencyInfo(collected);
-                            }
-                            packageDependencies[collected].AddDependent(node.GUID);
-                            packageDependencies[collected].State = PackageDependencyState.Loaded;
-                        }
-                    }
+                    nodeLibraryDependencies = ComputeNodeLibraryDependencies();
+                    return nodeLibraryDependencies;
                 }
-                return packageDependencies.Values.ToList<INodeLibraryDependencyInfo>();
+                else
+                {
+                    return nodeLibraryDependencies;
+                }
             }
             set
             {
@@ -720,63 +678,22 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
+        /// <summary>
+        /// Local Node Definitions that the nodes in this graph depend on
+        /// </summary>
         internal List<INodeLibraryDependencyInfo> NodeLocalDefinitions
         {
             get
             {
-                var nodeLocalDefinitions = new Dictionary<object, DependencyInfo>();
-
-                foreach (var node in Nodes)
+                if (HasUnsavedChanges || ForceComputeWorkspaceReferences)
                 {
-                    var collected = GetNodePackage(node);
-
-                    if (!nodePackageDictionary.ContainsKey(node.GUID) && collected == null)
-                    {
-                        string localDefinitionName;
-
-                        if (node.IsCustomFunction)
-                        {
-                            localDefinitionName = node.Name + customNodeExtension;
-
-                            if (!nodeLocalDefinitions.ContainsKey(localDefinitionName))
-                            {
-                                nodeLocalDefinitions[localDefinitionName] = new DependencyInfo(localDefinitionName);
-                            }
-
-                            nodeLocalDefinitions[localDefinitionName].AddDependent(node.GUID);
-                            nodeLocalDefinitions[localDefinitionName].ReferenceType = ReferenceType.DYFFile;
-                        }
-                        else if (node is DSFunctionBase functionNode)
-                        {
-                            string assemblyPath = functionNode.Controller.Definition.Assembly;
-                            var directoryName = Path.GetDirectoryName(assemblyPath);
-
-                            // For the local definition reference, the assembly directory exists on disc.
-                            if (!string.IsNullOrEmpty(directoryName) && Directory.Exists(directoryName))
-                            {
-                                localDefinitionName = Path.GetFileName(assemblyPath);
-
-                                if (!nodeLocalDefinitions.ContainsKey(localDefinitionName))
-                                {
-                                    nodeLocalDefinitions[localDefinitionName] = new DependencyInfo(localDefinitionName, assemblyPath);
-                                }
-
-                                nodeLocalDefinitions[localDefinitionName].AddDependent(node.GUID);
-                                nodeLocalDefinitions[localDefinitionName].ReferenceType = ReferenceType.ZeroTouch;
-                            }
-                        }
-                        else if (node is DummyNode)
-                        {
-                            // Read the serialized value if the node is not resolved.
-                            if (localDefinitionsDictionary.TryGetValue(node.GUID, out var localDefinitionInfo))
-                            {
-                                nodeLocalDefinitions[localDefinitionInfo.Name] = localDefinitionInfo;
-                            }
-                        }
-                    }
+                    nodeLocalDefinitions = ComputeNodeLocalDefinitions();
+                    return nodeLocalDefinitions;
                 }
-
-                return nodeLocalDefinitions.Values.ToList<INodeLibraryDependencyInfo>();
+                else
+                {
+                    return nodeLocalDefinitions;
+                }
             }
             set
             {
@@ -795,11 +712,22 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
+        /// <summary>
+        /// External File references that the nodes in this graph depend on
+        /// </summary>
         internal List<INodeLibraryDependencyInfo> ExternalFiles
         {
             get
             {
-                return GetExternalFiles();
+                if (HasUnsavedChanges || ForceComputeWorkspaceReferences)
+                {
+                    externalFileReferences = ComputeExternalFileReferences();
+                    return externalFileReferences;
+                }
+                else
+                {
+                    return externalFileReferences;
+                }
             }
             set
             {
@@ -819,10 +747,141 @@ namespace Dynamo.Graph.Workspaces
         }
 
         /// <summary>
+        /// Computes the node library dependencies in the current workspace.
+        /// </summary>
+        /// <returns></returns>
+        private List<INodeLibraryDependencyInfo> ComputeNodeLibraryDependencies()
+        {
+            var packageDependencies = new Dictionary<PackageInfo, PackageDependencyInfo>();
+
+            foreach (var node in Nodes)
+            {
+                var collected = GetNodePackage(node);
+
+                if (nodePackageDictionary.ContainsKey(node.GUID))
+                {
+                    var saved = nodePackageDictionary[node.GUID];
+                    if (!packageDependencies.ContainsKey(saved))
+                    {
+                        packageDependencies[saved] = new PackageDependencyInfo(saved);
+                    }
+                    packageDependencies[saved].AddDependent(node.GUID);
+
+                    // if the package is not installed.
+                    if (collected == null)
+                    {
+                        packageDependencies[saved].State = PackageDependencyState.Missing;
+                    }
+                    // If the state is Missing for at least one of the nodes,
+                    // we set the state of the whole package dependency to Missing.
+                    // Set other states accordingly, only if the PackageDependencyState(for that package)
+                    // is not set to Missing by any of the other nodes. 
+                    else if (packageDependencies[saved].State != PackageDependencyState.Missing)
+                    {
+                        if (saved.Name == collected.Name)
+                        {
+                            // if the correct version of package is installed.
+                            if (saved.Version == collected.Version)
+                            {
+                                packageDependencies[saved].State = PackageDependencyState.Loaded;
+                            }
+                            // If incorrect version of package is installed and not marked for uninstall,
+                            // set the state. Otherwise, keep the RequiresRestart state away from overwritten.
+                            else if (packageDependencies[saved].State != PackageDependencyState.RequiresRestart)
+                            {
+                                packageDependencies[saved].State = PackageDependencyState.IncorrectVersion;
+                            }
+                        }
+                        // if the package is not installed, but the nodes are resolved by a different package.
+                        else
+                        {
+                            packageDependencies[saved].State = PackageDependencyState.Warning;
+                        }
+                    }
+                }
+                else
+                {
+                    if (collected != null)
+                    {
+                        if (!packageDependencies.ContainsKey(collected))
+                        {
+                            packageDependencies[collected] = new PackageDependencyInfo(collected);
+                        }
+                        packageDependencies[collected].AddDependent(node.GUID);
+                        packageDependencies[collected].State = PackageDependencyState.Loaded;
+                    }
+                }
+            }
+
+            return packageDependencies.Values.ToList<INodeLibraryDependencyInfo>();
+        }
+
+        /// <summary>
+        /// Computes the node local definitions in the current workspace.
+        /// </summary>
+        /// <returns></returns>
+        private List<INodeLibraryDependencyInfo> ComputeNodeLocalDefinitions()
+        {
+            var nodeLocalDefinitions = new Dictionary<object, DependencyInfo>();
+
+            foreach (var node in Nodes)
+            {
+                var collected = GetNodePackage(node);
+
+                if (!nodePackageDictionary.ContainsKey(node.GUID) && collected == null)
+                {
+                    string localDefinitionName;
+
+                    if (node.IsCustomFunction)
+                    {
+                        localDefinitionName = node.Name + customNodeExtension;
+
+                        if (!nodeLocalDefinitions.ContainsKey(localDefinitionName))
+                        {
+                            nodeLocalDefinitions[localDefinitionName] = new DependencyInfo(localDefinitionName);
+                        }
+
+                        nodeLocalDefinitions[localDefinitionName].AddDependent(node.GUID);
+                        nodeLocalDefinitions[localDefinitionName].ReferenceType = ReferenceType.DYFFile;
+                    }
+                    else if (node is DSFunctionBase functionNode)
+                    {
+                        string assemblyPath = functionNode.Controller.Definition.Assembly;
+                        var directoryName = Path.GetDirectoryName(assemblyPath);
+
+                        // For the local definition reference, the assembly directory exists on disc.
+                        if (!string.IsNullOrEmpty(directoryName) && Directory.Exists(directoryName))
+                        {
+                            localDefinitionName = Path.GetFileName(assemblyPath);
+
+                            if (!nodeLocalDefinitions.ContainsKey(localDefinitionName))
+                            {
+                                nodeLocalDefinitions[localDefinitionName] = new DependencyInfo(localDefinitionName, assemblyPath);
+                            }
+
+                            nodeLocalDefinitions[localDefinitionName].AddDependent(node.GUID);
+                            nodeLocalDefinitions[localDefinitionName].ReferenceType = ReferenceType.ZeroTouch;
+                        }
+                    }
+                    else if (node is DummyNode)
+                    {
+                        // Read the serialized value if the node is not resolved.
+                        if (localDefinitionsDictionary.TryGetValue(node.GUID, out var localDefinitionInfo))
+                        {
+                            nodeLocalDefinitions[localDefinitionInfo.Name] = localDefinitionInfo;
+                        }
+                    }
+                }
+            }
+
+            return nodeLocalDefinitions.Values.ToList<INodeLibraryDependencyInfo>();
+        }
+
+        /// <summary>
         /// Computes the external file references if the Workspace Model is a HomeWorkspaceModel and graph is not running.
         /// </summary>
         /// <returns></returns>
-        private List<INodeLibraryDependencyInfo> GetExternalFiles()
+        private List<INodeLibraryDependencyInfo> ComputeExternalFileReferences()
         {
             var externalFiles = new Dictionary<object, DependencyInfo>();
 
@@ -876,10 +935,14 @@ namespace Dynamo.Graph.Workspaces
             return externalFiles.Values.ToList<INodeLibraryDependencyInfo>();
         }
 
-        private Dictionary<Guid, PackageInfo> nodePackageDictionary = new Dictionary<Guid, PackageInfo>();
-        private Dictionary<Guid, DependencyInfo> localDefinitionsDictionary = new Dictionary<Guid, DependencyInfo>();
-        private Dictionary<Guid, DependencyInfo> externalFilesDictionary = new Dictionary<Guid, DependencyInfo>();
-
+        internal bool ForceComputeWorkspaceReferences
+        {
+            get { return forceComputeWorkspaceReferences; }
+            set
+            {
+                forceComputeWorkspaceReferences = value;
+            }
+        }
 
         /// <summary>
         ///     An author of the workspace
@@ -1233,9 +1296,13 @@ namespace Dynamo.Graph.Workspaces
 
             this.annotations = new List<AnnotationModel>(annotations);
 
-            this.NodeLibraryDependencies = new List<INodeLibraryDependencyInfo>();
-            this.NodeLocalDefinitions = new List<INodeLibraryDependencyInfo>();
-            this.ExternalFiles = new List<INodeLibraryDependencyInfo>();
+            NodeLibraryDependencies = new List<INodeLibraryDependencyInfo>();
+            NodeLocalDefinitions = new List<INodeLibraryDependencyInfo>();
+            ExternalFiles = new List<INodeLibraryDependencyInfo>();
+
+            nodeLibraryDependencies = new List<INodeLibraryDependencyInfo>();
+            nodeLocalDefinitions = new List<INodeLibraryDependencyInfo>();
+            externalFileReferences = new List<INodeLibraryDependencyInfo>();
 
             // Set workspace info from WorkspaceInfo object
             Name = info.Name;

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -387,7 +387,7 @@
                         <DataGridTemplateColumn.Header>
                             <fa:ImageAwesome Name="RefreshExternalReferences" 
                                              Icon="Refresh" 
-                                             MouseLeftButtonDown="Refresh_MouseLeftButtonDown">
+                                             MouseLeftButtonDown="ForceRefresh_MouseLeftButtonDown">
                                 <fa:ImageAwesome.ToolTip>
                                     <ToolTip Content="{x:Static w:Resources.RefreshButtonTooltipText}" Style="{StaticResource GenericToolTipLight}"/>
                                 </fa:ImageAwesome.ToolTip>

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -100,7 +100,7 @@ namespace Dynamo.WorkspaceDependency
                 {
                     currentWorkspace.PropertyChanged -= OnWorkspacePropertyChanged;
                 }
-                DependencyRegen(obj as WorkspaceModel);
+                DependencyRegen(obj as WorkspaceModel, true);
                 // Update current workspace
                 currentWorkspace = obj as WorkspaceModel;
                 currentWorkspace.Saved += TriggerDependencyRegen;
@@ -131,9 +131,12 @@ namespace Dynamo.WorkspaceDependency
         /// Regenerate dependency table
         /// </summary>
         /// <param name="ws">workspace model</param>
-        internal void DependencyRegen(WorkspaceModel ws)
+        /// <param name="forceCompute">flag indicating if the workspace references should be computed</param>
+        internal void DependencyRegen(WorkspaceModel ws, bool forceCompute = false)
         {
             RestartBanner.Visibility = Visibility.Hidden;
+            ws.ForceComputeWorkspaceReferences = forceCompute;
+
             var packageDependencies = ws.NodeLibraryDependencies.Where(d => d is PackageDependencyInfo).ToList();
             var localDefinitions = ws.NodeLocalDefinitions.Where(d => d is DependencyInfo).ToList();
             var externalFiles = ws.ExternalFiles.Where(d => d is DependencyInfo).ToList();
@@ -213,6 +216,7 @@ namespace Dynamo.WorkspaceDependency
             LocalDefinitions.IsExpanded = localDefinitionDataRows.Count() > 0;
             ExternalFiles.IsExpanded = externalFilesDataRows.Count() > 0;
 
+            ws.ForceComputeWorkspaceReferences = false;
 
             PackageDependencyTable.ItemsSource = dataRows;
             LocalDefinitionsTable.ItemsSource = localDefinitionDataRows;
@@ -220,7 +224,7 @@ namespace Dynamo.WorkspaceDependency
         }
 
         /// <summary>
-        /// Calls the DependencyRegen function when the DummyNodesReloaded event is triggered from the dynamo model.
+        /// Calls the DependencyRegen function when workspace is saved or when DummyNodesReloaded event is fired
         /// </summary>
         internal void TriggerDependencyRegen()
         {
@@ -283,7 +287,6 @@ namespace Dynamo.WorkspaceDependency
         internal void DownloadSpecifiedPackageAndRefresh(PackageDependencyInfo info)
         {
             packageInstaller.DownloadAndInstallPackage(info);
-            DependencyRegen(currentWorkspace);
         }
 
         /// <summary>

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -224,11 +224,19 @@ namespace Dynamo.WorkspaceDependency
         }
 
         /// <summary>
-        /// Calls the DependencyRegen function when workspace is saved or when DummyNodesReloaded event is fired
+        /// Calls DependencyRegen when workspace is saved
         /// </summary>
         internal void TriggerDependencyRegen()
         {
             DependencyRegen(currentWorkspace);
+        }
+
+        /// <summary>
+        /// Calls DependencyRegen with forceCompute as true, as dummy nodes are reloaded.
+        /// </summary>
+        internal void ForceTriggerDependencyRegen()
+        {
+            DependencyRegen(currentWorkspace, true);
         }
 
         /// <summary>
@@ -240,7 +248,7 @@ namespace Dynamo.WorkspaceDependency
             InitializeComponent();
             this.DataContext = this;
             currentWorkspace = p.CurrentWorkspaceModel as WorkspaceModel;
-            WorkspaceModel.DummyNodesReloaded += TriggerDependencyRegen;
+            WorkspaceModel.DummyNodesReloaded += ForceTriggerDependencyRegen;
             currentWorkspace.Saved += TriggerDependencyRegen;
             p.CurrentWorkspaceChanged += OnWorkspaceChanged;
             p.CurrentWorkspaceCleared += OnWorkspaceCleared;
@@ -340,7 +348,7 @@ namespace Dynamo.WorkspaceDependency
             loadedParams.CurrentWorkspaceChanged -= OnWorkspaceChanged;
             loadedParams.CurrentWorkspaceCleared -= OnWorkspaceCleared;
             currentWorkspace.PropertyChanged -= OnWorkspacePropertyChanged;
-            WorkspaceModel.DummyNodesReloaded -= TriggerDependencyRegen;
+            WorkspaceModel.DummyNodesReloaded -= ForceTriggerDependencyRegen;
             currentWorkspace.Saved -= TriggerDependencyRegen;
             HomeWorkspaceModel.WorkspaceClosed -= this.CloseExtensionTab;
             PackageDependencyTable.ItemsSource = null;
@@ -354,6 +362,11 @@ namespace Dynamo.WorkspaceDependency
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             DependencyRegen(currentWorkspace);
+        }
+
+        private void ForceRefresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            DependencyRegen(currentWorkspace, true);
         }
     }
 

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -87,7 +87,7 @@ namespace Dynamo.WorkspaceDependency
 
             pmExtension.PackageLoader.PackgeLoaded += (package) =>
             {
-                DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
+                DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel, true);
             };
 
             // Adding a button in view menu to refresh and show manually
@@ -97,7 +97,7 @@ namespace Dynamo.WorkspaceDependency
                 if (workspaceReferencesMenuItem.IsChecked)
                 {
                     // Refresh dependency data
-                    DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel);
+                    DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel, true);
                     viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
                     workspaceReferencesMenuItem.IsChecked = true;
                 }

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -64,7 +64,11 @@ namespace Dynamo.Tests
 
             // Assert package dependency is collected
             OpenModel(path);
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             var package = packageDependencies.First();
             Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), package);
@@ -78,7 +82,7 @@ namespace Dynamo.Tests
             }
  
             // Assert package dependency is serialized
-            var ToJson = CurrentDynamoModel.CurrentWorkspace.ToJson(CurrentDynamoModel.EngineController);
+            var ToJson = currentws.ToJson(CurrentDynamoModel.EngineController);
             var JObject = (JObject)JsonConvert.DeserializeObject(ToJson);
             var deserializedPackageDependencies = JObject[WorkspaceReadConverter.NodeLibraryDependenciesPropString];
             Assert.AreEqual(1, deserializedPackageDependencies.Count());
@@ -106,7 +110,11 @@ namespace Dynamo.Tests
 
             // Assert package dependency is collected
             OpenModel(path);
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             var package = packageDependencies.First();
             Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), package);
@@ -232,14 +240,17 @@ namespace Dynamo.Tests
             var node1 = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList()[0];
             var node2 = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList()[1];
 
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Verify package dependencies
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(2, packageDependencies.First().Nodes.Count);
 
             // Remove one node and assert is is no longer listed as a dependent node
             CurrentDynamoModel.CurrentWorkspace.RemoveAndDisposeNode(node1);
-            packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(1, packageDependencies.First().Nodes.Count);
             Assert.True(!packageDependencies.First().Nodes.Contains(node1.GUID));
@@ -255,14 +266,14 @@ namespace Dynamo.Tests
 
             // Remove te second node and assert package dependencies is now empty
             CurrentDynamoModel.CurrentWorkspace.RemoveAndDisposeNode(node2);
-            packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(0, packageDependencies.Count);
 
             // Add another node from the "Dynamo Samples" package
             // and assert that the two removed nodes do not return
             var node3 = GetNodeInstance("Examples.PeriodicIncrement.Increment");
             CurrentDynamoModel.AddNodeToCurrentWorkspace(node3, true);
-            packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(1, packageDependencies.First().Nodes.Count);
             Assert.True(!packageDependencies.First().Nodes.Contains(node1.GUID));
@@ -316,15 +327,18 @@ namespace Dynamo.Tests
             var node = GetNodeInstance("ZTTestPackage.RRTestClass.RRTestClass");
             CurrentDynamoModel.AddNodeToCurrentWorkspace(node, true);
 
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Assert new package dependency is collected
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.Contains(pi, packageDependencies);
 
             // Clear current workspace
             CurrentDynamoModel.ClearCurrentWorkspace();
 
             // Assert package dependency list is cleared
-            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies.Count == 0);
+            Assert.IsTrue(currentws.NodeLibraryDependencies.Count == 0);
         }
 
         [Test]
@@ -334,12 +348,15 @@ namespace Dynamo.Tests
             string path = Path.Combine(TestDirectory, @"core\packageDependencyTests\UnloadedPackage.dyn");
             OpenModel(path);
 
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Assert ZTTestPackage is not loaded
             var pi = GetPackageInfo("ZTTestPackage");
             Assert.IsNull(pi);
 
             // Assert ZTTestPackage is still a package dependency
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.Contains(new PackageDependencyInfo("ZTTestPackage", new Version("0.0.1")), packageDependencies);
 
             var package = packageDependencies.First();
@@ -364,8 +381,11 @@ namespace Dynamo.Tests
             var pi = GetPackageInfo("ZTTestPackage");
             Assert.IsNull(pi);
 
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Assert ZTTestPackage is still a package dependency
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.Contains(new PackageDependencyInfo("ZTTestPackage", new Version("0.0.1")), packageDependencies);
 
             // Assert that the package is not loaded. 
@@ -413,8 +433,11 @@ namespace Dynamo.Tests
 
             OpenModel(path);
 
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Assert clockwork is still the only dependency returned
-            var packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(clockworkInfo, packageDependencies.First());
 
@@ -423,7 +446,7 @@ namespace Dynamo.Tests
 
             // Assert local package dependency overrides deserialized package dependency
             var pi = GetPackageInfo("Custom Rounding");
-            packageDependencies = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(pi, packageDependencies.First());
         }
@@ -436,8 +459,11 @@ namespace Dynamo.Tests
             string path = Path.Combine(TestDirectory, @"core\packageDependencyTests\PackageDependencyStates.dyn");
             OpenModel(path);
 
+            var currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Assert the total number of package dependencies.
-            var packageDependenciesList = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            var packageDependenciesList = currentws.NodeLibraryDependencies;
             Assert.AreEqual(4, packageDependenciesList.Count);
 
             // Check for Missing package state
@@ -468,8 +494,11 @@ namespace Dynamo.Tests
             path = Path.Combine(TestDirectory, @"core\packageDependencyTests\PackageDependencyStates.dyn");
             OpenModel(path);
 
+            currentws = CurrentDynamoModel.CurrentWorkspace;
+            currentws.ForceComputeWorkspaceReferences = true;
+
             // Assert the total number of package dependencies.
-            packageDependenciesList = CurrentDynamoModel.CurrentWorkspace.NodeLibraryDependencies;
+            packageDependenciesList = currentws.NodeLibraryDependencies;
             Assert.AreEqual(4, packageDependenciesList.Count);
 
             // Check for Missing package state

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -14,6 +14,7 @@ using Dynamo.Scheduler;
 using Dynamo.Utilities;
 using Dynamo.WorkspaceDependency;
 using Dynamo.Wpf.Extensions;
+using Dynamo.WorkspaceDependency.Properties;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -36,6 +37,14 @@ namespace DynamoCoreWpfTests
                 ProcessMode = TaskProcessMode.Synchronous,
                 Preferences = new PreferenceSettings() { CustomPackageFolders = new List<string>() { this.PackagesDirectory } }
             };
+        }
+
+        private WorkspaceDependencyViewExtension WorkspaceReferencesExtension
+        {
+            get
+            {
+                return (WorkspaceDependencyViewExtension)View.viewExtensionManager.ViewExtensions.FirstOrDefault(x => x.Name.Equals(Resources.ExtensionName));
+            }
         }
 
         protected override void GetLibrariesToPreload(List<string> libraries)
@@ -144,8 +153,7 @@ namespace DynamoCoreWpfTests
         {
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;
-            WorkspaceDependencyViewExtension workspaceDependencyViewExtension = (WorkspaceDependencyViewExtension) extensionManager.ViewExtensions
-                                                                                .Where(ve => ve.Name.Equals("Workspace References")).FirstOrDefault();
+
             // Open a graph which should bring up the Workspace References view extension window with one tab
             Open(@"pkgs\Dynamo Samples\extra\CustomRenderExample.dyn");
             Assert.AreEqual(1, View.ExtensionTabItems.Count);
@@ -153,16 +161,16 @@ namespace DynamoCoreWpfTests
             var loadedParams = new ViewLoadedParams(View, ViewModel);
 
             // Assert that the workspace references menu item is checked.
-            Assert.IsTrue(workspaceDependencyViewExtension.workspaceReferencesMenuItem.IsChecked);
+            Assert.IsTrue(WorkspaceReferencesExtension.workspaceReferencesMenuItem.IsChecked);
 
             // Closing the view extension side bar should trigger the Closed() on the workspace dependency view extension.
             // This will un-check the workspace references menu item.
-            loadedParams.CloseExtensioninInSideBar(workspaceDependencyViewExtension);
+            loadedParams.CloseExtensioninInSideBar(WorkspaceReferencesExtension);
 
             Assert.AreEqual(0, View.ExtensionTabItems.Count);
 
             // Assert that the workspace references menu item is un-checked.
-            Assert.IsFalse(workspaceDependencyViewExtension.workspaceReferencesMenuItem.IsChecked);
+            Assert.IsFalse(WorkspaceReferencesExtension.workspaceReferencesMenuItem.IsChecked);
         }
 
         /// <summary>
@@ -270,7 +278,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void TestPropertiesWithCodeInIt()
         {
-            Assert.AreEqual("Workspace References", viewExtension.Name);
+            Assert.AreEqual(Resources.ExtensionName, viewExtension.Name);
 
             Assert.AreEqual("A6706BF5-11C2-458F-B7C8-B745A77EF7FD", viewExtension.UniqueId);
         }
@@ -285,10 +293,7 @@ namespace DynamoCoreWpfTests
             Open(examplePath);
             Assert.AreEqual(1, View.ExtensionTabItems.Count);
 
-            var workspaceViewExtension = (WorkspaceDependencyViewExtension) View.viewExtensionManager.ViewExtensions
-                                                                                .Where(x => x.Name.Equals("Workspace References")).FirstOrDefault();
-
-            foreach (PackageDependencyRow packageDependencyRow in workspaceViewExtension.DependencyView.dataRows) 
+            foreach (PackageDependencyRow packageDependencyRow in WorkspaceReferencesExtension.DependencyView.dataRows)
             {
                 var dependencyInfo = packageDependencyRow.DependencyInfo;
                 Assert.Contains(dependencyInfo.Name, dependenciesList);
@@ -311,11 +316,8 @@ namespace DynamoCoreWpfTests
             examplePath = Path.Combine(@"core\LocalDefinitionsTest.dyn");
             Open(examplePath);
            
-            var workspaceViewExtension = (WorkspaceDependencyViewExtension)View.viewExtensionManager.ViewExtensions
-                                                                                .Where(x => x.Name.Equals("Workspace References")).FirstOrDefault();
-
-            Assert.AreEqual(1, workspaceViewExtension.DependencyView.localDefinitionDataRows.Count());
-            DependencyRow localDefinitionRow = workspaceViewExtension.DependencyView.localDefinitionDataRows.FirstOrDefault();
+            Assert.AreEqual(1, WorkspaceReferencesExtension.DependencyView.localDefinitionDataRows.Count());
+            DependencyRow localDefinitionRow = WorkspaceReferencesExtension.DependencyView.localDefinitionDataRows.FirstOrDefault();
             var dependencyInfo = localDefinitionRow.DependencyInfo;
             Assert.Contains(dependencyInfo.Name, dependenciesList);
         }
@@ -329,18 +331,16 @@ namespace DynamoCoreWpfTests
             var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
             Open(examplePath);
 
-            var workspaceViewExtension = (WorkspaceDependencyViewExtension)View.viewExtensionManager.ViewExtensions
-                                                                                .Where(x => x.Name.Equals("Workspace References")).FirstOrDefault();
+            WorkspaceReferencesExtension.DependencyView.DependencyRegen(Model.CurrentWorkspace, true);
 
-            workspaceViewExtension.DependencyView.TriggerDependencyRegen();
-
-            Assert.AreEqual(2, workspaceViewExtension.DependencyView.externalFilesDataRows.Count());
-            foreach (DependencyRow localDefinitionRow in workspaceViewExtension.DependencyView.externalFilesDataRows)
+            Assert.AreEqual(2, WorkspaceReferencesExtension.DependencyView.externalFilesDataRows.Count());
+            foreach (DependencyRow localDefinitionRow in WorkspaceReferencesExtension.DependencyView.externalFilesDataRows)
             {
                 var dependencyInfo = localDefinitionRow.DependencyInfo;
                 Assert.Contains(dependencyInfo.Name, dependenciesList);
             }
         }
+
         [Test]
         public void GetExternalFilesShouldBailIfGraphExecuting()
         {
@@ -348,12 +348,13 @@ namespace DynamoCoreWpfTests
             var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
             Open(examplePath);
             (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = false;
+            WorkspaceReferencesExtension.DependencyView.DependencyRegen(Model.CurrentWorkspace, true);
             var results = Model.CurrentWorkspace.ExternalFiles;
             Assert.AreEqual(0, results.Count());
             (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = true;
+            WorkspaceReferencesExtension.DependencyView.DependencyRegen(Model.CurrentWorkspace, true);
             results = Model.CurrentWorkspace.ExternalFiles;
             Assert.AreEqual(2, results.Count());
-
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR is to refactor some of the code related to workspace references view extension. 

Task: https://jira.autodesk.com/browse/DYN-5028

In the current workflow, the workspace references are computed when a workspace is saved(to serialize the new data) and when the data needs to be updated on the view extension. To avoid doing it twice, a new flag is introduced that would control the workspace references computation. After this change, if the user clicks on "recalculate" button, the references would be computed only if the workspace has unsaved changes. On the other hand, if the user saves the workspace, the references are computed during serialization, saved in a list and that list is displayed in the view extension. 
When a workspace is opened, we want to compute the references even though there are no saved changes. This can done by using the 'ForceComputeWorkspaceReferences' flag. The same is the case when the view extension is opened using the menu item or when a new package is loaded after downloading the missing package references.

Also cleaned up some of the related code.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Workspace References refactoring

### Reviewers
@QilongTang @zeusongit @aparajit-pratap @mjkkirschner 
