### PR TITLE
Rename Connector context menu item

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -475,7 +475,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Go to End Node.
+        ///   Looks up a localized string similar to Navigate Downstream.
         /// </summary>
         public static string ConnectorContextMenuHeaderEndNode {
             get {
@@ -520,7 +520,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Go to Start Node.
+        ///   Looks up a localized string similar to Navigate Upstream.
         /// </summary>
         public static string ConnectorContextMenuHeaderStartNode {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3281,10 +3281,10 @@ You can manage this in Preferences -&gt; Security.</value>
     <value>Show All Wires</value>
   </data>
   <data name="ConnectorContextMenuHeaderStartNode" xml:space="preserve">
-    <value>Go to Start Node</value>
+    <value>Navigate Upstream</value>
   </data>
   <data name="ConnectorContextMenuHeaderEndNode" xml:space="preserve">
-    <value>Go to End Node</value>
+    <value>Navigate Downtream</value>
   </data>
   <data name="ContextMenuNodeConnections" xml:space="preserve">
     <value>Node Connections</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3268,10 +3268,10 @@ You can manage this in Preferences -&gt; Security.</value>
     <value>Show All Wires</value>
   </data>
   <data name="ConnectorContextMenuHeaderStartNode" xml:space="preserve">
-    <value>Go to Start Node</value>
+    <value>Navigate Upstream</value>
   </data>
   <data name="ConnectorContextMenuHeaderEndNode" xml:space="preserve">
-    <value>Go to End Node</value>
+    <value>Navigate Downstream</value>
   </data>
   <data name="ContextMenuNodeConnections" xml:space="preserve">
     <value>Node Connections</value>


### PR DESCRIPTION
### Purpose

Follow up to https://github.com/DynamoDS/Dynamo/pull/13429, to rename the context menu items.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Rename Connector context menu item

### Reviewers
@QilongTang 

