### PR TITLE
setting the min width to 130

### DIFF
--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml
@@ -176,7 +176,9 @@
                 <Button Name="StartTourButton" 
                         Visibility="{Binding ShowPopupButton, Converter={StaticResource BooleanToVisibilityConverter}}"
                         Style="{StaticResource PoupButtonStyle}"
-                        Grid.Column="3"                      
+                        Grid.Column="3"   
+                        MinWidth="130"
+                        Padding="10,0,10,0"
                         Margin="0,0,10,0"              
                         Content="{x:Static p:Resources.StartTourButtonText}"
                         Click="StartTourButton_Click" >


### PR DESCRIPTION
### Purpose
Increased the size of the min-width of the button and added padding to the left and right

![image](https://user-images.githubusercontent.com/89042471/184658953-09d32b40-ec82-4b67-8fe4-21241aac22d9.png)
![image](https://user-images.githubusercontent.com/89042471/184659410-27ba1cfe-cb46-44f9-b97a-19384e336de9.png)
![image](https://user-images.githubusercontent.com/89042471/184660146-6cb0f7c4-59cd-4369-b650-9e5812abbf02.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

