### PR TITLE
use total milliseconds for perf tests

### DIFF
--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -49,9 +49,9 @@ namespace Dynamo.Tests
             {
                 var (graph, oldEngineCompileAndExecutionTime, newEngineCompileTime, newEngineExecutionTime) = item;
                 Console.WriteLine("{0,50}{1,11}{2,9}{3,9}{4,11}", graph,
-                    oldEngineCompileAndExecutionTime.Milliseconds, newEngineCompileTime.Milliseconds,
-                    newEngineExecutionTime.Milliseconds,
-                    newEngineCompileTime.Milliseconds + newEngineExecutionTime.Milliseconds);
+                    oldEngineCompileAndExecutionTime.TotalMilliseconds, newEngineCompileTime.TotalMilliseconds,
+                    newEngineExecutionTime.TotalMilliseconds,
+                    newEngineCompileTime.TotalMilliseconds + newEngineExecutionTime.TotalMilliseconds);
             });
             executionData.Clear();
         }


### PR DESCRIPTION
### Purpose

use total milliseconds when comparing test times.
https://stackoverflow.com/questions/5484382/c-sharp-timespan-milliseconds-vs-totalmilliseconds

new times
```
                                            Graph    Old C+E    New C    New E    New C+E
                              add_array_values.dyn   145.2112  41.0491  42.3286    83.3777
                            aniform-simplified.dyn 26849.9857   4.880626755.1098 26759.9904
                            array_ilist_coerce.dyn     2.9478   7.0244   0.7667     7.7911
                             array_list_coerce.dyn     1.1078   1.8727   0.9371     2.8098
                        color-geometry-minimal.dyn     9.2095   2.3023   1.3861     3.6884
                        cross_product_lacing_2.dyn   341.1342   2.9453 481.5793   484.5246
                   cross_product_lacing_arrays.dyn  5452.6258   2.94695727.1593  5730.1062
                          double_long_coercion.dyn     1.1217   2.0446   0.7497     2.7943
                              double_range_sum.dyn     0.9909   2.8981   1.4285     4.3266
               ienumerable_int_double_coercion.dyn     5.8833   8.8107   1.3749    10.1856
                      ilist_ienumerable_coerce.dyn    27.7416   1.3671   0.9867     2.3538
                    ilist_t_ienumerable_coerce.dyn     1.8548   2.1153   0.8629     2.9782
                 index_mixed_type_nested_array.dyn     2.1645   2.3331   1.3839      3.717
                               instance_method.dyn     2.9021   1.9513   1.0337      2.985
                 int_array_double_array_coerce.dyn     0.7907   1.7785   0.8808     2.6593
                        int_double_mixed_array.dyn      0.851   1.7972   0.6428       2.44
                           list_array_coercion.dyn     5.0269   2.5184   2.3543     4.8727
                     list_ienumerable_coercion.dyn     1.0654   2.0604    1.274     3.3344
                       longest_shortest_lacing.dyn     4.2138   2.9674    5.969     8.9364
                longest_shortest_lacing_arrays.dyn  4029.4316   2.81866010.1334   6012.952
                        long_double_just_works.dyn     1.0332    1.917   0.7785     2.6955
                 lotsofcoloredstuff-simplified.dyn 12445.1491   2.870412367.0001 12369.8705
                                     Operators.dyn    12.1527   4.0323   9.1574    13.1897
                                  point_sphere.dyn     1.0119   1.4018   1.4649     2.8667
                   replication_wrappers_reused.dyn     69.703 892.9202 112.7497  1005.6699
                                  simple_point.dyn     0.6819   1.1224   0.5016      1.624
```

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
