### PR TITLE
Dyn5272

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1022,7 +1022,7 @@ namespace ProtoScript.Runners
 
                     //Check if the subtree (ie a node in graph) is an input and has primitive Right hand Node type
                     if (redefinitionAllowed && st.IsInput && node is BinaryExpressionNode bne  && CoreUtils.IsPrimitiveASTNode(bne.RightNode)
-                        && CoreUtils.IsPrimitiveASTNode(prevBNE.RightNode) || prevBNE == null)
+                        && (CoreUtils.IsPrimitiveASTNode(prevBNE.RightNode) || prevBNE == null))
                     {
                         // An input node is not re-compiled and executed
                         // It is handled by the ChangeSetApply by re-executing the modified node with the updated changes

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1028,7 +1028,7 @@ namespace ProtoScript.Runners
                     //Check if the subtree (ie a node in graph) is an input and has primitive Right hand Node type, also
                     //ensure that the previous RHS of this assignment was a primitive value, or we'll have generated incorrect instructions.
                     if (redefinitionAllowed && st.IsInput && bne != null && CoreUtils.IsPrimitiveASTNode(bne.RightNode)
-                        && (CoreUtils.IsPrimitiveASTNode(prevBNE.RightNode) || prevBNE == null))
+                        && (prevBNE == null || CoreUtils.IsPrimitiveASTNode(prevBNE.RightNode)))
                     {
                         // An input node is not re-compiled and executed
                         // It is handled by the ChangeSetApply by re-executing the modified node with the updated changes

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1011,17 +1011,20 @@ namespace ProtoScript.Runners
                     subtree.ForceExecution = false;
 
                     BinaryExpressionNode prevBNE = null;
-                    if (node is BinaryExpressionNode bne1){
-                        var prevNode = st.AstNodes.OfType<BinaryExpressionNode>().Where(x => (x.LeftNode as IdentifierNode).Name == bne1.LeftNode.Name);
-                        if(prevNode.Count() > 1)
+                    var bne = node as BinaryExpressionNode;
+                    if (bne != null){
+                        foreach (var astNode in st.AstNodes)
                         {
-                            throw new Exception("1 prevnode expected");
+                            if(astNode is BinaryExpressionNode curBNE && curBNE.LeftNode is IdentifierNode id && id.Name == bne.LeftNode.Name)
+                            {
+                                prevBNE = curBNE;
+                            }
                         }
-                        prevBNE = prevNode.FirstOrDefault();
                     }
 
-                    //Check if the subtree (ie a node in graph) is an input and has primitive Right hand Node type
-                    if (redefinitionAllowed && st.IsInput && node is BinaryExpressionNode bne  && CoreUtils.IsPrimitiveASTNode(bne.RightNode)
+                    //Check if the subtree (ie a node in graph) is an input and has primitive Right hand Node type, also
+                    //ensure that the previous RHS of this assignment was a primitive value, or we'll have generated incorrect instructions.
+                    if (redefinitionAllowed && st.IsInput && bne != null && CoreUtils.IsPrimitiveASTNode(bne.RightNode)
                         && (CoreUtils.IsPrimitiveASTNode(prevBNE.RightNode) || prevBNE == null))
                     {
                         // An input node is not re-compiled and executed

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1010,14 +1010,17 @@ namespace ProtoScript.Runners
                     // It can then be handled normally regardless of its ForceExecution state
                     subtree.ForceExecution = false;
 
+                    //search the cached subtree(node's asts) for a binary expression containing a matching LHS identifer node.
+                    //we can currently only apply input optimizations if the previous assignment was also from a primitive.
                     BinaryExpressionNode prevBNE = null;
                     var bne = node as BinaryExpressionNode;
                     if (bne != null){
-                        foreach (var astNode in st.AstNodes)
+                        foreach (var prevNode in st.AstNodes)
                         {
-                            if(astNode is BinaryExpressionNode curBNE && curBNE.LeftNode is IdentifierNode id && id.Name == bne.LeftNode.Name)
+                            if(prevNode is BinaryExpressionNode PrevNodeBNE && PrevNodeBNE.LeftNode is IdentifierNode prevId &&
+                                bne.LeftNode is IdentifierNode curId && prevId.Value == curId.Value)
                             {
-                                prevBNE = curBNE;
+                                prevBNE = PrevNodeBNE;
                             }
                         }
                     }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1010,8 +1010,19 @@ namespace ProtoScript.Runners
                     // It can then be handled normally regardless of its ForceExecution state
                     subtree.ForceExecution = false;
 
+                    BinaryExpressionNode prevBNE = null;
+                    if (node is BinaryExpressionNode bne1){
+                        var prevNode = st.AstNodes.OfType<BinaryExpressionNode>().Where(x => (x.LeftNode as IdentifierNode).Name == bne1.LeftNode.Name);
+                        if(prevNode.Count() > 1)
+                        {
+                            throw new Exception("1 prevnode expected");
+                        }
+                        prevBNE = prevNode.FirstOrDefault();
+                    }
+
                     //Check if the subtree (ie a node in graph) is an input and has primitive Right hand Node type
-                    if (redefinitionAllowed && st.IsInput && node is BinaryExpressionNode bne  && CoreUtils.IsPrimitiveASTNode(bne.RightNode))
+                    if (redefinitionAllowed && st.IsInput && node is BinaryExpressionNode bne  && CoreUtils.IsPrimitiveASTNode(bne.RightNode)
+                        && CoreUtils.IsPrimitiveASTNode(prevBNE.RightNode) || prevBNE == null)
                     {
                         // An input node is not re-compiled and executed
                         // It is handled by the ChangeSetApply by re-executing the modified node with the updated changes

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1021,6 +1021,7 @@ namespace ProtoScript.Runners
                                 bne.LeftNode is IdentifierNode curId && prevId.Value == curId.Value)
                             {
                                 prevBNE = PrevNodeBNE;
+                                break;
                             }
                         }
                     }

--- a/test/DynamoCoreWpfTests/NodeExecutionUITest.cs
+++ b/test/DynamoCoreWpfTests/NodeExecutionUITest.cs
@@ -307,5 +307,26 @@ namespace DynamoCoreWpfTests
 
             AssertPreviewValue(tsn.GUID.ToString(), 0);
         }
+        [Test]
+        public void TestSelectionNodeUpdate2()
+        {
+            var model = GetModel();
+            var tsn = new TestSelectionNode2();
+
+            tsn.UpdateSelection(new List<int> { 1, 2, 3 });
+            var command = new DynamoModel.CreateNodeCommand(tsn, 0, 0, true, false);
+            model.ExecuteCommand(command);
+            AssertPreviewValue(tsn.GUID.ToString(), 3);
+
+            tsn.ClearSelections();
+            AssertPreviewValue(tsn.GUID.ToString(), 0);
+
+            tsn.UpdateSelection(new List<int> { 2, 4, 6,8 });
+            AssertPreviewValue(tsn.GUID.ToString(), 4);
+
+            tsn.ClearSelections();
+            AssertPreviewValue(tsn.GUID.ToString(), 0);
+
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeExecutionUITest.cs
+++ b/test/DynamoCoreWpfTests/NodeExecutionUITest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using CoreNodeModels.Input;
 using DesignScript.Builtin;
 using Dynamo.Graph.Nodes;
@@ -10,12 +11,21 @@ using CoreNodeModels;
 using CoreNodeModelsWpf;
 using NUnit.Framework;
 using ProtoCore.Namespace;
+using TestUINodes;
 
 namespace DynamoCoreWpfTests
 {
     [TestFixture]
     public class NodeExecutionUITest : DynamoViewModelUnitTest
     {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+
+            base.GetLibrariesToPreload(libraries);
+        }
+
         //case 1 : Node in Freeze and Not execute state. True for all parent nodes.
         [Test]
         [Category("DynamoUI")]
@@ -279,6 +289,23 @@ namespace DynamoCoreWpfTests
             cdn.OnNodeModified();
 
             AssertPreviewValue(cdn.GUID.ToString(), 2);
+        }
+
+        [Test]
+        public void TestSelectionNodeUpdate()
+        {
+            var model = GetModel();
+            var tsn = new TestSelectionNode2();
+
+            tsn.UpdateSelection(new List<int> { 1, 2, 3 });
+            var command = new DynamoModel.CreateNodeCommand(tsn, 0, 0, true, false);
+            model.ExecuteCommand(command);
+
+            AssertPreviewValue(tsn.GUID.ToString(), 3);
+
+            tsn.ClearSelections();
+
+            AssertPreviewValue(tsn.GUID.ToString(), 0);
         }
     }
 }

