### PR TITLE
Cherry-Pick DYN-5106-WebView2-DocumentationBrowser-Fix1 (#13256)

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -125,8 +125,7 @@ namespace Dynamo.DocumentationBrowser
             //Due that the Web Browser(WebView2 - Chromium) security CORS is blocking the load of resources like images then we need to create a virtual folder in which the image are located.
             this.documentationBrowser.CoreWebView2.SetVirtualHostNameToFolderMapping(VIRTUAL_FOLDER_MAPPING, FallbackDirectoryName, CoreWebView2HostResourceAccessKind.DenyCors);
 
-            //This will remove special characters in paths (like <img src="/path")
-            string htmlContent = HttpUtility.UrlDecode(this.viewModel.GetContent());
+            string htmlContent = this.viewModel.GetContent();
 
             Dispatcher.BeginInvoke(new Action(() =>
             {

--- a/src/Tools/Md2Html/Md2Html.cs
+++ b/src/Tools/Md2Html/Md2Html.cs
@@ -81,7 +81,7 @@ namespace Md2Html
                     continue;
 
                 var imageName = Path.GetFileName(image.Url);
-                var absoluteImagePath = Path.Combine(VIRTUAL_FOLDER_MAPPING, imageName);
+                var absoluteImagePath = string.Join("/", VIRTUAL_FOLDER_MAPPING, imageName);
 
                 image.Url = $"{HTTP_IMAGE_PATH_PREFIX}{absoluteImagePath}";
             }


### PR DESCRIPTION
Cherry-Pick
https://github.com/DynamoDS/Dynamo/pull/13256

When displaying the documentation for NodeAutocomplete the GIFs were not showing correctly because the base64 content was filtered by HttpUtility.UrlDecode method then I removed this method call and also added code for joining the two sections of the URL, for this I'm using a call to  string.Join. After this fix the images for nodes and for node autocomplete are shown correctly.