### PR TITLE
Expose dynamic wrappers to compiler, defer marshaling to/from where possible.

### DIFF
--- a/src/Engine/EmitMSIL/BuiltIn.cs
+++ b/src/Engine/EmitMSIL/BuiltIn.cs
@@ -36,7 +36,7 @@ namespace EmitMSIL
             {
                 get
                 {
-                    var obj = Unmarshal(key);
+                    var obj = UnmarshalKey(key);
                     backingDict[key] = obj;
                     return obj;
                 }
@@ -53,7 +53,7 @@ namespace EmitMSIL
                 return marshaler.UnMarshal(clrwrapped, clrwrapped.CLRFEPReturnType, runtimeCore);
             }
 
-            private V Unmarshal(K key)
+            private V UnmarshalKey(K key)
             {
                 //TODO consider scanning for nested wrappers we missed.
                 if (backingDict[key] is CLRStackValue clrwrapped)
@@ -66,12 +66,21 @@ namespace EmitMSIL
 
             public ICollection<K> Keys => backingDict.Keys;
 
-            public ICollection<V> Values => backingDict.Keys.Select((x) =>
+            public ICollection<V> Values
             {
-                var obj = Unmarshal(x);
-                backingDict[x] = obj;
-                return obj;
-            }).ToArray();
+                get
+                {
+                    var output = new List<V>(backingDict.Count);
+                    //copy keys so we can mutate dictionary.
+                    foreach (var key in backingDict.Keys.ToList())
+                    {
+                        var obj = UnmarshalKey(key);
+                        output.Add(obj);
+                        backingDict[key] = obj;
+                    }
+                    return output;
+                }
+            }
 
 
             public int Count => backingDict.Count;
