### PR TITLE
DYN-5426 Setting different font size when the height of the library is smaller

### DIFF
--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -9,8 +9,16 @@
     <!-- input::-ms-clear setting is to disable unnecessary close button of search bar -->
     <style>
 
-        html {
-            font-size: 14px !important;
+        @media (min-height: 551px) {
+            html {
+                font-size: 14px !important;
+            }
+        }
+
+        @media (max-height: 450px) {
+            html {
+                font-size: 8px !important;
+            }
         }
 
         body {

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -9,18 +9,6 @@
     <!-- input::-ms-clear setting is to disable unnecessary close button of search bar -->
     <style>
 
-        @media (min-height: 551px) {
-            html {
-                font-size: 14px !important;
-            }
-        }
-
-        @media (max-height: 450px) {
-            html {
-                font-size: 8px !important;
-            }
-        }
-
         body {
             padding: 0;
             margin: 0;
@@ -244,6 +232,10 @@
              window.chrome.webview.postMessage(JSON.stringify({"func":"logEventsToInstrumentation","data":["Filter-Categories",categories.join(",")]}));
         });
 
+
+        function setLibraryFontSize(fontSize) {
+            document.getElementsByTagName('html')[0].style.fontSize = fontSize + 'px';
+        }
 
         //This will find a specific div in the html and then it will apply the glow animation on it
         function highlightLibraryItem(itemName, enableHighlight) {


### PR DESCRIPTION
### Purpose

Sets the font size depending on the height of the library

**Scale at 350% and resolution 3840 x 2160**
![image (3)](https://user-images.githubusercontent.com/89042471/204564892-eb7b6069-a2f1-4eca-bb55-eee5968005ce.png)

**Scale at 150% and resolution 1920 x 1080**
![image](https://user-images.githubusercontent.com/89042471/204565708-fe76b8bc-6606-4254-9481-868077a030a1.png)

**Scale at 100% and resolution 1920 x 1080**
![image](https://user-images.githubusercontent.com/89042471/204565838-2466ccfc-6799-4d72-b203-a9aff6234493.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

### FYIs

@RobertGlobant20 
