### PR TITLE
DYN-4949 Develop test framework to test correctness of graph results

### DIFF
--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dynamo.Events;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Graph.Workspaces;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    [TestFixture, Category("Performance")]
+    public class PerformanceTests : DynamoModelTestBase
+    {
+        private TimeSpan lastExecutionDuration = new TimeSpan();
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("GeometryColor.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+        public object[] FindWorkspaces()
+        {
+            var di = new DirectoryInfo(Path.Combine(TestDirectory, "core", "performance"));
+            var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
+            return fis.Select(fi => fi.FullName).ToArray();
+        }
+
+        [TestFixtureSetUp]
+        public void FixtureSetup()
+        {
+            ExecutionEvents.GraphPostExecution += ExecutionEvents_GraphPostExecution;
+        }
+
+        [TestFixtureTearDown]
+        public void TearDown()
+        {
+            ExecutionEvents.GraphPostExecution -= ExecutionEvents_GraphPostExecution;
+        }
+
+        private void ExecutionEvents_GraphPostExecution(Session.IExecutionSession session)
+        {
+            lastExecutionDuration = (TimeSpan)session.GetParameterValue(Session.ParameterKeys.LastExecutionDuration);
+        }
+
+        [Test, TestCaseSource("FindWorkspaces"), Category("Performance")]
+        public void PerformanceTest(string filePath)
+        {
+            DoWorkspaceOpenAndCompare(filePath);
+        }
+
+        private void DoWorkspaceOpenAndCompare(string filePath)
+        {
+            OpenModel(filePath);
+
+            var model = CurrentDynamoModel;
+            var ws1 = model.CurrentWorkspace;
+            ws1.Description = "TestDescription";
+
+            var dummyNodes = ws1.Nodes.Where(n => n is DummyNode);
+            if (dummyNodes.Any())
+            {
+                Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.Name).ToArray()));
+            }
+
+            var cbnErrorNodes = ws1.Nodes.Where(n => n is CodeBlockNodeModel && n.State == ElementState.Error);
+            if (cbnErrorNodes.Any())
+            {
+                Assert.Inconclusive("The Workspace contains code block nodes in error state due to which rest " +
+                                    "of the graph will not execute; skipping test ...");
+            }
+
+            if (((HomeWorkspaceModel)ws1).RunSettings.RunType == Dynamo.Models.RunType.Manual)
+            {
+                RunCurrentModel();
+            }
+
+            var wcd1 = new serializationTestUtils.WorkspaceComparisonData(ws1, CurrentDynamoModel.EngineController);
+
+            // The big hammer, maybe not needed
+            Cleanup();
+
+            // TODO, Switch to the new VM
+
+            Setup();
+
+            OpenModel(filePath);
+            model = CurrentDynamoModel;
+            var ws2 = model.CurrentWorkspace;
+            ws2.Description = "TestDescription";
+
+            if (((HomeWorkspaceModel)ws2).RunSettings.RunType == Dynamo.Models.RunType.Manual)
+            {
+                RunCurrentModel();
+            }
+
+            Assert.NotNull(ws2);
+
+            dummyNodes = ws2.Nodes.Where(n => n is DummyNode);
+            if (dummyNodes.Any())
+            {
+                Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.Name).ToArray()));
+            }
+
+            var wcd2 = new serializationTestUtils.WorkspaceComparisonData(ws2, CurrentDynamoModel.EngineController);
+
+            serializationTestUtils.CompareWorkspaceModels(wcd1, wcd2, null);
+        }
+    }
+}

--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Dynamo.Events;
 using Dynamo.Graph.Nodes;
-using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using NUnit.Framework;
 

