### PR TITLE
Add-ons section icon is not loading

### DIFF
--- a/src/LibraryViewExtensionWebView2/Handlers/IconResourceProvider.cs
+++ b/src/LibraryViewExtensionWebView2/Handlers/IconResourceProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -111,11 +111,12 @@ namespace Dynamo.LibraryViewExtensionWebView2.Handlers
 
             //before trying to create a uri we have to handle resources that might 
             //be embedded into the resources.dlls
-            //these paths will start with ./dist
-            if (url.StartsWith(@"./dist"))
+            //these paths will start with ./dist or http://localhost/dist
+            if (url.StartsWith(@"./dist") || url.StartsWith(@"http://localhost/dist"))
             {
+                var urlAbs = url;
                 //make relative url a full uri
-                var urlAbs = url.Replace(@"./dist", @"http://localhost/dist");
+                urlAbs = url.Replace(@"./dist", @"http://localhost/dist");
                 var ext = string.Empty;
                 var stream = embeddedDllResourceProvider.GetResource(urlAbs, out ext);
                 if (stream != null)

--- a/src/LibraryViewExtensionWebView2/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtensionWebView2/web/library/layoutSpecs.json
@@ -9,7 +9,7 @@
       "childElements": [
         {
           "text": "List",
-          "iconUrl": "./dist/resources/Category.List.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.List.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -297,7 +297,7 @@
         },
         {
           "text": "Dictionary",
-          "iconUrl": "./dist/resources/Category.Dictionary.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Dictionary.svg",
           "elementType": "category",
           "include": [
             {
@@ -329,7 +329,7 @@
         },
         {
           "text": "Input",
-          "iconUrl": "./dist/resources/Category.Input.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Input.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -527,7 +527,7 @@
         },
         {
           "text": "Math",
-          "iconUrl": "./dist/resources/Category.Math.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Math.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -655,7 +655,7 @@
             },
             {
               "text": "Operators",
-              "iconUrl": "./dist/resources/Category.Operators.svg",
+              "iconUrl": "http://localhost/dist/resources/Category.Operators.svg",
               "elementType": "group",
               "include": [
                 {
@@ -727,7 +727,7 @@
         },
         {
           "text": "Units",
-          "iconUrl": "./dist/resources/Category.Units.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Units.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -854,7 +854,7 @@
         },
         {
           "text": "Script",
-          "iconUrl": "./dist/resources/Category.Script.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Script.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -913,7 +913,7 @@
         },
         {
           "text": "Display",
-          "iconUrl": "./dist/resources/Category.Display.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Display.svg",
           "elementType": "category",
           "include": [
             {
@@ -1006,7 +1006,7 @@
         },
         {
           "text": "ImportExport",
-          "iconUrl": "./dist/resources/Category.ImportExport.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.ImportExport.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -1177,7 +1177,7 @@
         },
         {
           "text": "String",
-          "iconUrl": "./dist/resources/Category.String.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.String.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -1296,7 +1296,7 @@
         },
         {
           "text": "Geometry",
-          "iconUrl": "./dist/resources/Category.Geometry.svg",
+          "iconUrl": "http://localhost/dist/resources/Category.Geometry.svg",
           "elementType": "category",
           "include": [],
           "childElements": [
@@ -1519,19 +1519,19 @@
       ]
     },
     {
-      "text": "Add-ons",
-      "iconUrl": "./dist/resources/plus-symbol.svg",
-      "elementType": "section",
-      "showHeader": true,
-      "include": [
-        {
-          "path": "pkg://"
-        },
-        {
-          "path": "dyf://"
-        }
-      ],
-      "childElements": []
+        "text": "Add-ons",
+        "iconUrl": " http://localhost/dist/resources/plus-symbol.svg",
+        "elementType": "section",
+        "showHeader": true,
+        "include": [
+            {
+                "path": "pkg://"
+            },
+            {
+                "path": "dyf://"
+            }
+        ],
+        "childElements": []
     }
   ]
 }


### PR DESCRIPTION
### Purpose

I found that at somepoint, probably when switching to edge that we can no longer set `<img>` elements `.src` properties to invalid uris - the browser will set them to `""` at somepoint during the `OnError` callback so we can't cache the original source as we were doing before.

Instead I modified the layout spec to use a mock absolute uri and then handle that case.

Now the icon loads correctly.

I also modified the other icons from the dist folder that were set like this, but it seems that during the visual refresh the category icons are no longer visually seen - we should probably remove them from the binary since they are a waste of space, and remove them from the layout spec.
FYI @QilongTang.
![Screen Shot 2022-11-14 at 6 21 03 PM](https://user-images.githubusercontent.com/508936/201788950-b5586e04-9807-4680-9b36-e5399ca53f2b.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix addon section icon not loading.


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
