### PR TITLE
Sanitize preference settings values

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -858,6 +859,43 @@ namespace Dynamo.Configuration
             settings.DeserializeInternalPrefsContent(content);
 
             return settings;
+        }
+
+        /// <summary>
+        /// Return the predefined Font size values
+        /// </summary>
+        [XmlIgnore]
+        public ObservableCollection<int> PredefinedGroupStyleFontSizes
+        {
+            get
+            {
+                return new ObservableCollection<int>
+            {
+                14,
+                18,
+                24,
+                30,
+                36,
+                48,
+                60,
+                72,
+                96
+            };
+            }
+        }
+
+        /// <summary>
+        /// Checking for invalid values or tainted data and sanitize them
+        /// </summary>
+        internal void SanitizeValues()
+        {
+            foreach (var groupStyle in GroupStyleItemsList)
+            {
+                if (!PredefinedGroupStyleFontSizes.Contains(groupStyle.FontSize))
+                {
+                    groupStyle.FontSize = GroupStyleItem.DefaultGroupStyleItems.FirstOrDefault().FontSize;
+                }
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -994,24 +994,10 @@ namespace Dynamo.ViewModels
                 }
             }
 
-            SanitizeValues();
+            preferenceSettings.SanitizeValues();
             RaisePropertyChanged(string.Empty);
             return true;
-        }
-
-        /// <summary>
-        /// Checking for invalid values or tainted data and sanitize them
-        /// </summary>
-        internal void SanitizeValues()
-        {
-            foreach (var groupStyle in preferenceSettings.GroupStyleItemsList)
-            {
-                if (!GroupStyleFontSizeList.Contains(groupStyle.FontSize))
-                {
-                    groupStyle.FontSize = GroupStyleItem.DefaultGroupStyleItems.FirstOrDefault().FontSize;
-                }
-            }
-        }
+        }        
 
         /// <summary>
         /// The PreferencesViewModel constructor basically initialize all the ItemsSource for the corresponding ComboBox in the View (PreferencesView.xaml)
@@ -1047,18 +1033,7 @@ namespace Dynamo.ViewModels
             };
             SelectedFontSize = Wpf.Properties.Resources.ScalingMediumButton;
 
-            GroupStyleFontSizeList = new ObservableCollection<int>
-            {
-                14,
-                18,
-                24,
-                30,
-                36,
-                48,
-                60,
-                72,
-                96
-            };
+            GroupStyleFontSizeList = preferenceSettings.PredefinedGroupStyleFontSizes;
 
             // Number format settings
             NumberFormatList = new ObservableCollection<string>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -994,8 +994,23 @@ namespace Dynamo.ViewModels
                 }
             }
 
+            SanitizeValues();
             RaisePropertyChanged(string.Empty);
             return true;
