### PR TITLE
Remove libg227 files from files to sign

### DIFF
--- a/tools/install/Extra/additional-files-to-sign.txt
+++ b/tools/install/Extra/additional-files-to-sign.txt
@@ -12,13 +12,6 @@ ProtoGeometry.customization.dll
 ProtoGeometry.dll
 .\en-US\ProtoGeometry.resources.dll
 
-.\libg_227_0_0\LibG.AsmPreloader.Managed.dll
-.\libg_227_0_0\LibG.AsmPreloader.Unmanaged.dll
-.\libg_227_0_0\LibG.dll
-.\libg_227_0_0\LibG.Managed.dll
-.\libg_227_0_0\LibG.ProtoInterface.dll
-.\libg_227_0_0\LibGCore.dll
-
 .\libg_228_0_0\LibG.AsmPreloader.Managed.dll
 .\libg_228_0_0\LibG.AsmPreloader.Unmanaged.dll
 .\libg_228_0_0\LibG.dll


### PR DESCRIPTION
I'm not sure if this will fix all the issues with the .msi build / sign steps, in my last PR I replaced the libG227 files with dummy text files to avoid accidentally loading them and to save some space in host installers, but that may not be possible since we can't "sign" text files.

Let's see if this resolves the build issue, and then decide what the correct move is for hosts, signed unused wasted space, or unsigned empty text files 🤦 .