### PR TITLE
Update Recent Files list on startup page based on MaxNumRecentFiles

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -839,6 +839,12 @@ namespace Dynamo.ViewModels
             {
                 model.PreferenceSettings.RecentFiles = this.RecentFiles.ToList();
             };
+
+            int maxNumRecentFiles = Model.PreferenceSettings.MaxNumRecentFiles;
+            if (RecentFiles.Count > maxNumRecentFiles)
+            {
+                RecentFiles.RemoveRange(maxNumRecentFiles, RecentFiles.Count - maxNumRecentFiles);
+            }
         }
 
         private void SubscribeLoggerHandlers()

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -839,12 +839,6 @@ namespace Dynamo.ViewModels
             {
                 model.PreferenceSettings.RecentFiles = this.RecentFiles.ToList();
             };
-
-            int maxNumRecentFiles = Model.PreferenceSettings.MaxNumRecentFiles;
-            if (RecentFiles.Count > maxNumRecentFiles)
-            {
-                RecentFiles.RemoveRange(maxNumRecentFiles, RecentFiles.Count - maxNumRecentFiles);
-            }
         }
 
         private void SubscribeLoggerHandlers()

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1280,6 +1280,7 @@ namespace Dynamo.ViewModels
                     goto default;
                 case nameof(MaxNumRecentFiles):
                     description = Resources.ResourceManager.GetString(nameof(Res.PreferencesSettingMaxRecentFiles), System.Globalization.CultureInfo.InvariantCulture);
+                    UpdateRecentFiles();
                     goto default;
                 case nameof(PythonTemplateFilePath):
                     description = Resources.ResourceManager.GetString(nameof(Res.PreferencesSettingCustomPythomTemplate), System.Globalization.CultureInfo.InvariantCulture);
@@ -1407,6 +1408,14 @@ namespace Dynamo.ViewModels
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
                 AddPythonEnginesOptions();
+            }
+        }
+
+        private void UpdateRecentFiles()
+        {
+            if (dynamoViewModel.RecentFiles.Count > MaxNumRecentFiles)
+            {
+                dynamoViewModel.RecentFiles.RemoveRange(MaxNumRecentFiles, dynamoViewModel.RecentFiles.Count - MaxNumRecentFiles);
             }
         }
     }


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5325

The Recent Files list should be updated on the startup page when the MaxNumRecentFiles is changed. 

This list will be modified accordingly when a new file is opened or when Dynamo is started. 
For the first case, we are already checking that here: https://github.com/DynamoDS/Dynamo/blob/master/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs#L1428.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Update Recent Files list on startup page based on MaxNumRecentFiles

### Reviewers
@QilongTang 

