### PR TITLE
AGD-2808 : add data folder option for cli

### DIFF
--- a/src/DynamoApplications/PathResolvers.cs
+++ b/src/DynamoApplications/PathResolvers.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Dynamo.Interfaces;
 
@@ -73,7 +73,7 @@ namespace Dynamo.Applications
         private readonly List<string> additionalNodeDirectories;
         private readonly List<string> preloadedLibraryPaths;
 
-        public CLIPathResolver(string preloaderLocation)
+        public CLIPathResolver(string preloaderLocation, string userDataFolder, string commonDataFolder)
         {
             // If a suitable preloader cannot be found on the system, then do 
             // not add invalid path into additional resolution. The default 
@@ -103,6 +103,8 @@ namespace Dynamo.Applications
                 "GeometryColor.dll"
             };
 
+            UserDataRootFolder = userDataFolder;
+            CommonDataRootFolder = commonDataFolder;
         }
 
         public IEnumerable<string> AdditionalResolutionPaths
@@ -120,14 +122,8 @@ namespace Dynamo.Applications
             get { return preloadedLibraryPaths; }
         }
 
-        public string UserDataRootFolder
-        {
-            get { return string.Empty; }
-        }
+        public string UserDataRootFolder { get; private set; }
 
-        public string CommonDataRootFolder
-        {
-            get { return string.Empty; }
-        }
+        public string CommonDataRootFolder { get; private set; }
     }
 }

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -262,7 +262,7 @@ namespace Dynamo.Applications
         public static DynamoModel MakeModel(bool CLImode, string asmPath = "", string hostName ="")
         {
             var isASMloaded = PreloadASM(asmPath, out string geometryFactoryPath, out string preloaderLocation);
-            var model = StartDynamoWithDefaultConfig(CLImode, "", "", geometryFactoryPath, preloaderLocation, new HostAnalyticsInfo() { HostName = hostName });
+            var model = StartDynamoWithDefaultConfig(CLImode, string.Empty, string.Empty, geometryFactoryPath, preloaderLocation, new HostAnalyticsInfo() { HostName = hostName });
             model.IsASMLoaded = isASMloaded;
             return model;
         }
@@ -279,7 +279,7 @@ namespace Dynamo.Applications
             // Preload ASM and display corresponding message on splash screen
             DynamoModel.OnRequestUpdateLoadBarStatus(new SplashScreenLoadEventArgs(Resources.SplashScreenPreLoadingAsm, 10));
             var isASMloaded = PreloadASM(asmPath, out string geometryFactoryPath, out string preloaderLocation);
-            var model = StartDynamoWithDefaultConfig(CLImode, "", "", geometryFactoryPath, preloaderLocation, info);
+            var model = StartDynamoWithDefaultConfig(CLImode, string.Empty, string.Empty, geometryFactoryPath, preloaderLocation, info);
             model.IsASMLoaded = isASMloaded;
             return model;
         }
@@ -295,7 +295,7 @@ namespace Dynamo.Applications
         public static DynamoModel MakeModel(bool CLImode, string asmPath)
         {
             var isASMloaded = PreloadASM(asmPath, out string geometryFactoryPath, out string preloaderLocation);
-            var model = StartDynamoWithDefaultConfig(CLImode, "", "", geometryFactoryPath, preloaderLocation);
+            var model = StartDynamoWithDefaultConfig(CLImode, string.Empty, string.Empty, geometryFactoryPath, preloaderLocation);
             model.IsASMLoaded = isASMloaded;
             return model;
         }
