### PR TITLE
Keep Node AutoComplete popup hidden when window deactivated

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -33,37 +33,33 @@ namespace Dynamo.UI.Controls
             InitializeComponent();
             if (Application.Current != null)
             {
-                Application.Current.Deactivated += currentApplicationDeactivated;
+                Application.Current.Deactivated += CurrentApplicationDeactivated;
             }
-            Unloaded += InCanvasSearchControl_Unloaded;
+            Application.Current.MainWindow.Closing += InCanvasSearchControl_Unloaded;
 
         }
 
-        private void InCanvasSearchControl_Unloaded(object sender, RoutedEventArgs e)
+        private void InCanvasSearchControl_Unloaded(object sender, System.ComponentModel.CancelEventArgs e)
         {
             if (Application.Current != null)
             {
-                Application.Current.Deactivated -= currentApplicationDeactivated;
+                Application.Current.Deactivated -= CurrentApplicationDeactivated;
             }
         }
 
-        private void currentApplicationDeactivated(object sender, EventArgs e)
+        private void CurrentApplicationDeactivated(object sender, EventArgs e)
         {
             OnRequestShowInCanvasSearch(ShowHideFlags.Hide);
         }
 
         private void OnRequestShowInCanvasSearch(ShowHideFlags flags)
         {
-            if (RequestShowInCanvasSearch != null)
-            {
-                RequestShowInCanvasSearch(flags);
-            }
+            RequestShowInCanvasSearch?.Invoke(flags);
         }
 
         private void OnMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            var listBoxItem = sender as ListBoxItem;
-            if (listBoxItem == null || e.OriginalSource is Thumb) return;
+            if (!(sender is ListBoxItem listBoxItem) || e.OriginalSource is Thumb) return;
 
             ExecuteSearchElement(listBoxItem);
             OnRequestShowInCanvasSearch(ShowHideFlags.Hide);
@@ -86,8 +82,7 @@ namespace Dynamo.UI.Controls
 
         private void OnMouseEnter(object sender, MouseEventArgs e)
         {
-            FrameworkElement fromSender = sender as FrameworkElement;
-            if (fromSender == null) return;
+            if (!(sender is FrameworkElement fromSender)) return;
 
             toolTipPopup.DataContext = fromSender.DataContext;
             toolTipPopup.IsOpen = true;

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -34,9 +34,8 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated += CurrentApplicationDeactivated;
+                Application.Current.MainWindow.Closing += InCanvasSearchControl_Unloaded;
             }
-            Application.Current.MainWindow.Closing += InCanvasSearchControl_Unloaded;
-
         }
 
         private void InCanvasSearchControl_Unloaded(object sender, System.ComponentModel.CancelEventArgs e)

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -43,6 +43,7 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated -= CurrentApplicationDeactivated;
+                Application.Current.MainWindow.Closing -= InCanvasSearchControl_Unloaded;
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -37,8 +37,8 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated += CurrentApplicationDeactivated;
+                Application.Current.MainWindow.Closing += NodeAutoCompleteSearchControl_Unloaded;
             }
-            Application.Current.MainWindow.Closing += NodeAutoCompleteSearchControl_Unloaded;
             HomeWorkspaceModel.WorkspaceClosed += this.CloseAutoCompletion;
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -47,6 +47,7 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated -= CurrentApplicationDeactivated;
+                Application.Current.MainWindow.Closing -= NodeAutoCompleteSearchControl_Unloaded;
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -36,31 +36,28 @@ namespace Dynamo.UI.Controls
             InitializeComponent();
             if (Application.Current != null)
             {
-                Application.Current.Deactivated += currentApplicationDeactivated;
+                Application.Current.Deactivated += CurrentApplicationDeactivated;
             }
-            Unloaded += NodeAutoCompleteSearchControl_Unloaded;
+            Application.Current.MainWindow.Closing += NodeAutoCompleteSearchControl_Unloaded;
             HomeWorkspaceModel.WorkspaceClosed += this.CloseAutoCompletion;
         }
 
