### PR TITLE
Update PackageManagerClient.cs

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -31,6 +31,11 @@ namespace Dynamo.PackageManager
         ///     The directory where new packages are created during the upload process.
         /// </summary>
         private readonly string packageUploadDirectory;
+
+        /// <summary>
+        ///     The dictionay stores the package name corresponding to the boolean result of whether the user is an author of that package or not.
+        /// </summary>
+        private Dictionary<string, bool> packageMaintainers;
        
         /// <summary>
         ///     The URL of the package manager website
@@ -47,6 +52,7 @@ namespace Dynamo.PackageManager
             this.packageUploadDirectory = packageUploadDirectory;
             this.uploadBuilder = builder;
             this.client = client;
+            this.packageMaintainers = new Dictionary<string, bool>();
         }
 
         internal bool Upvote(string packageId)
@@ -277,9 +283,15 @@ namespace Dynamo.PackageManager
 
         internal bool DoesCurrentUserOwnPackage(Package package,string username) 
         {
+            bool value;
+            if (this.packageMaintainers.Count > 0 && this.packageMaintainers.TryGetValue(package.Name, out value)) {
+                return value;
+            }
             var pkg = new PackageInfo(package.Name, new Version(package.VersionName));
             var mnt = GetPackageMaintainers(pkg);
-            return (mnt != null) && (mnt.maintainers.Any(maintainer => maintainer.username.Equals(username)));
+            value = (mnt != null) && (mnt.maintainers.Any(maintainer => maintainer.username.Equals(username)));
+            this.packageMaintainers[package.Name] = value;
+            return value;
         }
     }
 }


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-5103

When a user right clicks a package in Dynamo package manager preference tab, we check if the user is an author of that package or not in order to enable/disable Deprecate/Undeprecate option for that package.

Created a cache in Dynamo to record the result so that we do not call the API again and again for one session.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Created a cache in Dynamo to record the result so that we do not call the API again and again for one session.



### Reviewers

@QilongTang 
