### PR TITLE
Notification bell hover color to match with rest of the dynamo elements

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -186,18 +186,37 @@
                         <MenuItem.Header>
                             <Button x:Name="notificationsButton"
                                     BorderBrush="Transparent"
+                                    Margin="10,0,10,0"
                                     BorderThickness="0"
-                                    Background="Transparent"
                                     Cursor="Hand">
                                 <Button.ToolTip>
                                     <ToolTip Content="{x:Static p:Resources.NotificationCenterButtonTooltip}" Style="{StaticResource GenericToolTipLight}" />
                                 </Button.ToolTip>
+                                <Button.Style>
+                                    <Style TargetType="{x:Type Button}">
+                                        <Setter Property="Background" Value="{StaticResource DarkerGreyBrush}"/>
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="{x:Type Button}">
+                                                    <Border Background="{TemplateBinding Background}">
+                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                    </Border>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Style.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="#424242"/>
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
                                 <DockPanel>
-                                    <fa:FontAwesome Margin="0,0,25,0"  
+                                    <fa:FontAwesome Margin="10,0,25,0"  
                                                     DockPanel.Dock="Top" 
                                                     Icon="{Binding Path=DataContext.PreferenceSettings.EnableNotificationCenter, RelativeSource={RelativeSource AncestorType={x:Type Window}}, 
                                                          Converter={StaticResource BoolToFAIconNameConverter}}"
-                                                    HorizontalAlignment="Left"
+                                                    HorizontalAlignment="Center"
                                                     VerticalAlignment="Center"
                                                     Foreground="{StaticResource PrimaryCharcoal300Brush}"
                                                     FontSize="18px"/>
@@ -206,6 +225,7 @@
                                             CornerRadius="2"
                                             Visibility="{Binding IsNotificationsCounterVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" 
                                             Padding="2"
+                                            Margin="10,0,0,0"
                                             Height="14"
                                             Width="14"
                                             VerticalAlignment="Center" 

--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -206,7 +206,7 @@
                                         </Setter>
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Background" Value="#424242"/>
+                                                <Setter Property="Background" Value="{StaticResource HighlightedBrush}"/>
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5240

Before:
![dyn-5240](https://user-images.githubusercontent.com/43763136/187892896-5b5024a2-92e2-4b42-8612-4fe7eb0bc00f.gif)

After:
![notification bell hover](https://user-images.githubusercontent.com/43763136/187892908-14ee287f-7815-4d9e-ae20-ad03e033aef4.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Notification bell hover color to match with rest of the dynamo elements

### Reviewers
@QilongTang @Amoursol 

