### PR TITLE
Revert "setting exit tour method to internal and calling it when a new workspace is set" (#13180)

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -224,7 +224,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This method exits from tour 
         /// </summary>
-        private void ExitTour()
+        internal void ExitTour()
         {
 
             if (currentGuide != null)

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -224,7 +224,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This method exits from tour 
         /// </summary>
-        internal void ExitTour()
+        private void ExitTour()
         {
 
             if (currentGuide != null)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1104,19 +1104,12 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged("IsPanning");
                     RaisePropertyChanged("IsOrbiting");
                     //RaisePropertyChanged("RunEnabled");
-                    ExitGuidedTourIfOpened();
                     break;
 
                 case "EnablePresetOptions":
                     RaisePropertyChanged("EnablePresetOptions");
                     break;
             }
-        }
-
-        private void ExitGuidedTourIfOpened()
-        {
-            if (GuideFlowEvents.IsAnyGuideActive)
-                MainGuideManager.ExitTour();
         }
 
         // TODO(Sriram): This method is currently not used, but it should really 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1104,12 +1104,22 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged("IsPanning");
                     RaisePropertyChanged("IsOrbiting");
                     //RaisePropertyChanged("RunEnabled");
+                    if (!DynamoModel.IsTestMode)
+                    {
+                        ExitGuidedTourIfOpened();
+                    }
                     break;
 
                 case "EnablePresetOptions":
                     RaisePropertyChanged("EnablePresetOptions");
                     break;
             }
+        }
+
+        private void ExitGuidedTourIfOpened()
+        {
+            if (GuideFlowEvents.IsAnyGuideActive)
+                MainGuideManager.ExitTour();
         }
 
         // TODO(Sriram): This method is currently not used, but it should really 


### PR DESCRIPTION
### Purpose

After some testing, I found that the self-serve tests on master-15 are failing due to this change:
https://github.com/DynamoDS/Dynamo/pull/13180

**Comparison:**
Master(head pointing to: https://github.com/DynamoDS/Dynamo/pull/13178): https://master-15.jenkins.autodesk.com/view/DYN/job/DYN-DevCI_Self_Service/1066/ has -500 failing tests.

Master(with reverting https://github.com/DynamoDS/Dynamo/pull/13180) https://master-15.jenkins.autodesk.com/view/DYN/job/DYN-DevCI_Self_Service/1065/ passing all tests.

I am not exactly sure why all the json serialization tests are failing in this case. I think, there is one test failing which is causing all those failures but I cannot pin-point it yet. Looking more into it. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes


### Reviewers
@filipeotero @QilongTang @mjkkirschner 

