### PR TITLE
Save style on Enter key press and show full name for styles in tooltip

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -59,7 +59,11 @@
                                         HorizontalAlignment="Left"
                                         Grid.Row="0"
                                         Margin="5,0,0,0"
-                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                        Foreground="{StaticResource PreferencesWindowFontColor}">
+                                    <Label.ToolTip>
+                                        <ToolTip Content="{Binding Name}" Style="{StaticResource GenericToolTipLight}"/>
+                                    </Label.ToolTip>
+                                </Label>
                                 <StackPanel Orientation="Horizontal"
                                             HorizontalAlignment="Left"
                                             Width="auto"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -54,16 +54,18 @@
                                     <RowDefinition Height="*"></RowDefinition>
                                     <RowDefinition Height="*"></RowDefinition>
                                 </Grid.RowDefinitions>
-                                <Label Name="groupNameLabel"
-                                        Content="{Binding Name}"
+                                <TextBlock Name="groupNameLabel"
+                                        Text="{Binding Name}"
                                         HorizontalAlignment="Left"
                                         Grid.Row="0"
                                         Margin="5,0,0,0"
+                                        TextTrimming="CharacterEllipsis"
+                                        MaxWidth="140"
                                         Foreground="{StaticResource PreferencesWindowFontColor}">
-                                    <Label.ToolTip>
+                                    <TextBlock.ToolTip>
                                         <ToolTip Content="{Binding Name}" Style="{StaticResource GenericToolTipLight}"/>
-                                    </Label.ToolTip>
-                                </Label>
+                                    </TextBlock.ToolTip>
+                                </TextBlock>
                                 <StackPanel Orientation="Horizontal"
                                             HorizontalAlignment="Left"
                                             Width="auto"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -380,6 +380,10 @@ namespace Dynamo.Wpf.Views
             if (string.IsNullOrEmpty(groupNameBox.Text))
             {
                 viewModel.IsSaveButtonEnabled = false;
+                if (e.Key == Key.Return)
+                {
+                    viewModel.EnableGroupStyleWarningState(Res.PreferencesViewAlreadyExistingStyleWarning);
+                }
             }
             else
             {

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -386,6 +386,10 @@ namespace Dynamo.Wpf.Views
                 viewModel.IsSaveButtonEnabled = true;
                 viewModel.CurrentWarningMessage = string.Empty;
                 viewModel.IsWarningEnabled = false;
+                if (e.Key == Key.Return)
+                {
+                    AddStyle_SaveButton_Click(AddStyle_SaveButton, new RoutedEventArgs());
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -256,10 +256,10 @@ namespace Dynamo.Wpf.Views
            var grid = (removeButton.Parent as Grid).Parent as Grid;
 
             //Find inside the Grid the label that contains the GroupName (unique id)
-           var groupNameLabel = grid.FindName("groupNameLabel") as Label;
+           var groupNameLabel = grid.FindName("groupNameLabel") as TextBlock;
 
             //Remove the selected style from the list
-            viewModel.RemoveStyleEntry(groupNameLabel.Content.ToString());
+            viewModel.RemoveStyleEntry(groupNameLabel.Text.ToString());
             Logging.Analytics.TrackEvent(Actions.Delete, Categories.GroupStyleOperations, nameof(GroupStyleItem));
         }
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -240,7 +240,10 @@ namespace DynamoSandbox
         {
             splashScreen.SetLabels();
             LoadDynamoView();
-            splashScreen.webView.NavigationCompleted -= WebView_NavigationCompleted;
+            if (splashScreen.webView != null)
+            {
+                splashScreen.webView.NavigationCompleted -= WebView_NavigationCompleted;
+            }
         }
 
         private void ASMPreloadFailureHandler(string failureMessage)


### PR DESCRIPTION
### Purpose

[DYN-4664](https://jira.autodesk.com/browse/DYN-4664)  and [DYN-4663](https://jira.autodesk.com/browse/DYN-4663)

This PR:
- Enables the group style name to be saved when Enter key is pressed.
- Show full style name in tooltip.
- Included a small check to avoid crash in case when splash screen is skipped.

![Screen Shot 2022-11-03 at 5 09 10 PM](https://user-images.githubusercontent.com/32665108/199835259-1bc0344a-8142-4599-96a8-2973bdaba17b.png)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes




### Reviewers

@QilongTang 
@RobertGlobant20 
