### PR TITLE
Fix Regression with GetCLRObject impacting Node Preview and Tessellation 

### DIFF
--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -141,41 +141,28 @@ namespace ProtoCore.Mirror
             return null;
         }
 
-        //Store marshaller for repeated calls to GetCLRObject.  Used for short-circuit of re-allocation of marshaller / interpreter object.
-        private static Interpreter interpreter;
-        private static ProtoFFI.FFIObjectMarshaler marshaler;
-        
         internal object GetCLRObject(StackValue svData, RuntimeCore runtimeCore)
         {
             if (null == runtimeCore.DSExecutable.classTable)
                 return null;
 
-            //The GetCLRObject function is typically utilized to retrieve a ClrObject from a StackValue of type pointer.
-            //There is an edge cases for pointers where the pointer references a non CLR object.  This code
-            //checks for this edge case by verifying that the requested StackValue pointer is associated with an
-            //imported library.  An example is the "Function" pointer which does not have an associated CLRObject.
-            //In that case, the return value should be null.
-            var classNode = runtimeCore.DSExecutable.classTable.GetClassNodeAtIndex(svData.metaData.type);
-            if (classNode != null  && !classNode.IsImportedClass)
-            {
+            IList<ClassNode> classNodes = runtimeCore.DSExecutable.classTable.ClassNodes;
+            if (null == classNodes || (classNodes.Count <= 0))
                 return null;
-            }
 
-            if (marshaler != null)
-            {
-                return marshaler.UnMarshal(svData, null, interpreter, typeof(object));
-            }
+            ClassNode classnode = runtimeCore.DSExecutable.classTable.ClassNodes[svData.metaData.type];
+            if (!classnode.IsImportedClass) //TODO: look at properties to see if it contains any FFI objects.
+                return null;
 
             try
             {
-                interpreter = new ProtoCore.DSASM.Interpreter(runtimeCore, false);
+                ProtoCore.DSASM.Interpreter interpreter = new ProtoCore.DSASM.Interpreter(runtimeCore, false);
                 var helper = ProtoFFI.DLLFFIHandler.GetModuleHelper(ProtoFFI.FFILanguage.CSharp);
-                marshaler = helper.GetMarshaler(runtimeCore);
+                var marshaler = helper.GetMarshaler(runtimeCore);
                 return marshaler.UnMarshal(svData, null, interpreter, typeof(object));
             }
             catch (System.Exception)
             {
-                marshaler = null;
                 return null;
             }
         }

--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -165,12 +165,6 @@ namespace ProtoCore.Mirror
             {
                 return null;
             }
-        }
-
-        internal static void ClearMarshaller()
-        {
-            interpreter = null;
-            marshaler = null;
         }
     }
 

--- a/src/Engine/ProtoCore/RuntimeCore.cs
+++ b/src/Engine/ProtoCore/RuntimeCore.cs
@@ -6,7 +6,6 @@ using ProtoCore.AssociativeGraph;
 using ProtoCore.DSASM;
 using ProtoCore.Lang;
 using ProtoCore.Lang.Replication;
-using ProtoCore.Mirror;
 using ProtoCore.Runtime;
 using ProtoCore.Utils;
 using ProtoFFI;
@@ -272,7 +271,6 @@ namespace ProtoCore
         {
             OnDispose();
             CLRModuleType.ClearTypes();
-            GraphicDataProvider.ClearMarshaller();
         }
 
         public void NotifyExecutionEvent(ExecutionStateEventArgs.State state)


### PR DESCRIPTION
### Purpose

This fix addresses a regression found in Dynamo 2.16 related to the preview bubble and tessellation for the background preview.  After installing a package during a session both would stop working correctly.  This appears to be relates to changes introduced in https://github.com/DynamoDS/Dynamo/pull/12934 and https://github.com/DynamoDS/Dynamo/pull/11920.  This PR reverts the behavior to the previous code.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Corrects regression in Dynamo where after installing a package during a session the node preview bubble and background preview would not operate correctly.

### Reviewers

@mjkkirschner 

### FYIs

@aparajit-pratap @QilongTang @pinzart 
