### PR TITLE
Treat null AST as primitive for update graph execution cycle

### DIFF
--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -966,7 +966,8 @@ namespace ProtoCore.Utils
             if (node is IntNode
                 || node is DoubleNode
                 || node is BooleanNode
-                || node is StringNode)
+                || node is StringNode
+                || node is NullNode)
             {
                 return true;
             }

--- a/test/DynamoCoreWpfTests/NodeExecutionUITest.cs
+++ b/test/DynamoCoreWpfTests/NodeExecutionUITest.cs
@@ -6,6 +6,8 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Models;
 using Dynamo.Tests;
+using CoreNodeModels;
+using CoreNodeModelsWpf;
 using NUnit.Framework;
 using ProtoCore.Namespace;
 
@@ -253,6 +255,30 @@ namespace DynamoCoreWpfTests
             // Assert that function "test" is not defined any longer
             // by asserting null for code block node invoking it.
             AssertPreviewValue(cbn.GUID.ToString(), null);
+        }
+
+        [Test]
+        public void TestDropdownNodeUpdate()
+        {
+            var model = GetModel();
+            var cdn = new CustomSelection();
+
+            var command = new DynamoModel.CreateNodeCommand(cdn, 0, 0, true, false);
+            model.ExecuteCommand(command);
+
+            AssertPreviewValue(cdn.GUID.ToString(), 1);
+
+            cdn.SelectedIndex = -1;
+            var vm = new CustomSelectionViewModel(cdn);
+            var item = cdn.Items[0];
+            vm.RemoveCommand.Execute(item);
+
+            AssertPreviewValue(cdn.GUID.ToString(), null);
+            
+            cdn.SelectedIndex = 0;
+            cdn.OnNodeModified();
+
+            AssertPreviewValue(cdn.GUID.ToString(), 2);
         }
     }
 }


### PR DESCRIPTION
### Purpose

There is a regression with NodeModel nodes in 2.15 where they don't update after being assigned to null AST after the optimization implemented in #12835. This was reported by the Vera team with a new UI node they're implementing, that stopped updating once a dropdown item was updated after the node was assigned to a null value.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate 
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 



### FYIs

@twastvedt 
