### PR TITLE
Range graph test

### DIFF
--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -893,21 +893,21 @@ namespace ProtoCore.Utils
 
             return value.StringData;
         }
-
-        public static object GetDataOfCLRValue(object value)
+        
+        internal static object GetDataOfCLRValue(object value)
         {
-                // This is because stackvalues directly store value types
-                // while they store the string representation of reference types.
-                if (value is long || value is int || value is double || value is char || value is bool)
-                {
-                    return value;
-                }
-                else if (value is DesignScript.Builtin.Dictionary)
+            // This is because stackvalues directly store value types
+            // while they store the string representation of reference types.
+            if (value is long || value is int || value is double || value is char || value is bool)
+            {
+                return value;
+            }
+            else if (value is DesignScript.Builtin.Dictionary)
             {
                 throw new NotImplementedException("get clr value of DSDictionary.");
             }
-                //TODO expand.
-                else if(value is ICollection vc)
+            //TODO expand.
+            else if (value is ICollection vc)
             {
                 return vc.Cast<Object>().Select(x => GetDataOfCLRValue(x)).ToList();
             }

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -906,10 +906,9 @@ namespace ProtoCore.Utils
             {
                 throw new NotImplementedException("get clr value of DSDictionary.");
             }
-            //TODO expand.
-            else if (value is ICollection vc)
+            else if(value is IEnumerable ve)
             {
-                return vc.Cast<Object>().Select(x => GetDataOfCLRValue(x)).ToList();
+                return ve.Cast<object>().Select(x => GetDataOfCLRValue(x)).ToList();
             }
             return value.ToString();
         }

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
@@ -890,6 +892,26 @@ namespace ProtoCore.Utils
             }
 
             return value.StringData;
+        }
+
+        public static object GetDataOfCLRValue(object value)
+        {
+                // This is because stackvalues directly store value types
+                // while they store the string representation of reference types.
+                if (value is long || value is int || value is double || value is char || value is bool)
+                {
+                    return value;
+                }
+                else if (value is DesignScript.Builtin.Dictionary)
+            {
+                throw new NotImplementedException("get clr value of DSDictionary.");
+            }
+                //TODO expand.
+                else if(value is ICollection vc)
+            {
+                return vc.Cast<Object>().Select(x => GetDataOfCLRValue(x)).ToList();
+            }
+            return value.ToString();
         }
 
         public static bool IsNonStaticPropertyLookupOnClass(ProcedureNode procCallNode, string className)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -189,22 +189,8 @@ namespace Dynamo.Tests
                             portvalues.AddRange(n.OutPorts.Select(p =>
                             {
                                 var objs = n.GetCLRValue(p.Index, controller).Cast<object>();
-                                var values = objs.Select(x =>
-                                {
-                                    // This is because stackvalues directly store value types
-                                    // while they store the string representation of reference types.
-                                    if (x is long || x is int || x is double || x is char || x is bool)
-                                    {
-                                        return x;
-                                    }
-                                    else
-                                    {
-                                        return x.ToString();
-                                    }
-                                }).ToList();
-
-                                if(values.Count == 1) { return values[0]; }
-
+                                var values = objs.Select(x => ProtoCore.Utils.CoreUtils.GetDataOfCLRValue(x)).ToList();
+                                if (values.Count == 1) { return values[0]; }
                                 return values;
                             }));
                         }

--- a/test/core/Performance/double_range_sum.dyn
+++ b/test/core/Performance/double_range_sum.dyn
@@ -1,0 +1,234 @@
+{
+  "Uuid": "d52b5b0f-d4af-48f1-af68-fb3550f154d4",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "RangeTest",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;\n10;\n0.2;",
+      "Id": "371e858653044014822b6aa7d5b8cf60",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8128b83c1475464193af5dcc639dea25",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1651f10fc46f49158820a4959855fb67",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "12fd9cf73d5e4d8b97f4df53ca34eef0",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "start..end..step;",
+      "Id": "a60f176fc542427cafda67d7bfd23ad4",
+      "Inputs": [
+        {
+          "Id": "a5d016bfe7eb45d6b3bf6867b611f8c0",
+          "Name": "start",
+          "Description": "start",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3c32d545f4914e57b161f189a756e04c",
+          "Name": "end",
+          "Description": "end",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "250705ed399f4e3eb709d47360f84e71",
+          "Name": "step",
+          "Description": "step",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8aa530c71c89462891dfdbc5b406a770",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Math.Sum@double[]",
+      "Id": "7b8d70eec59b4ed5bea0fd9faf015358",
+      "Inputs": [
+        {
+          "Id": "6d8a4ec52a684195b4ae1fc8ebf78c39",
+          "Name": "values",
+          "Description": "Numbers to add to sum\n\ndouble[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cd4d93deed134cf787329c152abdbeb3",
+          "Name": "double",
+          "Description": "The sum of the values",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Find the sum of a series of numbers\n\nMath.Sum (values: double[]): double"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "8128b83c1475464193af5dcc639dea25",
+      "End": "a5d016bfe7eb45d6b3bf6867b611f8c0",
+      "Id": "8e9ce56a9ae443c3b2ee281949571414",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "1651f10fc46f49158820a4959855fb67",
+      "End": "3c32d545f4914e57b161f189a756e04c",
+      "Id": "d830f99f53fb4009996246bac34b9838",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "12fd9cf73d5e4d8b97f4df53ca34eef0",
+      "End": "250705ed399f4e3eb709d47360f84e71",
+      "Id": "6696c3ea70654534810fa753b645c1ef",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "8aa530c71c89462891dfdbc5b406a770",
+      "End": "6d8a4ec52a684195b4ae1fc8ebf78c39",
+      "Id": "5b16fabf670b4708a5a05f7c56fb7d06",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.16",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.16.0.1985",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "371e858653044014822b6aa7d5b8cf60",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 263.0,
+        "Y": 368.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "a60f176fc542427cafda67d7bfd23ad4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 276.0,
+        "Y": 587.0
+      },
+      {
+        "Name": "Math.Sum",
+        "ShowGeometry": true,
+        "Id": "7b8d70eec59b4ed5bea0fd9faf015358",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 751.5,
+        "Y": 409.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION

![Screen Shot 2022-07-18 at 2 59 30 PM](https://user-images.githubusercontent.com/508936/179583792-c1864b20-1c0a-4c68-8e4c-86daad37a9dd.png)

### Purpose

* Adds a graph test for a double range passed to a function that takes an argument of `double[]`.
* improves workspace comparison constructor so it can handle arrays from the MSIL engine.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
