### PR TITLE
DYN-5332 : handle cli mode in release no console

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -104,6 +104,7 @@ namespace Dynamo.Applications
                 // and issue commands until the extension calls model.Shutdown().
                 bool keepAlive = false;
                 bool showHelp = false;
+                bool noConsoleCli = false;
 
                 // Disables all analytics (Google and ADP)
                 bool disableAnalytics = false;
@@ -131,6 +132,7 @@ namespace Dynamo.Applications
                 " - if you wish to import multiple dlls - use this flag multiple times: -i 'assembly1.dll' -i 'assembly2.dll' ", i => importPaths.Add(i))
                 .Add("gp=|GP=|geometrypath=|GeometryPath=", "relative or absolute path to a directory containing ASM. When supplied, instead of searching the hard disk for ASM, it will be loaded directly from this path.", gp => asmPath = gp)
                 .Add("k|K|keepalive", "Keepalive mode, leave the Dynamo process running until a loaded extension shuts it down.", k => keepAlive = k != null)
+                .Add("nc|NC|noconsolecli", "Don't rely on the console window to interact with CLI in Keepalive mode", nc => noConsoleCli = nc != null)
                 .Add("hn=|HN=|hostname", "Identify Dynamo variation associated with host", hn => hostname = hn)
                 .Add("si=|SI=|sessionId", "Identify Dynamo host analytics session id", si => sessionId = si)
                 .Add("pi=|PI=|parentId", "Identify Dynamo host analytics parent id", pi => parentId = pi)
@@ -159,6 +161,7 @@ namespace Dynamo.Applications
                     ImportedPaths = importPaths,
                     ASMPath = asmPath,
                     KeepAlive = keepAlive,
+                    NoConsoleCli = noConsoleCli,
                     DisableAnalytics = disableAnalytics,
                     AnalyticsInfo = new HostAnalyticsInfo() { HostName = hostname, ParentId = parentId, SessionId = sessionId },
                     CERLocation = cerLocation
@@ -180,6 +183,7 @@ namespace Dynamo.Applications
             public IEnumerable<String> ImportedPaths { get; set; }
             public string ASMPath { get; set; }
             public bool KeepAlive { get; set; }
+            public bool NoConsoleCli { get; set; }
             [Obsolete("This property will be removed in Dynamo 3.0 - please use AnalyticsInfo")]
             public string HostName { get; set; }
             public bool DisableAnalytics { get; set; }

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -8,6 +8,8 @@ namespace DynamoCLI
 {
     internal class Program
     {
+        private static EventWaitHandle suspendEvent = new AutoResetEvent(false);
+
         [STAThread]
         static internal void Main(string[] args)
         {
@@ -28,8 +30,12 @@ namespace DynamoCLI
                     thread.SetApartmentState(ApartmentState.STA);
                     thread.Start();
 
+#if DEBUG
                     Console.WriteLine("Starting DynamoCLI in keepalive mode");
                     Console.ReadLine();
+#else
+                    suspendEvent.WaitOne();
+#endif
 
                     ShutDown();
                 }
@@ -52,8 +58,10 @@ namespace DynamoCLI
                 {
                 }
 
+#if DEBUG
                 Console.WriteLine(e.Message);
                 Console.WriteLine(e.StackTrace);
+#endif
             }
         }
 
@@ -63,9 +71,11 @@ namespace DynamoCLI
             {
                 StartupDynamo(cmdLineArgs);
 
+#if DEBUG
                 Console.WriteLine("-----------------------------------------");
                 Console.WriteLine("DynamoCLI is running in keepalive mode");
                 Console.WriteLine("Press Enter to shutdown...");
+#endif
 
                 System.Windows.Threading.Dispatcher.Run();
             }

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -13,9 +13,12 @@ namespace DynamoCLI
         [STAThread]
         static internal void Main(string[] args)
         {
+            bool useConsole = true;
+            
             try
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
+                useConsole = !cmdLineArgs.NoConsoleCli;
                 var locale = StartupUtils.SetLocale(cmdLineArgs);
                 if (cmdLineArgs.DisableAnalytics)
                 {
@@ -30,12 +33,15 @@ namespace DynamoCLI
                     thread.SetApartmentState(ApartmentState.STA);
                     thread.Start();
 
-#if DEBUG
-                    Console.WriteLine("Starting DynamoCLI in keepalive mode");
-                    Console.ReadLine();
-#else
-                    suspendEvent.WaitOne();
-#endif
+                    if (!useConsole)
+                    {
+                        suspendEvent.WaitOne();
+                    }
+                    else
+                    {
+                        Console.WriteLine("Starting DynamoCLI in keepalive mode");
+                        Console.ReadLine();
+                    }
 
                     ShutDown();
                 }
@@ -58,10 +64,12 @@ namespace DynamoCLI
                 {
                 }
 
-#if DEBUG
-                Console.WriteLine(e.Message);
-                Console.WriteLine(e.StackTrace);
-#endif
+                if (useConsole)
+                {
+                    Console.WriteLine(e.Message);
+                    Console.WriteLine(e.StackTrace);
+                }
+
             }
         }
 
