### PR TITLE
Fixed Bug Causing Dynamo Crash

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -5245,7 +5245,7 @@
                     <Grid>
                         <TextBox x:Name="InputTextBox"
                                      Padding="8,10"
-                                     Background="{StaticResource DarkThemeInputBoxBackgroundColor}"
+                                     Background="{StaticResource DarkThemeInputBoxBackgroundBrush}"
                                      BorderThickness="0"
                                      CaretBrush="{StaticResource Blue300Brush}"
                                      Focusable="True"


### PR DESCRIPTION
- fixed a bug of incorrectly using color instead of brush in styles causing Dynamo to crash.

### Purpose

Bugfix. Incorrectly used Color instead of SolidColorBrush causing Dynamo to crash.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

The Background value of the HintingInputStyle TextBox was being assigned a Color instead of SolidColorBrush, as it should have. This was causing a difficult-to-trace Crash when the dialog containing the textbox style was used. 


### Reviewers

@reddyashish 
