### PR TITLE
DYN-4958: Performance benchmarking of current state of graph compilation vs. compilation to MSIL assembly

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Reflection;
 using System.Resources;

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
@@ -45,7 +46,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.17.0.2904")]
+[assembly: AssemblyVersion("2.17.0.2366")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +65,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.17.0.2904")]
+[assembly: AssemblyFileVersion("2.17.0.2366")]

--- a/src/build.xml
+++ b/src/build.xml
@@ -9,7 +9,7 @@
 	
 <ItemGroup>
     <ProjectToBuild Include="$(Solution)" >
-        <Properties>Configuration=Debug;Platform=Any CPU</Properties>
+        <Properties>Configuration=Release;Platform=Any CPU</Properties>
     </ProjectToBuild>
 </ItemGroup>
 

--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -27,6 +27,7 @@ namespace Dynamo.Tests
         {
             var di = new DirectoryInfo(Path.Combine(TestDirectory, "core", "performance"));
             var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
+
             var failingTests = new string[] { 
                 "aniform.dyn",
                 "lotsofcoloredstuff.dyn"};
@@ -48,11 +49,11 @@ namespace Dynamo.Tests
             executionData.ForEach(item =>
             {
                 var (graph, oldEngineCompileTime, oldEngineExecutionTime, newEngineCompileTime, newEngineExecutionTime) = item;
-                Console.WriteLine("{0,50}{1,9}{2,9}{3,11}{4,9}{5,9}{6,11}", graph,
-                    oldEngineCompileTime.Milliseconds, oldEngineExecutionTime.Milliseconds,
-                    oldEngineCompileTime.Milliseconds + oldEngineExecutionTime.Milliseconds,
-                    newEngineCompileTime.Milliseconds, newEngineExecutionTime.Milliseconds,
-                    newEngineCompileTime.Milliseconds + newEngineExecutionTime.Milliseconds);
+                Console.WriteLine("{0,50}{1,9:0}{2,9:0}{3,11:0}{4,9:0}{5,9:0}{6,11:0}", graph,
+                    oldEngineCompileTime.TotalMilliseconds, oldEngineExecutionTime.TotalMilliseconds,
+                    oldEngineCompileTime.TotalMilliseconds + oldEngineExecutionTime.TotalMilliseconds,
+                    newEngineCompileTime.TotalMilliseconds, newEngineExecutionTime.TotalMilliseconds,
+                    newEngineCompileTime.TotalMilliseconds + newEngineExecutionTime.TotalMilliseconds);
             });
             executionData.Clear();
         }
@@ -116,9 +117,9 @@ namespace Dynamo.Tests
 
             var newEngineCompileAndExecutionTime = model.EngineController.CompileAndExecutionTime;
 
-            Console.WriteLine("Compile and Execution time old Engine={0}+{1} ms, new Engine={2}+{3} ms",
-                oldEngineCompileAndExecutionTime.compileTime.Milliseconds, oldEngineCompileAndExecutionTime.executionTime.Milliseconds,
-                newEngineCompileAndExecutionTime.compileTime.Milliseconds, newEngineCompileAndExecutionTime.executionTime.Milliseconds);
+            Console.WriteLine("Compile and Execution time old Engine={0:0}+{1:0} ms, new Engine={2:0}+{3:0} ms",
+                oldEngineCompileAndExecutionTime.compileTime.TotalMilliseconds, oldEngineCompileAndExecutionTime.executionTime.TotalMilliseconds,
+                newEngineCompileAndExecutionTime.compileTime.TotalMilliseconds, newEngineCompileAndExecutionTime.executionTime.TotalMilliseconds);
             var execution = (Path.GetFileName(filePath),
                 oldEngineCompileAndExecutionTime.compileTime, oldEngineCompileAndExecutionTime.executionTime,
                 newEngineCompileAndExecutionTime.compileTime, newEngineCompileAndExecutionTime.executionTime);

--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -49,7 +49,7 @@ namespace Dynamo.Tests
             executionData.ForEach(item =>
             {
                 var (graph, oldEngineCompileTime, oldEngineExecutionTime, newEngineCompileTime, newEngineExecutionTime) = item;
-                Console.WriteLine("{0,50}{1,9:0}{2,9:0}{3,11:0}{4,9:0}{5,9:0}{6,11:0}", graph,
+                Console.WriteLine("{0,50}{1,9:0.0}{2,9:0.0}{3,11:0.0}{4,9:0.0}{5,9:0.0}{6,11:0.0}", graph,
                     oldEngineCompileTime.TotalMilliseconds, oldEngineExecutionTime.TotalMilliseconds,
                     oldEngineCompileTime.TotalMilliseconds + oldEngineExecutionTime.TotalMilliseconds,
                     newEngineCompileTime.TotalMilliseconds, newEngineExecutionTime.TotalMilliseconds,
@@ -117,7 +117,7 @@ namespace Dynamo.Tests
 
             var newEngineCompileAndExecutionTime = model.EngineController.CompileAndExecutionTime;
 
-            Console.WriteLine("Compile and Execution time old Engine={0:0}+{1:0} ms, new Engine={2:0}+{3:0} ms",
+            Console.WriteLine("Compile and Execution time old Engine={0:0.0}+{1:0.0} ms, new Engine={2:0.0}+{3:0.0} ms",
                 oldEngineCompileAndExecutionTime.compileTime.TotalMilliseconds, oldEngineCompileAndExecutionTime.executionTime.TotalMilliseconds,
                 newEngineCompileAndExecutionTime.compileTime.TotalMilliseconds, newEngineCompileAndExecutionTime.executionTime.TotalMilliseconds);
             var execution = (Path.GetFileName(filePath),

--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Tests
     [TestFixture, Category("Performance")]
     public class PerformanceTests : DynamoModelTestBase
     {
-        private List<(string graph, TimeSpan oldEngineExecutionTime, TimeSpan newEngineCompileTime, TimeSpan newEngineExecutionTime)> executionData;
+        private List<(string graph, TimeSpan oldEngineCompileTime, TimeSpan oldEngineExecutionTime, TimeSpan newEngineCompileTime, TimeSpan newEngineExecutionTime)> executionData;
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -38,19 +38,20 @@ namespace Dynamo.Tests
         [TestFixtureSetUp]
         public void SetupPerformanceTests()
         {
-            executionData = new List<(string, TimeSpan, TimeSpan, TimeSpan)>();
+            executionData = new List<(string, TimeSpan, TimeSpan, TimeSpan, TimeSpan)>();
         }
 
         [TestFixtureTearDown]
         public void TeardownPerformanceTests()
         {
-            Console.WriteLine("{0,50}{1,11}{2,9}{3,9}{4,11}", "Graph", "Old C+E", "New C", "New E", "New C+E");
+            Console.WriteLine("{0,50}{1,9}{2,9}{3,11}{4,9}{5,9}{6,11}", "Graph", "Old C", "Old E", "Old C+E", "New C", "New E", "New C+E");
             executionData.ForEach(item =>
             {
-                var (graph, oldEngineCompileAndExecutionTime, newEngineCompileTime, newEngineExecutionTime) = item;
-                Console.WriteLine("{0,50}{1,11}{2,9}{3,9}{4,11}", graph,
-                    oldEngineCompileAndExecutionTime.Milliseconds, newEngineCompileTime.Milliseconds,
-                    newEngineExecutionTime.Milliseconds,
+                var (graph, oldEngineCompileTime, oldEngineExecutionTime, newEngineCompileTime, newEngineExecutionTime) = item;
+                Console.WriteLine("{0,50}{1,9}{2,9}{3,11}{4,9}{5,9}{6,11}", graph,
+                    oldEngineCompileTime.Milliseconds, oldEngineExecutionTime.Milliseconds,
+                    oldEngineCompileTime.Milliseconds + oldEngineExecutionTime.Milliseconds,
+                    newEngineCompileTime.Milliseconds, newEngineExecutionTime.Milliseconds,
                     newEngineCompileTime.Milliseconds + newEngineExecutionTime.Milliseconds);
             });
             executionData.Clear();
@@ -115,11 +116,11 @@ namespace Dynamo.Tests
 
             var newEngineCompileAndExecutionTime = model.EngineController.CompileAndExecutionTime;
 
-            Console.WriteLine("Compile and Execution time old Engine={0} ms, new Engine={1}+{2} ms",
-                oldEngineCompileAndExecutionTime.executionTime.Milliseconds,
-                newEngineCompileAndExecutionTime.compileTime.Milliseconds,
-                newEngineCompileAndExecutionTime.executionTime.Milliseconds);
-            var execution = (Path.GetFileName(filePath), oldEngineCompileAndExecutionTime.executionTime,
+            Console.WriteLine("Compile and Execution time old Engine={0}+{1} ms, new Engine={2}+{3} ms",
+                oldEngineCompileAndExecutionTime.compileTime.Milliseconds, oldEngineCompileAndExecutionTime.executionTime.Milliseconds,
+                newEngineCompileAndExecutionTime.compileTime.Milliseconds, newEngineCompileAndExecutionTime.executionTime.Milliseconds);
+            var execution = (Path.GetFileName(filePath),
+                oldEngineCompileAndExecutionTime.compileTime, oldEngineCompileAndExecutionTime.executionTime,
                 newEngineCompileAndExecutionTime.compileTime, newEngineCompileAndExecutionTime.executionTime);
             executionData.Add(execution);
         }


### PR DESCRIPTION
### Purpose

This pull request does:
* add a compile timer for old engine.
* change the execution timer for the old engine so it now only measures execution.
* format total ms

![image](https://user-images.githubusercontent.com/7033002/196711649-179719bd-c789-4d08-bcc6-32b815785e13.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
