### PR TITLE
Export Sample Images ViewExtesnion, DPI Aware Export 3d Image

### DIFF
--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -49,5 +49,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("IronPythonTests")]
 [assembly: InternalsVisibleTo("DynamoPackagesWPF")]
 [assembly: InternalsVisibleTo("GraphNodeManagerViewExtension")]
+[assembly: InternalsVisibleTo("ExportSampleImagesViewExtension")]
 
 [assembly: TypeForwardedTo(typeof(Dynamo.Scheduler.Disposable))]

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -21,6 +21,7 @@ namespace Dynamo.ViewModels
             ShowSaveDialogAndSaveResultCommand = new DelegateCommand(ShowSaveDialogAndSaveResult, CanShowSaveDialogAndSaveResult);
             ShowSaveDialogIfNeededAndSaveResultCommand = new DelegateCommand(ShowSaveDialogIfNeededAndSaveResult, CanShowSaveDialogIfNeededAndSaveResultCommand);
             SaveImageCommand = new DelegateCommand(SaveImage, CanSaveImage);
+            Save3DImageCommand = new DelegateCommand(Save3DImage, CanSaveImage);
             ShowSaveImageDialogAndSaveResultCommand = new DelegateCommand(ShowSaveImageDialogAndSaveResult, CanShowSaveImageDialogAndSaveResult);
             WriteToLogCmd = new DelegateCommand(o => model.Logger.Log(o.ToString()), CanWriteToLog);
             PostUiActivationCommand = new DelegateCommand(model.PostUIActivation);
@@ -132,6 +133,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand ToggleBackgroundGridVisibilityCommand { get; set; }
         public DelegateCommand SelectAllCommand { get; set; }
         public DelegateCommand SaveImageCommand { get; set; }
+        public DelegateCommand Save3DImageCommand { get; set; }
         public DelegateCommand ShowSaveImageDialogAndSaveResultCommand { get; set; }
         public DelegateCommand ToggleConsoleShowingCommand { get; set; }
         public DelegateCommand ShowPackageManagerCommand { get; set; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -49,8 +50,12 @@ using Dynamo.Wpf.Views.FileTrust;
 using Dynamo.Wpf.Views.Gallery;
 using Dynamo.Wpf.Windows;
 using HelixToolkit.Wpf.SharpDX;
+using Brush = System.Windows.Media.Brush;
+using Image = System.Windows.Controls.Image;
+using Point = System.Windows.Point;
 using Res = Dynamo.Wpf.Properties.Resources;
 using ResourceNames = Dynamo.Wpf.Interfaces.ResourceNames;
+using Size = System.Windows.Size;
 using String = System.String;
 
 namespace Dynamo.Controls
@@ -1330,10 +1335,14 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestSave3DImage(object sender, ImageSaveEventArgs e)
         {
-            var bitmapSource =BackgroundPreview.View.RenderBitmap();
-            //this image only really needs 24bits per pixel but to match previous implementation we'll use 32bit images.
-            var rtBitmap = new RenderTargetBitmap(bitmapSource.PixelWidth, bitmapSource.PixelHeight, 96, 96,
-     PixelFormats.Pbgra32);
+            // dpi aware, otherwise incorrect images are created
+            var scale = VisualTreeHelper.GetDpi(this);
+            var dpiX = scale.PixelsPerInchX;
+            var dpiY = scale.PixelsPerInchY;
+
+            var bitmapSource = BackgroundPreview.View.RenderBitmap();
+            // this image only really needs 24bits per pixel but to match previous implementation we'll use 32bit images.
+            var rtBitmap = new RenderTargetBitmap(bitmapSource.PixelWidth, bitmapSource.PixelHeight, dpiX, dpiY, PixelFormats.Pbgra32);
             rtBitmap.Render(BackgroundPreview.View);
             var encoder = new PngBitmapEncoder();
             encoder.Frames.Add(BitmapFrame.Create(rtBitmap));


### PR DESCRIPTION
### Purpose

This is a small PR with the main function to allow an external View Extension to use Dynamo internal logic.
The PR also addresses a small issue found where Exporting Background images will get wrong scaling on DPI different than 100% (96). Fixes the hard-coded value and makes it platform aware. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- changes to DynamoViewModelRequestSave3DImage based on current windows DPI settings instead of hard-coded values
- added ExportSampleImagesViewExtension to InternalVisible assemblies list

### Reviewers

@reddyashish 
@QilongTang 

### FYIs

@Amoursol 
