### PR TITLE
Prevent Shift Drag Crash when single group selected

### DIFF
--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -112,9 +112,20 @@ namespace Dynamo.ViewModels
                     var dragC = command as DynamoModel.DragSelectionCommand;
 
                     if (DynamoModel.DragSelectionCommand.Operation.BeginDrag == dragC.DragOperation)
-                        CurrentSpaceViewModel.BeginDragSelection(dragC.MouseCursor);
+                    {
+                        try
+                        {
+                            CurrentSpaceViewModel.BeginDragSelection(dragC.MouseCursor);
+                        }
+                        catch (Exception ex)
+                        {
+                            model.Logger.Log(ex.Message);
+                        }
+                    }
                     else
+                    {
                         CurrentSpaceViewModel.EndDragSelection(dragC.MouseCursor);
+                    }
                     break;
 
                 case "DeleteModelCommand":

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3516,6 +3516,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is nothing being dragged. If you see this message, most likely your recent Dynamo interaction is not recommended..
+        /// </summary>
+        public static string InvalidDraggingOperationMessgae {
+            get {
+                return ResourceManager.GetString("InvalidDraggingOperationMessgae", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid URL for login page!.
         /// </summary>
         public static string InvalidLoginUrl {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3252,4 +3252,7 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="UnableToAccessTrustedDirectory" xml:space="preserve">
     <value>Unable To Access Trusted Directory</value>
   </data>
+  <data name="InvalidDraggingOperationMessgae" xml:space="preserve">
+    <value>There is nothing being dragged. If you see this message, most likely your recent Dynamo interaction is not recommended.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3239,4 +3239,7 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="UnableToAccessTrustedDirectory" xml:space="preserve">
     <value>Unable To Access Directory</value>
   </data>
+  <data name="InvalidDraggingOperationMessgae" xml:space="preserve">
+    <value>There is nothing being dragged. If you see this message, most likely your recent Dynamo interaction is not recommended.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -27,7 +27,7 @@ namespace Dynamo.ViewModels
 
         #region State Machine Related Methods/Data Members
 
-        private StateMachine stateMachine = null;
+        private readonly StateMachine stateMachine = null;
         private List<DraggedNode> draggedNodes = new List<DraggedNode>();
 
         // When a new connector is created or a single connector is selected,
@@ -146,19 +146,12 @@ namespace Dynamo.ViewModels
 
             if (draggedNodes.Count <= 0) // There is nothing to drag.
             {
-                string message = "Shouldn't get here if nothing is dragged";
-                throw new InvalidOperationException(message);
+                throw new InvalidOperationException(Wpf.Properties.Resources.InvalidDraggingOperationMessgae);
             }
         }
 
         internal void UpdateDraggedSelection(Point2D mouseCursor)
         {
-            if (draggedNodes.Count <= 0)
-            {
-                throw new InvalidOperationException(
-                    "UpdateDraggedSelection cannot be called now");
-            }
-
             foreach (DraggedNode draggedNode in draggedNodes)
                 draggedNode.Update(mouseCursor);
         }
@@ -343,7 +336,7 @@ namespace Dynamo.ViewModels
             List<ModelBase> changedPositionModels = new List<ModelBase>();
             foreach (DraggedNode draggedNode in draggedNodes)
             {
-                //Checks if the draggednoded has changed its position
+                //Checks if the dragged node has changed its position
                 if (draggedNode.HasChangedPosition(mousePoint))
                 {
                     ModelBase model = DynamoSelection.Instance.Selection.
@@ -351,7 +344,7 @@ namespace Dynamo.ViewModels
 
                     changedPositionModels.Add(model);
 
-                    //The nodes are being reseted to inital position for recording the model purposes 
+                    //The nodes are being reseted to initial position for recording the model purposes 
                     draggedNode.UpdateInitialPosition();
                 }
             }
@@ -363,15 +356,13 @@ namespace Dynamo.ViewModels
         private void OnDragSelectionStarted(object sender, EventArgs e)
         {
             //Debug.WriteLine("Drag started : Visualization paused.");
-            if (DragSelectionStarted != null)
-                DragSelectionStarted(sender, e);
+            DragSelectionStarted?.Invoke(sender, e);
         }
 
         private void OnDragSelectionEnded(object sender, EventArgs e)
         {
             //Debug.WriteLine("Drag ended : Visualization unpaused.");
-            if (DragSelectionEnded != null)
-                DragSelectionEnded(sender, e);
+            DragSelectionEnded?.Invoke(sender, e);
         }
 
         #endregion
@@ -384,10 +375,12 @@ namespace Dynamo.ViewModels
         /// </summary>
         public class DraggedNode
         {
-            double deltaX = 0, deltaY = 0;
-            ILocatable locatable = null;
+            private readonly double deltaX = 0;
+            private readonly double deltaY = 0;
+            readonly ILocatable locatable = null;
             internal Guid guid;
-            double initialPositionX = 0, initialPositionY = 0;
+            private readonly double initialPositionX = 0;
+            private readonly double initialPositionY = 0;
 
             /// <summary>
             /// Construct a DraggedNode for a given ILocatable object.
@@ -399,9 +392,6 @@ namespace Dynamo.ViewModels
             /// <param name="mouseCursor">The mouse cursor at the point this 
             /// DraggedNode object is constructed. This is used to determine the 
             /// offset of the ILocatable from the mouse cursor.</param>
-            /// <param name="region">The region within which the ILocatable can 
-            /// be moved. However, the movement of ILocatable will be limited by 
-            /// region and that it cannot be moved beyond the region.</param>
             /// 
             public DraggedNode(ILocatable locatable, Point2D mouseCursor)
             {


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-5075, prevent crash when a group selected and the user still shit + left click to drag and update to display a message to the user after that or in similar situations. The original reason of the crash is that shift + left click will deselect the single node in the group first then Dynamo lost the drag target, in this case, the drag should just fail.

![image](https://user-images.githubusercontent.com/3942418/178363432-cd6bf543-bf00-43f1-a517-37303f4791ed.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Prevent Shift Drag Crash when single group selected


### Reviewers

@DynamoDS/dynamo 

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
