### PR TITLE
DYN-5386: Switch CER feature flag from the old "CER" to "CER_v2"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ logo.png
 /src/DynamoCoreWpf/package-lock.json
 /src/DynamoCoreWpf/package.json
 /src/DynamoCoreWpf/.npm-cache
+/src/DynamoSandbox/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,3 @@ logo.png
 /src/DynamoCoreWpf/package-lock.json
 /src/DynamoCoreWpf/package.json
 /src/DynamoCoreWpf/.npm-cache
-/src/DynamoSandbox/node_modules

--- a/src/DynamoCore/Core/CrashPromptArgs.cs
+++ b/src/DynamoCore/Core/CrashPromptArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Dynamo.Core
@@ -125,12 +125,12 @@ namespace Dynamo.Core
         /// <summary>
         /// Allow Dynamo to send the log file to the CER system.
         /// </summary>
-        internal bool SendLogFile { get; set; } = false;
+        internal bool SendLogFile { get; set; } = true;
 
         /// <summary>
         /// Allow Dynamo to send the settings file to the CER system.
         /// </summary>
-        internal bool SendSettingsFile { get; set; } = false;
+        internal bool SendSettingsFile { get; set; } = true;
 
         /// <summary>
         /// Allow Dynamo to send the recorded commands file to the CER system.

--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -1,4 +1,4 @@
-﻿using Dynamo.Core;
+using Dynamo.Core;
 using Dynamo.Models;
 using Dynamo.ViewModels;
 using System;
@@ -163,7 +163,7 @@ namespace Dynamo.Wpf.Utilities
         /// <returns>True if the CER tool process was successfully started. False otherwise</returns>
         internal static bool ShowCrashErrorReportWindow(DynamoViewModel viewModel, CrashErrorReportArgs args)
         {
-            if (DynamoModel.FeatureFlags?.CheckFeatureFlag("CER", false) == false)
+            if (DynamoModel.FeatureFlags?.CheckFeatureFlag("CER_v2", false) == false)
             {
                 return false;
             }


### PR DESCRIPTION
### Purpose

This pull request does:
* change the feature flag for CER from CER to CER_v2
* default CER to send Dynamo log and settings files

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
