### PR TITLE
Hiding the insert icon inside the Documentation Browser

### DIFF
--- a/src/DocumentationBrowserViewExtension/Docs/MarkdownStyling.html
+++ b/src/DocumentationBrowserViewExtension/Docs/MarkdownStyling.html
@@ -269,8 +269,8 @@
             border: 0;
             margin: -2px;
             text-decoration: none;
-            width: 24px;
-            height: 24px;
+            width: 20px;
+            height: 20px;
             background-position: center;
             opacity: 1;
         }
@@ -414,9 +414,9 @@
         .container .btn--container {
             position: absolute;
             border-radius: 10%;
-            top: 12px;
+            top: 10px;
             box-shadow: rgba(15, 15, 15, 0.1) 2px 2px 2px 2px, rgba(15, 15, 15, 0.1) -2px -2px 2px 2px;
-            right: 45px;
+            right: 10px;
         }
         .container .btn--insert--container {
             position: absolute;
@@ -424,6 +424,7 @@
             top: 12px;
             box-shadow: rgba(15, 15, 15, 0.1) 2px 2px 2px 2px, rgba(15, 15, 15, 0.1) -2px -2px 2px 2px;
             right: 12px;
+            visibility: collapse;
         }
     </style>
 </head>


### PR DESCRIPTION
### Purpose

For 2.17 hide the Insert button in the Documentation Browser until fully tested and example graphs have been added.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Hiding the insert icon inside the Documentation Browser.

### Reviewers

@reddyashish 

### FYIs

@QilongTang 
