### PR TITLE
fallback to DynamoModel.Hostname when reporting to CER

### DIFF
--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -238,11 +238,10 @@ namespace Dynamo.Wpf.Utilities
                     string appConfig = "";
                     if (model != null)
                     {
-                        var appName = string.IsNullOrEmpty(model.HostAnalyticsInfo.HostName) ? Process.GetCurrentProcess().ProcessName :
-                            model.HostAnalyticsInfo.HostName;
+                        var appName = GetHostAppName(model);
                         appConfig = $@"<ProductInformation name=\""{appName}\"" build_version=\""{model.Version}\"" " +
-                        $@"registry_version=\""{model.Version}\"" registry_localeID=\""{CultureInfo.CurrentCulture.LCID}\"" uptime=\""0\"" " +
-                        $@"session_start_count=\""0\"" session_clean_close_count=\""0\"" current_session_length=\""0\"" />";
+                                    $@"registry_version=\""{model.Version}\"" registry_localeID=\""{CultureInfo.CurrentCulture.LCID}\"" uptime=\""0\"" " +
+                                    $@"session_start_count=\""0\"" session_clean_close_count=\""0\"" current_session_length=\""0\"" />";
                     }
 
                     string dynConfig = string.Empty;
@@ -266,6 +265,23 @@ namespace Dynamo.Wpf.Utilities
                 model?.Logger?.LogError($"Failed to invoke CER with the following error : {ex.Message}");
             }
             return false;
+        }
+
+        internal static string GetHostAppName(DynamoModel model)
+        {
+            //default to app name being process name, but prefer HostAnalyticsInfo.HostName
+            //then legacy Model.HostName
+            var appName = Process.GetCurrentProcess().ProcessName;
+            if (!string.IsNullOrEmpty(model.HostAnalyticsInfo.HostName))
+            {
+                appName = model.HostAnalyticsInfo.HostName;
+            }
+            else if (!string.IsNullOrEmpty(model.HostName))
+            {
+                appName = model.HostName;
+            }
+
+            return appName;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/CrashReportingTests.cs
+++ b/test/DynamoCoreWpfTests/CrashReportingTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Threading;
+using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
@@ -190,6 +191,22 @@ namespace Dynamo.Tests
                 Assert.IsTrue(File.Exists(dumpLocation));
                 File.Delete(dumpLocation);//cleanup
             }
+        }
+        [Test]
+        public void TestAppNameSentToCER()
+        {
+            CurrentDynamoModel.HostName = null;
+            var name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
+            //if both hostname and hostinfo.hostname are null, then use proc name.
+            Assert.AreEqual("testhost.net48", name);
+            CurrentDynamoModel.HostName = "dynamotestmock";
+            name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
+            //use hostname over proc name
+            Assert.AreEqual(CurrentDynamoModel.HostName, name);
+            CurrentDynamoModel.HostAnalyticsInfo = new  HostAnalyticsInfo(){HostName = "123"};
+            name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
+            //prefer hostinfo.hostname over others.
+            Assert.AreEqual(CurrentDynamoModel.HostAnalyticsInfo.HostName, name);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/CrashReportingTests.cs
+++ b/test/DynamoCoreWpfTests/CrashReportingTests.cs
@@ -198,7 +198,7 @@ namespace Dynamo.Tests
             CurrentDynamoModel.HostName = null;
             var name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
             //if both hostname and hostinfo.hostname are null, then use proc name.
-            Assert.AreEqual("testhost.net48", name);
+            Assert.True(name.Contains("testhost") ||  name.Contains("nunit-agent"));
             CurrentDynamoModel.HostName = "dynamotestmock";
             name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
             //use hostname over proc name


### PR DESCRIPTION
### Purpose
fallback to the obsolete property `HostName` when reporting to CER as some hosts don't yet use `HostAnalyticsInfo` and it's preferable to use this host name rather than process name.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Use correct hostname when reporting crashes

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
