### PR TITLE
DYN-5208-DynamoRevit-Crash-Fix

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -23,6 +23,7 @@ namespace Dynamo.DocumentationBrowser
         private const string VIRTUAL_FOLDER_MAPPING = "appassets";
         static readonly string HTML_IMAGE_PATH_PREFIX = @"http://";
 
+        internal string WebBrowserUserDataFolder { get; set; }
         internal string FallbackDirectoryName { get; set; }
 
         /// <summary>
@@ -116,6 +117,15 @@ namespace Dynamo.DocumentationBrowser
 
         async void InitializeAsync()
         {
+            if (!string.IsNullOrEmpty(WebBrowserUserDataFolder))
+            {
+                //This indicates in which location will be created the WebView2 cache folder
+                documentationBrowser.CreationProperties = new CoreWebView2CreationProperties()
+                {
+                    UserDataFolder = WebBrowserUserDataFolder
+                };
+            }
+
             //Initialize the CoreWebView2 component otherwise we can't navigate to a web page
             await documentationBrowser.EnsureCoreWebView2Async();
 

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -68,10 +68,6 @@ namespace Dynamo.DocumentationBrowser
             {
                 var docsDir = new DirectoryInfo(Path.Combine(pathManager.DynamoCoreDirectory, FALLBACK_DOC_DIRECTORY_NAME));
                 fallbackDocPath = docsDir.Exists ? docsDir : null;
-
-                //When executing DynamoSandbox the WebView2 cache folder will be located in the same directory than the executable
-                var userDataDir = new DirectoryInfo(pathManager.DynamoCoreDirectory);
-                webBrowserUserDataFolder = userDataDir.Exists ? userDataDir : null;
             }
 
             if (!string.IsNullOrEmpty(pathManager.HostApplicationDirectory))
@@ -81,11 +77,11 @@ namespace Dynamo.DocumentationBrowser
                 var hostAppDirectory = Directory.GetParent(pathManager.HostApplicationDirectory).FullName;
                 var docsDir = new DirectoryInfo(Path.Combine(hostAppDirectory, FALLBACK_DOC_DIRECTORY_NAME));
                 fallbackDocPath = docsDir.Exists ? docsDir : null;
-
-                //When executing Dynamo inside Revit the WebView2 cache folder will be located in the Revit AppData folder
-                var userDataDir = new DirectoryInfo(pathManager.UserDataDirectory);
-                webBrowserUserDataFolder = userDataDir.Exists ? userDataDir : null;
             }
+
+            //When executing Dynamo as Sandbox or inside any host like Revit, FormIt, Civil3D the WebView2 cache folder will be located in the AppData folder
+            var userDataDir = new DirectoryInfo(pathManager.UserDataDirectory);
+            webBrowserUserDataFolder = userDataDir.Exists ? userDataDir : null;
 
             if (this.BrowserView == null) return;
 

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -24,6 +24,8 @@ namespace Dynamo.DocumentationBrowser
         private const string FALLBACK_DOC_DIRECTORY_NAME = "fallback_docs";
         //these fields should only be directly set by tests.
         internal DirectoryInfo fallbackDocPath;
+        //these fields should only be directly set by tests.
+        internal DirectoryInfo webBrowserUserDataFolder;
 
         internal DocumentationBrowserView BrowserView { get; private set; }
         internal DocumentationBrowserViewModel ViewModel { get; private set; }
@@ -67,17 +69,35 @@ namespace Dynamo.DocumentationBrowser
             {
                 var docsDir = new DirectoryInfo(Path.Combine(pathManager.DynamoCoreDirectory, FALLBACK_DOC_DIRECTORY_NAME));
                 fallbackDocPath = docsDir.Exists ? docsDir : null;
+
+                //When executing DynamoSandbox the WebView2 cache folder will be located in the same directory than the executable
+                var userDataDir = new DirectoryInfo(pathManager.DynamoCoreDirectory);
+                webBrowserUserDataFolder = userDataDir.Exists ? userDataDir : null;
             }
 
             if (!string.IsNullOrEmpty(pathManager.HostApplicationDirectory))
             {
-                var docsDir = new DirectoryInfo(Path.Combine(pathManager.HostApplicationDirectory, FALLBACK_DOC_DIRECTORY_NAME));
+                //when running over Revit HostApplicationDirectory = C:\Program Files\Autodesk\Revit 2023\AddIns\DynamoForRevit\Revit
+                //Then we need to remove the Revit folder from the path so we can find the fallback_docs directory.
+                var hostAppDirectory = Directory.GetParent(pathManager.HostApplicationDirectory).FullName;
+                var docsDir = new DirectoryInfo(Path.Combine(hostAppDirectory, FALLBACK_DOC_DIRECTORY_NAME));
                 fallbackDocPath = docsDir.Exists ? docsDir : null;
+
+                //When executing Dynamo inside Revit the WebView2 cache folder will be located in the Revit AppData folder
+                var userDataDir = new DirectoryInfo(pathManager.UserDataDirectory);
+                webBrowserUserDataFolder = userDataDir.Exists ? userDataDir : null;
             }
 
