### PR TITLE
Fixing CustomNode WorkSpace first scenario and trusted bubble behavior

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -218,8 +218,8 @@ namespace Dynamo.ViewModels
 
                     // Keep DynamoModel.CurrentWorkspace update-to-date
                     int modelIndex = model.Workspaces.IndexOf(currentWorkspaceViewModel.Model);
-                    ExecuteCommand(new DynamoModel.SwitchTabCommand(modelIndex));
-                    (HomeSpaceViewModel as HomeWorkspaceViewModel).UpdateRunStatusMsgBasedOnStates();
+                    ExecuteCommand(new DynamoModel.SwitchTabCommand(modelIndex));                   
+                    (HomeSpaceViewModel as HomeWorkspaceViewModel)?.UpdateRunStatusMsgBasedOnStates();
                 }
             }
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2507,8 +2507,8 @@ namespace Dynamo.Controls
         }
 
         private void DynamoView_Activated(object sender, EventArgs e)
-        {
-            if (fileTrustWarningPopup != null)
+        {            
+            if (fileTrustWarningPopup != null && dynamoViewModel.ViewingHomespace)
             {
                 fileTrustWarningPopup.ManagePopupActivation(true);
             }

--- a/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
+++ b/src/DynamoCoreWpf/Views/FileTrust/FileTrustWarning.xaml.cs
@@ -52,9 +52,16 @@ namespace Dynamo.Wpf.Views.FileTrust
 
         private void DynViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "CurrentSpace" && !dynViewModel.ViewingHomespace)
+            if (e.PropertyName == nameof(DynamoViewModel.CurrentSpace))
             {
-                IsOpen = false;
+                if (dynViewModel.ViewingHomespace)
+                {
+                    ManagePopupActivation(true);
+                }
+                else
+                {
+                    IsOpen = false;
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose

Fixing the second flow from the trusted bubble behavior with 2 workspaces when an user opens an already created .dyf file first.
https://jira.autodesk.com/browse/DYN-5089

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@RobertGlobant20 @filipeotero
