### PR TITLE
DYN-5437 Export image button shortcut

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -39,15 +39,15 @@ namespace Dynamo.UI.Controls
         /// Construct a ShortcutToolbar.
         /// </summary>
         /// <param name="updateManager"></param>
-        public ShortcutToolbar(IUpdateManager updateManager)
+        public ShortcutToolbar(DynamoViewModel dynamoViewModel)
         {
             shortcutBarItems = new ObservableCollection<ShortcutBarItem>();
             shortcutBarRightSideItems = new ObservableCollection<ShortcutBarItem>();    
 
             InitializeComponent();
-            UpdateControl.DataContext = updateManager;
+            UpdateControl.DataContext = dynamoViewModel.Model.UpdateManager;            
 
-            var shortcutToolbar = new ShortcutToolbarViewModel();
+            var shortcutToolbar = new ShortcutToolbarViewModel(dynamoViewModel);
             DataContext = shortcutToolbar;
         }
 
@@ -103,6 +103,11 @@ namespace Dynamo.UI.Controls
         {
             get { return shortcutToolTip; }
             set { shortcutToolTip = value; }
+        }
+
+        public void Test()
+        {
+
         }
     }
 

--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
@@ -104,11 +104,6 @@ namespace Dynamo.UI.Controls
             get { return shortcutToolTip; }
             set { shortcutToolTip = value; }
         }
-
-        public void Test()
-        {
-
-        }
     }
 
     internal partial class ImageExportShortcutBarItem : ShortcutBarItem

--- a/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
@@ -1,13 +1,16 @@
-﻿using Dynamo.ViewModels;
+using Dynamo.UI.Commands;
+using Dynamo.ViewModels;
+using System;
 using System.Windows;
 
 namespace Dynamo.Wpf.ViewModels.Core
 {
     internal class ShortcutToolbarViewModel : ViewModelBase
     {
-        public ShortcutToolbarViewModel()
+        public ShortcutToolbarViewModel(DynamoViewModel dynamoViewModel)
         {
             NotificationsNumber = 0;
+            ShowSaveImageDialogAndSaveResultCommand = new DelegateCommand(dynamoViewModel.ShowSaveImageDialogAndSaveResult);
         }
 
         private int notificationsNumber;
@@ -36,5 +39,11 @@ namespace Dynamo.Wpf.ViewModels.Core
                 return true;
             }
         }
+
+
+        /// <summary>
+        /// Exports an image from the user's 3D background or workpace
+        /// </summary>
+        public DelegateCommand ShowSaveImageDialogAndSaveResultCommand { get; set; }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -796,7 +796,7 @@ namespace Dynamo.Controls
 
         private void InitializeShortcutBar()
         {
-            shortcutBar = new ShortcutToolbar(this.dynamoViewModel.Model.UpdateManager) { Name = "ShortcutToolbar" };
+            shortcutBar = new ShortcutToolbar(this.dynamoViewModel) { Name = "ShortcutToolbar" };
 
             var newScriptButton = new ShortcutBarItem
             {


### PR DESCRIPTION
### Purpose

It's included in this PR the fix for the export image button.
The DelegateCommand is now in the ShortcutToolbarViewModel, making it possible to call the same method from the shortcut menu.

![exportImage](https://user-images.githubusercontent.com/89042471/203078142-04ff4cb6-c7f6-4b20-ba49-37093e2c734f.gif)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 @jesusalvino 
