### PR TITLE
Add access to Core.Wpf for Player

### DIFF
--- a/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
+++ b/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
@@ -48,6 +48,7 @@ using System.Windows;
 [assembly: InternalsVisibleTo("Notifications")]
 [assembly: InternalsVisibleTo("IronPythonTests")]
 [assembly: InternalsVisibleTo("DynamoPackagesWPF")]
+[assembly: InternalsVisibleTo("DynamoPlayerExtension")]
 
 
 [assembly: TypeForwardedTo(typeof(Dynamo.Wpf.Interfaces.LayoutSpecification))]


### PR DESCRIPTION
### Purpose

Add internal access for DynamoPlayerExtension to Core.WPF

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@mjkkirschner  @BogdanZavu 

### FYIs

@twastvedt @QilongTang 
