### PR TITLE
fix slider localization bug

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
@@ -1,5 +1,5 @@
-﻿using System;
-
+using System;
+using System.Globalization;
 using CoreNodeModels.Input;
 
 using Dynamo.Core;
@@ -63,7 +63,16 @@ namespace CoreNodeModelsWpf
                 if (value.CompareTo(model.Min) == -1)
                     model.Min = value;
 
-                model.UpdateValue(new Dynamo.Graph.UpdateValueParams(nameof(Value), value.ToString()));
+                if(value is IFormattable formattableval)
+                {
+                    var invariantString  = formattableval.ToString(null,CultureInfo.InvariantCulture);
+                    model.UpdateValue(new Dynamo.Graph.UpdateValueParams(nameof(Value), invariantString));
+                }
+                else
+                {
+                    model.UpdateValue(new Dynamo.Graph.UpdateValueParams(nameof(Value), value.ToString()));
+                }
+
             }
         }
 

--- a/test/DynamoCoreWpfTests/SliderViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SliderViewModelTests.cs
@@ -136,7 +136,8 @@ namespace DynamoCoreWpfTests
         }
 
         /// <summary>
-        /// This test will validate that setting the string to a localized value
+        /// This test will validate that setting the string in a , dec seperator culture does not
+        /// modify the value.
         /// </summary>
         [Test]
         public void SliderViewModel_ValueTest_Localized()

--- a/test/DynamoCoreWpfTests/SliderViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SliderViewModelTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Windows.Controls;
 using CoreNodeModels;
 using CoreNodeModels.Input;
@@ -131,6 +133,44 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(WatchNode);
             Assert.AreEqual("-200", minTextBox.Text);
             Assert.AreEqual("200", maxTextBox.Text);
+        }
+
+        /// <summary>
+        /// This test will validate that setting the string to a localized value
+        /// </summary>
+        [Test]
+        public void SliderViewModel_ValueTest_Localized()
+        {
+            //change current thread culture to German.
+            var deCulture = CultureInfo.CreateSpecificCulture("de-DE");
+
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = deCulture;
+            Thread.CurrentThread.CurrentUICulture = deCulture;
+
+            //create a slider
+            var slider = new CoreNodeModels.Input.DoubleSlider();
+            Model.CurrentWorkspace.AddAndRegisterNode(slider);
+
+            DispatcherUtil.DoEvents();
+
+            //get viewmodel.
+            var nodeViews = View.NodeViewsInFirstWorkspace();
+            var nodeView = nodeViews.OfNodeModelType<CoreNodeModels.Input.DoubleSlider>().FirstOrDefault();
+            var dynamoSliderControl = nodeView.grid.ChildrenOfType<DynamoSlider>().FirstOrDefault();
+            //Setting the Value property from the SliderViewModel
+            var sliderViewModel = dynamoSliderControl.DataContext as SliderViewModel<double>;
+            sliderViewModel.Value = 10.7;
+
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(10.7,slider.Value);
+            //reset culture
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
+
         }
     }
 }


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/DYN-5291
Fixes slider localization bug and adds a test.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix slider going out of control while sliding in localized environments.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
