### PR TITLE
move to a single function with no globals

### DIFF
--- a/src/LibraryViewExtensionWebView2/ScriptingObject.cs
+++ b/src/LibraryViewExtensionWebView2/ScriptingObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,21 +24,21 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// Used to get access to the iconResourceProvider and return a base64encoded string version of an icon.
         /// </summary>
         /// <param name="iconurl"></param>
-        public async void GetBase64StringFromPath(string iconurl)
+        public string GetBase64StringFromPath(string iconurl)
         {
 
             string ext;
             var iconAsBase64 = controller.iconProvider.GetResourceAsString(iconurl, out ext);
             if (string.IsNullOrEmpty(iconAsBase64))
             {
-                await LibraryViewController.ExecuteScriptFunctionAsync(controller.browser, "completeReplaceImages", "","");
+                return "";
             }
             if (ext.Contains("svg"))
             {
                 ext = "svg+xml";
             }
             //send back result.
-            await LibraryViewController.ExecuteScriptFunctionAsync(controller.browser, "completeReplaceImages", $"data:image/{ext};base64, {iconAsBase64}", iconurl);
+            return $"data:image/{ext};base64, {iconAsBase64}";
         }
 
         /// <summary>

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -104,9 +104,8 @@
         LIBPLACEHOLDER
     </script>
 
-    <script>
+<script>
         var replaceImageDelayTime = 100;
-        var currentImage;
         let intervalId;
 
         // Disable the context menu
@@ -145,7 +144,7 @@
             for(var j = 0; j < allimages.length; j++){
 
                 var element = allimages[j];
-                currentImage = element;
+                let currentImage = element;
                 var src = element.src
                 if (element.orgSrc != null) {
                     src = element.orgSrc;
@@ -155,15 +154,12 @@
                      continue;
                 }
                 //request the icon from the extension.
-                await window.chrome.webview.hostObjects.bridgeTwoWay.GetBase64StringFromPath(src).sync();
+                var base64String = await window.chrome.webview.hostObjects.bridgeTwoWay.GetBase64StringFromPath(src);
+                if (currentImage != null) {
+                    currentImage.src = base64String;
+                }
             }
         }
-
-    function completeReplaceImages(base64String, img_src) {
-        if (currentImage != null) {
-            currentImage.src = base64String;
-        }
-    }
 
         function refreshLibViewFromData(loadedTypes,layoutSpec){
             var append = false; // Replace existing contents instead of appending.


### PR DESCRIPTION
### Purpose

continues trying to improve icon loading in librariejs - I think this is a good improvement,  we no longer split the method into two halves, and instead now we can use the new webView2 APIs to actually get return values from the c# functions - use this directly and avoid having globally scoped variables.


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
