### PR TITLE
[DRAFT] dealing with transparent background weview2 page

### DIFF
--- a/src/Notifications/View/NotificationUI.xaml
+++ b/src/Notifications/View/NotificationUI.xaml
@@ -8,72 +8,9 @@
        xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf" 
        xmlns:fa="http://schemas.fontawesome.io/icons/" 
        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
-       mc:Ignorable="d" 
-       AllowsTransparency="True"
-       StaysOpen="False"
-       Opacity="0.5"
+       mc:Ignorable="d"             
        Width="340"
-       Height="598">
-    <Popup.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
-                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
-            </ResourceDictionary.MergedDictionaries>
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-            <controls:PointsToPathConverter x:Key="PointsToPathConverter"/>
-        </ResourceDictionary>
-    </Popup.Resources>
-    <Canvas Background="Transparent"
-            Name="RootLayout" >
-        <Path x:Name="PopupPathRectangle" 
-              Style="{StaticResource PoupPathRectangleStyle}">
-            <Path.Data>
-                <RectangleGeometry x:Name="BackgroundRectangle">
-                </RectangleGeometry>
-            </Path.Data>
-            <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 135 grades-->
-            <Path.Effect>
-                <DropShadowEffect Opacity="0.2" 
-                                  Color="Black"
-                                  ShadowDepth="4"
-                                  BlurRadius="4"
-                                  Direction="135"/>
-            </Path.Effect>
-        </Path>
-
-        <Path x:Name="PopupPathRectangleShadow"   
-              Style="{StaticResource PoupPathRectangleStyle}">
-            <Path.Data>
-                <RectangleGeometry Rect="{Binding ElementName=BackgroundRectangle, Path=Rect}">
-                </RectangleGeometry>
-            </Path.Data>
-            <!--This effect will show a 4px shadow of 20% of tranparency with a angle of 315 grades-->
-            <Path.Effect>
-                <DropShadowEffect Opacity="0.2" 
-                                  Color="Black"
-                                  ShadowDepth="4"
-                                  BlurRadius="4"
-                                  Direction="315"/>
-            </Path.Effect>
-        </Path>
-
-        <!--This Path will draw on the Canvas the pointer (a triangle)-->
-        <Path  x:Name="TooltipPointer"
-               Data="{Binding Path=TooltipPointerPoints, Converter={StaticResource PointsToPathConverter}}"
-               Style="{StaticResource PoupPathPointerStyle}">
-            <Path.Effect>
-                <DropShadowEffect Opacity="0.2" 
-                                  Color="Black"
-                                  ShadowDepth="4"
-                                  BlurRadius="4"
-                                  Direction="{Binding Path=ShadowTooltipDirection}"/>
-            </Path.Effect>
-        </Path>
-
-        <Grid  x:Name="mainPopupGrid" Background="White"                
-               Width="{Binding PopupRectangleWidth}">
-            <wv2:WebView2 Name="webView" ></wv2:WebView2>
-        </Grid>
-    </Canvas>
+       AllowsTransparency="True"
+       Height="598">    
+        <wv2:WebView2 Name="webView" DefaultBackgroundColor="Transparent" Source="http://localhost:8080/" ></wv2:WebView2>    
 </Popup>

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -37,12 +37,12 @@ namespace Dynamo.Notifications.View
             //The BackgroundRectangle represent the tooltip background rectangle that is drawn over a Canvas
             //Needs to be moved 10 pixels over the X axis to show the direction pointers (Height was already increased above)
             //Needs to be moved 10 pixels over the Y axis to show the shadow at top and bottom.
-            BackgroundRectangle.Rect = new Rect(notificationsUIViewModel.PopupBordersOffSet, notificationsUIViewModel.PopupBordersOffSet, notificationsUIViewModel.PopupRectangleWidth, notificationsUIViewModel.PopupRectangleHeight);
+            //BackgroundRectangle.Rect = new Rect(notificationsUIViewModel.PopupBordersOffSet, .PopupBordersOffSet, notificationsUIViewModel.PopupRectangleWidth, notificationsUIViewModel.PopupRectangleHeight);
 
             //The CustomRichTextBox has a margin of 10 in left and 10 in right, also there is a indentation for drawing the PointerDirection of 10 of each side so that's why we are subtracting 40.
-            mainPopupGrid.Width = notificationsUIViewModel.PopupRectangleWidth;
-            mainPopupGrid.Height = notificationsUIViewModel.PopupRectangleHeight;
-            mainPopupGrid.Margin = new Thickness(notificationsUIViewModel.PopupBordersOffSet, notificationsUIViewModel.PopupBordersOffSet, 0, 0);
+            //mainPopupGrid.Width = notificationsUIViewModel.PopupRectangleWidth;
+            //mainPopupGrid.Height = notificationsUIViewModel.PopupRectangleHeight;
+            //mainPopupGrid.Margin = new Thickness(notificationsUIViewModel.PopupBordersOffSet, notificationsUIViewModel.PopupBordersOffSet, 0, 0);
         }
 
         internal void UpdatePopupLocation()


### PR DESCRIPTION
### Purpose

This PR is to set a transparent background to the Webview2 and load the notifications-flyout as a whole.
**Notice that the source of the webview2 is set to localhost**.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers


### FYIs

@RobertGlobant20 
@reddyashish 
@QilongTang 
