### PR TITLE
Skip sending sensitive data

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.16.0.1640")]
+[assembly: AssemblyVersion("2.16.0.2355")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.16.0.1640")]
+[assembly: AssemblyFileVersion("2.16.0.2355")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.16.0.2355")]
+[assembly: AssemblyVersion("2.16.0.2366")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.16.0.2355")]
+[assembly: AssemblyFileVersion("2.16.0.2366")]

--- a/src/DynamoCore/Core/CrashPromptArgs.cs
+++ b/src/DynamoCore/Core/CrashPromptArgs.cs
@@ -125,12 +125,12 @@ namespace Dynamo.Core
         /// <summary>
         /// Allow Dynamo to send the log file to the CER system.
         /// </summary>
-        public bool SendLogFile { get; set; } = true;
+        internal bool SendLogFile { get; set; } = false;
 
         /// <summary>
         /// Allow Dynamo to send the settings file to the CER system.
         /// </summary>
-        public bool SendSettingsFile { get; set; } = true;
+        internal bool SendSettingsFile { get; set; } = false;
 
         /// <summary>
         /// Allow Dynamo to send the recorded commands file to the CER system.

--- a/src/DynamoCore/Core/CrashPromptArgs.cs
+++ b/src/DynamoCore/Core/CrashPromptArgs.cs
@@ -116,6 +116,13 @@ namespace Dynamo.Core
         {}
 
         /// <summary>
+        /// Constructs the options class to customize what CER will collect.
+        /// </summary>
+        /// <param name="details">Crash details</param>
+        internal CrashErrorReportArgs(string details) : base(details)
+        { }
+
+        /// <summary>
         /// Allow Dynamo to send the log file to the CER system.
         /// </summary>
         public bool SendLogFile { get; set; } = true;
@@ -124,11 +131,6 @@ namespace Dynamo.Core
         /// Allow Dynamo to send the settings file to the CER system.
         /// </summary>
         public bool SendSettingsFile { get; set; } = true;
-
-        /// <summary>
-        /// Allow Dynamo to send the model file to the CER system.
-        /// </summary>
-        public bool SendDynFile { get; set; } = true;
 
         /// <summary>
         /// Allow Dynamo to send the recorded commands file to the CER system.

--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -163,11 +163,6 @@ namespace Dynamo.Wpf.Utilities
         /// <returns>True if the CER tool process was successfully started. False otherwise</returns>
         internal static bool ShowCrashErrorReportWindow(DynamoViewModel viewModel, CrashErrorReportArgs args)
         {
-            if (DynamoModel.FeatureFlags?.CheckFeatureFlag("CER", false) == false)
-            {
-                return false;
-            }
-
             DynamoModel model = viewModel?.Model;
 
             string cerToolDir = !string.IsNullOrEmpty(model.CERLocation) ?

--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -163,6 +163,11 @@ namespace Dynamo.Wpf.Utilities
         /// <returns>True if the CER tool process was successfully started. False otherwise</returns>
         internal static bool ShowCrashErrorReportWindow(DynamoViewModel viewModel, CrashErrorReportArgs args)
         {
+            if (DynamoModel.FeatureFlags?.CheckFeatureFlag("CER", false) == false)
+            {
+                return false;
+            }
+
             DynamoModel model = viewModel?.Model;
 
             string cerToolDir = !string.IsNullOrEmpty(model.CERLocation) ?

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1307,7 +1307,7 @@ namespace Dynamo.Controls
         {
             if (CrashReportTool.ShowCrashErrorReportWindow(dynamoViewModel,
                 (args is CrashErrorReportArgs cerArgs) ? cerArgs : 
-                new CrashErrorReportArgs(null)))
+                new CrashErrorReportArgs(args.Details)))
             {
                 return;
             }


### PR DESCRIPTION
PR changes:

Skip the following files until they are reviewed by the Data and Analytics team
1. Settings file
2. Log file

The dynamo file is considered IP so we will never send that through CER.
Send the call stack as it was recorded in the old crash prompt
Keep the Feature flag (as a production feature flag) so that we can still turn it off in case of something wrong.