### PR TITLE
DYN-5245-DynamoRevit-CreateCustom UserDataFolder

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -83,13 +83,13 @@ namespace Dynamo.Notifications
             // If user turns on the feature, they will need to restart Dynamo to see the count
             // This ensures no network traffic when Notification center feature is turned off
             if (dynamoViewModel.PreferenceSettings.EnableNotificationCenter) 
-            {
-                RequestNotifications();
+            {               
                 InitializeBrowserAsync();
+                RequestNotifications();
             }   
         }
 
-        async void InitializeBrowserAsync()
+        private void InitializeBrowserAsync()
         {
             if (webBrowserUserDataFolder != null)
             {
@@ -100,7 +100,7 @@ namespace Dynamo.Notifications
                 };
             }               
             notificationUIPopup.webView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
-            await notificationUIPopup.webView.EnsureCoreWebView2Async();
+            notificationUIPopup.webView.EnsureCoreWebView2Async();
         }
 
         private void WebView_NavigationCompleted(object sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationCompletedEventArgs e)


### PR DESCRIPTION
### Purpose

Added code for creating the WebView2 cache folder in the AppData location because when tries to create it inside C:\Program Files\Autodesk\Revit 2023\AddIns\DynamoForRevit is crashing due to permissions then now will be created in the AppData location.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Added code for creating the WebView2 cache folder in the AppData location


### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 
