### PR TITLE
Use IOAuth2AuthProvider interface for ML autocomplete authentication

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -382,19 +382,22 @@ namespace Dynamo.ViewModels
             MLNodeAutoCompletionResponse results = null;
             var authProvider = dynamoViewModel.Model.AuthenticationManager.AuthProvider;
 
-            if (authProvider is IOAuth2AuthProvider auth2AuthProvider)
+            if (authProvider is IOAuth2AuthProvider oauth2AuthProvider)
             {
                 try
                 {
-                    RestRequest restRequest = new RestRequest();
-                    RestClient restClient = new RestClient();
-                    auth2AuthProvider.SignRequest(ref restRequest, restClient);
+                    // TODO: We need to implement something like GetToken() on the IOAuth2AuthProvider interface which will be used by all auth providers.
+                    // For now, we are mocking the RestSharpRequest object to set the IDSDK token and then update the header in actual RestRequest with that token.
+                    // LoginRequest() is also not available on RevitOAuth2Provider, so using the SignRequest() which will show the sign-in page when the user is logged out.
+                    RestRequest restSharpRequest = new RestRequest();
+                    RestClient restSharpClient = new RestClient();
+                    oauth2AuthProvider.SignRequest(ref restSharpRequest, restSharpClient);
 
                     var uri = DynamoUtilities.PathHelper.getServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
                     var client = new RestClient(uri);
                     var request = new RestRequest(Method.POST);
 
-                    request.AddHeader("Authorization", restRequest.Parameters.FirstOrDefault(n => n.Name.Equals("Authorization")).Value.ToString());
+                    request.AddHeader("Authorization", restSharpRequest.Parameters.FirstOrDefault(n => n.Name.Equals("Authorization")).Value.ToString());
                     request = request.AddJsonBody(requestJSON) as RestRequest;
                     request.RequestFormat = DataFormat.Json;
                     RestResponse response = client.Execute(request) as RestResponse;


### PR DESCRIPTION
### Purpose

This PR is to use IOAuth2AuthProvider interface for ML autocomplete authentication, to support all integrators implementing that interface.

Note than, for now, we are using SignRequest method for now as the LoginRequest is not defined on the IOAuth2AuthProvider. This will show the sign in page on node-autocomplete, when the user is logged out. Ideally, we should have a GetToken method on the interface side which will give more control. I will look into those changes, which would need more testing and if time permits we can get those changes to 2.17.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Use IOAuth2AuthProvider interface for ML autocomplete authentication.

### Reviewers
@mjkkirschner @QilongTang 

