### PR TITLE
AGD-1983 : allow logs in cli mode

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -76,6 +76,7 @@ namespace Dynamo.Logging
         private WarningLevel _warningLevel;
         private bool _isDisposed;
         private readonly bool testMode;
+        private readonly bool cliMode;
 
         private TextWriter FileWriter { get; set; }
         private StringBuilder ConsoleWriter { get; set; }
@@ -195,6 +196,24 @@ namespace Dynamo.Logging
         }
 
         /// <summary>
+        /// Initializes a new instance of <see cref="DynamoLogger"/> class
+        /// with specified debug settings and directory where to write logs
+        /// </summary>
+        /// <param name="debugSettings">Debug settings</param>
+        /// <param name="logDirectory">Directory path where log file will be written</param>
+        /// <param name="isTestMode">Test mode is true or false.</param>
+        /// <param name="isCLIMode">CLI mode is true or false.</param>
+        public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean isTestMode, Boolean isCLIMode)
+            :this(debugSettings, logDirectory, isTestMode)
+        {
+            cliMode = isCLIMode;
+            if (cliMode)
+            {
+                StartLoggingToConsoleAndFile(logDirectory);
+            }
+        }
+
+        /// <summary>
         /// Logs the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
@@ -219,7 +238,7 @@ namespace Dynamo.Logging
                     Analytics.LogPiiInfo("LogMessage-" + level.ToString(), message);
 
                 // In test mode, write the logs only to std out. 
-                if (testMode)
+                if (testMode && !cliMode)
                 {
                     Console.WriteLine(string.Format("{0} : {1}", DateTime.UtcNow.ToString("u"), message));
                     return;
@@ -425,6 +444,11 @@ namespace Dynamo.Logging
         {
             lock (this.guardMutex)
             {
+                if (FileWriter != null && ConsoleWriter != null)
+                {
+                    return;
+                }
+
                 // We use a guid to uniquely identify the log name. This disambiguates log files
                 // so that parallel testing which needs to access the log files can be done, and
                 // so that services like Cloud Watch can match the dynamoLog_* pattern.

--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -202,7 +202,7 @@ namespace Dynamo.Logging
         /// <param name="debugSettings">Debug settings</param>
         /// <param name="logDirectory">Directory path where log file will be written</param>
         /// <param name="isTestMode">Test mode is true or false.</param>
-        /// <param name="isCLIMode">CLI mode is true or false.</param>
+        /// <param name="isCLIMode">We want to allow logging when CLI mode is true even if we are in test mode.</param>
         public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean isTestMode, Boolean isCLIMode)
             :this(debugSettings, logDirectory, isTestMode)
         {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -642,7 +642,7 @@ namespace Dynamo.Models
             IsHeadless = config.IsHeadless;
 
             DebugSettings = new DebugSettings();
-            Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory, IsTestMode);
+            Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory, IsTestMode, CLIMode);
 
             foreach (var exception in exceptions)
             {


### PR DESCRIPTION
### Purpose
We want to allow logging while in CLI mode as well. This is more important now because the CLI will be used by Generative Design.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### FYIs
@saintentropy 
