### PR TITLE
Resize the Group Styles panel in Preferences window

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -3609,7 +3609,7 @@
                                 Grid.Row="1"
                                 BorderThickness="1,0,1,1"
                                 CornerRadius="0,0,4,4">
-                            <ContentPresenter Margin="12,0,0,15" />
+                            <ContentPresenter Margin="12,0,0,12" />
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -4830,7 +4830,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">
-                    <Grid Margin="0,0,10,10"
+                    <Grid Margin="0,0,10,5"
                                   MinWidth="186"
                                   MinHeight="67">
                         <Border x:Name="mouseOverBorder"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -18,7 +18,7 @@
         WindowStartupLocation="CenterOwner"
         WindowStyle="None"
         mc:Ignorable="d" 
-        Height="474" 
+        Height="480" 
         Width="665"
         ResizeMode="NoResize">
 
@@ -39,8 +39,7 @@
 
             <!--This Template will be used for the controls generated in the Styles list when a new Style is saved-->
             <DataTemplate x:Key="styleViewItemTemplate">
-                <Border Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}"     
-                        Margin="4"
+                <Border Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}"
                         BorderThickness="1">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -535,8 +534,8 @@
                                 <ScrollViewer VerticalScrollBarVisibility="Auto" 
                                               x:Name="GroupStyleScrollViewer"                                              
                                               PreviewMouseWheel="ScrollViewer_PreviewMouseWheel"
-                                              MaxHeight="250">
-                                    <Grid Margin="0,0,0,0">
+                                              MaxHeight="260">
+                                    <Grid Margin="0,0,0,-2">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
@@ -548,7 +547,7 @@
                                                 Grid.Row="0"
                                                 MinWidth="100"
                                                 MinHeight="25"
-                                                Margin="3,10,0,10"
+                                                Margin="0,5,0,5"
                                                 Click="AddStyleButton_Click"
                                                 IsEnabled="{Binding IsEnabledAddStyleButton}"
                                                 Content="{x:Static p:Resources.AddStyleButton}" />
@@ -557,7 +556,7 @@
                                                 CornerRadius="4" 
                                                 MinHeight="100"
                                                 MinWidth="335"
-                                                Margin="7,0,72,10"
+                                                Margin="3,0,72,5"
                                                 Background="{StaticResource PreferencesWindowVisualSettingsAddStyleBackground}"
                                                 Grid.Row="1">
                                             <Grid>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -535,7 +535,7 @@
                                 <ScrollViewer VerticalScrollBarVisibility="Auto" 
                                               x:Name="GroupStyleScrollViewer"                                              
                                               PreviewMouseWheel="ScrollViewer_PreviewMouseWheel"
-                                              Height="220">
+                                              MaxHeight="250">
                                     <Grid Margin="0,0,0,0">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5051

The max height is set for the scroll-viewer to make the grid height dynamic.

When only the default styles are present. 
<img width="718" alt="Screen Shot 2022-07-13 at 8 53 59 AM" src="https://user-images.githubusercontent.com/43763136/178738584-0a7519c9-6d42-465c-8b53-5af5af87e578.png">

When custom styles are also present.
<img width="759" alt="Screen Shot 2022-07-13 at 8 53 44 AM" src="https://user-images.githubusercontent.com/43763136/178738554-61f38cfc-79af-4050-8e4a-66c3bef71fee.png">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Resize the Group Styles panel in Preferences window


### Reviewers
@QilongTang 