@@ -71,11 +79,12 @@ namespace DynamoCLI
             {
                 StartupDynamo(cmdLineArgs);
 
-#if DEBUG
-                Console.WriteLine("-----------------------------------------");
-                Console.WriteLine("DynamoCLI is running in keepalive mode");
-                Console.WriteLine("Press Enter to shutdown...");
-#endif
+                if (!cmdLineArgs.NoConsoleCli)
+                {
+                    Console.WriteLine("-----------------------------------------");
+                    Console.WriteLine("DynamoCLI is running in keepalive mode");
+                    Console.WriteLine("Press Enter to shutdown...");
+                }
 
                 System.Windows.Threading.Dispatcher.Run();
             }

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -17,10 +17,11 @@ namespace DynamoWPFCLI
         [STAThread]
         internal static void Main(string[] args)
         {
-
+            bool useConsole = true;
             try
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
+                useConsole = !cmdLineArgs.NoConsoleCli;
                 var locale = StartupUtils.SetLocale(cmdLineArgs);
 
                 if (cmdLineArgs.DisableAnalytics)
@@ -35,13 +36,16 @@ namespace DynamoWPFCLI
                     thread.Name = "DynamoModelKeepAlive";
                     thread.SetApartmentState(ApartmentState.STA);
                     thread.Start();
+                    if (!useConsole)
+                    {
+                        suspendEvent.WaitOne();
+                    }
+                    else
+                    {
+                        Console.WriteLine("Starting DynamoWPFCLI in keepalive mode");
+                        Console.ReadLine();
+                    }
 
-#if DEBUG
-                    Console.WriteLine("Starting DynamoWPFCLI in keepalive mode");
-                    Console.ReadLine();
-#else
-                    suspendEvent.WaitOne();
-#endif
                     ShutDown();
                 }
                 else
@@ -63,10 +67,11 @@ namespace DynamoWPFCLI
                 {
                 }
 
-#if DEBUG
-                Console.WriteLine(e.Message);
-                Console.WriteLine(e.StackTrace);
-#endif
+                if (useConsole)
+                {
+                    Console.WriteLine(e.Message);
+                    Console.WriteLine(e.StackTrace);
+                }
             }
         }
 
@@ -119,11 +124,12 @@ namespace DynamoWPFCLI
             {
                 StartupDaynamo(cmdLineArgs);
 
-#if DEBUG
-                Console.WriteLine("-----------------------------------------");
-                Console.WriteLine("DynamoWPFCLI is running in keepalive mode");
-                Console.WriteLine("Press Enter to shutdown...");
-#endif
+                if (!cmdLineArgs.NoConsoleCli)
+                {
+                    Console.WriteLine("-----------------------------------------");
+                    Console.WriteLine("DynamoWPFCLI is running in keepalive mode");
+                    Console.WriteLine("Press Enter to shutdown...");
+                }
 
                 Run();
             }

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -12,6 +12,8 @@ namespace DynamoWPFCLI
 {
     internal class Program
     {
+        private static EventWaitHandle suspendEvent = new AutoResetEvent(false);
+
         [STAThread]
         internal static void Main(string[] args)
         {
@@ -34,9 +36,12 @@ namespace DynamoWPFCLI
                     thread.SetApartmentState(ApartmentState.STA);
                     thread.Start();
 
+#if DEBUG
                     Console.WriteLine("Starting DynamoWPFCLI in keepalive mode");
                     Console.ReadLine();
-
+#else
+                    suspendEvent.WaitOne();
+#endif
                     ShutDown();
                 }
                 else
@@ -58,8 +63,10 @@ namespace DynamoWPFCLI
                 {
                 }
 
+#if DEBUG
                 Console.WriteLine(e.Message);
                 Console.WriteLine(e.StackTrace);
+#endif
             }
         }
 
@@ -112,9 +119,11 @@ namespace DynamoWPFCLI
             {
                 StartupDaynamo(cmdLineArgs);
 
+#if DEBUG
                 Console.WriteLine("-----------------------------------------");
                 Console.WriteLine("DynamoWPFCLI is running in keepalive mode");
                 Console.WriteLine("Press Enter to shutdown...");
+#endif
 
                 Run();
             }


### PR DESCRIPTION
### Purpose
Keep CLIs alive when there is no console available during run.

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@saintentropy @QilongTang 

