### PR TITLE
avoid access violation when creating images

### DIFF
--- a/src/Libraries/CoreNodes/FileSystem.cs
+++ b/src/Libraries/CoreNodes/FileSystem.cs
@@ -1,12 +1,17 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Autodesk.DesignScript.Runtime;
+using Dynamo.Events;
 using Dynamo.Graph.Nodes;
+using Dynamo.Logging;
+using Dynamo.Session;
 using Path = System.IO.Path;
 using Rectangle = System.Drawing.Rectangle;
 
@@ -440,6 +445,13 @@ namespace DSCore.IO
 
         private static Bitmap FromPixelsHelper(IEnumerable<Color> colors, int width, int height)
         {
+            //if the color data is larger than will fit in the bitmap buffer
+            //then this can cause an access violation - so we'll throw an exception.
+            if(colors?.Count() > width * height)
+            {
+                throw new ArgumentOutOfRangeException("colors", Properties.Resources.BitmapOverflowError);
+            }
+            
             var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
             var data = bitmap.LockBits(
                 new Rectangle(0, 0, width, height),

--- a/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace DSCore.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,15 @@ namespace DSCore.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The supplied color data is too large to fit in the image bounds..
+        /// </summary>
+        internal static string BitmapOverflowError {
+            get {
+                return ResourceManager.GetString("BitmapOverflowError", resourceCulture);
             }
         }
         

--- a/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BitmapOverflowError" xml:space="preserve">
+    <value>The supplied color data is too large to fit in the image bounds.</value>
+  </data>
   <data name="EnumDateOfWeekFriday" xml:space="preserve">
     <value>Friday</value>
   </data>

--- a/src/Libraries/CoreNodes/Properties/Resources.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BitmapOverflowError" xml:space="preserve">
+    <value>The supplied color data is too large to fit in the image bounds.</value>
+  </data>
   <data name="EnumDateOfWeekFriday" xml:space="preserve">
     <value>Friday</value>
   </data>

--- a/test/Libraries/CoreNodesTests/FileTests.cs
+++ b/test/Libraries/CoreNodesTests/FileTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -412,6 +413,17 @@ namespace Dynamo.Tests
             Assert.AreEqual(size, bmpFromFlat.Height);
 
             Assert.AreEqual(Image.Pixels(bmpFromRect), Image.Pixels(bmpFromFlat));
+        }
+        [Test, Category("UnitTests")]
+        public void Image_FromPixels_ThrowsWhenDataTooLarge()
+        {
+            const int size = 50;
+
+            var pixels = Enumerable.Repeat(Color.ByColor(System.Drawing.Color.Blue), size).ToArray();
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Image.FromPixels(pixels, 1, 1);
+            });
         }
 
         [Test, Category("UnitTests")]


### PR DESCRIPTION
### Purpose

This access violation occurs because sometimes the `Image.FromPixels` node is called with incorrect data, and the supplied number of colors will not fit into the bounds of the supplied `width*height`. This PR just throws before attempting to write the unmanaged data and overflowing.

The more serious VM problem of the node being called with incorrect data is tracked separately, and is not specific to this node, it can happen with any node, it's just obvious with this node because it writes unmanaged data and crashes.

<img width="276" alt="Screen Shot 2022-07-21 at 11 50 02 AM" src="https://user-images.githubusercontent.com/508936/180260039-0c308ca6-99d1-4993-9c3b-d823131d3020.png">



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix an unmanaged crash in the Image.FromPixels node.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