--- a/test/TestUINodes/TestUINodes.cs
+++ b/test/TestUINodes/TestUINodes.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Drawing;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Graph.Nodes;
+using CoreNodeModels;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
 using DSCore.IO;
+using System.Linq;
 
 namespace TestUINodes
 {
@@ -78,6 +81,63 @@ namespace TestUINodes
                 AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), func2),
 
             };
+        }
+    }
+
+    [NodeName("Test Selection Node2")]
+    [NodeCategory("TestUINodes")]
+    [NodeDescription("A test selection node.")]
+    [OutPortTypes("var")]
+    [IsDesignScriptCompatible]
+    [IsVisibleInDynamoLibrary(false)]
+    public class TestSelectionNode2 : SelectionBase<int, int>
+    {
+        public TestSelectionNode2() : base(
+                SelectionType.One,
+                SelectionObjectType.None,
+                "message",
+                "prefix")
+        {
+        }
+
+        public override IModelSelectionHelper<int> SelectionHelper => throw new NotImplementedException();
+
+        public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
+        {
+            AssociativeNode node;
+            Func<IList, int> func = DSCore.List.Count;
+
+            var results = SelectionResults.ToList();
+
+            if (SelectionResults == null || !results.Any())
+            {
+                node = AstFactory.BuildNullNode();
+            }
+            else
+            {
+                node = AstFactory.BuildFunctionCall(func,
+                    new List<AssociativeNode> { AstFactory.BuildExprList(SelectionResults.Select(i => AstFactory.BuildIntNode((long)i) as AssociativeNode).ToList()) });
+            }
+
+            return new[]
+            {
+                AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), node)
+            };
+        }
+
+        protected override IEnumerable<int> ExtractSelectionResults(int selections)
+        {
+            return new List<int> { selections };
+        }
+
+        protected override string GetIdentifierFromModelObject(int modelObject)
+        {
+            return modelObject.ToString();
+        }
+
+        protected override int GetModelObjectFromIdentifer(string id)
+        {
+            return id.Length;
         }
     }
 }


### PR DESCRIPTION
### Purpose

a continuation of @aparajit-pratap 's work started here:
https://github.com/DynamoDS/Dynamo/pull/13331
and here:
https://github.com/DynamoDS/Dynamo/pull/13221

We have issues using the input optimization that was put in place to skip recompiling primitive inputs when executing complex UI nodes where their AST produces primitive values sometimes and complex values other times - for example, the Revit Face selection node which returns null sometimes (a primitive) and the result of a function call other times.

We check the previous assignment statement for the node's output identifier to determine if the previous result was a primitive before attempting to apply any input optimization and skip compilation.

We have verified this fixes the Revit regressions with selection nodes using RTF.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes regression with selection nodes in Revit.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
