### PR TITLE
Type identifier in preview compact bubble.

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3311,16 +3311,18 @@ namespace Dynamo.Controls
             {
                 switch (values[0])
                 {
-                    case WatchViewModel.objectType:
+                    case nameof(TypeCode.Object):
                         return resourceDictionary["objectLabelBackground"] as SolidColorBrush;
-                    case WatchViewModel.doubleType:
+                    case nameof(TypeCode.Double):
                         return resourceDictionary["numberLabelBackground"] as SolidColorBrush;
-                    case WatchViewModel.intType:
+                    case nameof(TypeCode.Int32):
                         return resourceDictionary["numberLabelBackground"] as SolidColorBrush;
-                    case WatchViewModel.stringType:
+                    case nameof(TypeCode.Int64):
+                        return resourceDictionary["numberLabelBackground"] as SolidColorBrush;
+                    case nameof(TypeCode.String):
                         return resourceDictionary["stringLabelBackground"] as SolidColorBrush;
-                    case WatchViewModel.boolType:
-                        return resourceDictionary["boolLabelBackground"] as SolidColorBrush;                                                
+                    case nameof(TypeCode.Boolean):
+                        return resourceDictionary["boolLabelBackground"] as SolidColorBrush;                                        
                     default:
                         if (values[1].ToString() == "List")
                         {

--- a/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
+++ b/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Dynamo.Extensions;
 using Dynamo.ViewModels;
@@ -24,6 +24,7 @@ namespace Dynamo.Wpf.Utilities
         {
             items = 0;
             var viewModel = ProcessThing(value, true);
+            viewModel.SetObjectType(value.Data);
             viewModel.NumberOfItems = items;
             return viewModel;
         }

--- a/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
@@ -1,4 +1,9 @@
-﻿namespace Dynamo.ViewModels
+using System;
+using System.Globalization;
+using Dynamo.Configuration;
+using Dynamo.Wpf.Properties;
+
+namespace Dynamo.ViewModels
 {
     /// <summary>
     /// Class containing data to display in compact preview bubble
@@ -6,8 +11,14 @@
     public class CompactBubbleViewModel : ViewModelBase
     {
         #region Properties
-
+        internal const string doubleType = "double";
+        internal const string boolType = "bool";
+        internal const string intType = "int";
+        internal const string objectType = "object";
+        internal const string stringType = "string";
         private string nodeLabel;
+        private string valueType;
+
         /// <summary>
         /// Represents type of node output
         /// </summary>
@@ -19,6 +30,12 @@
                 nodeLabel = value;
                 RaisePropertyChanged("NodeLabel");
             }
+        }
+
+        public string ValueType
+        {
+            get { return valueType; }
+            set { valueType = value; RaisePropertyChanged(nameof(ValueType)); }
         }
 
         private int numberOfItems;
@@ -72,6 +89,38 @@
             NumberOfItems = items;
         }
 
+        public void SetObjectType(object obj)
+        {
+            if (obj != null)
+            {
+                ValueType = GetDisplayType(obj);
+            }
+        }
+
+        private string GetDisplayType(object obj)
+        {
+            TypeCode typeCode = Type.GetTypeCode(obj.GetType());
+
+            switch (typeCode)
+            {
+                case TypeCode.Boolean:
+                    return boolType;
+                case TypeCode.Double:
+                    return doubleType;
+                case TypeCode.Int64:
+                    return intType;
+                case TypeCode.Int32:
+                    return intType;
+                case TypeCode.Object:
+                    return objectType;
+                case TypeCode.String:
+                    return stringType;
+                case TypeCode.Empty:
+                    return String.Empty;
+                default:
+                    return String.Empty;
+            }
+        }
         #endregion
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
@@ -11,11 +11,6 @@ namespace Dynamo.ViewModels
     public class CompactBubbleViewModel : ViewModelBase
     {
         #region Properties
-        internal const string doubleType = "double";
-        internal const string boolType = "bool";
-        internal const string intType = "int";
-        internal const string objectType = "object";
-        internal const string stringType = "string";
         private string nodeLabel;
         private string valueType;
 
@@ -104,21 +99,21 @@ namespace Dynamo.ViewModels
             switch (typeCode)
             {
                 case TypeCode.Boolean:
-                    return boolType;
+                    return nameof(TypeCode.Boolean);
                 case TypeCode.Double:
-                    return doubleType;
+                    return nameof(TypeCode.Double);
                 case TypeCode.Int64:
-                    return intType;
+                    return nameof(TypeCode.Int64);
                 case TypeCode.Int32:
-                    return intType;
+                    return nameof(TypeCode.Int32);
                 case TypeCode.Object:
-                    return objectType;
+                    return nameof(TypeCode.Object);
                 case TypeCode.String:
-                    return stringType;
+                    return nameof(TypeCode.String);
                 case TypeCode.Empty:
-                    return String.Empty;
+                    return string.Empty;
                 default:
-                    return String.Empty;
+                    return string.Empty;
             }
         }
         #endregion

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -17,12 +17,6 @@ namespace Dynamo.ViewModels
         // Formats double value into string. E.g. 1054.32179 => "1054.32179"
         // For more info: https://msdn.microsoft.com/en-us/library/kfsatb94(v=vs.110).aspx
         private const string numberFormat = "g";
-
-        internal const string doubleType = "double";
-        internal const string boolType = "bool";
-        internal const string intType = "int";
-        internal const string objectType = "object";
-        internal const string stringType = "string";
 
         #region Events
 
@@ -290,17 +284,17 @@ namespace Dynamo.ViewModels
             switch (typeCode)
             {
                 case TypeCode.Boolean:
-                    return boolType;
+                    return nameof(TypeCode.Boolean);
                 case TypeCode.Double:
-                    return doubleType;
+                    return nameof(TypeCode.Double);
                 case TypeCode.Int64:
-                    return intType;
+                    return nameof(TypeCode.Int64);
                 case TypeCode.Int32:
-                    return intType;
+                    return nameof(TypeCode.Int32);
                 case TypeCode.Object:
-                    return objectType;
+                    return nameof(TypeCode.Object);
                 case TypeCode.String:
-                    return stringType;
+                    return nameof(TypeCode.String);
                 case TypeCode.Empty:
                     return String.Empty;
                 default:

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.UI.Controls.PreviewCompactView"
+<UserControl x:Class="Dynamo.UI.Controls.PreviewCompactView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -21,7 +21,14 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="15" />
         </Grid.ColumnDefinitions>
-        <TextBlock Name="Label" Foreground="{StaticResource PrimaryCharcoal200Brush}" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}" />
+        <TextBlock Name="Label" Grid.Column="0" Margin="10,5,0,5" FontFamily="{StaticResource SourceCodePro}" Text="{Binding Path=NodeLabel}">
+            <TextBlock.Foreground>
+                <MultiBinding Converter="{StaticResource ObjectTypeConverter}">
+                    <Binding Path="ValueType" />
+                    <Binding Path="NodeLabel" />
+                </MultiBinding>
+            </TextBlock.Foreground>
+        </TextBlock>
 
         <TextBlock Name="Items" Grid.Column="2" Margin="0,3,0,7" Foreground="{StaticResource PrimaryCharcoal200Brush}"
                    FontFamily="{StaticResource SourceCodePro}"


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5053

Add Type identifiers in preview compact bubble. Similar to preview bubble or watch node.

![type identifier](https://user-images.githubusercontent.com/43763136/195168507-86327951-3ab3-4dda-9253-fa675754e312.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Type identifier in preview compact bubble.

### Reviewers
@QilongTang @zeusongit 