+        }
+
+        /// <summary>
+        /// Checking for invalid values or tainted data and sanitize them
+        /// </summary>
+        internal void SanitizeValues()
+        {
+            foreach (var groupStyle in preferenceSettings.GroupStyleItemsList)
+            {
+                if (!GroupStyleFontSizeList.Contains(groupStyle.FontSize))
+                {
+                    groupStyle.FontSize = GroupStyleItem.DefaultGroupStyleItems.FirstOrDefault().FontSize;
+                }
+            }
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -413,5 +413,28 @@ namespace Dynamo.Tests.Configuration
             // checking the result            
             Assert.IsTrue(result == PreferenceSettings.AskForTrustedLocationResult.Ask, $"Conditions info: is opened file : {isOpenedFile} | is file in trusted location : {isFileInTrustedLocation} | is home space : {isHomeSpace} | is show Start page : {isShowStartPage} | is disable trust warnings : {isDisableTrustWarnings}");
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestSanitizeValues()
+        {
+            string settingDirectory = Path.Combine(TestDirectory, "settings");
+            string settingslFilePath = Path.Combine(settingDirectory, "DynamoSettings_Tainted_Values.xml");
+
+            var settings = PreferenceSettings.Load(settingslFilePath);
+            settings.SanitizeValues();
+
+            bool allTheGroupStylesHaveAValidFontSize = true;
+            foreach (var groupStyle in settings.GroupStyleItemsList)
+            {
+                if (!settings.PredefinedGroupStyleFontSizes.Contains(groupStyle.FontSize))
+                {
+                    allTheGroupStylesHaveAValidFontSize = false;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(allTheGroupStylesHaveAValidFontSize, $"All the GroupStyles have a valid Font size : {allTheGroupStylesHaveAValidFontSize}");
+        }
     }
 }

--- a/test/settings/DynamoSettings_Tainted_Values.xml
+++ b/test/settings/DynamoSettings_Tainted_Values.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<PreferenceSettings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <IsFirstRun>false</IsFirstRun>
+  <IsAnalyticsReportingApproved>true</IsAnalyticsReportingApproved>
+  <LibraryWidth>304</LibraryWidth>
+  <ConsoleHeight>0</ConsoleHeight>
+  <ShowPreviewBubbles>true</ShowPreviewBubbles>
+  <ShowCodeBlockLineNumber>true</ShowCodeBlockLineNumber>
+  <ShowConnector>true</ShowConnector>
+  <ShowConnectorToolTip>true</ShowConnectorToolTip>
+  <ConnectorType>BEZIER</ConnectorType>
+  <BackgroundPreviews>
+    <BackgroundPreviewActiveState>
+      <Name>IsBackgroundPreviewActive</Name>
+      <IsActive>true</IsActive>
+    </BackgroundPreviewActiveState>
+  </BackgroundPreviews>
+  <IsBackgroundGridVisible>true</IsBackgroundGridVisible>
+  <RenderPrecision>240</RenderPrecision>
+  <ShowEdges>true</ShowEdges>
+  <ShowDetailedLayout>true</ShowDetailedLayout>
+  <WindowX>0</WindowX>
+  <WindowY>0</WindowY>
+  <WindowW>1024</WindowW>
+  <WindowH>768</WindowH>
+  <UseHardwareAcceleration>true</UseHardwareAcceleration>
+  <NumberFormat>f3</NumberFormat>
+  <MaxNumRecentFiles>10</MaxNumRecentFiles>
+  <RecentFiles />
+  <BackupFiles>
+    <string>C:\Users\jesus.alvino\AppData\Roaming\Dynamo\Dynamo Core\backup\backup.DYN</string>
+  </BackupFiles>
+  <CustomPackageFolders>
+    <string>%BuiltInPackages%</string>
+    <string>C:\Users\jesus.alvino\AppData\Roaming\Dynamo\Dynamo Core\2.16</string>
+    <string>C:\ProgramData\Dynamo\Dynamo Core\2.16\packages</string>
+  </CustomPackageFolders>
+  <DisableTrustWarnings>true</DisableTrustWarnings>
+  <TrustedLocations>
+    <string>C:\ProgramData\Autodesk</string>
+    <string>C:\Program Files\Autodesk</string>
+	<string>C:\Autodesk</string>
+  </TrustedLocations>
+  <PackageDirectoriesToUninstall />
+  <PythonTemplateFilePath />
+  <BackupInterval>60000</BackupInterval>
+  <BackupFilesCount>1</BackupFilesCount>
+  <PackageDownloadTouAccepted>false</PackageDownloadTouAccepted>
+  <OpenFileInManualExecutionMode>false</OpenFileInManualExecutionMode>
+  <IsIronPythonDialogDisabled>false</IsIronPythonDialogDisabled>
+  <ShowTabsAndSpacesInScriptEditor>false</ShowTabsAndSpacesInScriptEditor>
+  <EnableNodeAutoComplete>false</EnableNodeAutoComplete>
+  <EnableNotificationCenter>false</EnableNotificationCenter>
+  <DefaultPythonEngine />
+  <SelectedPackagePathForInstall>C:\Users\jesus.alvino\AppData\Roaming\Dynamo\Dynamo Core\2.16</SelectedPackagePathForInstall>
+  <NamespacesToExcludeFromLibrary>
+    <string>ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline</string>
+  </NamespacesToExcludeFromLibrary>
+  <ViewExtensionSettings />
+  <DisableBuiltinPackages>false</DisableBuiltinPackages>
+  <DisableCustomPackageLocations>false</DisableCustomPackageLocations>
+  <DefaultRunType>Manual</DefaultRunType>
+  <ShowRunPreview>false</ShowRunPreview>
+  <GroupStyleItemsList>
+    <GroupStyleItem>
+      <Name>Actions</Name>
+      <HexColorString>B9F9E1</HexColorString>
+      <IsDefault>true</IsDefault>
+    </GroupStyleItem>
+    <GroupStyleItem>
+      <Name>Inputs</Name>
+      <HexColorString>FFB8D8</HexColorString>
+      <IsDefault>true</IsDefault>
+    </GroupStyleItem>
+    <GroupStyleItem>
+      <Name>Outputs</Name>
+      <HexColorString>FFC999</HexColorString>
+      <IsDefault>true</IsDefault>
+    </GroupStyleItem>
+    <GroupStyleItem>
+      <Name>Review</Name>
+      <HexColorString>A4E1FF</HexColorString>
+      <IsDefault>true</IsDefault>
+    </GroupStyleItem>
+    <GroupStyleItem>
+      <Name>style 5</Name>
+      <HexColorString>646D2D</HexColorString>
+      <IsDefault>false</IsDefault>
+	  <FontSize>-1</FontSize>
+    </GroupStyleItem>
+	<GroupStyleItem>
+      <Name>style 6</Name>
+      <HexColorString>FFC999</HexColorString>
+      <IsDefault>false</IsDefault>
+	  <FontSize>7</FontSize>
+    </GroupStyleItem>
+  </GroupStyleItemsList>
+  <NodeSearchTagSizeLimit>300</NodeSearchTagSizeLimit>
+  <IronPythonResolveTargetVersion>2.1.0</IronPythonResolveTargetVersion>
+</PreferenceSettings>


### PR DESCRIPTION
### Purpose

Sanitize the preference settings values according to the US https://jira.autodesk.com/browse/DYN-5400
### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang 

### FYIs
@RobertGlobant20
@filipeotero
