### PR TITLE
Remove red hover state from "Learn more" on agreement dialog box

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml
@@ -264,10 +264,8 @@
                            Margin="0 0 0 2"
                            VerticalAlignment="Bottom"
                            HorizontalAlignment="Stretch">
-                    <Hyperlink Click="OnLearnMoreClick">
-                        <TextBlock Name="LearnMore"
-                                   Foreground="#4790cd"
-                                   Text="{x:Static p:Resources.LearnMore}" />
+                    <Hyperlink Click="OnLearnMoreClick" Foreground="#4790cd">
+                        <TextBlock Name="LearnMore" Text="{x:Static p:Resources.LearnMore}" />
                     </Hyperlink>
                 </TextBlock>
 


### PR DESCRIPTION
### Purpose

Blue color applied to the whole text.
<img width="155" alt="Screen Shot 2022-11-08 at 4 34 59 PM" src="https://user-images.githubusercontent.com/32665108/200680568-575fefa1-1f6e-4ef5-91f9-c30cfa76b32b.png">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes




### Reviewers

@avidit 
