### PR TITLE
Add back timers

### DIFF
--- a/src/Engine/EmitMSIL/CodeGenIL.cs
+++ b/src/Engine/EmitMSIL/CodeGenIL.cs
@@ -65,21 +65,14 @@ namespace EmitMSIL
 
         internal IDictionary<string, object> Emit(List<AssociativeNode> astList)
         {
-            var timer = new Stopwatch();
-            timer.Start();
             var compileResult = CompileAstToDynamicType(astList, AssemblyBuilderAccess.RunAndSave);
-            timer.Stop();
-            CompileAndExecutionTime.compileTime = timer.Elapsed;
             // Invoke emitted method (ExecuteIL.Execute)
-            timer.Restart();
             var t = compileResult.tbuilder.CreateType();
             var mi = t.GetMethod("Execute", BindingFlags.NonPublic | BindingFlags.Static);
             var output = new Dictionary<string, object>();
 
             // null can be replaced by an 'input' dictionary if available.
             var obj = mi.Invoke(null, new object[] { null, methodCache, output, runtimeCore });
-            timer.Stop();
-            CompileAndExecutionTime.executionTime = timer.Elapsed;
 
             compileResult.asmbuilder.Save("DynamicAssembly.dll");
 
@@ -88,13 +81,21 @@ namespace EmitMSIL
 
         internal Dictionary<string, object> EmitAndExecute(List<AssociativeNode> astList)
         {
+            var timer = new Stopwatch();
+            timer.Start();
             var compileResult = CompileAstToDynamicType(astList, AssemblyBuilderAccess.RunAndCollect);
-            
+            timer.Stop();
+            CompileAndExecutionTime.compileTime = timer.Elapsed;
+
             // Invoke emitted method (ExecuteIL.Execute)
+            timer.Restart();
             var t = compileResult.tbuilder.CreateType();
             var mi = t.GetMethod("Execute", BindingFlags.NonPublic | BindingFlags.Static);
             var output = new Dictionary<string, object>();
             mi.Invoke(null, new object[] { null, methodCache, output, runtimeCore });
+            timer.Stop();
+            CompileAndExecutionTime.executionTime = timer.Elapsed;
+
             return output;
         }
 


### PR DESCRIPTION
### Purpose

Add back our timers for the performance tests. I missed this in the review.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
