### PR TITLE
DYN-5235-NotificationsCenter-Localization Part2

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -131,6 +131,12 @@ namespace Dynamo.Notifications
         private void WebView_NavigationCompleted(object sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationCompletedEventArgs e)
         {
             AddNotifications(notificationsModel.Notifications);
+
+            string setTitle = String.Format("window.setTitle('{0}');", Properties.Resources.NotificationsCenterTitle);
+            InvokeJS(setTitle);
+
+            string setBottomButtonText = String.Format("window.setBottomButtonText('{0}');", Properties.Resources.NotificationsCenterBottomButtonText);
+            InvokeJS(setBottomButtonText);
         }
 
         private void AddNotifications(List<NotificationItemModel> notifications)

--- a/src/Notifications/Properties/Resources.Designer.cs
+++ b/src/Notifications/Properties/Resources.Designer.cs
@@ -122,5 +122,23 @@ namespace Dynamo.Notifications.Properties {
                 return ResourceManager.GetString("NotificationCenterDisabledMsg", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mark all as read.
+        /// </summary>
+        public static string NotificationsCenterBottomButtonText {
+            get {
+                return ResourceManager.GetString("NotificationsCenterBottomButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notifications.
+        /// </summary>
+        public static string NotificationsCenterTitle {
+            get {
+                return ResourceManager.GetString("NotificationsCenterTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Notifications/Properties/Resources.en-US.resx
+++ b/src/Notifications/Properties/Resources.en-US.resx
@@ -138,4 +138,10 @@
   <data name="NotificationCenterDisabledMsg" xml:space="preserve">
     <value>Notification Center feature is disabled. Enable it in preference panel to see latest news.</value>
   </data>
+  <data name="NotificationsCenterBottomButtonText" xml:space="preserve">
+    <value>Mark all as read</value>
+  </data>
+  <data name="NotificationsCenterTitle" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
 </root>

--- a/src/Notifications/Properties/Resources.resx
+++ b/src/Notifications/Properties/Resources.resx
@@ -138,4 +138,10 @@
   <data name="NotificationCenterDisabledMsg" xml:space="preserve">
     <value>Notification Center feature is disabled. Enable it in preference panel to see latest news.</value>
   </data>
+  <data name="NotificationsCenterBottomButtonText" xml:space="preserve">
+    <value>Mark all as read</value>
+  </data>
+  <data name="NotificationsCenterTitle" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

Notifications Center Localization Part2
Adding the call to the js methods that will send the localized string for the title and the button text in the Notifications Center.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Notifications Center Localization Part2


### Reviewers

@QilongTang 

### FYIs

