### PR TITLE
DYN-5063 Make upiconfig.xml current (2.16)

### DIFF
--- a/src/Config/upiconfig.xml
+++ b/src/Config/upiconfig.xml
@@ -8,13 +8,13 @@
         <upi_attribute name='id' value='DYN'/>
         <upi_element name='level'>
           <upi_attribute name='name' value='release'/>
-          <upi_attribute name='id' value='2.15.0'/>
+          <upi_attribute name='id' value='2.16.0'/>
           <upi_element name='level'>
             <upi_attribute name='name' value='master'/>
             <upi_attribute name='id' value='Win64'/>
             <upi_element name='level'>
               <upi_attribute name='name' value='build'/>
-              <upi_attribute name='id' value='2.15.0' />
+              <upi_attribute name='id' value='2.16.0' />
             </upi_element>
           </upi_element>
         </upi_element>


### PR DESCRIPTION
### Purpose

This pull request does:
* Bump upiconfig.xml to 2.16

I noticed that upiconfig.xml still points to 2.15 while working on DYN-5063. @pinzart90 I assume it should point to 2.16 now in master as everything else?

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
