### PR TITLE
DYN-4833-Group-NodesAlignment

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1007,7 +1007,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionAverageX()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.CenterX)
                            .Average();
@@ -1015,7 +1015,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionAverageY()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.CenterY)
                            .Average();
@@ -1023,7 +1023,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMinX()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.X)
                            .Min();
@@ -1031,7 +1031,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMinY()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.Y)
                            .Min();
@@ -1039,7 +1039,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMaxX()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.X + x.Width)
                            .Max();
@@ -1047,7 +1047,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMaxLeftX()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.X)
                            .Max();
@@ -1055,7 +1055,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMaxY()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.Y + x.Height)
                            .Max();
@@ -1063,7 +1063,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMaxTopY()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.Y)
                            .Max();
@@ -1081,7 +1081,7 @@ namespace Dynamo.ViewModels
             IEnumerable<ModelBase> models = selection.OfType<ModelBase>();
             WorkspaceModel.RecordModelsForModification(models.ToList(), Model.UndoRecorder);
 
-            var toAlign = DynamoSelection.Instance.Selection.OfType<ILocatable>().ToList();
+            var toAlign = DynamoSelection.Instance.Selection.OfType<ILocatable>().Where(node => !(node is AnnotationModel)).ToList();
 
             switch (alignType)
             {
@@ -1163,7 +1163,8 @@ namespace Dynamo.ViewModels
                     break;
                 case "VerticalDistribute":
                 {
-                    if (DynamoSelection.Instance.Selection.Count <= 2) return;
+                    var nodesSelected = DynamoSelection.Instance.Selection.Where(node => !(node is AnnotationModel) && node is ILocatable);
+                    if (nodesSelected.Count() <= 2) return;
 
                     var yMin = GetSelectionMinY();
                     var yMax = GetSelectionMaxY();
@@ -1172,14 +1173,14 @@ namespace Dynamo.ViewModels
                     var span = yMax - yMin;
 
                     var nodeHeightSum =
-                        DynamoSelection.Instance.Selection.Where(y => y is ILocatable)
+                        nodesSelected.Where(y => y is ILocatable)
                             .Cast<ILocatable>()
                             .Sum((y) => y.Height);
 
                     if (span > nodeHeightSum)
                     {
                         spacing = (span - nodeHeightSum)
-                            /(DynamoSelection.Instance.Selection.Count - 1);
+                            /(nodesSelected.Count() - 1);
                     }
 
                     var cursor = yMin;
@@ -1192,7 +1193,8 @@ namespace Dynamo.ViewModels
                     break;
                 case "HorizontalDistribute":
                 {
-                    if (DynamoSelection.Instance.Selection.Count <= 2) return;
+                    var nodesSelected = DynamoSelection.Instance.Selection.Where(node => !(node is AnnotationModel) && node is ILocatable);
+                    if (nodesSelected.Count() <= 2) return;
 
                     var xMin = GetSelectionMinX();
                     var xMax = GetSelectionMaxX();
@@ -1200,7 +1202,7 @@ namespace Dynamo.ViewModels
                     var spacing = 0.0;
                     var span = xMax - xMin;
                     var nodeWidthSum =
-                        DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
+                        nodesSelected.Where((x) => x is ILocatable)
                             .Cast<ILocatable>()
                             .Sum((x) => x.Width);
 
@@ -1211,7 +1213,7 @@ namespace Dynamo.ViewModels
                     if (span > nodeWidthSum)
                     {
                         spacing = (span - nodeWidthSum)
-                            /(DynamoSelection.Instance.Selection.Count - 1);
+                            /(nodesSelected.Count() - 1);
                     }
 
                     var cursor = xMin;


### PR DESCRIPTION
### Purpose

Fixing nodes alignment when they are inside a Group
Before this fix all the  alignment calculations were considering all the nodes selected then also was considering the Group (AnnotationModel), so when aligning to Left, Right, X-Distribute, Y-Distribute the Group was being moved some pixels so the right, left or over X-axis and Y-axis.
My fix was not considering the Group in the selected items so if we are trying to align all the nodes inside the Group, the group location won't change (just if is necessary in some cases like Left or Right alignment).


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing nodes alignment when they are inside a Group


### Reviewers

@QilongTang 

### FYIs

@avidit 
