### PR TITLE
DYN-5106-WebView2-DocumentationBrowser-CrossPlatf-Fix1

### DIFF
--- a/src/Tools/Md2Html/Md2Html.cs
+++ b/src/Tools/Md2Html/Md2Html.cs
@@ -81,9 +81,8 @@ namespace Md2Html
                     continue;
 
                 var imageName = Path.GetFileName(image.Url);
-                var absoluteImagePath = string.Join("/", VIRTUAL_FOLDER_MAPPING, imageName);
-
-                image.Url = $"{HTTP_IMAGE_PATH_PREFIX}{absoluteImagePath}";
+                var baseAssetsUri = new Uri(HTTP_IMAGE_PATH_PREFIX + VIRTUAL_FOLDER_MAPPING);
+                image.Url = new Uri(baseAssetsUri, imageName).AbsoluteUri;
             }
         }
 


### PR DESCRIPTION
### Purpose

Fix for using cross-platform code.
Instead of using the normal slash that will produce problems in platforms like GNU Linux or Mac now it will be using URI so it will concatenate parts of the URI without the need of hard-coding the slash.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix for using cross-platform code.


### Reviewers

@QilongTang 
@mjkkirschner 

### FYIs

@avidit 