@@ -127,7 +136,7 @@ namespace EmitMSIL
             {
                 if (backingDict.TryGetValue(key, out _))
                 {
-                    value = Unmarshal(key);
+                    value = UnmarshalKey(key);
                     backingDict[key] = value;
                     return true;
                 }

--- a/src/Engine/EmitMSIL/BuiltIn.cs
+++ b/src/Engine/EmitMSIL/BuiltIn.cs
@@ -39,6 +39,7 @@ namespace EmitMSIL
 
             private V Unmarshal(K key)
             {
+                //TODO consider scanning for nested wrappers we missed.
                 if (backingDict[key] is CLRStackValue clrwrapped)
                 {
                     return marshaler.UnMarshal(clrwrapped, clrwrapped.CLRFEPReturnType, runtimeCore) as V;
@@ -103,12 +104,14 @@ namespace EmitMSIL
 
             public bool TryGetValue(K key, out V value)
             {
-                //TODO call
-                V intermediatevalue;
-                var result = backingDict.TryGetValue(key, out intermediatevalue);
-                // unmarshal intermediate val.
-                value = intermediatevalue;
-                return result;
+                if (backingDict.TryGetValue(key, out _))
+                {
+                    value = Unmarshal(key);
+                    return true;
+                }
+
+                value = null;
+                return false;
             }
 
             IEnumerator IEnumerable.GetEnumerator()

--- a/src/Engine/EmitMSIL/BuiltIn.cs
+++ b/src/Engine/EmitMSIL/BuiltIn.cs
@@ -34,7 +34,12 @@ namespace EmitMSIL
 
             public V this[K key]
             {
-                get => Unmarshal(key);
+                get
+                {
+                    var obj = Unmarshal(key);
+                    backingDict[key] = obj;
+                    return obj;
+                }
                 set => backingDict[key] = value;
             }
             /// <summary>
@@ -61,7 +66,12 @@ namespace EmitMSIL
 
             public ICollection<K> Keys => backingDict.Keys;
 
-            public ICollection<V> Values => backingDict.Keys.Select(x => Unmarshal(x)).ToArray();
+            public ICollection<V> Values => backingDict.Keys.Select((x) =>
+            {
+                var obj = Unmarshal(x);
+                backingDict[x] = obj;
+                return obj;
+            }).ToArray();
 
 
             public int Count => backingDict.Count;
@@ -118,6 +128,7 @@ namespace EmitMSIL
                 if (backingDict.TryGetValue(key, out _))
                 {
                     value = Unmarshal(key);
+                    backingDict[key] = value;
                     return true;
                 }
 

--- a/src/Engine/EmitMSIL/BuiltIn.cs
+++ b/src/Engine/EmitMSIL/BuiltIn.cs
@@ -18,7 +18,8 @@ namespace EmitMSIL
         /// </summary>
         /// <typeparam name="K"></typeparam>
         /// <typeparam name="V"></typeparam>
-        internal class MSILOutputMap<K, V> : IDictionary<K, V> where V : class
+        [Obsolete("Internal, do not use")]
+        public class MSILOutputMap<K, V> : IDictionary<K, V> where V : class
         {
             private Dictionary<K, V> backingDict = new Dictionary<K, V>();
             private MSILRuntimeCore runtimeCore;
@@ -35,6 +36,16 @@ namespace EmitMSIL
             {
                 get => Unmarshal(key);
                 set => backingDict[key] = value;
+            }
+            /// <summary>
+            /// A utility method for unmarshaling from replication wrappers to
+            /// plain c# objects.
+            /// </summary>
+            /// <param name="clrwrapped"></param>
+            /// <returns></returns>
+            public object Unmarshal(CLRStackValue clrwrapped)
+            {
+                return marshaler.UnMarshal(clrwrapped, clrwrapped.CLRFEPReturnType, runtimeCore);
             }
 
             private V Unmarshal(K key)

--- a/src/Engine/EmitMSIL/CodeGenIL.cs
+++ b/src/Engine/EmitMSIL/CodeGenIL.cs
@@ -1473,23 +1473,22 @@ namespace EmitMSIL
                     }
                 });
 
-                //TODO_MSIL if possible only marshal args that resulted from a replicated call.
-                //emit marshal for args
+                //TODO_MSIL if possible only unmarshal args that resulted from a replicated call.
+                //emit unmarshal for args
                 // Emit call to load the runtimeCore argument
                 EmitOpCode(OpCodes.Ldarg_3);
                 //TODO cache this at start.
-                //now call marshall to convert any clrstackvalues to plain c# objs. 
-                var marhshallMethod = typeof(Replication).GetMethod(nameof(Replication.UnMarshalFunctionArguments2), BindingFlags.Static | BindingFlags.Public);
-                EmitOpCode(OpCodes.Call, marhshallMethod);
-
-                var unMarshaledArgsArray = DeclareLocal(marhshallMethod.ReturnType, "unMarshaledArgsArray");
+                //now call unmarshall to convert any clrstackvalues to plain c# objs. 
+                var marshalMethod = typeof(Replication).GetMethod(nameof(Replication.UnMarshalFunctionArguments2),
+                    BindingFlags.Static | BindingFlags.Public);
+                EmitOpCode(OpCodes.Call, marshalMethod);
+                //TODO_MSIL can we just use unmarshal here instead of unmarshalfunctionargs?
+                var unMarshaledArgsArray = DeclareLocal(marshalMethod.ReturnType, "unMarshaledArgsArray");
                 if (unMarshaledArgsArray != null)
                 {
                     EmitOpCode(OpCodes.Stloc, unMarshaledArgsArray.LocalIndex);
                 }
-                //now on the stack we have a list of objects, we need to iterate through it and push each item to the stack.
-                //emit a for loop which pushes to stack.
-
+                
                 //foreach item in args -
                 //increment index
                 //emit code to index into array

--- a/src/Engine/EmitMSIL/CodeGenIL.cs
+++ b/src/Engine/EmitMSIL/CodeGenIL.cs
@@ -1432,7 +1432,7 @@ namespace EmitMSIL
                 if (unmarshalFunctionArgs)
                 {
                     EmitILComment("found replication wrapper arg, unmarshaling ");
-                    EmitUnmarshalFunctionArgs(args, numArgs, parameters, isStaticOrCtor);
+                    EmitUnmarshalFunctionArgs(args, parameters, isStaticOrCtor);
                 }
                 else
                 {
@@ -1470,7 +1470,7 @@ namespace EmitMSIL
             }
         }
 
