### PR TITLE
Fix guided tour crash

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2362,7 +2362,7 @@ namespace Dynamo.ViewModels
 
         private bool CanCloseHomeWorkspace(object parameter)
         {
-            return HomeSpace.RunSettings.RunEnabled;
+            return HomeSpace.RunSettings.RunEnabled || RunSettings.ForceBlockRun;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2362,7 +2362,7 @@ namespace Dynamo.ViewModels
 
         private bool CanCloseHomeWorkspace(object parameter)
         {
-            return HomeSpace.RunSettings.RunEnabled || parameter is true;
+            return HomeSpace.RunSettings.RunEnabled;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2362,7 +2362,7 @@ namespace Dynamo.ViewModels
 
         private bool CanCloseHomeWorkspace(object parameter)
         {
-            return HomeSpace.RunSettings.RunEnabled;
+            return HomeSpace.RunSettings.RunEnabled || parameter is true;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1283,7 +1283,8 @@ namespace Dynamo.ViewModels
 
             if (IsHomeSpace)
             {
-                DynamoViewModel.CloseHomeWorkspaceCommand.Execute(null);
+                if (DynamoViewModel.CloseHomeWorkspaceCommand.CanExecute(null))
+                    DynamoViewModel.CloseHomeWorkspaceCommand.Execute(null);
             }
             else
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1281,10 +1281,9 @@ namespace Dynamo.ViewModels
             // if there are no other custom workspace that is opened.
             // 
 
-            if (this.IsHomeSpace)
+            if (IsHomeSpace)
             {
-                if (DynamoViewModel.CloseHomeWorkspaceCommand.CanExecute(true))
-                    DynamoViewModel.CloseHomeWorkspaceCommand.Execute(null);
+                DynamoViewModel.CloseHomeWorkspaceCommand.Execute(null);
             }
             else
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1283,7 +1283,7 @@ namespace Dynamo.ViewModels
 
             if (this.IsHomeSpace)
             {
-                if (DynamoViewModel.CloseHomeWorkspaceCommand.CanExecute(null))
+                if (DynamoViewModel.CloseHomeWorkspaceCommand.CanExecute(true))
                     DynamoViewModel.CloseHomeWorkspaceCommand.Execute(null);
             }
             else

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Threading;
 using Dynamo.Controls;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
@@ -40,16 +41,18 @@ namespace Dynamo.Wpf.Views.FileTrust
             DataContext = fileTrustWarningViewModel;
 
             if (dynamoViewWindow == null) return;
-          
+
             //Creating the background of the Popup
             BackgroundRectangle.Rect = new Rect(fileTrustWarningViewModel.PopupBordersOffSet, fileTrustWarningViewModel.PopupBordersOffSet, fileTrustWarningViewModel.PopupRectangleWidth, fileTrustWarningViewModel.PopupRectangleHeight);
             SetUpPopup();
+
+            HomeWorkspaceModel.WorkspaceClosed += CloseWarningPopup;
         }
 
         private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             //When the ShowWarningPopup property is changed we need to enable or disable the Dynamo Run section
-            if (e.PropertyName == nameof(FileTrustWarningViewModel.ShowWarningPopup) )
+            if (e.PropertyName == nameof(FileTrustWarningViewModel.ShowWarningPopup))
             {
                 var fileTrustWarningViewModel = sender as FileTrustWarningViewModel;
                 if (fileTrustWarningViewModel == null) return;
@@ -59,12 +62,12 @@ namespace Dynamo.Wpf.Views.FileTrust
                     //Force to run all the drawing events in the Dispatcher so later we can disable the button/combobox in the Run section
                     mainWindow.Dispatcher.Invoke(DispatcherPriority.Background, new Action(delegate { }));
                     DisableRunInteractivity();
-                }                   
+                }
                 else
                 {
                     EnableRunInteractivity();
                 }
-                    
+
             }
         }
 
@@ -126,11 +129,11 @@ namespace Dynamo.Wpf.Views.FileTrust
         {
             fileTrustWarningViewModel.AllowOneTimeTrust = true;
             fileTrustWarningViewModel.ShowWarningPopup = false;
-            
+
             RunSettings.ForceBlockRun = false;
             if (FileTrustWarningCheckBox.IsChecked.Value == true)
             {
-                if(dynViewModel.PreferenceSettings.AddTrustedLocation(fileTrustWarningViewModel.DynFileDirectoryName))
+                if (dynViewModel.PreferenceSettings.AddTrustedLocation(fileTrustWarningViewModel.DynFileDirectoryName))
                     dynViewModel.MainGuideManager.CreateRealTimeInfoWindow(string.Format(Properties.Resources.TrustLocationAddedNotification, fileTrustWarningViewModel.DynFileDirectoryName));
             }
             if (dynViewModel.CurrentSpaceViewModel.RunSettingsViewModel.Model.RunType != RunType.Manual)
@@ -162,10 +165,12 @@ namespace Dynamo.Wpf.Views.FileTrust
         internal void CleanPopup()
         {
             if (fileTrustWarningViewModel != null)
-            { 
+            {
                 fileTrustWarningViewModel.PropertyChanged -= ViewModel_PropertyChanged;
                 fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
             }
+
+            HomeWorkspaceModel.WorkspaceClosed -= CloseWarningPopup;
         }
 
         /// <summary>
@@ -185,6 +190,15 @@ namespace Dynamo.Wpf.Views.FileTrust
             {
                 fileTrustWarningViewModel.PropertyChanged += ViewModel_PropertyChanged;
             }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        internal void CloseWarningPopup()
+        {
+            fileTrustWarningViewModel.ShowWarningPopup = false;
+            fileTrustWarningViewModel.DynFileDirectoryName = string.Empty;
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -192,7 +192,7 @@ namespace Dynamo.Wpf.Views.FileTrust
         }
 
         /// <summary>
-        /// 
+        /// Close the warning popup
         /// </summary>
         internal void CloseWarningPopup()
         {

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -67,7 +67,6 @@ namespace Dynamo.Wpf.Views.FileTrust
                 {
                     EnableRunInteractivity();
                 }
-
             }
         }
 

--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -105,5 +105,23 @@ namespace DynamoCoreWpfTests
             // After deleting all Warning nodes, the counter should get to 0 
             Assert.AreEqual((items[1] as FooterNotificationItem).NotificationCount, 0);
         }
+
+        [Test]
+        public void OpeningWorkspaceWithTrustWarning()
+        {
+            // Open workspace with test mode as false, to verify trust warning.
+            DynamoModel.IsTestMode = false;
+            Open(@"core\CustomNodes\TestAdd.dyn");
+
+            Assert.IsTrue(ViewModel.FileTrustViewModel.ShowWarningPopup);
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Asert that the warning popup is closed, when the workspace is closed.
+            Assert.IsFalse(ViewModel.FileTrustViewModel.ShowWarningPopup);
+            DynamoModel.IsTestMode = true;
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Fixes the crash in here : https://jira.autodesk.com/browse/DYN-5056

When a home workspace is closed, we will close the file trust dialog if it is open. This will prevent the guided tour crash and also enables the user to just close the workspace using the close button.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers
@QilongTang @zeusongit 