-            if(this.BrowserView != null)
+            if (this.BrowserView == null) return;
+
+            if(fallbackDocPath != null)
             {
                 this.BrowserView.FallbackDirectoryName = fallbackDocPath.FullName;
+            }
+
+            if(webBrowserUserDataFolder != null)
+            {
+                this.BrowserView.WebBrowserUserDataFolder = webBrowserUserDataFolder.FullName;
             }
         }
 

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -24,7 +24,6 @@ namespace Dynamo.DocumentationBrowser
         private const string FALLBACK_DOC_DIRECTORY_NAME = "fallback_docs";
         //these fields should only be directly set by tests.
         internal DirectoryInfo fallbackDocPath;
-        //these fields should only be directly set by tests.
         internal DirectoryInfo webBrowserUserDataFolder;
 
         internal DocumentationBrowserView BrowserView { get; private set; }

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -72,8 +72,9 @@ namespace Dynamo.DocumentationBrowser
 
             if (!string.IsNullOrEmpty(pathManager.HostApplicationDirectory))
             {
-                //when running over Revit HostApplicationDirectory = C:\Program Files\Autodesk\Revit 2023\AddIns\DynamoForRevit\Revit
-                //Then we need to remove the Revit folder from the path so we can find the fallback_docs directory.
+                //when running over any host app like Revit, FormIt, Civil3D... the path to the fallback_docs can change.
+                //e.g. for Revit the variable HostApplicationDirectory = C:\Program Files\Autodesk\Revit 2023\AddIns\DynamoForRevit\Revit
+                //Then we need to remove the last folder from the path so we can find the fallback_docs directory.
                 var hostAppDirectory = Directory.GetParent(pathManager.HostApplicationDirectory).FullName;
                 var docsDir = new DirectoryInfo(Path.Combine(hostAppDirectory, FALLBACK_DOC_DIRECTORY_NAME));
                 fallbackDocPath = docsDir.Exists ? docsDir : null;

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -430,6 +430,24 @@ namespace Dynamo.Wpf.UI.GuidedTour
             var formattedText = Res.ResourceManager.GetString(jsonStepInfo.StepContent.FormattedText);
             var title = Res.ResourceManager.GetString(jsonStepInfo.StepContent.Title);
 
+            DirectoryInfo userDataFolder = null;
+            if (dynamoViewModel != null)
+            {
+                var pathManager = dynamoViewModel.Model.PathManager;
+
+                if (!string.IsNullOrEmpty(pathManager.DynamoCoreDirectory))
+                {
+                    var docsDir = new DirectoryInfo(pathManager.DynamoCoreDirectory);
+                    userDataFolder = docsDir.Exists ? docsDir : null;
+                }
+
+                if (!string.IsNullOrEmpty(pathManager.HostApplicationDirectory))
+                {
+                    var docsDir = new DirectoryInfo(pathManager.UserDataDirectory);
+                    userDataFolder = docsDir.Exists ? docsDir : null;
+                }
+            }
+
             switch (jsonStepInfo.StepType)
             {
                 case Step.StepTypes.TOOLTIP:
@@ -446,6 +464,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
                             Title = title
                         }
                     };
+                    var popupWindow = newStep.stepUIPopup as PopupWindow;
+                    if(popupWindow != null)
+                    {
+                        popupWindow.WebBrowserUserDataFolder = userDataFolder != null ? userDataFolder.FullName : string.Empty;
+                    }
                     break;
                 case Step.StepTypes.SURVEY:
                     newStep = new Survey(hostControlInfo, jsonStepInfo.Width, jsonStepInfo.Height)

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -435,17 +435,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
             {
                 var pathManager = dynamoViewModel.Model.PathManager;
 
-                if (!string.IsNullOrEmpty(pathManager.DynamoCoreDirectory))
-                {
-                    var docsDir = new DirectoryInfo(pathManager.DynamoCoreDirectory);
-                    userDataFolder = docsDir.Exists ? docsDir : null;
-                }
+                //When executing Dynamo as Sandbox or inside any host like Revit, FormIt, Civil3D the WebView2 cache folder will be located in the AppData folder
+                var docsDir = new DirectoryInfo(pathManager.UserDataDirectory);
+                userDataFolder = docsDir.Exists ? docsDir : null;
 
-                if (!string.IsNullOrEmpty(pathManager.HostApplicationDirectory))
-                {
-                    var docsDir = new DirectoryInfo(pathManager.UserDataDirectory);
-                    userDataFolder = docsDir.Exists ? docsDir : null;
-                }
             }
 
             switch (jsonStepInfo.StepType)

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -458,7 +458,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                         }
                     };
                     var popupWindow = newStep.stepUIPopup as PopupWindow;
