### PR TITLE
Cherry-Pick  DYN-5388-SplashScreen-Revit (#13557)

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -191,7 +191,6 @@ namespace Dynamo.UI.Views
             DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             StaticSplashScreenReady -= OnStaticScreenReady;
             Close();
-            Application.Current.MainWindow = dynamoView;
             dynamoView.Show();
             dynamoView.Activate();
         }


### PR DESCRIPTION
### Purpose

Cherry-Pick https://github.com/DynamoDS/Dynamo/pull/13557

When Dynamo is opened from Revit it was crashing due that pplication.Current is null, so I removed the line, we already validated that the MainWindow is already set when reaching this line, then is not needed.


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Cherry-Pick https://github.com/DynamoDS/Dynamo/pull/13557


### Reviewers

@QilongTang 

### FYIs

@reddyashish 
