### PR TITLE
Fixing the typo in code block error message 

### DIFF
--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -251,7 +251,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;)&apos; expected - Imcomplete Closure.
+        ///   Looks up a localized string similar to &apos;)&apos; expected - Incomplete Closure.
         /// </summary>
         public static string CloseBracketExpected {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -142,7 +142,7 @@
     <value>Checks if the list has a uniform depth</value>
   </data>
   <data name="CloseBracketExpected" xml:space="preserve">
-    <value>')' expected - Imcomplete Closure</value>
+    <value>')' expected - Incomplete Closure</value>
   </data>
   <data name="ContainsKeys" xml:space="preserve">
     <value>Checks if the specified key is present in the specified key-value pair list</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -142,7 +142,7 @@
     <value>Checks if the list has a uniform depth</value>
   </data>
   <data name="CloseBracketExpected" xml:space="preserve">
-    <value>')' expected - Imcomplete Closure</value>
+    <value>')' expected - Incomplete Closure</value>
   </data>
   <data name="ContainsKeys" xml:space="preserve">
     <value>Checks if the specified key is present in the specified key-value pair list</value>


### PR DESCRIPTION
### Purpose

This fixes the typo in code block error messages as raised in the  #13135 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix #13135 

