### PR TITLE
[POC] Embed notification backend URL in notification web-app

### DIFF
--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -120,21 +120,9 @@ namespace Dynamo.PackageManager
         /// </summary>
         public void Startup(StartupParams startupParams)
         {
-            var path = this.GetType().Assembly.Location;
-            var config = ConfigurationManager.OpenExeConfiguration(path);
-            var key = config.AppSettings.Settings["packageManagerAddress"];
-            string url = null;
-            if (key != null)
-            {
-                url = key.Value;
-            }
+            string url = DynamoUtilities.PathHelper.getServiceBackendAddress(this, "packageManagerAddress");
 
             OnMessageLogged(LogMessage.Info("Dynamo will use the package manager server at : " + url));
-
-            if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
-            {
-                throw new ArgumentException("Incorrectly formatted URL provided for Package Manager address.", "url");
-            }
 
             PackageLoader = new PackageLoader(startupParams.PathManager);
             PackageLoader.MessageLogged += OnMessageLogged;

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
@@ -389,6 +390,33 @@ namespace DynamoUtilities
             string directoryPath = FormatDirectoryPath(directory);
             
             return subdirPath.StartsWith(directoryPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns the path configured for package manager to retrieve packages from 
+        /// as defined inside config file
+        /// </summary>
+        /// <returns>Path that will be used to fetch packages</returns>
+        public static string getServiceBackendAddress(object o, string serviceKey)
+        {
+            string url = null;
+            if (o != null)
+            {
+                var path = o.GetType().Assembly.Location;
+                var config = ConfigurationManager.OpenExeConfiguration(path);
+                var key = config.AppSettings.Settings[serviceKey];
+
+                if (key != null)
+                {
+                    url = key.Value;
+                }
+
+                if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
+                {
+                    throw new ArgumentException("Incorrectly formatted URL provided for the service.", "url");
+                }
+            }
+            return url;
         }
     }
 }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -396,6 +396,9 @@ namespace DynamoUtilities
         /// Returns the path configured for package manager to retrieve packages from 
         /// as defined inside config file
         /// </summary>
+        /// <param name="o">The "this" object from where the function is being called from.</param>
+        /// <param name="serviceKey">Service or feature for which the address is being requested. 
+        /// It should match the key specified in the config file.</param>
         /// <returns>Path that will be used to fetch packages</returns>
         public static string getServiceBackendAddress(object o, string serviceKey)
         {

--- a/src/Notifications/App.config
+++ b/src/Notifications/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
   <appSettings>
-    <add key="notificationAddress" value="https://d2xm4bcf3at21r.cloudfront.net/dynNotifications.json"/>
+    <add key="notificationAddress" value="https://ddehnr4ewobxc.cloudfront.net/dynNotifications.json"/>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/Notifications/App.config
+++ b/src/Notifications/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<configuration>
+  <appSettings>
+    <add key="notificationAddress" value="https://d2xm4bcf3at21r.cloudfront.net/dynNotifications.json"/>
+  </appSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Configuration;
 using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Dynamo.Controls;
+using Dynamo.Logging;
 using Dynamo.Notifications.View;
 
 namespace Dynamo.Notifications
@@ -20,6 +22,8 @@ namespace Dynamo.Notifications
 
         private static readonly string htmlEmbeddedFile = "Dynamo.Notifications.node_modules._dynamods.notifications_center.build.index.html";
         private static readonly string jsEmbeddedFile = "Dynamo.Notifications.node_modules._dynamods.notifications_center.build.index.bundle.js";
+
+        private event Action<ILogMessage> MessageLogged;
 
         internal NotificationCenterController(DynamoView dynamoView)
         {
@@ -55,10 +59,14 @@ namespace Dynamo.Notifications
                 htmlString = reader.ReadToEnd();
             }
 
+            //Fetch notification URL from config
+            string notificationURL = FetchNotificationURL();
+
             using (Stream stream = assembly.GetManifestResourceStream(jsEmbeddedFile))
             using (StreamReader reader = new StreamReader(stream))
             {
                 var jsString = reader.ReadToEnd();
+                jsString = jsString.Replace("http://demo9540080.mockable.io/notifications", notificationURL);
                 htmlString = htmlString.Replace("mainJs", jsString);
             }
 
@@ -91,6 +99,35 @@ namespace Dynamo.Notifications
             notificationUIPopup.IsOpen = !notificationUIPopup.IsOpen;
             if (notificationUIPopup.IsOpen)
                 notificationUIPopup.webView.Focus();
-        }        
+        }
+
+        private string FetchNotificationURL()
+        {
+            var path = this.GetType().Assembly.Location;
+            var config = ConfigurationManager.OpenExeConfiguration(path);
+            var key = config.AppSettings.Settings["notificationAddress"];
+            string url = null;
+            if (key != null)
+            {
+                url = key.Value;
+            }
+
+            OnMessageLogged(LogMessage.Info("Dynamo will use the notifications service at : "+ url));
+
+            if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
+            {
+                throw new ArgumentException("Incorrectly formatted URL provided for Notification service.", "url");
+            }
+
+            return url;
+        }
+
+        private void OnMessageLogged(ILogMessage msg)
+        {
+            if (this.MessageLogged != null)
+            {
+                this.MessageLogged(msg);
+            }
+        }
     }
 }

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -122,7 +122,7 @@ namespace Dynamo.Notifications
 
         /// <summary>
         /// Invokes the script on the notification web-app side to update the URL to fetch notifications from 
