### PR TITLE
fix deserialization issue with null workspace refs

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -604,6 +604,11 @@ namespace Dynamo.Graph.Workspaces
             if (obj[NodeLibraryDependenciesPropString] != null)
             {
                 workspaceReferences = obj[NodeLibraryDependenciesPropString].ToObject<IEnumerable<INodeLibraryDependencyInfo>>(serializer);
+                //if deserialization failed, reset to empty.
+                if (workspaceReferences == null)
+                {
+                    workspaceReferences = new List<INodeLibraryDependencyInfo>();
+                }
             }
             else
             {

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -649,6 +649,27 @@ namespace Dynamo.Tests
         {
             CurrentDynamoModel.AddHomeWorkspace();
             Assert.DoesNotThrow(() => { CurrentDynamoModel.CurrentWorkspace.ToJson(null); });
+        }
+        [Test]
+        public void NullWorkspaceRefsDeserializedAsEmpty()
+        {
+
+            var testFile = Path.Combine(TestDirectory, @"core\serialization\nullWorkspaceRefs.dyn");
+            var json = File.ReadAllText(testFile);
+
+            Assert.DoesNotThrow(() =>
+            {
+               var ws =  WorkspaceModel.FromJson(
+                json, this.CurrentDynamoModel.LibraryServices,
+                null,
+                null,
+                this.CurrentDynamoModel.NodeFactory,
+                true,
+                true,
+                this.CurrentDynamoModel.CustomNodeManager);
+
+                Assert.NotNull(ws);
+            });
         }
 
         [Test]

--- a/test/core/serialization/nullWorkspaceRefs.dyn
+++ b/test/core/serialization/nullWorkspaceRefs.dyn
@@ -1,0 +1,61 @@
+{
+  "Uuid": "077eb433-543f-4cc7-bc2a-91fcaea5687e",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "broken",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": null,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.16",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.16.0.1926",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

reported here:
https://github.com/DynamoDS/DynamoRevit/issues/2869

no jira ticket, fixed with an extra null check and a test, I have no idea how this became null to begin with though.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix issue loading file if it contains null list of workspace references.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
