### PR TITLE
Pin Wire from Right-click Context Menu

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -466,6 +466,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pin Wire.
+        /// </summary>
+        public static string ConnectorContextMenuHeaderPinConnector {
+            get {
+                return ResourceManager.GetString("ConnectorContextMenuHeaderPinConnector", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Connected.
         /// </summary>
         public static string ConnectorContextMenuHeaderSelectConnected {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3252,4 +3252,7 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="UnableToAccessTrustedDirectory" xml:space="preserve">
     <value>Unable To Access Trusted Directory</value>
   </data>
+  <data name="ConnectorContextMenuHeaderPinConnector" xml:space="preserve">
+    <value>Pin Wire</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3239,4 +3239,7 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="UnableToAccessTrustedDirectory" xml:space="preserve">
     <value>Unable To Access Directory</value>
   </data>
+  <data name="ConnectorContextMenuHeaderPinConnector" xml:space="preserve">
+    <value>Pin Wire</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -843,7 +843,7 @@ namespace Dynamo.ViewModels
         private void PinConnectorCommandExecute(object parameters)
         {
             MousePosition = new Point(PanelX - ConnectorPinModel.StaticWidth, PanelY - ConnectorPinModel.StaticWidth);
-            ConnectorAnchorViewModel.CurrentPosition = MousePosition;
+            if (ConnectorAnchorViewModel != null) ConnectorAnchorViewModel.CurrentPosition = MousePosition;
             if (MousePosition == new Point(0, 0)) return;
             var connectorPinModel = new ConnectorPinModel(MousePosition.X, MousePosition.Y, Guid.NewGuid(), model.GUID);
             ConnectorModel.AddPin(connectorPinModel);

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorContextMenuViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorContextMenuViewModel.cs
@@ -85,19 +85,24 @@ namespace Dynamo.ViewModels
         public DelegateCommand HideConnectorSurrogateCommand { get; set; }
 
         /// <summary>
-        /// Alerts ConnectorViewModel select connnected nodes.
+        /// Alerts ConnectorViewModel select connected nodes.
         /// </summary>
         public DelegateCommand SelectConnectedSurrogateCommand { get; set; }
         /// <summary>
         /// Alerts ConnectorViewModel to break the current connection.
         /// </summary>
         public DelegateCommand BreakConnectionsSurrogateCommand { get; set; }
+        /// <summary>
+        /// Alerts ConnectorViewModel to pin the connector
+        /// </summary>
+        public DelegateCommand PinConnectedSurrogateCommand { get; set; }
 
         private void InitCommands()
         {
             HideConnectorSurrogateCommand = new DelegateCommand(HideConnectorSurrogateCommandExecute, x => true);
             SelectConnectedSurrogateCommand = new DelegateCommand(SelectConnectedSurrogateCommandExecute, x => true);
             BreakConnectionsSurrogateCommand = new DelegateCommand(BreakConnectionsSurrogateCommandExecute, x => true);
+            PinConnectedSurrogateCommand = new DelegateCommand(PinConnectedSurrogateCommandExecute, x => true);
         }
 
         /// <summary>
@@ -138,6 +143,17 @@ namespace Dynamo.ViewModels
                 Analytics.TrackEvent(Actions.Hide, Categories.ConnectorOperations, "Connector", 1);
             }
             ViewModel.ShowhideConnectorCommand.Execute(null);
+        }
+
+        /// <summary>
+        /// Request disposal of this viewmodel after command has run.
+        /// </summary>
+        /// <param name="obj"></param>
+        private void PinConnectedSurrogateCommandExecute(object obj)
+        {
+            ViewModel.PinConnectorCommand.Execute(null);
+            // Track pin connected nodes event
+            Analytics.TrackEvent(Actions.Pin, Categories.ConnectorOperations, "PinWire");
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorContextMenuView.xaml
@@ -26,10 +26,12 @@
                          Width="170"
                          MouseLeave="OnMouseLeaveContextMenu"
                          ContextMenuClosing="OnContextMenuClosing">
-                <MenuItem x:Name="BreakItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderBreakConnection}" 
+                    <MenuItem x:Name="BreakItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderBreakConnection}" 
                           Command="{Binding BreakConnectionsSurrogateCommand}"/>
                     <MenuItem x:Name="SelectItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderSelectConnected}" 
                           Command="{Binding SelectConnectedSurrogateCommand}"/>
+                    <MenuItem x:Name="PinItem" Header="{x:Static props:Resources.ConnectorContextMenuHeaderPinConnector}" 
+                              Command="{Binding PinConnectedSurrogateCommand}"/>
                     <MenuItem x:Name="HideItem" Command="{Binding HideConnectorSurrogateCommand}">
                         <MenuItem.Style>
                             <Style TargetType="MenuItem" BasedOn="{StaticResource ContextMenuItemStyle}">


### PR DESCRIPTION
### Purpose

An additional feature to the context menu of the connection wire. When Right-clicked, now will display the option to Pin wire 

![pin right-click context](https://user-images.githubusercontent.com/5354594/178554834-7d36c119-8832-48f9-9909-2c1de0ccdf10.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- added right-click context menu to allow Pin wire
- the wire will be pinned at the mouse point, similar to the existing mouse hoover behavior


### Reviewers

@reddyashish 

### FYIs

@Amoursol 