-        /// and that will trigger a re-render of the panel. If a URL us provided then that will be used
+        /// and that will trigger a re-render of the panel. If a URL is provided then that will be used
         /// else the address will be fetched from the application configuration file.
         /// </summary>
         /// <param name="url">(Optional) If provided, this URL will be used to fetch notifications.</param>

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -28,7 +28,7 @@ namespace Dynamo.Notifications
 
         private DynamoLogger logger;
 
-        internal NotificationCenterController(DynamoView dynamoView, DynamoLogger dynLogger)
+        internal NotificationCenterController(DynamoView view, DynamoLogger dynLogger)
         {
             dynamoView = view;
             dynamoViewModel = dynamoView.DataContext as DynamoViewModel;

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -107,7 +107,7 @@ namespace Dynamo.Notifications
         private void LoadNotificationCenter()
         {
             var dynamoView = viewLoadedParams.DynamoWindow as DynamoView;
-            notificationCenterController = new NotificationCenterController(dynamoView);
+            notificationCenterController = new NotificationCenterController(dynamoView, logger);
         }
 
         internal void AddNotifications()

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -1,18 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
+﻿using System.Windows;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Dynamo.Notifications.View
 {


### PR DESCRIPTION
### Purpose

This is a proof of concept demonstrating one way of embedding notification service URL in web-app.
We are using the same technique as loading the javascript in WebView2 handler - string replacement to embed the URL.
The URL is read from an application config file.
```
<?xml version="1.0"?>
<configuration>
  <appSettings>
    <add key="notificationAddress" value="https://d2xm4bcf3at21r.cloudfront.net/dynNotifications.json"/>
  </appSettings>
<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
```

The app reads the key `notificationAddress` and replaces the URL hard-coded in the web-app.

We can update the mock URL in the web-app to any other string.

UPDATE:
With some help from @filipeotero I was able to re-render notifications after url update.
The notifications are fetched from https://ddehnr4ewobxc.cloudfront.net/dynNotifications.json
![DynamoSandbox_M9IXz2u1C4](https://user-images.githubusercontent.com/32665108/184735750-033b2ced-ec04-42ef-bc38-5f42add61bdc.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Add config file to provide notification URL


### Reviewers

@DynamoDS/dynamo
