### PR TITLE
move near clipping plane further away for more depth buffer precision.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -183,7 +183,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private int currentFrameSkipCount;
 
         private const double EqualityTolerance = 0.000001;
-        private double nearPlaneDistanceFactor = 0.001;
+        private double nearPlaneDistanceFactor = 0.01;
         internal const double DefaultNearClipDistance = 0.1f;
         internal const double DefaultFarClipDistance = 100000;
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -183,6 +183,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private int currentFrameSkipCount;
 
         private const double EqualityTolerance = 0.000001;
+        //near plane distance also affects depth precision.
+        //https://developer.nvidia.com/content/depth-precision-visualized
         private double nearPlaneDistanceFactor = 0.01;
         internal const double DefaultNearClipDistance = 0.1f;
         internal const double DefaultFarClipDistance = 100000;
@@ -2483,6 +2485,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Set the near clip plane to some fraction of the 
             // of the distance to the first point.
             var closest = distances.First(d => d >= 0);
+
+            //near plane distance disproportionately affects depth (zbuffer) precision.
+            //keep it as far away as possible.
+            //https://developer.nvidia.com/content/depth-precision-visualized
             near = closest.AlmostEqualTo(0, EqualityTolerance) ? DefaultNearClipDistance : Math.Max(DefaultNearClipDistance, closest * nearPlaneDistanceFactor);
             far = distances.Last() * 2;
 


### PR DESCRIPTION
### Purpose

An issue stemming from this change: 
https://github.com/DynamoDS/Dynamo/pull/12607
reported here:
https://forum.dynamobim.com/t/edges-preview-issue-why-do-the-edges-look-like-this-in-the-new-version-of-dynamo/81229

The artifact that is shown is that edges of the surfaces which should be hidden are being drawn as if they are on top of the surfaces in front of them.

While testing this I noticed that the effect was worse the further the geometry was from the camera (as we zoomed out).
My guess is that the depth buffer is not as precise far from the near plane, especially as our near and far plane are calculated dynamically as the camera moves.

As we introduce depth bias, those changes, while small near the near plane, become larger as precision decreases at the far plane.

I believe this article confirms my hypothesis:
https://developer.nvidia.com/content/depth-precision-visualized 
<img width="1365" alt="Screen Shot 2022-09-23 at 10 29 27 PM" src="https://user-images.githubusercontent.com/508936/192076329-6ca71a25-0602-4757-be09-3ead2803fb84.png">

okay so - some options:
1. implement this reversed depth buffer approach mentioned in the article - I don't believe helix supports this so we'd need to do a bunch of work there, and likely in our shaders as well.
2. this PR - simply moves the near plane further out (by a factor of 10) - we get a bit more precision, but we still keep the near plane in front of any geometry.
3. reduce our depth buffer biases - this will yield more z-fighting in general, but can probably still be made to work for selected geometry.

This PR goes with 2.

It seems to work for current issue at hand reducing *most* of the artifacting lines, and it also still works for the TSplines example we fixed in the previous PR that introduced this issue.

some before and after images:


<img width="1828" alt="Screen Shot 2022-09-23 at 10 56 49 PM" src="https://user-images.githubusercontent.com/508936/192077192-1f5d1ef5-e45e-48b6-b1f8-366d07d60652.png">
<img width="1707" alt="Screen Shot 2022-09-23 at 10 55 25 PM" src="https://user-images.githubusercontent.com/508936/192077193-2d4eb329-9bb9-40a3-9930-efd77c37f497.png">




### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Attempted to improve rendering of curves that should be hidden by meshes when geometry is far from camera.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