-        private void NodeAutoCompleteSearchControl_Unloaded(object sender, RoutedEventArgs e)
+        private void NodeAutoCompleteSearchControl_Unloaded(object sender, System.ComponentModel.CancelEventArgs e)
         {
             if (Application.Current != null)
             {
-                Application.Current.Deactivated -= currentApplicationDeactivated;
+                Application.Current.Deactivated -= CurrentApplicationDeactivated;
             }
         }
 
-        private void currentApplicationDeactivated(object sender, EventArgs e)
+        private void CurrentApplicationDeactivated(object sender, EventArgs e)
         {
             OnRequestShowNodeAutoCompleteSearch(ShowHideFlags.Hide);
         }
 
         private void OnRequestShowNodeAutoCompleteSearch(ShowHideFlags flags)
         {
-            if (RequestShowNodeAutoCompleteSearch != null)
-            {
-                RequestShowNodeAutoCompleteSearch(flags);
-            }
+            RequestShowNodeAutoCompleteSearch?.Invoke(flags);
         }
 
         private void OnSearchTextBoxTextChanged(object sender, TextChangedEventArgs e)
@@ -81,8 +78,7 @@ namespace Dynamo.UI.Controls
 
         private void OnMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            var listBoxItem = sender as ListBoxItem;
-            if (listBoxItem == null || e.OriginalSource is Thumb) return;
+            if (!(sender is ListBoxItem listBoxItem) || e.OriginalSource is Thumb) return;
 
             ExecuteSearchElement(listBoxItem);
             OnRequestShowNodeAutoCompleteSearch(ShowHideFlags.Hide);
@@ -109,8 +105,7 @@ namespace Dynamo.UI.Controls
 
         private void OnMouseEnter(object sender, MouseEventArgs e)
         {
-            FrameworkElement fromSender = sender as FrameworkElement;
-            if (fromSender == null) return;
+            if (!(sender is FrameworkElement fromSender)) return;
 
             toolTipPopup.DataContext = fromSender.DataContext;
             toolTipPopup.IsOpen = true;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -233,7 +233,10 @@ namespace Dynamo.Controls
             {
                 fileTrustWarningPopup = new FileTrustWarning(this);
             }
-            Application.Current.MainWindow = this;
+            if (!DynamoModel.IsTestMode && Application.Current != null)
+            {
+                Application.Current.MainWindow = this;
+            }
         }
         private void OnWorkspaceOpened(WorkspaceModel workspace)
         {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -43,7 +42,6 @@ using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.UI.GuidedTour;
 using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels.Core;
-using Dynamo.Wpf.ViewModels.FileTrust;
 using Dynamo.Wpf.Views;
 using Dynamo.Wpf.Views.Debug;
 using Dynamo.Wpf.Views.FileTrust;
@@ -53,7 +51,6 @@ using HelixToolkit.Wpf.SharpDX;
 using Brush = System.Windows.Media.Brush;
 using Image = System.Windows.Controls.Image;
 using Point = System.Windows.Point;
-using Res = Dynamo.Wpf.Properties.Resources;
 using ResourceNames = Dynamo.Wpf.Interfaces.ResourceNames;
 using Size = System.Windows.Size;
 using String = System.String;
@@ -236,6 +233,7 @@ namespace Dynamo.Controls
             {
                 fileTrustWarningPopup = new FileTrustWarning(this);
             }
+            Application.Current.MainWindow = this;
         }
         private void OnWorkspaceOpened(WorkspaceModel workspace)
         {
@@ -1563,7 +1561,7 @@ namespace Dynamo.Controls
             }
             else
             {
-                //Shutdown was cancelled
+                //Shutdown was canceled
                 return false;
             }
         }


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-3209, @mjkkirschner or a lot of Dynamo developers have noticed that in-canvas search and Node AutoComplete popup remains open during debugging of Dynamo. This is due to a bug that hidding Dynamo window calling unloaded on these two popups. I changed the code to have the handler nolonger binding to `Unload` event but `MainWindow.Closing` event and set `DynamoView` as mainwindow will make sure the event sequence is corrected. This PR also includes some small cleanup using pattern matching for the checks.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Keep Node AutoComplete popup hidden when window deactivated


### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