--- a/test/core/Performance/aniform.dyn
+++ b/test/core/Performance/aniform.dyn
@@ -1,0 +1,1675 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "aniform",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@Autodesk.DesignScript.Geometry.Point",
+      "Id": "f9a036cf71b14dd296cd7824d2d6604d",
+      "Inputs": [
+        {
+          "Id": "227d1108774b473d834d7b67a02f1a1a",
+          "Name": "origin",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "dea6c05cf78847d1bd6b04dee837e623",
+          "Name": "CoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a CoordinateSystem with origin at input Point, with X and Y Axes set as WCS X and Y Axes.\n\nCoordinateSystem.ByOrigin (origin: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)): CoordinateSystem"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "10;",
+      "Id": "0cf6582cc5fa45a0915a0a80add3ed20",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "443f95f921e04f8d85ecd2a21722e0d2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "df105095452d4d97a3df4eb666ed9882",
+      "Inputs": [
+        {
+          "Id": "d6f6e51a938645ab805c3a229d80825e",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "39572205610f4e289715a711c7320a30",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "47a0cc51051a4fadb2b3c1fb58b34298",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ffcb6f9ec08b42c5ae63c2bad2018a9c",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "30;",
+      "Id": "5cea4912dcbe40e9b6693014145ecc76",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "93d273e56fd241489e1ef04ae142ce9c",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0..#x..137.50776;",
+      "Id": "c6e2a20b39af4aaa960a61c4c32db570",
+      "Inputs": [
+        {
+          "Id": "71a46314715748f1a094fd3fa49a1743",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "624fc6cdfd5047f0aa40f95603855ccb",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..100..#x;",
+      "Id": "b5493b85bdd24e2fae3dae8e48caaa00",
+      "Inputs": [
+        {
+          "Id": "deff93f019214633be9a6c04b4de5f0a",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "afac4183e44d4c7ea1caadf5b6dca2d7",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.CoordinateSystem.BySphericalCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "Id": "6840c57f75db4f6c96329a0224e006a2",
+      "Inputs": [
+        {
+          "Id": "97a9bcc326e8442da136923590363c87",
+          "Name": "cs",
+          "Description": "CoordinateSystem\nDefault value : Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "03693643ae4e40488a58dc2e936eaef8",
+          "Name": "radius",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0e08bb1ec92b448fbfbd1346dd400e6b",
+          "Name": "theta",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "55a373eb5b2f447fb1d21e3f84f893bc",
+          "Name": "phi",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d6c4560629df4c6e96982c7284fb2180",
+          "Name": "CoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a CoordinateSystem at the specified spherical coordinate parameters with respect to the specified coordinate system\n\nCoordinateSystem.BySphericalCoordinates (cs: CoordinateSystem = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0), radius: double = 0, theta: double = 0, phi: double = 0): CoordinateSystem"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "68f0bb1a51554e28a57672c434204bad",
+      "Inputs": [
+        {
+          "Id": "42d61c69aa454452a77d7d6b7711f389",
+          "Name": "centerPoint",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "534c1140f57a4260af901dd4c698ca20",
+          "Name": "radius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "08663cd07dfd436d96aeca575a110cba",
+          "Name": "Sphere",
+          "Description": "Sphere",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a Solid Sphere cetered at the input Point, with given radius.\n\nSphere.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Sphere"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.IntegerSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Integer",
+      "InputValue": 908,
+      "MaximumValue": 1000,
+      "MinimumValue": 0,
+      "StepValue": 1,
+      "Id": "4aacb31a59544644a35e861f70e3da5b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "276db2afdd9845fba6067888daac6e22",
+          "Name": "",
+          "Description": "Int64",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces integer values."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "Id": "b8e0fe2532fd4c3fafac46f631f71108",
+      "Inputs": [
+        {
+          "Id": "c41a5dfdba4f493d88ab1b2cee068e5d",
+          "Name": "cs",
+          "Description": "CoordinateSystem\nDefault value : Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d2a65c960a5a4336bd4a5a9241df2f5e",
+          "Name": "height",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "65744966f68344799bb613c79f30d240",
+          "Name": "startRadius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ae0eebbf11384e42b9e20935db7a6981",
+          "Name": "endRadius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a86d0c860ab4455999bc3f20050cc22f",
+          "Name": "Cone",
+          "Description": "Cone",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Cone with base Point at CoordinateSystem origin, extending in the CoordinateSystem Z axis deriction length amount, with a circular bases in the CoordinateSystem XY Plane.\n\nCone.ByCoordinateSystemHeightRadii (cs: CoordinateSystem = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0), height: double = 1, startRadius: double = 1, endRadius: double = 1): Cone"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "-5;",
+      "Id": "0983d4db9f324efc85f589ca0c8f38c3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "fe2227ae2c074d7fbb02040097937929",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "aaa00d3c064b49cfbcbf3107d1b34b59",
+      "Inputs": [
+        {
+          "Id": "46b3a74fabd3484baac1cb198442eb27",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "25f6387de7224cb0ad35715d897af3e4",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3ec9f9b9c02e4e68b40ac6a5f2f0cd18",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e41993817bf14ba89e26d2143ca21e5d",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@Autodesk.DesignScript.Geometry.Point",
+      "Id": "91582996e8a94546a8f4b8193f9fc753",
+      "Inputs": [
+        {
+          "Id": "57a58b3554c045ce9f9e79126c867569",
+          "Name": "origin",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "766d5a3f53bc4280a6413caac3db5d16",
+          "Name": "CoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a CoordinateSystem with origin at input Point, with X and Y Axes set as WCS X and Y Axes.\n\nCoordinateSystem.ByOrigin (origin: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)): CoordinateSystem"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1;\n1;\n0.5;",
+      "Id": "86f4ed8724f0498cbf43bb3f978ff663",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "610ffdfb447c4e77b3b8acf56fdadc70",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f3447a1d595746baaf90cd876556b8a5",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6dd2f4b9ace7490487b3aa99c720e0be",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector",
+      "Id": "ee6c1bd5c2e14b24bcabbf831db819b3",
+      "Inputs": [
+        {
+          "Id": "04c7a9cec6ad41fbb81bddde7522e8e2",
+          "Name": "geometry",
+          "Description": "Autodesk.DesignScript.Geometry.Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4a7a85d26ccf41988845de925d18cd65",
+          "Name": "direction",
+          "Description": "Vector",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "908c13c32aae449bb1999dd05c821687",
+          "Name": "Geometry",
+          "Description": "Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Translate geometry in the given direction by the vector length\n\nGeometry.Translate (direction: Vector): Geometry"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double",
+      "Id": "4ffb687f48e4410286e0e63b1fa49468",
+      "Inputs": [
+        {
+          "Id": "d129135d5ed74152bdcf4578982cf14d",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "80f2815cf7ef45cabad8cd955eabf8e2",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "19564e4a418d430084e2d5fd8201788f",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "35cfb6a5e66244c4a3493d973b5813ee",
+          "Name": "Vector",
+          "Description": "Vector created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Vector by 3 Euclidean coordinates\n\nVector.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Vector"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "-0.5;",
+      "Id": "f5cd66a716084a529a9ac4250e7bbd9a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "b73ad603bcb541e7b9c5c4c65f34e63c",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Solid.Difference@Autodesk.DesignScript.Geometry.Solid",
+      "Id": "aa3c93026745497ebd8203a01bc8e0d3",
+      "Inputs": [
+        {
+          "Id": "eaf7e321d77448298909db340640d65a",
+          "Name": "solid",
+          "Description": "Autodesk.DesignScript.Geometry.Solid",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "867c5fbd37de442abb72e26891899fb2",
+          "Name": "other",
+          "Description": "Solid",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "fe9714213e8e46c598bc323b75a2af78",
+          "Name": "Solid",
+          "Description": "Solid",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "The boolean difference of this Solid with another\n\nSolid.Difference (other: Solid): Solid"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Solid.Fillet@Autodesk.DesignScript.Geometry.Edge[],double",
+      "Id": "0b3b5c4774ce44baa98136ce2c81a241",
+      "Inputs": [
+        {
+          "Id": "c51bd51c69b44271a529ec3abad56ebb",
+          "Name": "solid",
+          "Description": "Autodesk.DesignScript.Geometry.Solid",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "02e5ff94125a4ff3a420ac81ec65eb95",
+          "Name": "edges",
+          "Description": "Edge[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0cf86f33f2b54a3ba62ee9e81fcbdf55",
+          "Name": "radius",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "033eb7132b164400a4fd3c9a599dca87",
+          "Name": "Solid",
+          "Description": "Solid",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Fillets a Solid along input Edges with a given radius.\n\nSolid.Fillet (edges: Edge[], radius: double): Solid"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Topology.Edges",
+      "Id": "e3dc57ac9220429187452772883a78cf",
+      "Inputs": [
+        {
+          "Id": "f8ad2ba3d3b2458195dc6c66a89d849e",
+          "Name": "topology",
+          "Description": "Autodesk.DesignScript.Geometry.Topology",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "94bfde849a8f4faf98964ed2c88d758d",
+          "Name": "Edge[]",
+          "Description": "Edge[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "The Edges of the Topology\n\nTopology.Edges: Edge[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0.1;",
+      "Id": "ad2d3aa7291f4a43bd707c9c9da420f3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "19b94abaf0924b45b820dcbc947dc46f",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Geometry.Transform@Autodesk.DesignScript.Geometry.CoordinateSystem,Autodesk.DesignScript.Geometry.CoordinateSystem",
+      "Id": "a8422c13cdfb4a9c9f9d90c30a353dde",
+      "Inputs": [
+        {
+          "Id": "5352d955cd8b457e8b3dc5dc5291008a",
+          "Name": "geometry",
+          "Description": "Autodesk.DesignScript.Geometry.Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ae8696f94bd74ad1a124ff0756aa2292",
+          "Name": "fromCoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "099236d12c084feb98073264d6b64ca0",
+          "Name": "contextCoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "2701f4f038d84fd7ae8cdf6e0600591f",
+          "Name": "Geometry",
+          "Description": "Transformed Geometry.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Transforms this geometry from source CoordinateSystem to a new context CoordinateSystem.\n\nGeometry.Transform (fromCoordinateSystem: CoordinateSystem, contextCoordinateSystem: CoordinateSystem): Geometry"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Geometry.Scale@Autodesk.DesignScript.Geometry.Plane,double,double,double",
+      "Id": "98afcb1a6fba4cdc9f583b14c92200da",
+      "Inputs": [
+        {
+          "Id": "6d3f8b508b2848768d8aef70ccbb986f",
+          "Name": "geometry",
+          "Description": "Autodesk.DesignScript.Geometry.Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b8d9ac5c5f2044ec86e4c8f963e37078",
+          "Name": "plane",
+          "Description": "Plane",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "82f11ae583c04aa3bc34a618d879338f",
+          "Name": "xamount",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c9fef531a189423f8244cb7f00073838",
+          "Name": "yamount",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4da40c74a65f4d81851f077b5310d6e1",
+          "Name": "zamount",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bb5519a7754e4506bd1db854a297ec83",
+          "Name": "Geometry",
+          "Description": "Geometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Scale non-uniformly around a given Plane\n\nGeometry.Scale (plane: Plane, xamount: double = 1, yamount: double = 1, zamount: double = 1): Geometry"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.CoordinateSystem.XYPlane",
+      "Id": "6d062be373d943568d3f80755cd6a214",
+      "Inputs": [
+        {
+          "Id": "75c758148e4447bdba6a3d2b711494c6",
+          "Name": "coordinateSystem",
+          "Description": "Autodesk.DesignScript.Geometry.CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "192a7df5cd4e497cbc50eea70fe10d47",
+          "Name": "Plane",
+          "Description": "Plane",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the Plane the X and Y axes lie in, with root at the origin.\n\nCoordinateSystem.XYPlane: Plane"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0.3;\n1.5;",
+      "Id": "caee611548bc4306bfa15073010ba9b0",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "743f3a2e28844c439f8bdf9d758cab44",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6c3635679871483f8a0f9b3329fb6b0a",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Math.RemapRange@double[],double,double",
+      "Id": "830231bea24b44b2b8e2b53f761ea408",
+      "Inputs": [
+        {
+          "Id": "67448adc28be4e0590b07a0ae413f7cb",
+          "Name": "numbers",
+          "Description": "List of numbers to adjust range of.\n\ndouble[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ffb3116126e247b0bbf3d77373839c8f",
+          "Name": "newMin",
+          "Description": "New minimum of the range.\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2683fc38111f46b7b6cc242e15f32894",
+          "Name": "newMax",
+          "Description": "New maximum of the range\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "53213c079e0748499a3b1f873740c387",
+          "Name": "list",
+          "Description": "List remapped to new range.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Adjusts the range of a list of numbers while preserving the distribution ratio.\n\nMath.RemapRange (numbers: double[], newMin: double = 0, newMax: double = 1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@Autodesk.DesignScript.Geometry.Point",
+      "Id": "ff0652185bcf4fdcbe476c2520b70469",
+      "Inputs": [
+        {
+          "Id": "c6ac46189bb24d4caf275e77c6f76443",
+          "Name": "origin",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "84097028389e4966815e058a26ca2a9f",
+          "Name": "CoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a CoordinateSystem with origin at input Point, with X and Y Axes set as WCS X and Y Axes.\n\nCoordinateSystem.ByOrigin (origin: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)): CoordinateSystem"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "3;\n0.9;\n0.5;",
+      "Id": "cfe56ec9baf04306bf5c100c62cb2125",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "934688e408f0417b8670184eae173157",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5867fd4ded484d74b663676cea3719c5",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "faaa61485288471c9d43a631968a77d4",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Cone.ByCoordinateSystemHeightRadii@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+      "Id": "c8e0cfe00c4b44f6bde16e9caaf1de20",
+      "Inputs": [
+        {
+          "Id": "6eb802471029454891a01faef6dde147",
+          "Name": "cs",
+          "Description": "CoordinateSystem\nDefault value : Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "58be7618ae3e4044a7839eb1e9751881",
+          "Name": "height",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5586bfe0159f46f98d8ee98707763836",
+          "Name": "startRadius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b0bdcb87f66a407aa6b9f17ad2ee26d6",
+          "Name": "endRadius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5ad3435cdb3e4faf8bd530e04304efe6",
+          "Name": "Cone",
+          "Description": "Cone",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Cone with base Point at CoordinateSystem origin, extending in the CoordinateSystem Z axis deriction length amount, with a circular bases in the CoordinateSystem XY Plane.\n\nCone.ByCoordinateSystemHeightRadii (cs: CoordinateSystem = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0), height: double = 1, startRadius: double = 1, endRadius: double = 1): Cone"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "dea6c05cf78847d1bd6b04dee837e623",
+      "End": "97a9bcc326e8442da136923590363c87",
+      "Id": "660e8609a5f14ff384a5b049134ac3ac",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "443f95f921e04f8d85ecd2a21722e0d2",
+      "End": "39572205610f4e289715a711c7320a30",
+      "Id": "4429c188a48c4eb4869946acd13cde91",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "ffcb6f9ec08b42c5ae63c2bad2018a9c",
+      "End": "227d1108774b473d834d7b67a02f1a1a",
+      "Id": "d810d6c7cc09419689cf0e251d10e92b",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "ffcb6f9ec08b42c5ae63c2bad2018a9c",
+      "End": "42d61c69aa454452a77d7d6b7711f389",
+      "Id": "f10fc0dae8f340a0a32bc5b8926b672a",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "93d273e56fd241489e1ef04ae142ce9c",
+      "End": "03693643ae4e40488a58dc2e936eaef8",
+      "Id": "1d947f63907c43b19ef0778ce568f9c9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "93d273e56fd241489e1ef04ae142ce9c",
+      "End": "534c1140f57a4260af901dd4c698ca20",
+      "Id": "70a79bea93084f8c97ff35c375aefd59",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "624fc6cdfd5047f0aa40f95603855ccb",
+      "End": "0e08bb1ec92b448fbfbd1346dd400e6b",
+      "Id": "d59f1114d7c848d9884117af4f95a291",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "afac4183e44d4c7ea1caadf5b6dca2d7",
+      "End": "55a373eb5b2f447fb1d21e3f84f893bc",
+      "Id": "2dd96f182ab44cf589cfb18b40c76400",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "afac4183e44d4c7ea1caadf5b6dca2d7",
+      "End": "67448adc28be4e0590b07a0ae413f7cb",
+      "Id": "3c033b00f7ea4870a0b0ccf9db44434c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "d6c4560629df4c6e96982c7284fb2180",
+      "End": "099236d12c084feb98073264d6b64ca0",
+      "Id": "043f57a26d32412bb2226d81d320c066",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "d6c4560629df4c6e96982c7284fb2180",
+      "End": "75c758148e4447bdba6a3d2b711494c6",
+      "Id": "6a6e6c1e1905471f9ed565a79ec58858",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "276db2afdd9845fba6067888daac6e22",
+      "End": "deff93f019214633be9a6c04b4de5f0a",
+      "Id": "ee1469cd5c5a47948aace9ccb69a6167",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "276db2afdd9845fba6067888daac6e22",
+      "End": "71a46314715748f1a094fd3fa49a1743",
+      "Id": "8c46077502ce4e8e9ae75d5b7e5136c6",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "a86d0c860ab4455999bc3f20050cc22f",
+      "End": "eaf7e321d77448298909db340640d65a",
+      "Id": "3fd702df491841b6b951d3644d1e7516",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "fe2227ae2c074d7fbb02040097937929",
+      "End": "25f6387de7224cb0ad35715d897af3e4",
+      "Id": "48790b2953834dff8f7fbca066bd43cf",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e41993817bf14ba89e26d2143ca21e5d",
+      "End": "57a58b3554c045ce9f9e79126c867569",
+      "Id": "0f58cfcb9ead485d865fb0f7ef4cec85",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e41993817bf14ba89e26d2143ca21e5d",
+      "End": "c6ac46189bb24d4caf275e77c6f76443",
+      "Id": "25f6e2db53c5414e962b130ec06f2ecd",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "766d5a3f53bc4280a6413caac3db5d16",
+      "End": "c41a5dfdba4f493d88ab1b2cee068e5d",
+      "Id": "ad282f3a5186411385c7b79a4c3c62f5",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "766d5a3f53bc4280a6413caac3db5d16",
+      "End": "ae8696f94bd74ad1a124ff0756aa2292",
+      "Id": "c366c7fb70dc4f00a1b1e07edaca21b6",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "610ffdfb447c4e77b3b8acf56fdadc70",
+      "End": "d2a65c960a5a4336bd4a5a9241df2f5e",
+      "Id": "81a0fa84b8ca43e99b92c7b140b9ff9f",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f3447a1d595746baaf90cd876556b8a5",
+      "End": "65744966f68344799bb613c79f30d240",
+      "Id": "aa1dfe1b83a74e888c78716226efaffe",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "6dd2f4b9ace7490487b3aa99c720e0be",
+      "End": "ae0eebbf11384e42b9e20935db7a6981",
+      "Id": "2e40fd4cd8104302b94af06cf66bcfff",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "908c13c32aae449bb1999dd05c821687",
+      "End": "867c5fbd37de442abb72e26891899fb2",
+      "Id": "8a6f62f01422482f9639259caed561b1",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "35cfb6a5e66244c4a3493d973b5813ee",
+      "End": "4a7a85d26ccf41988845de925d18cd65",
+      "Id": "99929c36eb8847028d3bbe2c3e1f6b64",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "b73ad603bcb541e7b9c5c4c65f34e63c",
+      "End": "d129135d5ed74152bdcf4578982cf14d",
+      "Id": "aa1a6549f9854a3b9547bcc0c7910302",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "fe9714213e8e46c598bc323b75a2af78",
+      "End": "c51bd51c69b44271a529ec3abad56ebb",
+      "Id": "b4f45d340d474e3cb9da333f3585b974",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "fe9714213e8e46c598bc323b75a2af78",
+      "End": "f8ad2ba3d3b2458195dc6c66a89d849e",
+      "Id": "8042281a1b3a4eeba83183239475178e",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "033eb7132b164400a4fd3c9a599dca87",
+      "End": "5352d955cd8b457e8b3dc5dc5291008a",
+      "Id": "21b8439e0d3d44f09f5f2e3867a7ea1a",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "94bfde849a8f4faf98964ed2c88d758d",
+      "End": "02e5ff94125a4ff3a420ac81ec65eb95",
+      "Id": "ac3f0334927d43588999f59883b377f5",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "19b94abaf0924b45b820dcbc947dc46f",
+      "End": "0cf86f33f2b54a3ba62ee9e81fcbdf55",
+      "Id": "eb0945a9e4e34f18b9fad603116cf467",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2701f4f038d84fd7ae8cdf6e0600591f",
+      "End": "6d3f8b508b2848768d8aef70ccbb986f",
+      "Id": "2587d5c5f1ea497bade13e5945b490af",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "192a7df5cd4e497cbc50eea70fe10d47",
+      "End": "b8d9ac5c5f2044ec86e4c8f963e37078",
+      "Id": "bd56a18a2f964af983046ccc04643ced",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "743f3a2e28844c439f8bdf9d758cab44",
+      "End": "ffb3116126e247b0bbf3d77373839c8f",
+      "Id": "5ba1b499a4404f19ab64f2e05bd06a8a",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "6c3635679871483f8a0f9b3329fb6b0a",
+      "End": "2683fc38111f46b7b6cc242e15f32894",
+      "Id": "617d91e0653e4aea8ccb450a4f2eb913",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "53213c079e0748499a3b1f873740c387",
+      "End": "82f11ae583c04aa3bc34a618d879338f",
+      "Id": "d44bf34e0c8b4bdebf16dcd82df01ae0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "84097028389e4966815e058a26ca2a9f",
+      "End": "6eb802471029454891a01faef6dde147",
+      "Id": "5149143160284011be9dd1aeffd91b80",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "934688e408f0417b8670184eae173157",
+      "End": "58be7618ae3e4044a7839eb1e9751881",
+      "Id": "91f910c3e8da491192ca6cdd024641d5",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5867fd4ded484d74b663676cea3719c5",
+      "End": "5586bfe0159f46f98d8ee98707763836",
+      "Id": "22e8b85a9f5a4d868f9923e6f2cfc564",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "faaa61485288471c9d43a631968a77d4",
+      "End": "b0bdcb87f66a407aa6b9f17ad2ee26d6",
+      "Id": "10f7ab77873441618e4b5b5f49a97648",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5ad3435cdb3e4faf8bd530e04304efe6",
+      "End": "04c7a9cec6ad41fbb81bddde7522e8e2",
+      "Id": "78506358f6474ff190b4331bc3787f87",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": null,
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4953",
+      "RunType": "Automatic",
+      "RunPeriod": "100"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": 26.358572006225586,
+      "EyeY": 102.24191284179688,
+      "EyeZ": 80.50164794921875,
+      "LookX": -31.358572006225586,
+      "LookY": -91.241912841796875,
+      "LookZ": -88.50164794921875,
+      "UpX": -0.17599307000637054,
+      "UpY": 0.849892795085907,
+      "UpZ": -0.4966978132724762
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "CoordinateSystem.ByOrigin",
+        "ShowGeometry": true,
+        "Id": "f9a036cf71b14dd296cd7824d2d6604d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1111.9063479719305,
+        "Y": 1282.9795087698985
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "0cf6582cc5fa45a0915a0a80add3ed20",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 205.10634797193029,
+        "Y": 1244.8070087698984
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": false,
+        "Id": "df105095452d4d97a3df4eb666ed9882",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 663.50634797193038,
+        "Y": 1167.9795087698985
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "5cea4912dcbe40e9b6693014145ecc76",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1111.9063479719305,
+        "Y": 1135.8070087698984
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "c6e2a20b39af4aaa960a61c4c32db570",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1111.9063479719305,
+        "Y": 1431.8070087698984
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "b5493b85bdd24e2fae3dae8e48caaa00",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1111.9063479719305,
+        "Y": 1578.8070087698984
+      },
+      {
+        "Name": "CoordinateSystem.BySphericalCoordinates",
+        "ShowGeometry": false,
+        "Id": "6840c57f75db4f6c96329a0224e006a2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1490.3063479719306,
+        "Y": 1240.9795087698985
+      },
+      {
+        "Name": "Sphere.ByCenterPointRadius",
+        "ShowGeometry": true,
+        "Id": "68f0bb1a51554e28a57672c434204bad",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2416.7063479719309,
+        "Y": 1054.7473689359347
+      },
+      {
+        "Name": "Integer Slider",
+        "ShowGeometry": true,
+        "Id": "4aacb31a59544644a35e861f70e3da5b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 663.50634797193038,
+        "Y": 1505.3070087698984
+      },
+      {
+        "Name": "Cone.ByCoordinateSystemHeightRadii",
+        "ShowGeometry": false,
+        "Id": "b8e0fe2532fd4c3fafac46f631f71108",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 205.10634797193029,
+        "Y": 793.47950876989842
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "0983d4db9f324efc85f589ca0c8f38c3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -1210.4936520280696,
+        "Y": 968.68200876989852
+      },
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": false,
+        "Id": "aaa00d3c064b49cfbcbf3107d1b34b59",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -956.49365202806962,
+        "Y": 934.85450876989842
+      },
+      {
+        "Name": "CoordinateSystem.ByOrigin",
+        "ShowGeometry": true,
+        "Id": "91582996e8a94546a8f4b8193f9fc753",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -253.29365202806969,
+        "Y": 887.22950876989842
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "86f4ed8724f0498cbf43bb3f978ff663",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -253.29365202806969,
+        "Y": 713.96200876989872
+      },
+      {
+        "Name": "Geometry.Translate",
+        "ShowGeometry": false,
+        "Id": "ee6c1bd5c2e14b24bcabbf831db819b3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 205.10634797193029,
+        "Y": 1054.4795087698985
+      },
+      {
+        "Name": "Vector.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "4ffb687f48e4410286e0e63b1fa49468",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -253.29365202806969,
+        "Y": 1295.4795087698985
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "f5cd66a716084a529a9ac4250e7bbd9a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -631.69365202806966,
+        "Y": 1304.3070087698984
+      },
+      {
+        "Name": "Solid.Difference",
+        "ShowGeometry": false,
+        "Id": "aa3c93026745497ebd8203a01bc8e0d3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 663.50634797193038,
+        "Y": 928.47950876989842
+      },
+      {
+        "Name": "Solid.Fillet",
+        "ShowGeometry": false,
+        "Id": "0b3b5c4774ce44baa98136ce2c81a241",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1490.3063479719306,
+        "Y": 1015.9795087698984
+      },
+      {
+        "Name": "Topology.Edges",
+        "ShowGeometry": true,
+        "Id": "e3dc57ac9220429187452772883a78cf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1111.9063479719305,
+        "Y": 840.97950876989842
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "ad2d3aa7291f4a43bd707c9c9da420f3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1111.9063479719305,
+        "Y": 988.80700876989852
+      },
+      {
+        "Name": "Geometry.Transform",
+        "ShowGeometry": false,
+        "Id": "a8422c13cdfb4a9c9f9d90c30a353dde",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1983.1063479719307,
+        "Y": 1060.9795087698985
+      },
+      {
+        "Name": "Geometry.Scale",
+        "ShowGeometry": true,
+        "Id": "98afcb1a6fba4cdc9f583b14c92200da",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2416.7063479719309,
+        "Y": 1230.9795087698985
+      },
+      {
+        "Name": "CoordinateSystem.XYPlane",
+        "ShowGeometry": false,
+        "Id": "6d062be373d943568d3f80755cd6a214",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1983.1063479719307,
+        "Y": 1286.9795087698985
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "caee611548bc4306bfa15073010ba9b0",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1490.3063479719306,
+        "Y": 1501.6345087698987
+      },
+      {
+        "Name": "Math.RemapRange",
+        "ShowGeometry": true,
+        "Id": "830231bea24b44b2b8e2b53f761ea408",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1983.1063479719307,
+        "Y": 1446.9795087698985
+      },
+      {
+        "Name": "CoordinateSystem.ByOrigin",
+        "ShowGeometry": true,
+        "Id": "ff0652185bcf4fdcbe476c2520b70469",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -631.69365202806966,
+        "Y": 982.47950876989842
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "cfe56ec9baf04306bf5c100c62cb2125",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -631.69365202806966,
+        "Y": 1130.9620087698986
+      },
+      {
+        "Name": "Cone.ByCoordinateSystemHeightRadii",
+        "ShowGeometry": false,
+        "Id": "c8e0cfe00c4b44f6bde16e9caaf1de20",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -253.29365202806969,
+        "Y": 1035.4795087698985
+      }
+    ],
+    "Annotations": [],
+    "X": -838.89382976075558,
+    "Y": -812.86695692770854,
+    "Zoom": 0.90504895734337021
+  }
+}

--- a/test/core/Performance/lotsofcoloredstuff.dyn
+++ b/test/core/Performance/lotsofcoloredstuff.dyn
@@ -1,0 +1,1200 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "lotsofcoloredstuff",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [
+    {
+      "Id": "e639df9313324b9ea9888262dbdc86f6",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "0.7",
+      "MaximumValue": 1.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.05,
+      "NumberType": "Double",
+      "Description": "A slider that produces numeric values.",
+      "SelectedIndex": 0
+    },
+    {
+      "Id": "92e62696da4b44b2b3e4addc5eedf3a7",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "255",
+      "MaximumValue": 255.0,
+      "MinimumValue": 0.0,
+      "StepValue": 25.0,
+      "NumberType": "Double",
+      "Description": "A slider that produces numeric values.",
+      "SelectedIndex": 0
+    },
+    {
+      "Id": "34b20b93a74840a2a99121c247535b1c",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "75",
+      "MaximumValue": 255.0,
+      "MinimumValue": 0.0,
+      "StepValue": 25.0,
+      "NumberType": "Double",
+      "Description": "A slider that produces numeric values.",
+      "SelectedIndex": 0
+    },
+    {
+      "Id": "670bcf1792034607aed50da5479c6b6a",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "255",
+      "MaximumValue": 255.0,
+      "MinimumValue": 0.0,
+      "StepValue": 25.0,
+      "NumberType": "Double",
+      "Description": "A slider that produces numeric values.",
+      "SelectedIndex": 0
+    }
+  ],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "8190039b694b4ef2ad33c48f5d964519",
+      "Inputs": [
+        {
+          "Id": "b56de8c9476c4b02a47a69796c65a6ce",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3ecfde3b0e1c45de906567ec39756cc9",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b36af3447e1b433390d01367ec56488b",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f9030fc05e314fcd9dc963daa740c40a",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "CrossProduct",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0..50..2;",
+      "Id": "7c9f9b44efd4490893d4dc76fc3c10fe",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "46af34c469c242018cff919f050e33e1",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "88f09e6c057f4a5c95a7f4f0b25161e2",
+      "Inputs": [
+        {
+          "Id": "17301129273948dcbeb55a23fe512c58",
+          "Name": "centerPoint",
+          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e5c289b4737c4726934def916d1030b3",
+          "Name": "radius",
+          "Description": "double\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "42733a3afb804cb399d1e4785b9a1758",
+          "Name": "Sphere",
+          "Description": "Sphere",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a Solid Sphere cetered at the input Point, with given radius.\n\nSphere.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Sphere"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.Point,double,double,double",
+      "Id": "932166f3acf44180946580a57aa6c0bf",
+      "Inputs": [
+        {
+          "Id": "fd6535d385ca469eb7fce776b4ba172e",
+          "Name": "origin",
+          "Description": "Origin point\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2d454a5893ec49f38cc6f1c44a9b74f8",
+          "Name": "width",
+          "Description": "Width of cuboid\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ea1407c45a5044d5b0f839599e136675",
+          "Name": "length",
+          "Description": "Length of cuboid\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6534d228603a414094bee678bf3f3d79",
+          "Name": "height",
+          "Description": "Height of cuboid\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f981f62594314f6b9065a711d5b6cebc",
+          "Name": "Cuboid",
+          "Description": "Cuboid created by lengths",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a Cuboid centered at input Point, with specified width, length, and height.\n\nCuboid.ByLengths (origin: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), width: double = 1, length: double = 1, height: double = 1): Cuboid"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Topology.Edges",
+      "Id": "39114e8acf1445cfb0ee167d4eb2a621",
+      "Inputs": [
+        {
+          "Id": "ce1d3d7e67a24964aa42894656c3feff",
+          "Name": "topology",
+          "Description": "Autodesk.DesignScript.Geometry.Topology",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4c8ae10bf2a2447bb339d599c9beaae2",
+          "Name": "Edge[]",
+          "Description": "Edge[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "The Edges of the Topology\n\nTopology.Edges: Edge[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Edge.CurveGeometry",
+      "Id": "d0d56164c15f476fa4dd017a87901c97",
+      "Inputs": [
+        {
+          "Id": "5a063f548f8544d088dcfaa4d104ef54",
+          "Name": "edge",
+          "Description": "Autodesk.DesignScript.Geometry.Edge",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5f95b7a750404955823c983b02a39586",
+          "Name": "Curve",
+          "Description": "Curve",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "The underlying Curve making up the Edge\n\nEdge.CurveGeometry: Curve"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Id": "3f20164eefac49dab3bd3b38b3ef356f",
+      "Inputs": [
+        {
+          "Id": "dc0d2c23b9c44394bba8d95e28c362c9",
+          "Name": "centerPoint",
+          "Description": "Center point of circle\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0) (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3a055fe2f9244b3c8efe862ae8cff470",
+          "Name": "radius",
+          "Description": "Radius\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "99d84d7c085e4af0afcdadd4d17c19f6",
+          "Name": "Circle",
+          "Description": "Circle created with center point and radius",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "MaximumValue": 1.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.05,
+      "InputValue": 0.7,
+      "Id": "e639df9313324b9ea9888262dbdc86f6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "2b9eaa01cef34b00bb6fbfa86055e1ca",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces numeric values."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "MaximumValue": 255.0,
+      "MinimumValue": 0.0,
+      "StepValue": 25.0,
+      "InputValue": 255.0,
+      "Id": "92e62696da4b44b2b3e4addc5eedf3a7",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e1250051e02b4c7ea5b0b7ae8c1a0ef9",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces numeric values."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Color.ByARGB@int,int,int,int",
+      "Id": "e59b2a9039b943dda22e19980ced7d17",
+      "Inputs": [
+        {
+          "Id": "6c3573ed311b4c4b84ba1765cb5666f1",
+          "Name": "alpha",
+          "Description": "Alpha value (between 0 and 255 inclusive)\n\nint\nDefault value : 255",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8b9b94e5f8d841bebb7a7de9292b3986",
+          "Name": "red",
+          "Description": "Red value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "deec996f75784bf78acca0b4ed17c29f",
+          "Name": "green",
+          "Description": "Green value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2526f8cb71c84cfc8e569240ba885529",
+          "Name": "blue",
+          "Description": "Blue value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5f630fc8f6bb4089a55d3b36498080c4",
+          "Name": "color",
+          "Description": "Color created from ARGB",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Construct a color by alpha, red, green, and blue components.\n\nColor.ByARGB (alpha: int = 255, red: int = 0, green: int = 0, blue: int = 0): Color"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Color.ByARGB@int,int,int,int",
+      "Id": "124b68b5c67e4975846cd7d93669cb8d",
+      "Inputs": [
+        {
+          "Id": "0bd41baab5ec462faf0e999b1e58487f",
+          "Name": "alpha",
+          "Description": "Alpha value (between 0 and 255 inclusive)\n\nint\nDefault value : 255",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c1450e13f7224aed9f3dfc01b628d563",
+          "Name": "red",
+          "Description": "Red value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "28e72e94e0774b69a680b12823fc1375",
+          "Name": "green",
+          "Description": "Green value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b8daca7c8a234914a6ddc1b7f3260c22",
+          "Name": "blue",
+          "Description": "Blue value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "28ff2d8a40864573895a9449bf3980c3",
+          "Name": "color",
+          "Description": "Color created from ARGB",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Construct a color by alpha, red, green, and blue components.\n\nColor.ByARGB (alpha: int = 255, red: int = 0, green: int = 0, blue: int = 0): Color"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Color.ByARGB@int,int,int,int",
+      "Id": "08cfa9ebc49a45afb2960b51b88b157a",
+      "Inputs": [
+        {
+          "Id": "b97955ccb32c49f2ae10e5ccf413ed67",
+          "Name": "alpha",
+          "Description": "Alpha value (between 0 and 255 inclusive)\n\nint\nDefault value : 255",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b97585613b814185be578845142961dd",
+          "Name": "red",
+          "Description": "Red value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "625a4604492a434b8a031ebf23729610",
+          "Name": "green",
+          "Description": "Green value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2b8678f397cf4e51b9652e2e2a316283",
+          "Name": "blue",
+          "Description": "Blue value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a449e51a17cd4a1a9bba87c082cdd113",
+          "Name": "color",
+          "Description": "Color created from ARGB",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Construct a color by alpha, red, green, and blue components.\n\nColor.ByARGB (alpha: int = 255, red: int = 0, green: int = 0, blue: int = 0): Color"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Color.ByARGB@int,int,int,int",
+      "Id": "02aac675c7b647ac89a9aa35c1c22d33",
+      "Inputs": [
+        {
+          "Id": "43c3cd46768243d09563fe0710d185f7",
+          "Name": "alpha",
+          "Description": "Alpha value (between 0 and 255 inclusive)\n\nint\nDefault value : 255",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c3b21c5bae8849b6a44715d8c7f4e99e",
+          "Name": "red",
+          "Description": "Red value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "20213be1fe0549ea9f74cb4a961db279",
+          "Name": "green",
+          "Description": "Green value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f478d46653564fbf85acffe320b02fbd",
+          "Name": "blue",
+          "Description": "Blue value for RGB color model (between 0 and 255 inclusive)\n\nint\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9e9a45305b444385b683aad73e28f76a",
+          "Name": "color",
+          "Description": "Color created from ARGB",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Construct a color by alpha, red, green, and blue components.\n\nColor.ByARGB (alpha: int = 255, red: int = 0, green: int = 0, blue: int = 0): Color"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "MaximumValue": 255.0,
+      "MinimumValue": 0.0,
+      "StepValue": 25.0,
+      "InputValue": 75.0,
+      "Id": "34b20b93a74840a2a99121c247535b1c",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4e208b15ca9d4719be8411b569af9046",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces numeric values."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "MaximumValue": 255.0,
+      "MinimumValue": 0.0,
+      "StepValue": 25.0,
+      "InputValue": 255.0,
+      "Id": "670bcf1792034607aed50da5479c6b6a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "759f126391464189b3481b8bcea1b85e",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A slider that produces numeric values."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Modifiers.GeometryColor.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
+      "Id": "45e01769bf3b4a68811a83d799533c8e",
+      "Inputs": [
+        {
+          "Id": "5254f3f6281a47e4a79fdf56b6337bc3",
+          "Name": "geometry",
+          "Description": "The geometry to which you would like to apply color.\n\nGeometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e7d3bc46f21c45ffaea5fc420b664193",
+          "Name": "color",
+          "Description": "The color.\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "fcdd31a3764d46688cf0fa6df8df6c25",
+          "Name": "GeometryColor",
+          "Description": "A Display object.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Display geometry using a color.\n\nGeometryColor.ByGeometryColor (geometry: Geometry, color: Color): GeometryColor"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Modifiers.GeometryColor.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
+      "Id": "169e634174af4e5f8ca7f7faa43cfc75",
+      "Inputs": [
+        {
+          "Id": "9ee42d59a253483d9c757acde7ddf2a7",
+          "Name": "geometry",
+          "Description": "The geometry to which you would like to apply color.\n\nGeometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "94a52a8f9fe94e9b9665a6bf154db684",
+          "Name": "color",
+          "Description": "The color.\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cc5348ca08a64cccb38a574b638afc32",
+          "Name": "GeometryColor",
+          "Description": "A Display object.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Display geometry using a color.\n\nGeometryColor.ByGeometryColor (geometry: Geometry, color: Color): GeometryColor"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Modifiers.GeometryColor.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
+      "Id": "7ccd9095bb36473e8016f812fc0aa40f",
+      "Inputs": [
+        {
+          "Id": "6aa1e01596934fd780a383416ed77ec3",
+          "Name": "geometry",
+          "Description": "The geometry to which you would like to apply color.\n\nGeometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4c92ed1c9c6742a7837035c7a9bb4865",
+          "Name": "color",
+          "Description": "The color.\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "532012898c634e2c9eb1708ecfb7d06a",
+          "Name": "GeometryColor",
+          "Description": "A Display object.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Display geometry using a color.\n\nGeometryColor.ByGeometryColor (geometry: Geometry, color: Color): GeometryColor"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Modifiers.GeometryColor.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
+      "Id": "445d348aefb74ca9a4bcd8b8bfa2deb6",
+      "Inputs": [
+        {
+          "Id": "6a02578a7aab49d1bcb015350cbaa9a2",
+          "Name": "geometry",
+          "Description": "The geometry to which you would like to apply color.\n\nGeometry",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9fb1ce0bf5a141ac9efa08d2818f3aa6",
+          "Name": "color",
+          "Description": "The color.\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "688e1d34dc084fd3b851b0b2dadf464e",
+          "Name": "GeometryColor",
+          "Description": "A Display object.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Display geometry using a color.\n\nGeometryColor.ByGeometryColor (geometry: Geometry, color: Color): GeometryColor"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "f9030fc05e314fcd9dc963daa740c40a",
+      "End": "fd6535d385ca469eb7fce776b4ba172e",
+      "Id": "b5a3f268011145d39221ed702ba32e51",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f9030fc05e314fcd9dc963daa740c40a",
+      "End": "17301129273948dcbeb55a23fe512c58",
+      "Id": "873751ab554e46b8a8a4fc6cf2afb8fa",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f9030fc05e314fcd9dc963daa740c40a",
+      "End": "dc0d2c23b9c44394bba8d95e28c362c9",
+      "Id": "b6e51f02277c41339422d83d492dc2bb",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "46af34c469c242018cff919f050e33e1",
+      "End": "b56de8c9476c4b02a47a69796c65a6ce",
+      "Id": "541715d719c947428d3424fdd3086351",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "46af34c469c242018cff919f050e33e1",
+      "End": "3ecfde3b0e1c45de906567ec39756cc9",
+      "Id": "04a1f5f005a0442a9a343e8581f4d3cb",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "46af34c469c242018cff919f050e33e1",
+      "End": "b36af3447e1b433390d01367ec56488b",
+      "Id": "ff90121975544aac86273ec5adc0734b",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "42733a3afb804cb399d1e4785b9a1758",
+      "End": "9ee42d59a253483d9c757acde7ddf2a7",
+      "Id": "567005e4a0d740259409db679140d4d9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f981f62594314f6b9065a711d5b6cebc",
+      "End": "ce1d3d7e67a24964aa42894656c3feff",
+      "Id": "870642893a0843ffb724f19892c63801",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f981f62594314f6b9065a711d5b6cebc",
+      "End": "6aa1e01596934fd780a383416ed77ec3",
+      "Id": "0d8398b8252746789b250392b37669cf",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "4c8ae10bf2a2447bb339d599c9beaae2",
+      "End": "5a063f548f8544d088dcfaa4d104ef54",
+      "Id": "2ba8cf5bb815421e82f14c391c6e0899",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5f95b7a750404955823c983b02a39586",
+      "End": "6a02578a7aab49d1bcb015350cbaa9a2",
+      "Id": "b9f0c8a18c2744dca6603f99fc7730e9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "99d84d7c085e4af0afcdadd4d17c19f6",
+      "End": "5254f3f6281a47e4a79fdf56b6337bc3",
+      "Id": "cc60e1f98a884232ab9549eed95e1736",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2b9eaa01cef34b00bb6fbfa86055e1ca",
+      "End": "3a055fe2f9244b3c8efe862ae8cff470",
+      "Id": "ba8affaa88c8444e81101c541e919aec",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2b9eaa01cef34b00bb6fbfa86055e1ca",
+      "End": "e5c289b4737c4726934def916d1030b3",
+      "Id": "48a5daa11359443289c3aefc57b0dd57",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e1250051e02b4c7ea5b0b7ae8c1a0ef9",
+      "End": "b8daca7c8a234914a6ddc1b7f3260c22",
+      "Id": "cc4a8a5426014d37890d0ac686011aed",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e1250051e02b4c7ea5b0b7ae8c1a0ef9",
+      "End": "8b9b94e5f8d841bebb7a7de9292b3986",
+      "Id": "41ba77f81b794ea39d1db140a3a3796d",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5f630fc8f6bb4089a55d3b36498080c4",
+      "End": "9fb1ce0bf5a141ac9efa08d2818f3aa6",
+      "Id": "bf9a295f583b44a88d8b6e61a27dbce0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "28ff2d8a40864573895a9449bf3980c3",
+      "End": "4c92ed1c9c6742a7837035c7a9bb4865",
+      "Id": "877a94d4ac39468db412a352a8c610a2",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "a449e51a17cd4a1a9bba87c082cdd113",
+      "End": "94a52a8f9fe94e9b9665a6bf154db684",
+      "Id": "c5baaa16c48d4c06a9de61ee2e9de032",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9e9a45305b444385b683aad73e28f76a",
+      "End": "e7d3bc46f21c45ffaea5fc420b664193",
+      "Id": "8f63d1ccab864190981c61a4160c2d43",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "4e208b15ca9d4719be8411b569af9046",
+      "End": "c3b21c5bae8849b6a44715d8c7f4e99e",
+      "Id": "50ae6ec618e1407aa434478f2042dafa",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "4e208b15ca9d4719be8411b569af9046",
+      "End": "2b8678f397cf4e51b9652e2e2a316283",
+      "Id": "01ffdb21c0f34bc8b957f7acf8416f97",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "759f126391464189b3481b8bcea1b85e",
+      "End": "625a4604492a434b8a031ebf23729610",
+      "Id": "82c71cbeaf6a4d04aa733d72cbcab994",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "759f126391464189b3481b8bcea1b85e",
+      "End": "deec996f75784bf78acca0b4ed17c29f",
+      "Id": "c1f80984e5024f658c66c1b3d3d3d16c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "759f126391464189b3481b8bcea1b85e",
+      "End": "c1450e13f7224aed9f3dfc01b628d563",
+      "Id": "35ca9326bc864a7090633c61bbee8ffe",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": null,
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.15",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.15.0.4953",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": 66.010910034179688,
+      "EyeY": 58.547088623046875,
+      "EyeZ": 30.807262420654297,
+      "LookX": -41.010414123535156,
+      "LookY": -33.897079467773438,
+      "LookZ": -55.807258605957031,
+      "UpX": -0.14024661481380463,
+      "UpY": 0.97154915332794189,
+      "UpZ": -0.19084835052490234
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "8190039b694b4ef2ad33c48f5d964519",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1362.9459712817,
+        "Y": 379.201169296295
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "7c9f9b44efd4490893d4dc76fc3c10fe",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1108.9459712817,
+        "Y": 413.028669296295
+      },
+      {
+        "Name": "Sphere.ByCenterPointRadius",
+        "ShowGeometry": false,
+        "Id": "88f09e6c057f4a5c95a7f4f0b25161e2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": 379.201169296295
+      },
+      {
+        "Name": "Cuboid.ByLengths",
+        "ShowGeometry": false,
+        "Id": "932166f3acf44180946580a57aa6c0bf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1687.7459712817,
+        "Y": 835.20116929629512
+      },
+      {
+        "Name": "Topology.Edges",
+        "ShowGeometry": false,
+        "Id": "39114e8acf1445cfb0ee167d4eb2a621",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1996.5459712816998,
+        "Y": 998.201169296295
+      },
+      {
+        "Name": "Edge.CurveGeometry",
+        "ShowGeometry": false,
+        "Id": "d0d56164c15f476fa4dd017a87901c97",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": 1065.2011692962951
+      },
+      {
+        "Name": "Circle.ByCenterPointRadius",
+        "ShowGeometry": false,
+        "Id": "3f20164eefac49dab3bd3b38b3ef356f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": -58.798830703704994
+      },
+      {
+        "Name": "Number Slider",
+        "ShowGeometry": true,
+        "Id": "e639df9313324b9ea9888262dbdc86f6",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1996.5459712816998,
+        "Y": 194.201169296295
+      },
+      {
+        "Name": "Number Slider",
+        "ShowGeometry": true,
+        "Id": "92e62696da4b44b2b3e4addc5eedf3a7",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1996.5459712816998,
+        "Y": 1157.7011692962951
+      },
+      {
+        "Name": "Color.ByARGB",
+        "ShowGeometry": true,
+        "Id": "e59b2a9039b943dda22e19980ced7d17",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": 1226.2011692962951
+      },
+      {
+        "Name": "Color.ByARGB",
+        "ShowGeometry": true,
+        "Id": "124b68b5c67e4975846cd7d93669cb8d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": 817.201169296295
+      },
+      {
+        "Name": "Color.ByARGB",
+        "ShowGeometry": true,
+        "Id": "08cfa9ebc49a45afb2960b51b88b157a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": 569.201169296295
+      },
+      {
+        "Name": "Color.ByARGB",
+        "ShowGeometry": true,
+        "Id": "02aac675c7b647ac89a9aa35c1c22d33",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2444.9459712816997,
+        "Y": 131.201169296295
+      },
+      {
+        "Name": "Number Slider",
+        "ShowGeometry": true,
+        "Id": "34b20b93a74840a2a99121c247535b1c",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1996.5459712816998,
+        "Y": 418.201169296295
+      },
+      {
+        "Name": "Number Slider",
+        "ShowGeometry": true,
+        "Id": "670bcf1792034607aed50da5479c6b6a",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1996.5459712816998,
+        "Y": 850.201169296295
+      },
+      {
+        "Name": "GeometryColor.ByGeometryColor",
+        "ShowGeometry": true,
+        "Id": "45e01769bf3b4a68811a83d799533c8e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2832.9459712816997,
+        "Y": 316.201169296295
+      },
+      {
+        "Name": "GeometryColor.ByGeometryColor",
+        "ShowGeometry": true,
+        "Id": "169e634174af4e5f8ca7f7faa43cfc75",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2832.9459712816997,
+        "Y": 494.201169296295
+      },
+      {
+        "Name": "GeometryColor.ByGeometryColor",
+        "ShowGeometry": true,
+        "Id": "7ccd9095bb36473e8016f812fc0aa40f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2832.9459712816997,
+        "Y": 672.201169296295
+      },
+      {
+        "Name": "GeometryColor.ByGeometryColor",
+        "ShowGeometry": true,
+        "Id": "445d348aefb74ca9a4bcd8b8bfa2deb6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2832.9459712816997,
+        "Y": 850.201169296295
+      }
+    ],
+    "Annotations": [],
+    "X": -321.39358146429549,
+    "Y": 62.501708947863008,
+    "Zoom": 0.5527611443779108
+  }
+}


### PR DESCRIPTION
### Purpose

This pull request does:
* add a test framework for the new engine work.
* use WorkspaceComparisonData for comparing the results from two runs of the same graph.
* do the comparison in memory.
* restart Dynamo between each run,
* not add a way to switch between the old and new engine. This is future work.
* target the emitMSIL branch. Testing was done using the master branch.

This eventually boiled down to be very little code. I opted for comparing the run results in memory. This assumes that we will have a way to switch between the engines at runtime. We can always change this and start serialize the results if we need to compare the results from different binaries.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
