### PR TITLE
add infrastructure to run existing tests against MSIL compiler

### DIFF
--- a/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
+++ b/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
@@ -345,13 +345,19 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        /// <summary>
-        /// The public method to compile DS AST and stores the executable in core
-        /// </summary>
-        /// <param name="astList"></param>
-        /// <param name="compileCore"></param>
-        /// <returns></returns>
-        public bool CompileAndGenerateExe(
+        public Dictionary<string, object> CompileAndGenerateMSIL(string souce, EmitMSIL.CodeGenIL codegen)
+        {
+            var ast = ParserUtils.Parse(souce).Body;
+            return codegen.EmitAndExecute(ast);
+        }
+
+    /// <summary>
+    /// The public method to compile DS AST and stores the executable in core
+    /// </summary>
+    /// <param name="astList"></param>
+    /// <param name="compileCore"></param>
+    /// <returns></returns>
+    public bool CompileAndGenerateExe(
             List<ProtoCore.AST.AssociativeAST.AssociativeNode> astList, 
             ProtoCore.Core compileCore,
             ProtoCore.CompileTime.Context context)

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -406,6 +406,7 @@ namespace ProtoTestFx.TD
 
             if (testMSILExecution)
             {
+                Console.WriteLine($"!!!!test {NUnit.Framework.TestContext.CurrentContext.Test.Name} being run with MSIL compiler!!!!");
                 var assemblyPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
                 var outputpath = Path.Combine(assemblyPath, "MSILTestOutput");
                 System.IO.Directory.CreateDirectory(outputpath);

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -35,9 +35,7 @@ namespace ProtoTestFx.TD
         bool testImport;
         bool testDebug;
         //control which VM is used to run tests.
-        //TODO move to prototestbase?
-        //TODO can we reuse the bool that controls execution?
-        bool testMSILExecution = true;
+        bool testMSILExecution = false;
         Dictionary<string, object> MSILMirror;
 
         bool dumpDS =false;


### PR DESCRIPTION
### Purpose

These are the minimum changes needed to run and verify some of the existing replication tests against the new compiler/runtime.

It would be nice to come back to this later and create a runtime mirror so this runner could have a unified API - but I don't think it's worth it right now, and I'm not sure maintaining this complex runner is really worth it anyway in the longterm - for now this is just to get the tests running with no changes to them.

⚠️ 
I was wrong initially, the tests on master-5 actually did complete in just over 30 minutes, there are 3007 failures!
https://master-5.jenkins.autodesk.com/job/Dynamo/job/DynamoSelfServe/job/pullRequestValidation/7197/#showFailuresLink

I think thats a bit much to leave on, for now I propose leaving the bool set to use the old VM, and running these locally as we make progress.

Additionally we can leave a PR open that sets the bool to use the new compiler and we'll get test results automatically without polluting the test results of the other builds.

![Screen Shot 2022-10-03 at 3 50 26 PM](https://user-images.githubusercontent.com/508936/193666190-773401a4-a616-48fe-9986-06750d8e7fa8.png)
![Screen Shot 2022-09-30 at 2 10 48 PM](https://user-images.githubusercontent.com/508936/193331236-856e9fe1-f296-40ae-876f-8133e15f7bab.png)


Many of these fail for two reasons:
1. We have not implemented EmitFunctionDeclarion etc
2. The current tests don't need to fully namespace functions, but we do - maybe @pinzart90's type reuse will fix this.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
