### PR TITLE
Saving SelectedPackagePathForInstall

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -981,6 +981,7 @@ namespace Dynamo.ViewModels
             dynamoViewModel.RenderPackageFactoryViewModel.ShowEdges = preferenceSettings.ShowEdges;
             PackagePathsForInstall = null;
             PackagePathsViewModel?.InitializeRootLocations();
+            SelectedPackagePathForInstall = preferenceSettings.SelectedPackagePathForInstall;
 
             dynamoViewModel.IsShowingConnectors = preferenceSettings.ShowConnector;
             dynamoViewModel.IsShowingConnectorTooltip = preferenceSettings.ShowConnectorToolTip;


### PR DESCRIPTION
### Purpose
Saving the SelectedPackagePathForInstall setting in memory just after importing as part of the story https://jira.autodesk.com/browse/DYN-5398 in order to display a proper message to the user.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang

### FYIs
@filipeotero @RobertGlobant20 

