### PR TITLE
localize obsolete messages in protogeo

### DIFF
--- a/src/DynamoCore/Graph/Nodes/Attributes.cs
+++ b/src/DynamoCore/Graph/Nodes/Attributes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -210,20 +210,8 @@ namespace Dynamo.Graph.Nodes
         {
         }
 
-        public NodeObsoleteAttribute(string descriptionResourceID, Type resourceType)
+        public NodeObsoleteAttribute(string descriptionResourceID, Type resourceType):base(descriptionResourceID, resourceType)
         {
-            if (resourceType == null)
-                throw new ArgumentNullException("resourceType");
-
-            var prop = resourceType.GetProperty(descriptionResourceID, BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
-            if (prop != null && prop.PropertyType == typeof(String))
-            {
-                Message = (string)prop.GetValue(null, null);
-            }
-            else
-            {
-                Message = descriptionResourceID;
-            }
         }
     }
 

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -290,7 +290,7 @@ namespace Autodesk.DesignScript.Runtime
     /// <summary> 
     /// This attribute indicates the node is obsolete
     /// </summary> 
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method| AttributeTargets.Constructor | AttributeTargets.Property)]
     public class IsObsoleteAttribute : Attribute
     {
         public string Message { get; protected set; }

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -290,33 +290,49 @@ namespace Autodesk.DesignScript.Runtime
     /// <summary> 
     /// This attribute indicates the node is obsolete
     /// </summary> 
-    [AttributeUsage(AttributeTargets.Method)] 
-    public class IsObsoleteAttribute : Attribute 
-    { 
-        public string Message { get; protected set; } 
- 
-        public IsObsoleteAttribute() 
-        { 
-            Message = String.Empty; 
-        } 
- 
-        public IsObsoleteAttribute(string message) 
-        { 
-            Message = message; 
+    [AttributeUsage(AttributeTargets.Method)]
+    public class IsObsoleteAttribute : Attribute
+    {
+        public string Message { get; protected set; }
+
+        public IsObsoleteAttribute()
+        {
+            Message = String.Empty;
+        }
+
+        public IsObsoleteAttribute(string message)
+        {
+            Message = message;
         }
 
         /// <summary>
         /// Attribute constructor which enables localized message lookup.
         /// </summary>
         /// <param name="descriptionResourceID">resx id for this resource</param>
-        /// <param name="resourceType">type of resource assembly we are looking in for the above id.</param>
+        /// <param name="resourceType">type that contains resource strings.</param>
         /// <exception cref="ArgumentNullException"></exception>
         public IsObsoleteAttribute(string descriptionResourceID, Type resourceType)
+        {
+            LookupResourceByID(descriptionResourceID, resourceType);
+        }
+        /// <summary>
+        /// Attribute constructor which enables localized message lookup.
+        /// </summary>
+        /// <param name="descriptionResourceID">resx id for this resource</param>
+        /// <param name="typeName">name of type that contains resource strings.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public IsObsoleteAttribute(string descriptionResourceID, string typeName)
+        {
+            var type = Type.GetType(typeName);
+            LookupResourceByID(descriptionResourceID, type);
+        }
+        private void LookupResourceByID(string descriptionResourceID, Type resourceType)
         {
             if (resourceType == null)
                 throw new ArgumentNullException(nameof(resourceType));
 
-            var prop = resourceType.GetProperty(descriptionResourceID, BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+            var prop = resourceType.GetProperty(descriptionResourceID,
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
             if (prop != null && prop.PropertyType == typeof(string))
             {
                 Message = prop.GetValue(null, null) as string;
@@ -326,7 +342,7 @@ namespace Autodesk.DesignScript.Runtime
                 Message = descriptionResourceID;
             }
         }
-    } 
+    }
 
 
     /// <summary>

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -319,7 +319,10 @@ namespace Autodesk.DesignScript.Runtime
         /// Attribute constructor which enables localized message lookup.
         /// </summary>
         /// <param name="descriptionResourceID">resx id for this resource</param>
-        /// <param name="typeName">name of type that contains resource strings.</param>
+        /// <param name="typeName">name of type that contains resource strings.
+        /// !!!Please note that in some .net contexts you must use the fully assembly qualified type name
+        /// including version,culture info etc. In others only the type, assembly name are required.
+        ///  <see cref="Type.AssemblyQualifiedName"/> </param>
         /// <exception cref="ArgumentNullException"></exception>
         public IsObsoleteAttribute(string descriptionResourceID, string typeName)
         {

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections;
+using System.Reflection;
 
 namespace Autodesk.DesignScript.Runtime
 {
@@ -302,7 +303,29 @@ namespace Autodesk.DesignScript.Runtime
         public IsObsoleteAttribute(string message) 
         { 
             Message = message; 
-        } 
+        }
+
+        /// <summary>
+        /// Attribute constructor which enables localized message lookup.
+        /// </summary>
+        /// <param name="descriptionResourceID">resx id for this resource</param>
+        /// <param name="resourceType">type of resource assembly we are looking in for the above id.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public IsObsoleteAttribute(string descriptionResourceID, Type resourceType)
+        {
+            if (resourceType == null)
+                throw new ArgumentNullException(nameof(resourceType));
+
+            var prop = resourceType.GetProperty(descriptionResourceID, BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+            if (prop != null && prop.PropertyType == typeof(string))
+            {
+                Message = prop.GetValue(null, null) as string;
+            }
+            else
+            {
+                Message = descriptionResourceID;
+            }
+        }
     } 
 
 


### PR DESCRIPTION
### Purpose

[DYN-5249](https://jira.autodesk.com/browse/DYN-5249)

This PR adds localization capabilities into the base class of our custom obsolete attribute types. This way it can be used from LibG.

This PR must be merged and ideally generate a nuget package before we can merge the related LibG PR which localizes most obsolete node messages.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Improves API for localizing obsolete node messages


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
