### PR TITLE
add infrastructure to run existing tests against MSIL compiler - attempt 2

### DIFF
--- a/src/Engine/EmitMSIL/Properties/AssemblyInfo.cs
+++ b/src/Engine/EmitMSIL/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,3 +12,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("2e7be1fb-7038-4277-9dae-fd0faabf5768")]
 [assembly: InternalsVisibleTo("CodeGenILTests")]
 [assembly: InternalsVisibleTo("ProtoScript")]
+[assembly: InternalsVisibleTo("ProtoTestFx")]

--- a/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
+++ b/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
@@ -345,9 +345,9 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        public Dictionary<string, object> CompileAndGenerateMSIL(string souce, EmitMSIL.CodeGenIL codegen)
+        public Dictionary<string, object> CompileAndGenerateMSIL(string source, EmitMSIL.CodeGenIL codegen)
         {
-            var ast = ParserUtils.Parse(souce).Body;
+            var ast = ParserUtils.Parse(source).Body;
             return codegen.EmitAndExecute(ast);
         }
 

--- a/test/CodeGenILTests/RangeMicroTests.cs
+++ b/test/CodeGenILTests/RangeMicroTests.cs
@@ -26,6 +26,8 @@ namespace CodeGenILTests
         [SetUp]
         public void Setup()
         {
+            //TODO_MSIL: remove the dependency on the old VM by implementing
+            //necesary Emit functions(ex mitFunctionDefinition and EmitImportStatements and all the preloading logic)
             liveRunner = new ProtoScript.Runners.LiveRunner();
 
             List<string> libraries = new List<string>();

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Autodesk.DesignScript.Interfaces;
 using NUnit.Framework;
@@ -37,7 +38,11 @@ namespace ProtoTestFx.TD
         bool cfgImport = Convert.ToBoolean(Environment.GetEnvironmentVariable("Import"));
         bool cfgDebug = Convert.ToBoolean(Environment.GetEnvironmentVariable("Debug"));
         bool executeInDebugMode = true;
- 
+        //hold results from using MSIL compiler / execution.
+        private Dictionary<string, object> MSILMirror;
+        //control which engine to use for tests run with this test framework.
+        private bool testMSILExecution = false;
+
         public TestFrameWork()
         {
             runner = new ProtoScriptRunner();

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -35,7 +35,7 @@ namespace ProtoTestFx.TD
         bool testImport;
         bool testDebug;
         //control which VM is used to run tests.
-        bool testMSILExecution = true;
+        bool testMSILExecution = false;
         Dictionary<string, object> MSILMirror;
 
         bool dumpDS =false;

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -35,7 +35,7 @@ namespace ProtoTestFx.TD
         bool testImport;
         bool testDebug;
         //control which VM is used to run tests.
-        bool testMSILExecution = false;
+        bool testMSILExecution = true;
         Dictionary<string, object> MSILMirror;
 
         bool dumpDS =false;


### PR DESCRIPTION
### Purpose

attempts to complete work started in:
https://github.com/DynamoDS/Dynamo/pull/13362

I needed to construct a live runner and set it up the same way @pinzart90 did in the micro tests - I've added the same TODOs matching the one in the core to remove this when the other ast nodes are implemented in codegenMSIL.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
