### PR TITLE
DYN-5037 library expand bug

### DIFF
--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -123,35 +123,35 @@
         let intervalId;
 
         // Disable the context menu
-        document.oncontextmenu = function () {
-            return false;
-        }
+        //document.oncontextmenu = function () {
+        //    return false;
+        //}
 
         // Disable zoom by keyboard
-        document.addEventListener("keydown",
-            function(event) {
-                if ((event.ctrlKey === true || event.metaKey === true) &&
-                    (event.which === 61 ||
-                    event.which === 107 ||
-                    event.which === 173 ||
-                    event.which === 109 ||
-                    event.which === 187 ||
-                    event.which === 189)) {
-                        event.preventDefault();
-                    }
-            },
-            false
-        );
+        //document.addEventListener("keydown",
+        //    function(event) {
+        //        if ((event.ctrlKey === true || event.metaKey === true) &&
+        //            (event.which === 61 ||
+        //            event.which === 107 ||
+        //            event.which === 173 ||
+        //            event.which === 109 ||
+        //            event.which === 187 ||
+        //            event.which === 189)) {
+        //                event.preventDefault();
+        //            }
+        //    },
+        //    false
+        //);
 
-        // Disable zoom by mouse wheel
-        document.addEventListener("mousewheel",
-            function(event) {
-                if (event.ctrlKey === true || event.metaKey) {
-                    event.preventDefault();
-                }
-            },
-            false
-        );
+        //// Disable zoom by mouse wheel
+        //document.addEventListener("mousewheel",
+        //    function(event) {
+        //        if (event.ctrlKey === true || event.metaKey) {
+        //            event.preventDefault();
+        //        }
+        //    },
+        //    false
+        //);
 
         function replaceImages() {
             var allimages = document.getElementsByTagName("img");
@@ -333,7 +333,9 @@
             }
             var containerCatDiv = found_div.parentNode.parentNode;
             var itemBodyContainer = containerCatDiv.getElementsByClassName(libraryClassName)[0];
-            itemBodyContainer.click();
+            if (!itemBodyContainer.parentElement.parentElement.className.includes('expanded')) {
+                itemBodyContainer.click();
+            }
         }
 
         //This will call the NextStep() function located in the LibraryViewController

--- a/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
+++ b/src/LibraryViewExtensionMSWebBrowser/web/library/library.html
@@ -123,35 +123,35 @@
         let intervalId;
 
         // Disable the context menu
-        //document.oncontextmenu = function () {
-        //    return false;
-        //}
+        document.oncontextmenu = function () {
+            return false;
+        }
 
         // Disable zoom by keyboard
-        //document.addEventListener("keydown",
-        //    function(event) {
-        //        if ((event.ctrlKey === true || event.metaKey === true) &&
-        //            (event.which === 61 ||
-        //            event.which === 107 ||
-        //            event.which === 173 ||
-        //            event.which === 109 ||
-        //            event.which === 187 ||
-        //            event.which === 189)) {
-        //                event.preventDefault();
-        //            }
-        //    },
-        //    false
-        //);
+        document.addEventListener("keydown",
+            function(event) {
+                if ((event.ctrlKey === true || event.metaKey === true) &&
+                    (event.which === 61 ||
+                    event.which === 107 ||
+                    event.which === 173 ||
+                    event.which === 109 ||
+                    event.which === 187 ||
+                    event.which === 189)) {
+                        event.preventDefault();
+                    }
+            },
+            false
+        );
 
-        //// Disable zoom by mouse wheel
-        //document.addEventListener("mousewheel",
-        //    function(event) {
-        //        if (event.ctrlKey === true || event.metaKey) {
-        //            event.preventDefault();
-        //        }
-        //    },
-        //    false
-        //);
+        // Disable zoom by mouse wheel
+        document.addEventListener("mousewheel",
+            function(event) {
+                if (event.ctrlKey === true || event.metaKey) {
+                    event.preventDefault();
+                }
+            },
+            false
+        );
 
         function replaceImages() {
             var allimages = document.getElementsByTagName("img");


### PR DESCRIPTION
### Purpose

The purpose of this PR is to include a verification in the guided tour where the menu item expands.
Before clicking on the menu item in the library, we will now have a check if the item is already expanded.

![libraryNotCollapsing](https://user-images.githubusercontent.com/89042471/185149604-2d678469-ffdf-4357-bd1c-aaa4b956cd82.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
