### PR TITLE
install notifications-center under Notifications

### DIFF
--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
-		<Exec Command="npm install @dynamods/notifications-center@latest" />
+		<Exec Command="npm install --prefix ./ @dynamods/notifications-center@latest" />
 	</Target>
 
 	<ItemGroup>


### PR DESCRIPTION
I found that because of my directory structure this npm install command was finding my global node_modules location. Then the embeddedResource targets were failing because the package was not installed there.

The prefix option prefixes the node_modules folder were npm will install, here we just use current directory.
