### PR TITLE
Fix InCanvas-search after interacting with a WebView2 component.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -738,6 +738,10 @@ namespace Dynamo.Views
             }
             else if (e.ChangedButton == MouseButton.Right && e.OriginalSource == zoomBorder)
             {
+                // Setting the focus back to workspace explicitly as the workspace-focus is lost after interacting with a WebView2 component.
+                this.Focusable = true;
+                this.Focus();
+
                 // open if workspace is right-clicked itself 
                 // (not node, note, not buttons from viewControlPanel such as zoom, pan and so on)
                 ContextMenuPopup.IsOpen = true;


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5410

After interacting a WebView2 component, the InCanvas search was not capturing the key press as the focus was lost. It would work after left-clicking on the workspace. So before the context menu is opened, we will set the focus to the workspace and after it is loaded, the focus is anyways set on the search bar.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Fix InCanvas-search after interacting with a WebView2 component.

### Reviewers
@QilongTang @RobertGlobant20 
