### PR TITLE
Optimize getting common base class for types in an array

### DIFF
--- a/src/Engine/ProtoCore/Lang/FunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionEndPoint.cs
@@ -63,7 +63,7 @@ namespace ProtoCore
                     }
                     else if (arrayTypes.Count > 1)
                     {
-                        ClassNode commonBaseType = ArrayUtils.GetGreatestCommonSubclassForArray(formalParameters[i], runtimeCore);
+                        ClassNode commonBaseType = ArrayUtils.GetGreatestCommonSubclassForArrayInternal(arrayTypes, runtimeCore);
 
                         if (commonBaseType == null)
                             throw new ProtoCore.Exceptions.ReplicationCaseNotCurrentlySupported(

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -262,7 +262,7 @@ namespace ProtoCore
                 }
                 else if (arrayTypes.Count > 1)
                 {
-                    ClassNode commonBaseType = ArrayUtils.GetGreatestCommonSubclassForArray(reducedSVs[i], runtimeCore);
+                    ClassNode commonBaseType = ArrayUtils.GetGreatestCommonSubclassForArrayInternal(arrayTypes, runtimeCore);
 
                     if (commonBaseType == null)
                         throw new ProtoCore.Exceptions.ReplicationCaseNotCurrentlySupported(


### PR DESCRIPTION
### Purpose

`ArrayUtils.GetTypeStatisticsForArray` used to unnecessarily be called twice in a few callers, once outside and once inside the call to `GetCommonSubClassForArray`. This PR refactors the code so that the type stats from `GetTypeStatisticsForArray` can be passed into the method that returns the common base type if the type stats are already computed.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Performance optimization in determining types in arrays.
