### PR TITLE
Add ADP track events for splash screen operations

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -413,7 +413,8 @@ namespace Dynamo.Wpf.Views
             {
                 try
                 {
-                    if (viewModel.importSettings(openFileDialog.FileName))
+                    bool isImported = viewModel.importSettings(openFileDialog.FileName);
+                    if (isImported)
                     {
                         Wpf.Utilities.MessageBoxService.Show(
                             this, Res.ImportSettingsSuccessMessage, Res.ImportSettingsDialogTitle, MessageBoxButton.OK, MessageBoxImage.Information);
@@ -422,7 +423,8 @@ namespace Dynamo.Wpf.Views
                     {
                         Wpf.Utilities.MessageBoxService.Show(
                             this, Res.ImportSettingsFailedMessage, Res.ImportSettingsDialogTitle, MessageBoxButton.OK, MessageBoxImage.Exclamation);
-                    }                    
+                    }
+                    Analytics.TrackEvent(Actions.ImportSettings, Categories.Preferences, isImported.ToString());
                 }
                 catch (Exception ex)
                 {

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -140,9 +140,10 @@ namespace DynamoSandbox
         /// Import setting file from chosen path
         /// </summary>
         /// <param name="fileContent"></param>
-        private async void ImportSettings(string fileContent)
+        private void ImportSettings(string fileContent)
         {
-            if (viewModel.PreferencesViewModel.importSettingsContent(fileContent))
+            bool isImported = viewModel.PreferencesViewModel.importSettingsContent(fileContent);
+            if (isImported)
             {
                 splashScreen.SetImportStatus(ImportStatus.success, Resources.SplashScreenSettingsImported, string.Empty);
             }
@@ -150,6 +151,7 @@ namespace DynamoSandbox
             {
                 splashScreen.SetImportStatus(ImportStatus.error, Resources.SplashScreenFailedImportSettings, Resources.SplashScreenImportSettingsFailDescription);
             }
+            Analytics.TrackEvent(Actions.ImportSettings, Categories.SplashScreenOperations, isImported.ToString());
         }
 
         /// <summary>
@@ -159,14 +161,18 @@ namespace DynamoSandbox
         private bool SignIn()
         {
             authManager.Login();
-            return authManager.IsLoggedIn();
+            bool ret = authManager.IsLoggedIn();
+            Analytics.TrackEvent(Actions.SignIn, Categories.SplashScreenOperations, ret.ToString());
+            return ret;
         }
 
         //Returns true if the user was successfully logged out, else false.
         private bool SignOut()
         {
             authManager.Logout();
-            return !authManager.IsLoggedIn();
+            bool ret = !authManager.IsLoggedIn();
+            Analytics.TrackEvent(Actions.SignOut, Categories.SplashScreenOperations, ret.ToString());
+            return ret;
         }
 
         private void DynamoModel_RequestUpdateLoadBarStatus(SplashScreenLoadEventArgs args)

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Dynamo.Logging
 {
@@ -126,6 +126,11 @@ namespace Dynamo.Logging
         /// Events Category related to guided tours
         /// </summary>
         GuidedTourOperations,
+
+        /// <summary>
+        /// Events Category related to the splash screen
+        /// </summary>
+        SplashScreenOperations,
     }
 
     /// <summary>
@@ -409,6 +414,21 @@ namespace Dynamo.Logging
         /// TimeElapsed event, e.g. tracks the time elapsed since an event
         /// </summary>
         TimeElapsed,
+
+        /// <summary>
+        /// SignIn event, e.g. tracks the SignIn event
+        /// </summary>
+        SignIn,
+
+        /// <summary>
+        /// SignOut event, e.g. tracks the SignOut event
+        /// </summary>
+        SignOut,
+
+        /// <summary>
+        /// ImportSettings event, e.g. tracks the ImportSettings event
+        /// </summary>
+        ImportSettings
     }
 
     /// <summary>


### PR DESCRIPTION
### Purpose

Analytics.NET PR: https://git.autodesk.com/Dynamo/Analytics.NET/pull/60

Add ADP logs for the following actions:
- Sign In
- Sign Out
- Import Settings from Splash Screen
- Import Settings from Preferences
- Close Splash Screen (feature not yet implemented)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes




### Reviewers

@QilongTang 
