### PR TITLE
Revert "add infrastructure to run existing tests against MSIL compiler"

### DIFF
--- a/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
+++ b/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
@@ -345,19 +345,13 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        public Dictionary<string, object> CompileAndGenerateMSIL(string souce, EmitMSIL.CodeGenIL codegen)
-        {
-            var ast = ParserUtils.Parse(souce).Body;
-            return codegen.EmitAndExecute(ast);
-        }
-
-    /// <summary>
-    /// The public method to compile DS AST and stores the executable in core
-    /// </summary>
-    /// <param name="astList"></param>
-    /// <param name="compileCore"></param>
-    /// <returns></returns>
-    public bool CompileAndGenerateExe(
+        /// <summary>
+        /// The public method to compile DS AST and stores the executable in core
+        /// </summary>
+        /// <param name="astList"></param>
+        /// <param name="compileCore"></param>
+        /// <returns></returns>
+        public bool CompileAndGenerateExe(
             List<ProtoCore.AST.AssociativeAST.AssociativeNode> astList, 
             ProtoCore.Core compileCore,
             ProtoCore.CompileTime.Context context)

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using Autodesk.DesignScript.Interfaces;
 using NUnit.Framework;
@@ -34,11 +33,7 @@ namespace ProtoTestFx.TD
         private static string mErrorMessage = "";
         bool testImport;
         bool testDebug;
-        //control which VM is used to run tests.
-        bool testMSILExecution = false;
-        Dictionary<string, object> MSILMirror;
-
-        bool dumpDS =false;
+        bool dumpDS=false;
         bool cfgImport = Convert.ToBoolean(Environment.GetEnvironmentVariable("Import"));
         bool cfgDebug = Convert.ToBoolean(Environment.GetEnvironmentVariable("Debug"));
         bool executeInDebugMode = true;
@@ -402,18 +397,6 @@ namespace ProtoTestFx.TD
         {
             sourceCode = sourceCode.Insert(0, "import(\"DesignScriptBuiltin.dll\");");
 
-            if (testMSILExecution)
-            {
-                Console.WriteLine($"!!!!test {NUnit.Framework.TestContext.CurrentContext.Test.Name} being run with MSIL compiler!!!!");
-                var assemblyPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-                var outputpath = Path.Combine(assemblyPath, "MSILTestOutput");
-                System.IO.Directory.CreateDirectory(outputpath);
-                var inputs = new Dictionary<string, IList>();
-                var codeGen = new EmitMSIL.CodeGenIL(inputs, Path.Combine(outputpath, $"OpCodesTEST{NUnit.Framework.TestContext.CurrentContext.Test.Name}.txt"));
-                MSILMirror = runner.CompileAndGenerateMSIL(sourceCode, codeGen);
-                return null;
-            }
-
             if (testImport)
             {
                 Guid g;
@@ -757,17 +740,9 @@ namespace ProtoTestFx.TD
 
         public void Verify(string dsVariable, object expectedValue, int startBlock = 0)
         {
-            //TODO create a MSILRuntime mirror and interface for mirrors?
-            if (testMSILExecution)
-            {
-                var result = MSILMirror[dsVariable];
-                Assert.AreEqual(result, expectedValue);
-                return;
-            }
             RuntimeMirror mirror = new RuntimeMirror(dsVariable, startBlock, GetTestRuntimeCore());
             AssertValue(mirror.GetData(), expectedValue);
-
-
+            //Verify(testMirror, dsVariable, expectedValue, startBlock);
         }
 
         public static void VerifyBuildWarning(ProtoCore.BuildData.WarningID id)


### PR DESCRIPTION
Reverts DynamoDS/Dynamo#13362

I need to incorporate changes from https://github.com/DynamoDS/Dynamo/pull/13361