### PR TITLE
Fix test regression on watchnode/preview bubble

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -330,7 +330,7 @@ namespace Dynamo.ViewModels
             var listLevelAndItemCount = GetMaximumDepthAndItemNumber(this);
             maxListLevel = listLevelAndItemCount.Item1;
             NumberOfItems = listLevelAndItemCount.Item2;
-            IsCollection = maxListLevel + numberOfItems > 1 || (Children.Count > 0 && (Children[0].NodeLabel == LIST || Children[0].NodeLabel == DICTIONARY));
+            IsCollection = maxListLevel > 1 || (Children.Count > 0 && (Children[0].NodeLabel == LIST || Children[0].NodeLabel == DICTIONARY));
         }
 
         private Tuple<int, int> GetMaximumDepthAndItemNumber(WatchViewModel wvm)

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -330,7 +330,7 @@ namespace Dynamo.ViewModels
             var listLevelAndItemCount = GetMaximumDepthAndItemNumber(this);
             maxListLevel = listLevelAndItemCount.Item1;
             NumberOfItems = listLevelAndItemCount.Item2;
-            IsCollection = maxListLevel + numberOfItems > 5;
+            IsCollection = maxListLevel + numberOfItems > 1 || (Children.Count > 0 && (Children[0].NodeLabel == LIST || Children[0].NodeLabel == DICTIONARY));
         }
 
         private Tuple<int, int> GetMaximumDepthAndItemNumber(WatchViewModel wvm)
@@ -350,7 +350,7 @@ namespace Dynamo.ViewModels
             }
 
             // if it's a list, recurse
-            if (wvm.NodeLabel == LIST || wvm.NodeLabel == DICTIONARY)
+            if (wvm.NodeLabel == LIST)
             {
                 var depthAndNumbers = wvm.Children.Select(GetMaximumDepthAndItemNumber);
                 var maxDepth = depthAndNumbers.Select(t => t.Item1).DefaultIfEmpty(1).Max() + 1;


### PR DESCRIPTION
### Purpose

This followup PR to fix couple of regression tests related to item counts and list levels for a dictionary in watch node/preview bubble. Reverting back to old solution and showing the resize thumb if the input is list of dictionary. No change in UI but fixes failing test.

Related to: https://github.com/DynamoDS/Dynamo/pull/13169

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Related to: https://github.com/DynamoDS/Dynamo/pull/13169

### Reviewers
@jesusalvino 

