### PR TITLE
Pinned Note on Dismissed Warnings

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2522,12 +2522,7 @@ namespace Dynamo.Models
                                 connector.End != null && connector.End.Owner.IsSelected
                                     && !ClipBoard.Contains(connector));
 
-                var pins =
-                    connectors.SelectMany(x => x.ConnectorPinModels);
-
                 ClipBoard.AddRange(connectors);
-
-                ClipBoard.AddRange(pins);
             }
         }
 
@@ -2579,7 +2574,6 @@ namespace Dynamo.Models
             var nodes = ClipBoard.OfType<NodeModel>();
             var connectors = ClipBoard.OfType<ConnectorModel>();
             var notes = ClipBoard.OfType<NoteModel>();
-            var pins = ClipBoard.OfType<ConnectorPinModel>();
             // we only want to get groups that either has nested groups
             // or does not belong to a group here.
             // We handle creation of nested groups when creating the
@@ -2692,35 +2686,7 @@ namespace Dynamo.Models
                     select
                         ConnectorModel.Make(startNode, endNode, c.Start.Index, c.End.Index);
 
-
-                var newPins = new List<ConnectorPinModel>();
-                var oldAndNewConnectors = connectors.Zip(newConnectors, (o, n) => new { oldConnector = o, newConnector = n });
-
-                foreach (var on in oldAndNewConnectors)
-                {
-                    modelLookup.Add(on.oldConnector.GUID, on.newConnector);
-                }
-
-                foreach (var pin in pins)
-                {
-                    ModelBase connectorModel;
-                    var connector = modelLookup.TryGetValue(pin.ConnectorId, out connectorModel) && connectorModel as ConnectorModel != null ? connectorModel as ConnectorModel : null;
-                    if (connector != null)
-                    {
-                        double x = pin.CenterX + shiftX + offset;
-                        double y = pin.CenterY + shiftY + offset;
-
-                        var newPin = new ConnectorPinModel(x, y, Guid.NewGuid(), connector.GUID);
-
-                        connector.AddPin(newPin);
-                        newPins.Add(newPin);
-                    }
-                }
-
                 createdModels.AddRange(newConnectors);
-                createdModels.AddRange(newPins);
-
-                newItems = newItems.Concat(newPins);
 
                 //Grouping depends on the selected node models.
                 //so adding the group after nodes / notes are added to workspace.

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -468,8 +468,8 @@ namespace Dynamo.ViewModels
             if (PinnedNode == null) return;
 
             var distanceToNode = DISTANCE_TO_PINNED_NODE;
-            if (Model.PinnedNode.State == ElementState.Error ||
-                Model.PinnedNode.State == ElementState.Warning)
+            if ((Model.PinnedNode.State == ElementState.Error ||
+                Model.PinnedNode.State == ElementState.Warning) && Model.PinnedNode.DismissedAlerts.Count == 0)
             {
                 distanceToNode = DISTANCE_TO_PINNED_NODE_WITH_WARNING;
             }


### PR DESCRIPTION


### Purpose

The purpose of this PR is to rectify an issue where a pinned Note would remain in the same offset location after a Warning (dialog) has been dismissed. Normally, a Note would correctly get pushed up to provide space for the Warning tooltip dialog. However, when a Warning is dismissed, the space provided is no longer needed. This PR fixes this issue.

A secondary purpose of this PR is to make sure a Warning Dialog is always displayed on top, even in case of a more recent UI element (note). Currently, a note added after a Warning has been registered will appear on top of the Warning, which should not be the case. (Postponed)

A third potential goal is to allow to copy Connector Pins when copying/pasting Nodes with Pinned Connectors. (WIP)

**Pin Dismissed Warnings**
![pin dismissed warnings](https://user-images.githubusercontent.com/5354594/179957978-99c00fb9-be26-4e3d-8d85-416e9537e7b8.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- pinned Note correctly aligns to the Node once a Warning is dismissed

### Reviewers

@reddyashish 
@mjkkirschner 

### FYIs

@Amoursol 

