### PR TITLE
Filter Mouse Pressed Removed

### DIFF
--- a/src/GraphNodeManagerViewExtension/Controls/FilterItemControl.xaml
+++ b/src/GraphNodeManagerViewExtension/Controls/FilterItemControl.xaml
@@ -18,7 +18,7 @@
             <local:BooleanToColorConverter x:Key="BooleanToColorConverter" 
                                            DefaultBrush="{StaticResource DarkGreyBrush}" 
                                            HoverBrush="{StaticResource DarkMidGreyBrush}" 
-                                           PressedBrush="{StaticResource PrimaryCharcoal300Brush}" 
+                                           PressedBrush="{StaticResource DarkMidGreyBrush}" 
                                            ToggleDefaultBrush="{StaticResource MidBlueBrush}" 
                                            ToggleHoverBrush="{StaticResource MidDarkBlueBrush}" 
                                            TogglePressedBrush="{StaticResource MidLightBlueBrush}" />


### PR DESCRIPTION
### Purpose

A minor visual update for the Graph Node Manager view extension. Removed mouse pressed behavior on the filter UI elements causing a flashing-white appearance, which was not consistent with the styling.

#### Change
<img src="https://user-images.githubusercontent.com/5354594/190726649-80ba66c7-7a96-4653-aa3b-dadd730452cc.gif" width="500">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- removed flashing white color on mouse pressed for the filter UI element


### Reviewers

@Amoursol 