@@ -305,7 +305,7 @@ namespace Dynamo.Applications
         public static DynamoModel MakeModel(bool CLImode)
         {
             var isASMloaded = PreloadASM(string.Empty, out string geometryFactoryPath, out string preloaderLocation);
-            var model = StartDynamoWithDefaultConfig(CLImode, "", "", geometryFactoryPath, preloaderLocation);
+            var model = StartDynamoWithDefaultConfig(CLImode, string.Empty, string.Empty, geometryFactoryPath, preloaderLocation);
             model.IsASMLoaded = isASMloaded;
             return model;
         }

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -18,7 +18,7 @@ namespace DynamoCLI
             try
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
-                useConsole = !cmdLineArgs.NoConsoleCli;
+                useConsole = !cmdLineArgs.NoConsole;
                 var locale = StartupUtils.SetLocale(cmdLineArgs);
                 if (cmdLineArgs.DisableAnalytics)
                 {
@@ -79,7 +79,7 @@ namespace DynamoCLI
             {
                 StartupDynamo(cmdLineArgs);
 
-                if (!cmdLineArgs.NoConsoleCli)
+                if (!cmdLineArgs.NoConsole)
                 {
                     Console.WriteLine("-----------------------------------------");
                     Console.WriteLine("DynamoCLI is running in keepalive mode");
@@ -103,8 +103,8 @@ namespace DynamoCLI
         {
             DynamoModel model;
             model = Dynamo.Applications.StartupUtils.MakeCLIModel(String.IsNullOrEmpty(cmdLineArgs.ASMPath) ? string.Empty : cmdLineArgs.ASMPath,
-                cmdLineArgs.UserDataFolderCli,
-                cmdLineArgs.CommonDataFolderCli,
+                cmdLineArgs.UserDataFolder,
+                cmdLineArgs.CommonDataFolder,
                 cmdLineArgs.AnalyticsInfo);
 
             if (!string.IsNullOrEmpty(cmdLineArgs.CERLocation))

--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using Dynamo.Applications;
@@ -102,14 +102,10 @@ namespace DynamoCLI
         private static DynamoModel StartupDynamo(StartupUtils.CommandLineArguments cmdLineArgs)
         {
             DynamoModel model;
-            if (!String.IsNullOrEmpty(cmdLineArgs.ASMPath))
-            {
-                model = Dynamo.Applications.StartupUtils.MakeModel(true, cmdLineArgs.ASMPath, cmdLineArgs.AnalyticsInfo);
-            }
-            else
-            {
-                model = Dynamo.Applications.StartupUtils.MakeModel(true, string.Empty, cmdLineArgs.AnalyticsInfo);
-            }
+            model = Dynamo.Applications.StartupUtils.MakeCLIModel(String.IsNullOrEmpty(cmdLineArgs.ASMPath) ? string.Empty : cmdLineArgs.ASMPath,
+                cmdLineArgs.UserDataFolderCli,
+                cmdLineArgs.CommonDataFolderCli,
+                cmdLineArgs.AnalyticsInfo);
 
             if (!string.IsNullOrEmpty(cmdLineArgs.CERLocation))
             {

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -21,7 +21,7 @@ namespace DynamoWPFCLI
             try
             {
                 var cmdLineArgs = StartupUtils.CommandLineArguments.Parse(args);
-                useConsole = !cmdLineArgs.NoConsoleCli;
+                useConsole = !cmdLineArgs.NoConsole;
                 var locale = StartupUtils.SetLocale(cmdLineArgs);
 
                 if (cmdLineArgs.DisableAnalytics)
@@ -84,8 +84,8 @@ namespace DynamoWPFCLI
         {
             DynamoModel model;
             model = Dynamo.Applications.StartupUtils.MakeCLIModel(String.IsNullOrEmpty(cmdLineArgs.ASMPath) ? string.Empty : cmdLineArgs.ASMPath,
-                cmdLineArgs.UserDataFolderCli,
-                cmdLineArgs.CommonDataFolderCli,
+                cmdLineArgs.UserDataFolder,
+                cmdLineArgs.CommonDataFolder,
                 cmdLineArgs.AnalyticsInfo);
 
             if (!string.IsNullOrEmpty(cmdLineArgs.CERLocation))
@@ -120,7 +120,7 @@ namespace DynamoWPFCLI
             {
                 StartupDaynamo(cmdLineArgs);
 
-                if (!cmdLineArgs.NoConsoleCli)
+                if (!cmdLineArgs.NoConsole)
                 {
                     Console.WriteLine("-----------------------------------------");
                     Console.WriteLine("DynamoWPFCLI is running in keepalive mode");

--- a/src/DynamoWPFCLI/Program.cs
+++ b/src/DynamoWPFCLI/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using Dynamo.Applications;
@@ -83,14 +83,10 @@ namespace DynamoWPFCLI
         private static DynamoViewModel StartupDaynamo(StartupUtils.CommandLineArguments cmdLineArgs)
         {
             DynamoModel model;
-            if (!String.IsNullOrEmpty(cmdLineArgs.ASMPath))
-            {
-                model = Dynamo.Applications.StartupUtils.MakeModel(true, cmdLineArgs.ASMPath, cmdLineArgs.AnalyticsInfo);
-            }
-            else
-            {
-                model = Dynamo.Applications.StartupUtils.MakeModel(true, string.Empty, cmdLineArgs.AnalyticsInfo);
-            }
+            model = Dynamo.Applications.StartupUtils.MakeCLIModel(String.IsNullOrEmpty(cmdLineArgs.ASMPath) ? string.Empty : cmdLineArgs.ASMPath,
+                cmdLineArgs.UserDataFolderCli,
+                cmdLineArgs.CommonDataFolderCli,
+                cmdLineArgs.AnalyticsInfo);
 
             if (!string.IsNullOrEmpty(cmdLineArgs.CERLocation))
             {


### PR DESCRIPTION
### Purpose
Allow the DynamoCLI to work with specific userData and commonData folder.
We need more control over these locations for a few reasons :
- we want to be able to use a custom location ( in a way similar to the way D4R does it )
- for our usage ( in parallel with D4R ) we want to avoid using common packages location to avoid potential conflicts or execution mismatch when running the same graph in D4R.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@mjkkirschner @saintentropy @QilongTang 

