### PR TITLE
DYN-5245-DynamoRevit-Crash-WhenExiting

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -68,7 +68,8 @@ namespace Dynamo.Notifications
 
             dynamoView.SizeChanged += DynamoView_SizeChanged;
             dynamoView.LocationChanged += DynamoView_LocationChanged;
-            notificationsButton.Click += NotificationsButton_Click;            
+            notificationsButton.Click += NotificationsButton_Click;
+            dynamoView.Closing += View_Closing;
 
             notificationUIPopup = new NotificationUI
             {
@@ -87,6 +88,32 @@ namespace Dynamo.Notifications
                 InitializeBrowserAsync();
                 RequestNotifications();
             }   
+        }
+
+        private void View_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            dynamoView.Closing -= View_Closing;
+            SuspendCoreWebviewAsync();
+        }
+
+        async void SuspendCoreWebviewAsync()
+        {
+            notificationUIPopup.IsOpen = false;
+            notificationUIPopup.webView.Visibility = Visibility.Hidden;
+
+            if (notificationUIPopup.webView.CoreWebView2 != null)
+            {
+                await notificationUIPopup.webView.CoreWebView2.TrySuspendAsync();
+
+                notificationUIPopup.webView.CoreWebView2.Stop();
+                notificationUIPopup.webView.CoreWebView2InitializationCompleted -= WebView_CoreWebView2InitializationCompleted;
+                notificationUIPopup.webView.CoreWebView2.NewWindowRequested -= WebView_NewWindowRequested;
+
+                dynamoView.SizeChanged -= DynamoView_SizeChanged;
+                dynamoView.LocationChanged -= DynamoView_LocationChanged;
+                notificationsButton.Click -= NotificationsButton_Click;
+                notificationUIPopup.webView.NavigationCompleted -= WebView_NavigationCompleted;
+            }
         }
 
         private void InitializeBrowserAsync()
@@ -133,7 +160,7 @@ namespace Dynamo.Notifications
             }
 
             CountUnreadNotifications();
-            notificationUIPopup.webView.NavigationCompleted += WebView_NavigationCompleted;
+            notificationUIPopup.webView.NavigationCompleted += WebView_NavigationCompleted;        
         }
 
         private void CountUnreadNotifications()
@@ -200,19 +227,6 @@ namespace Dynamo.Notifications
                 notificationUIPopup.webView.CoreWebView2.AddHostObjectToScript("scriptObject", 
                     new ScriptObject(OnMarkAllAsRead));
             }
-        }
-
-        internal void Dispose()
-        {
-            notificationUIPopup.webView.CoreWebView2InitializationCompleted -= WebView_CoreWebView2InitializationCompleted;
-            if (notificationUIPopup.webView.CoreWebView2 != null)
-            {
-                notificationUIPopup.webView.CoreWebView2.NewWindowRequested -= WebView_NewWindowRequested;
-            }
-            dynamoView.SizeChanged -= DynamoView_SizeChanged;
-            dynamoView.LocationChanged -= DynamoView_LocationChanged;
-            notificationsButton.Click -= NotificationsButton_Click;
-            notificationUIPopup.webView.NavigationCompleted -= WebView_NavigationCompleted;
         }
 
         private void DynamoView_LocationChanged(object sender, EventArgs e)

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -103,8 +103,6 @@ namespace Dynamo.Notifications
 
             if (notificationUIPopup.webView.CoreWebView2 != null)
             {
-                await notificationUIPopup.webView.CoreWebView2.TrySuspendAsync();
-
                 notificationUIPopup.webView.CoreWebView2.Stop();
                 notificationUIPopup.webView.CoreWebView2InitializationCompleted -= WebView_CoreWebView2InitializationCompleted;
                 notificationUIPopup.webView.CoreWebView2.NewWindowRequested -= WebView_NewWindowRequested;

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -66,7 +66,6 @@ namespace Dynamo.Notifications
                 BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
                 notificationsMenuItem = null;
                 disposed = true;
-                notificationCenterController.Dispose();
             }
         }
 


### PR DESCRIPTION
### Purpose
Fixing crash in Dynamo for Revit when exiting Dynamo and notifications are displayed.
I added some code for stopping the WebView2 instance when Dynamo is being closed because otherwise is crashing and also not loading the notifications. Also the Dispose method was deleted due that we are doing the same in the new method added SuspendCoreWebviewAsync.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing crash in Dynamo for Revit when exiting Dynamo and notifications are displayed.


### Reviewers

@QilongTang 

### FYIs

