### PR TITLE
Dealing the null color in the Preview and Watch Nodes

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3280,20 +3280,20 @@ namespace Dynamo.Controls
         {
             throw new NotImplementedException();
         }
-    }
+    }    
 
     /// <summary>
     /// Converts the object type to forground color for the object.
     /// </summary>
-    public class ObjectTypeConverter : IValueConverter
+    public class ObjectTypeConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
 
-            if (value != null)
+            if (values != null)
             {
-                switch (value)
+                switch (values[0])
                 {
                     case WatchViewModel.objectType:
                         return resourceDictionary["objectLabelBackground"] as SolidColorBrush;
@@ -3304,14 +3304,25 @@ namespace Dynamo.Controls
                     case WatchViewModel.stringType:
                         return resourceDictionary["stringLabelBackground"] as SolidColorBrush;
                     case WatchViewModel.boolType:
-                        return resourceDictionary["boolLabelBackground"] as SolidColorBrush;
+                        return resourceDictionary["boolLabelBackground"] as SolidColorBrush;                                                
                     default:
-                        return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+                        if (values[1].ToString() == "List")
+                        {
+                            return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+                        }
+                        else
+                        {
+                            return resourceDictionary["nullLabelBackground"] as SolidColorBrush;
+                        }
                 };
             }
-            return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+            else
+            {
+                return resourceDictionary["PrimaryCharcoal200Brush"] as SolidColorBrush;
+            }
         }
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -101,6 +101,8 @@
                      Color="#EEEEEE" />
     <SolidColorBrush x:Key="boolLabelBackground"
                      Color="#F9F9A5" />
+    <SolidColorBrush x:Key="nullLabelBackground"
+                     Color="#F9F9A5" />
 
     <!-- Node Autocomplete -->
     <SolidColorBrush x:Key="autocompletionWindow" Color="#535353" />

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -329,7 +329,7 @@
                         <TextBlock x:Name="listIndex"
                                    Width="Auto"
                                    Margin="{Binding Path=IsCollection, Converter={StaticResource ListIndexMarginConverter}}"
-                                   Padding="0,0,0,-1"
+                                   Padding="0,0,0,-1"                                   
                                    VerticalAlignment="Center"
                                    Background="{Binding Path=IsCollection, Converter={StaticResource ListIndexBackgroundConverter}}"
                                    FontFamily="{StaticResource SourceCodePro}"
@@ -352,11 +352,17 @@
 
                         <TextBlock Width="Auto"
                                    Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
-                                   VerticalAlignment="Center"
-                                   Foreground="{Binding Path=ValueType, Converter={StaticResource ObjectTypeConverter}}"
+                                   VerticalAlignment="Center"                                                                      
                                    FontFamily="{StaticResource SourceCodePro}"
                                    Text="{Binding Path=NodeLabel}"
-                                   Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
+                                   Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" >
+                            <TextBlock.Foreground>
+                                <MultiBinding Converter="{StaticResource ObjectTypeConverter}">
+                                    <Binding Path="ValueType" />
+                                    <Binding Path="NodeLabel" />
+                                    </MultiBinding>
+                            </TextBlock.Foreground>
+                            </TextBlock>
 
                         <Button Margin="10,2,2,2"
                                 Padding="4,0,4,0"


### PR DESCRIPTION
### Purpose

Set the null color in the Preview and Watch Nodes
https://jira.autodesk.com/browse/DYN-5085

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@RobertGlobant20 @filipeotero 
