### PR TITLE
fix intermittent issue loading icons (timing)

### DIFF
--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -104,7 +104,7 @@
         LIBPLACEHOLDER
     </script>
 
-<script>
+    <script>
         var replaceImageDelayTime = 100;
         var currentImage;
         let intervalId;

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -104,7 +104,7 @@
         LIBPLACEHOLDER
     </script>
 
-    <script>
+<script>
         var replaceImageDelayTime = 100;
         var currentImage;
         let intervalId;
@@ -140,7 +140,7 @@
             false
         );
 
-        function replaceImages() {
+    async function replaceImages() {
             var allimages = document.getElementsByTagName("img");
             for(var j = 0; j < allimages.length; j++){
 
@@ -155,19 +155,15 @@
                      continue;
                 }
                 //request the icon from the extension.
-                window.chrome.webview.hostObjects.bridgeTwoWay.GetBase64StringFromPath(src);
+                await window.chrome.webview.hostObjects.bridgeTwoWay.GetBase64StringFromPath(src).sync();
             }
         }
 
-        function completeReplaceImages(base64String, img_src) {
-            var images = document.getElementsByTagName('img');
-            for (var i = 0; i < images.length; ++i) {
-                if (images[i].src == img_src) {
-                    images[i].src = base64String;
-                }
-                    
-            }     
+    function completeReplaceImages(base64String, img_src) {
+        if (currentImage != null) {
+            currentImage.src = base64String;
         }
+    }
 
         function refreshLibViewFromData(loadedTypes,layoutSpec){
             var append = false; // Replace existing contents instead of appending.

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -214,6 +214,9 @@
             setTimeout(function () {
                 replaceImages();
             }, replaceImageDelayTime);
+            setTimeout(function () {
+                replaceImages();
+            }, replaceImageDelayTime*5);
         }, true);
 
         libController.on(libController.ItemMouseEnterEventName, function (arg) {


### PR DESCRIPTION
### Purpose

You can see that in the original MSWebBrowser version of the library extension - we use a single global `currentImage` which gets set to some base64 encoded string as images are loaded.
https://github.com/DynamoDS/Dynamo/blob/RC2.13.0_master/src/LibraryViewExtensionMSWebBrowser/web/library/library.html#L170

When we moved to WebView2 - there is no longer a simple synchronous invoke method - so the `completeReplaceImages` got changed to iterate all images and set them to a single base64 encoded string if they had not already been set to some base64 string value- that was previously requested by `ReplaceImages` . IMO this is not robust (it's also potentially slow) , as we have seen by intermittent failures on 3 machines. I believe it is very prone to timing issues. Kind of just luck of the draw.

This change moves to using the `sync` object proxy that webview2 provides and then awaits it, so the behavior is as before. Images now load for me.
![Screen Shot 2022-11-04 at 10 48 49 AM](https://user-images.githubusercontent.com/508936/200004332-21264c07-bf23-4cfc-a41d-0b9eabfd265f.png)

FYI @QilongTang @hwahlstrom 


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
