### PR TITLE
DYN-5210: Fix column width in custom selection node when no entries.

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/CustomSelectionControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/CustomSelectionControl.xaml
@@ -95,12 +95,18 @@
                             <TextBox Grid.Column="1" Style="{StaticResource InputStyle}" Margin="0,0,0,0" Text="{Binding Item}" LostFocus="ItemValueChanged" />
 
                             <core:DynamoNodeButton Grid.Column="2"
+                                                   x:Name="RemoveButton"
                                                    Style="{StaticResource SingleCharButton}"
                                                    HorizontalAlignment="Right"
                                                    Command="{Binding ElementName=EnumItemsListbox, Path=DataContext.RemoveCommand}"
                                                    CommandParameter="{Binding}"
                                                    Content="-" />
                         </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding Path=DataContext.Model.Items.Count, ElementName=EnumItemsListbox}" Value="1">
+                                <Setter TargetName="RemoveButton" Property="Visibility" Value="Hidden" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/CustomSelectionControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/CustomSelectionControl.xaml
@@ -52,10 +52,10 @@
         IsHitTestVisible="True"
         Template="{StaticResource ExpanderTemplate}">
         <DockPanel Margin="-20,50,0,0" Grid.IsSharedSizeScope="True">
-            <Grid DockPanel.Dock="Top">
+            <Grid DockPanel.Dock="Top" Margin="2,0,0,0">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition SharedSizeGroup="display" />
-                    <ColumnDefinition SharedSizeGroup="value" />
+                    <ColumnDefinition Width="105" SharedSizeGroup="display" />
+                    <ColumnDefinition Width="105" SharedSizeGroup="value" />
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Grid.Column="0"
@@ -86,8 +86,8 @@
                     <DataTemplate>
                         <Grid Margin="0,8,0,8">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="105" SharedSizeGroup="display" />
-                                <ColumnDefinition Width="105" SharedSizeGroup="value" />
+                                <ColumnDefinition SharedSizeGroup="display" />
+                                <ColumnDefinition SharedSizeGroup="value" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 

--- a/src/Libraries/CoreNodeModelsWpf/CustomSelectionViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/CustomSelectionViewModel.cs
@@ -30,7 +30,7 @@ namespace CoreNodeModelsWpf
 
         private void RemoveItem(object parameter)
         {
-            if (parameter is DynamoDropDownItem item)
+            if (Model.Items.Count > 1 && parameter is DynamoDropDownItem item)
             {
                 Model.Items.Remove(item);
                 Model.OnNodeModified();


### PR DESCRIPTION
### Purpose
| Issue | Fixed |
| ------------- | ------------- |
| ![issue](https://user-images.githubusercontent.com/8107026/191994346-4633d9c9-7d62-4ced-ab9a-1935751135c3.png) | ![fixed](https://user-images.githubusercontent.com/8107026/192040166-83ece6af-fff8-4b32-a95b-846d6352a7a1.png) |

This PR fixes [DYN-5210](https://jira.autodesk.com/browse/DYN-5210). When the custom selection node's list is empty, the "Display" and "Value" headers would collapse to a minimum width. Now they stay in the same place.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
 
### Reviewers
@avidit 