### PR TITLE
DYN-5326-Import-PreferencesSettings

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -203,6 +203,10 @@ namespace Dynamo.UI.Views
             // Stop the timer in any case
             loadingTimer.Stop();
             loadingTimer = null;
+
+            //When a xml preferences settings file is located at C:\ProgramData\Dynamo will be read and deserialized so the settings can be set correctly.
+            LoadPreferencesFileAtStartup();
+
             // If user is launching Dynamo for the first time or chose to always show splash screen, display it. Otherwise, display Dynamo view directly.
             if (viewModel.PreferenceSettings.IsFirstRun || viewModel.PreferenceSettings.EnableStaticSplashScreen)
             {

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -154,9 +154,6 @@ namespace DynamoSandbox
             splashScreen.DynamoView = new DynamoView(viewModel);
             splashScreen.OnRequestStaticSplashScreen();
 
-            //When a xml preferences settings file is located at C:\ProgramData\Dynamo will be read and deserialized so the settings can be set correctly.
-            splashScreen.LoadPreferencesFileAtStartup();
-
             splashScreen.DynamicSplashScreenReady -= LoadDynamoView;
             Analytics.TrackStartupTime("DynamoSandbox", TimeSpan.FromMilliseconds(splashScreen.totalLoadingTime));
         }

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -154,6 +154,9 @@ namespace DynamoSandbox
             splashScreen.DynamoView = new DynamoView(viewModel);
             splashScreen.OnRequestStaticSplashScreen();
 
+            //When a xml preferences settings file is located at C:\ProgramData\Dynamo will be read and deserialized so the settings can be set correctly.
+            splashScreen.LoadPreferencesFileAtStartup();
+
             splashScreen.DynamicSplashScreenReady -= LoadDynamoView;
             Analytics.TrackStartupTime("DynamoSandbox", TimeSpan.FromMilliseconds(splashScreen.totalLoadingTime));
         }


### PR DESCRIPTION
### Purpose

Load Preferences xml file located in the ProgramData/Dynamo path.
I added some code that at dynamo startup will check for xml configuration files in the next path: C:\ProgramData\Dynamo, if any xml file is found it will be deserialized, if deserialization is successful then load the settings (it will check for all the xml files in the location until one is deserialized successfully).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Load Preferences xml file located in the ProgramData/Dynamo path.


### Reviewers

@QilongTang 

### FYIs

@jesusalvino 