-                    if(popupWindow != null)
+                    if(popupWindow != null && hostControlInfo.HtmlPage != null && !string.IsNullOrEmpty(hostControlInfo.HtmlPage.FileName))
                     {
                         popupWindow.WebBrowserUserDataFolder = userDataFolder != null ? userDataFolder.FullName : string.Empty;
                     }

--- a/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using Dynamo.Logging;
 using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.UI.GuidedTour;
+using Dynamo.Wpf.Utilities;
 using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Collections.Generic;
@@ -330,12 +331,23 @@ namespace Dynamo.Utilities
         /// <param name="resourcesPath">Path of the resources that will be loaded into the HTML page</param>
         /// <param name="fontStylePath">Path to the Font Style that will be used in some part of the HTML page</param>
         /// <param name="localAssembly">Local Assembly in which the resource will be loaded</param>
-        internal static async void LoadWebBrowser(HtmlPage htmlPage, WebView2 webBrowserComponent, string resourcesPath, string fontStylePath, Assembly localAssembly)
+        /// <param name="userDataFolder">the folder that WebView2 will use for storing cache info</param>
+        internal static async void LoadWebBrowser(HtmlPage htmlPage, WebView2 webBrowserComponent, string resourcesPath, string fontStylePath, Assembly localAssembly, string userDataFolder = default(string))
         {
             var bodyHtmlPage = ResourceUtilities.LoadContentFromResources(htmlPage.FileName, localAssembly, false, false);
 
             bodyHtmlPage = LoadResouces(bodyHtmlPage, htmlPage.Resources, resourcesPath);
             bodyHtmlPage = LoadResourceAndReplaceByKey(bodyHtmlPage, "#fontStyle", fontStylePath);
+
+            if (!string.IsNullOrEmpty(userDataFolder))
+            {
+                //This indicates in which location will be created the WebView2 cache folder
+                webBrowserComponent.CreationProperties = new CoreWebView2CreationProperties()
+                {
+                    UserDataFolder = userDataFolder
+                };
+            }
+
             await webBrowserComponent.EnsureCoreWebView2Async();
             // Context menu disabled
             webBrowserComponent.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
@@ -31,6 +31,11 @@ namespace Dynamo.Wpf.Views.GuidedTour
         //Assembly path to the Resources folder
         private const string resourcesPath = "Dynamo.Wpf.Views.GuidedTour.HtmlPages.Resources";
 
+        /// <summary>
+        /// This property will be hold the path of the WebView2 cache folder, the value will change based in if DynamoSandbox is executed or Dynamo from Revit is executed
+        /// </summary>
+        internal string WebBrowserUserDataFolder { get; set; }
+
         public PopupWindow(PopupWindowViewModel viewModel, HostControlInfo hInfo)
         {
             InitializeComponent();
@@ -116,7 +121,7 @@ namespace Dynamo.Wpf.Views.GuidedTour
             contentGrid.Children.Add(webBrowserComponent);
             Grid.SetRow(webBrowserComponent, 1);
 
-            ResourceUtilities.LoadWebBrowser(hostControlInfo.HtmlPage, webBrowserComponent, resourcesPath, mainFontStylePath, GetType().Assembly);
+            ResourceUtilities.LoadWebBrowser(hostControlInfo.HtmlPage, webBrowserComponent, resourcesPath, mainFontStylePath, GetType().Assembly, WebBrowserUserDataFolder);
         }
 
        

--- a/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/GuidedTour/PopupWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace Dynamo.Wpf.Views.GuidedTour
         private const string resourcesPath = "Dynamo.Wpf.Views.GuidedTour.HtmlPages.Resources";
 
         /// <summary>
-        /// This property will be hold the path of the WebView2 cache folder, the value will change based in if DynamoSandbox is executed or Dynamo from Revit is executed
+        /// This property will be hold the path of the WebView2 cache folder, the value will change based in if DynamoSandbox is executed or Dynamo is executed from a different host (like Revit, FormIt, Civil, etc).
         /// </summary>
         internal string WebBrowserUserDataFolder { get; set; }
 


### PR DESCRIPTION
### Purpose

Fixing crash in Dynamo for Revit when initializing WebView2.
DocumentationBrowser was crashing in Dynamo for Revit due that WebView2 was trying to create the cache folder in the path "C:\Program Files\Autodesk\Revit 2023\AddIns\DynamoForRevit" due to permissions so in this fix I'm changing the folder to use the AppData for Revit "C:\Users\roberto.tellez\AppData\Roaming\Dynamo\Dynamo Revit\2.16".
The same medicin was applied for the WebView2 used in Guided Tours, when using the ResourceUtilities.LoadWebBrowser() method it will using the cache folder passed as parameter.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing crash in Dynamo for Revit when initializing WebView2.


### Reviewers

@QilongTang 

### FYIs

@avidit 