-        private void EmitUnmarshalFunctionArgs(List<AssociativeNode> args, int numArgs, List<Type> parameters, bool isStaticOrCtor)
+        private void EmitUnmarshalFunctionArgs(List<AssociativeNode> args, List<Type> parameters, bool isStaticOrCtor)
         {
 
             // Emit methodCache passed as arg to global Execute method.
@@ -1480,7 +1480,7 @@ namespace EmitMSIL
 
             // Emit methodName for input to call to CodeGenIL.KeyGen
             EmitOpCode(OpCodes.Ldstr, methodName);
-            EmitOpCode(OpCodes.Ldc_I4, numArgs);
+            EmitOpCode(OpCodes.Ldc_I4, args.Count);
             var keygen = typeof(CodeGenIL).GetMethod(nameof(CodeGenIL.KeyGen));
             EmitOpCode(OpCodes.Call, keygen);
 
@@ -1527,7 +1527,7 @@ namespace EmitMSIL
             //emit unmarshal for args
             // Emit call to load the runtimeCore argument
             EmitOpCode(OpCodes.Ldarg_3);
-            //TODO cache this at start.
+            //TODO_MSIL cache this and other method lookups at start to speedup compile.
             //now call unmarshall to convert any clrstackvalues to plain c# objs. 
             var marshalMethod = typeof(Replication).GetMethod(nameof(Replication.UnMarshalFunctionArguments2),
                 BindingFlags.Static | BindingFlags.Public);

--- a/src/Engine/EmitMSIL/Replication.cs
+++ b/src/Engine/EmitMSIL/Replication.cs
@@ -16,7 +16,7 @@ namespace EmitMSIL
     [Obsolete("This is an internal class, do not use it.")]
     public class Replication
     {
-        public static List<CLRStackValue> MarshalFunctionArguments(IList args, MSILRuntimeCore runtimeCore)
+        internal static List<CLRStackValue> MarshalFunctionArguments(IList args, MSILRuntimeCore runtimeCore)
         {
             var marshaller = ProtoFFI.CLRDLLModule.GetMarshaler(runtimeCore);
             List<CLRStackValue> stackValues = new List<CLRStackValue>();
@@ -48,6 +48,7 @@ namespace EmitMSIL
 
         public static IList<object> UnMarshalFunctionArguments2(IEnumerable<CLRFunctionEndPoint> feps, IEnumerable args, MSILRuntimeCore runtimeCore)
         {
+            //TODO_MSIL figure out how to handle multiple feps here.
             return UnmarshalFunctionArguments(feps.FirstOrDefault().FormalParams, (IList)args, runtimeCore).ToArray();
         }
 

--- a/src/Engine/ProtoCore/DSASM/InstructionSet.cs
+++ b/src/Engine/ProtoCore/DSASM/InstructionSet.cs
@@ -140,11 +140,18 @@ namespace ProtoCore.DSASM
         // TODO_MSIL: Figure out how bad boxing/unboxing is for performance
         public object Value { get; set; }
 
+        //TODO can we move this higher up and outside of this type?
+        //TODO better name.
+        /// <summary>
+        /// The underlying type of object this wrapper wraps. Usually inferred from the FEP.ReturnType that created this wrapper.
+        /// </summary>
+        public System.Type CLRFEPReturnType { get; internal set; }
 
-        internal CLRStackValue(object value, int protoType)
+        internal CLRStackValue(object value, int protoType, System.Type FEPReturnType = null)
         {
             this.Value = value;
             this.TypeUID = protoType;
+            this.CLRFEPReturnType = FEPReturnType;
         }
 
         internal static CLRStackValue Null => new CLRStackValue(null, (int)PrimitiveType.Null);

--- a/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
+++ b/src/Engine/ProtoScript/Runners/ProtoScriptRunner.cs
@@ -345,7 +345,7 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        public Dictionary<string, object> CompileAndGenerateMSIL(string source, EmitMSIL.CodeGenIL codegen)
+        public IDictionary<string, object> CompileAndGenerateMSIL(string source, EmitMSIL.CodeGenIL codegen)
         {
             var ast = ParserUtils.Parse(source).Body;
             return codegen.EmitAndExecute(ast);

--- a/test/CodeGenILTests/IndexingMicroTests.cs
+++ b/test/CodeGenILTests/IndexingMicroTests.cs
@@ -186,7 +186,7 @@ a = 0..100..10; //a is an ILIST because of replication?
 b = 5;
 c=a[b];";
             var ast = ParserUtils.Parse(dscode).Body;
-            var output = codeGen.EmitAndExecute(ast);
+            var output = codeGen.Emit(ast);
             Assert.IsNotEmpty(output);
             Assert.AreEqual(50, output["c"]);
         }

--- a/test/CodeGenILTests/ReplicationTests.cs
+++ b/test/CodeGenILTests/ReplicationTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using ProtoCore.Utils;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -583,19 +584,19 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
                 return (int)a == (int)b;
             }
 
-            bool isAIEnum = typeof(IEnumerable<object>).IsAssignableFrom(a.GetType());
-            bool isBIEnum = typeof(IEnumerable<object>).IsAssignableFrom(b.GetType());
-            if (isAIEnum && isBIEnum)
+            bool isAList = a is IList;
+            bool isBList = b is IList;
+            if (isAList && isBList)
             {
-                var aIEnum = (a as IEnumerable<object>).ToList();
-                var bIEnum = (b as IEnumerable<object>).ToList();
+                var aIEnum = a as IList;
+                var bIEnum = b as IList;
 
-                if (aIEnum.Count() != bIEnum.Count()) 
+                if (aIEnum.Count != bIEnum.Count) 
                 { 
                     return false; 
                 }
 
-                for (int ii=0; ii < aIEnum.Count(); ii++)
+                for (int ii=0; ii < aIEnum.Count; ii++)
                 {
                     if (!AreEqual(aIEnum[ii], bIEnum[ii]))
                     {
@@ -605,7 +606,7 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
 
                 return true;
             }
-            else if (isAIEnum || isBIEnum)
+            else if (isAList || isBList)
             {
                 return false;
             }

--- a/test/CodeGenILTests/ReplicationTests.cs
+++ b/test/CodeGenILTests/ReplicationTests.cs
@@ -724,7 +724,6 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
         }
 
         [Test]
-        [Category("Failure")]//TODO fails when trying to call sum.
         public void IEnumerable_IntDouble_Coercion()
         {
             string code =
@@ -737,8 +736,7 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
             test2 = DSCore.Math.Sum(test1);    
             ";
             var ast = ParserUtils.Parse(code).Body;
-            //TODO undo
-            var output = codeGen.Emit(ast);
+            var output = codeGen.EmitAndExecute(ast);
             Assert.IsNotEmpty(output);
             Assert.AreEqual(new int[] { 1, 2, 4, 4 }, output["test1"]);
             Assert.AreEqual(11, output["test2"]);
@@ -748,7 +746,6 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
         }
 
         [Test]
-        [Category("Failure")] //TODO fails when trying to call sum.
         public void IList_T_IEnumerable_Coerce()
         {
             string code =
@@ -761,8 +758,7 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
             num2 = DSCore.Math.Sum(num1);  
             ";
             var ast = ParserUtils.Parse(code).Body;
-            //TODO undo
-            var output = codeGen.Emit(ast);
+            var output = codeGen.EmitAndExecute(ast);
             Assert.IsNotEmpty(output);
             Assert.AreEqual(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, output["num1"]);
             Assert.AreEqual(55, output["num2"]);

--- a/test/CodeGenILTests/ReplicationTests.cs
+++ b/test/CodeGenILTests/ReplicationTests.cs
@@ -724,6 +724,7 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
         }
 
         [Test]
+        [Category("Failure")]//TODO fails when trying to call sum.
         public void IEnumerable_IntDouble_Coercion()
         {
             string code =
@@ -736,7 +737,8 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
             test2 = DSCore.Math.Sum(test1);    
             ";
             var ast = ParserUtils.Parse(code).Body;
-            var output = codeGen.EmitAndExecute(ast);
+            //TODO undo
+            var output = codeGen.Emit(ast);
             Assert.IsNotEmpty(output);
             Assert.AreEqual(new int[] { 1, 2, 4, 4 }, output["test1"]);
             Assert.AreEqual(11, output["test2"]);
@@ -746,6 +748,7 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
         }
 
         [Test]
+        [Category("Failure")] //TODO fails when trying to call sum.
         public void IList_T_IEnumerable_Coerce()
         {
             string code =
@@ -758,7 +761,8 @@ list = DSCore.List.Reverse([ 1, 2, 3 ]);
             num2 = DSCore.Math.Sum(num1);  
             ";
             var ast = ParserUtils.Parse(code).Body;
-            var output = codeGen.EmitAndExecute(ast);
+            //TODO undo
+            var output = codeGen.Emit(ast);
             Assert.IsNotEmpty(output);
             Assert.AreEqual(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, output["num1"]);
             Assert.AreEqual(55, output["num2"]);

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -39,7 +39,7 @@ namespace ProtoTestFx.TD
         bool cfgDebug = Convert.ToBoolean(Environment.GetEnvironmentVariable("Debug"));
         bool executeInDebugMode = true;
         //hold results from using MSIL compiler / execution.
-        private Dictionary<string, object> MSILMirror;
+        private IDictionary<string, object> MSILMirror;
         //control which engine to use for tests run with this test framework.
         private bool testMSILExecution = false;
 

--- a/test/core/Performance/replication_wrappers_reused.dyn
+++ b/test/core/Performance/replication_wrappers_reused.dyn
@@ -1,0 +1,906 @@
+{
+  "Uuid": "1884cf3a-2778-4814-82ab-e9f3a8ce3e9c",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "replication_wrappers_reused",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "35d408fac639462096f8afc6daff3e19",
+      "Inputs": [
+        {
+          "Id": "f11f00b7d85a406cb655d89ff121781a",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "37ccea101d1d40da89e337578684dd83",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4ab4c63a3b61486ca3130519523e4c32",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9c427f0e542245dca244652ae0d6d817",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "CrossProduct",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0..10;",
+      "Id": "e637479d319443a380ba1a8c9b2d99c6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e9fbbafb60ea4fdaab54c3b59341ff18",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "c1351f1e0e6244b9a42ffa89a9342a00",
+      "Inputs": [
+        {
+          "Id": "f9abc5f8630a4c60b33ce032b6146817",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "51961fd0f2b3414a92de8d2da9c8b8d2",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "ab766875f2154138a62d43e2cea1accd",
+      "Inputs": [
+        {
+          "Id": "25e5c126e99c47c8b6196455a54f9d90",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c9196263fa814ebdbeb18e9aa0f1803c",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "265ecac6d07a4719b0530006f379ee1c",
+      "Inputs": [
+        {
+          "Id": "5ff8e9662e1a4309b19a16f88adcb7dc",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6b1d3ec41e94401bb6e666c1a8df6f57",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "7ebacd92e19c476692a0d4082eef94e3",
+      "Inputs": [
+        {
+          "Id": "47e98c699fd24044befd742fcee4aebf",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e1b77f2c99c648d3a63e2eed1724b1e7",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "b968c262d6b948e39885dbb4d4dbca45",
+      "Inputs": [
+        {
+          "Id": "1205a660f6794a51a52f05fe2009c36b",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8f569d3ea0ca4f85a9c60725444473c1",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "3447cbeabcbe483ab81e8e19d7eda444",
+      "Inputs": [
+        {
+          "Id": "73293e254cdc4a3e889d4849751dea20",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d007c57c725946d59f340b8c86945ffd",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "d34b2e28f8f1426c8922d835c3330f49",
+      "Inputs": [
+        {
+          "Id": "9e0b70dbe8ec431e99e2f51e37ff8b95",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9b79d7a51f5449489a809d5cff3c4228",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "48a19435d43b48b1864fb4ae8f319c24",
+      "Inputs": [
+        {
+          "Id": "9dd17f82119f43fd84adecbeb6789710",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5a4d949c2b694e288af8a5bc74dc52ba",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "0e1e86bad48b4c81bec8fabfc2134675",
+      "Inputs": [
+        {
+          "Id": "5e7eab9f4a204ca5968cf7f5994a99ff",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "599db1a0f5744f949a2f4796176073ec",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "cd2d3119444447f9baed231f398a0224",
+      "Inputs": [
+        {
+          "Id": "4be632d0ee3241ef81d897761b6d5cac",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "91353de54797448b9c6bdd95296656be",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "ca97e96277b04bd8b91168701ce94dfd",
+      "Inputs": [
+        {
+          "Id": "1f916bd90c6e4f9b8d131af1806f71e0",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "dd8ae1922c754eceb35b5a4bb590e21b",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "b6c7a0f1ea90450a82c4b37a1287cc19",
+      "Inputs": [
+        {
+          "Id": "5bb8a0eead9c47818ca79bdd5d62b434",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7f9f9061cfb144e48298bd980001eed4",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "c8aa9a8714214068b60f14bb6237187a",
+      "Inputs": [
+        {
+          "Id": "e8fd3859157f470eb6e0a2055239d9bd",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "22f003cf96c244328b1c30cbd975f798",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "747a0ee3f1ab414fbc70a9694e76ae8c",
+      "Inputs": [
+        {
+          "Id": "4f18830826cb48a3b874f947b5de1780",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3b6bec7308744c06a989ef4ca7f07a64",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "76f5cc04d52443fdac6301bdd3ef80bc",
+      "Inputs": [
+        {
+          "Id": "9362c2cb30604fa6be860da949286c59",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c2c7070ad1a542d185f0d607b545ddc1",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.X",
+      "Id": "9442e819bb10455187a8a1e1ee85431f",
+      "Inputs": [
+        {
+          "Id": "419d6909d25f44b28c7467c38de60dfa",
+          "Name": "point",
+          "Description": "Autodesk.DesignScript.Geometry.Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c6462f9093254b82b8ef80148adf856a",
+          "Name": "double",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the X component of a Point\n\nPoint.X: double"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "f9abc5f8630a4c60b33ce032b6146817",
+      "Id": "8450880ceb024406a45974a1e4ecdbd8",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "25e5c126e99c47c8b6196455a54f9d90",
+      "Id": "277ea1cea6f54056929066bea27e949a",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "5ff8e9662e1a4309b19a16f88adcb7dc",
+      "Id": "3efc813b8dd34d9e9c883534d54e7812",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "47e98c699fd24044befd742fcee4aebf",
+      "Id": "25b8d1b9a9834d6c94fe301781802911",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "1205a660f6794a51a52f05fe2009c36b",
+      "Id": "ccca1894374e4ee0a50f9da510e62980",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "73293e254cdc4a3e889d4849751dea20",
+      "Id": "52e97f99c42a440e94473bd43ab0703b",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "9e0b70dbe8ec431e99e2f51e37ff8b95",
+      "Id": "51d595b4988a4091ab98484e9a9cf481",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "9dd17f82119f43fd84adecbeb6789710",
+      "Id": "10a1b1371afc4c72be8f5d83e7bcc7a0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "5e7eab9f4a204ca5968cf7f5994a99ff",
+      "Id": "ccedf02b931e4ea595207133870a9c5c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "4be632d0ee3241ef81d897761b6d5cac",
+      "Id": "7061457eca8741c9a98a68c28ac9e85d",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "1f916bd90c6e4f9b8d131af1806f71e0",
+      "Id": "4b3cb9dabf144262829b1472a1e28795",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "5bb8a0eead9c47818ca79bdd5d62b434",
+      "Id": "79d67dcb86b74984b60c591948f457e0",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "e8fd3859157f470eb6e0a2055239d9bd",
+      "Id": "742d31ea597744df9d92cf07ead7c88f",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "4f18830826cb48a3b874f947b5de1780",
+      "Id": "bc18623bd71641719369f131b3639cd8",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "9362c2cb30604fa6be860da949286c59",
+      "Id": "1684324c6180420c91386d21c575e8a5",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "9c427f0e542245dca244652ae0d6d817",
+      "End": "419d6909d25f44b28c7467c38de60dfa",
+      "Id": "69c65cbe43224a18ab9d623de2887c04",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e9fbbafb60ea4fdaab54c3b59341ff18",
+      "End": "f11f00b7d85a406cb655d89ff121781a",
+      "Id": "3c4322c9b09f4c96b8164b9894987d9a",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e9fbbafb60ea4fdaab54c3b59341ff18",
+      "End": "37ccea101d1d40da89e337578684dd83",
+      "Id": "7593358895e64ac387325a60d59ceace",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e9fbbafb60ea4fdaab54c3b59341ff18",
+      "End": "4ab4c63a3b61486ca3130519523e4c32",
+      "Id": "3eada148094648a3a96c08f497979d67",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.16",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.16.0.1926",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "Point.ByCoordinates",
+        "ShowGeometry": true,
+        "Id": "35d408fac639462096f8afc6daff3e19",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 212.0,
+        "Y": 279.0
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "e637479d319443a380ba1a8c9b2d99c6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -42.0,
+        "Y": 312.82749999999987
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "c1351f1e0e6244b9a42ffa89a9342a00",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 353.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "ab766875f2154138a62d43e2cea1accd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": -824.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "265ecac6d07a4719b0530006f379ee1c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": -677.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "7ebacd92e19c476692a0d4082eef94e3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 500.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "b968c262d6b948e39885dbb4d4dbca45",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 647.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "3447cbeabcbe483ab81e8e19d7eda444",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": -530.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "d34b2e28f8f1426c8922d835c3330f49",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": -383.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "48a19435d43b48b1864fb4ae8f319c24",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 794.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "0e1e86bad48b4c81bec8fabfc2134675",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 205.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "cd2d3119444447f9baed231f398a0224",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 58.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "ca97e96277b04bd8b91168701ce94dfd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": -89.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "b6c7a0f1ea90450a82c4b37a1287cc19",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 941.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "c8aa9a8714214068b60f14bb6237187a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": -236.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "747a0ee3f1ab414fbc70a9694e76ae8c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 1088.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "76f5cc04d52443fdac6301bdd3ef80bc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 1235.0
+      },
+      {
+        "Name": "Point.X",
+        "ShowGeometry": true,
+        "Id": "9442e819bb10455187a8a1e1ee85431f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 537.0,
+        "Y": 1382.0
+      }
+    ],
+    "Annotations": [],
+    "X": 134.73513143200321,
+    "Y": 142.43428179954623,
+    "Zoom": 0.23008496324569594
+  }
+}


### PR DESCRIPTION
### Purpose
based on:
https://github.com/DynamoDS/Dynamo/pull/13379

The intent of this PR is to attempt to reduce the time required for marshaling and un-marshaling when making replicated calls via `ReplicationLogic` I'll refer to this as dynamic replication in the rest of this PR. (as opposed to replication unrolling at compile time which we don't currently support).

⚠️ 
### Notes:
1. ~This PR currently causes 5 test regressions related to coercion - dreaded invalid program exception - might need assistance looking into these.~ ✅ 
2. Performance gains seem moderate, I guess they are mostly from deferring unmarshaling until after execution where possible. This is kind of like cheating?
3.  ~~I think we can avoid calling `unmarshalFunctionArgs` before all direct function calls by checking if arg type is `CLRStackValue` - currently I just do it for all the args.~~ done. ✅ 
4. Yet to be seen if we should proceed further in this direction, IE is the complexity worth the perf gains.

### What does this PR do:

1. Short circuits marshaling arguments to replicated calls, if the value is already a `CLRStackValue`. This is now probable because of point 2.
2. We no longer un-marshal `CLRStackValues` back to plain c# objects after every replicated call. - Instead we defer this un-marshling until later.
3. Short circuit un-marshaling - if the value is not a CLRStackValue, we can just return.
4. **unmarshal case 1** - Introduces a new Dictionary wrapper type that un-marshals when a client tries to get a value at a key. This means that unmarshaling happens at test time or UI time, when the client asks for a specific value, we lazily un-marshal instead of doing it all up front. I think this will be especially valuable in a headless scenario where you only care about a few values, or for example in a UI scenario if we only show preview bubbles when a user interacts with them.
5. **unmarshal case 2** -We are attempting to make a non replicated direct function call - but one or more of our inputs was the result of a dynamic replicated call - now the argument is a `CLRStackValue` and we are forced to unmarshal before calling our function. This means we lose any benefit of points 1 and 2 - and incur a serious addition of complexity to our direct function emit code. Currently in this PR we **always** unmarshal when calling a direct function - but we could avoid this by only unmarshaling if an argument is a CLRStackValue or from a replicated call - I think we can figure this out at compile by checking the return type of that AST.

 
### TODO:
- [x] profile perf
- [ ]  profile memory of slightly larger wrapper type (stores FEP return type)
- [x]   fix tests. 😢 




### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
