### PR TITLE
DYN-5286-MLNodeAutocomplete Adding Analytics 

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -301,6 +301,11 @@ namespace Dynamo.UI.Controls
         private void ShowLowConfidenceResults(object sender, RoutedEventArgs e)
         {
             ViewModel.ShowLowConfidenceResults();
+            //Tracking Analytics when the Low Confidence combobox (located in the Autocomplete popup)  is clicked
+            Analytics.TrackEvent(
+                    Actions.ExpandConfidenceLevel,
+                    Categories.NodeAutoCompleteOperations,
+                    "LowConfidenceResults");
         }
 
         private void OnSuggestion_Click(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -303,7 +303,7 @@ namespace Dynamo.UI.Controls
             ViewModel.ShowLowConfidenceResults();
             //Tracking Analytics when the Low Confidence combobox (located in the Autocomplete popup)  is clicked
             Analytics.TrackEvent(
-                    Actions.ExpandConfidenceLevel,
+                    Actions.Expanded,
                     Categories.NodeAutoCompleteOperations,
                     "LowConfidenceResults");
         }

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
@@ -314,10 +315,12 @@ namespace Dynamo.UI.Controls
             if (selectedSuggestion.Name.Contains(nameof(Models.NodeAutocompleteSuggestion.MLRecommendation)))
             {
                 ViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = Models.NodeAutocompleteSuggestion.MLRecommendation;
+                Analytics.TrackEvent(Actions.Select, Categories.Preferences, nameof(NodeAutocompleteSuggestion.MLRecommendation));
             }
             else
             {
                 ViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = Models.NodeAutocompleteSuggestion.ObjectType;
+                Analytics.TrackEvent(Actions.Select, Categories.Preferences, nameof(NodeAutocompleteSuggestion.ObjectType));
             }
             ViewModel.PopulateAutoCompleteCandidates();
         }

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -860,11 +860,13 @@ namespace Dynamo.ViewModels
                 {
                     preferenceSettings.DefaultNodeAutocompleteSuggestion = NodeAutocompleteSuggestion.MLRecommendation;
                     nodeAutocompleteSuggestion = NodeAutocompleteSuggestion.MLRecommendation;
+                    Analytics.TrackEvent(Actions.Select,Categories.Preferences,nameof(NodeAutocompleteSuggestion.MLRecommendation));
                 }
                 else
                 {
                     preferenceSettings.DefaultNodeAutocompleteSuggestion = NodeAutocompleteSuggestion.ObjectType;
                     nodeAutocompleteSuggestion = NodeAutocompleteSuggestion.ObjectType;
+                    Analytics.TrackEvent(Actions.Select, Categories.Preferences, nameof(NodeAutocompleteSuggestion.ObjectType));
                 }
 
                 dynamoViewModel.HomeSpaceViewModel.NodeAutoCompleteSearchViewModel.ResetAutoCompleteSearchViewState();

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -11,6 +11,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.Properties;
 using Dynamo.Search.SearchElements;
@@ -476,17 +477,17 @@ namespace Dynamo.ViewModels
                 DisplayMachineLearningResults();
                 //Tracking Analytics when raising Node Autocomplete with the Recommended Nodes option selected (Machine Learning)
                 Analytics.TrackEvent(
-                    Actions.Select,
+                    Actions.Show,
                     Categories.NodeAutoCompleteOperations,
-                    "DisplayingMLRecommendations");
+                    nameof(NodeAutocompleteSuggestion.MLRecommendation));
             }
             else
             {
                 //Tracking Analytics when raising Node Autocomplete with the Object Types option selected.
                 Analytics.TrackEvent(
-                    Actions.Select,
+                    Actions.Show,
                     Categories.NodeAutoCompleteOperations,
-                    "DisplayingObjectTypeRecomendations");
+                    nameof(NodeAutocompleteSuggestion.ObjectType));
                 // Only call GetMatchingSearchElements() for object type match comparison
                 var objectTypeMatchingElements = GetMatchingSearchElements().ToList();
                 // If node match searchElements found, use default suggestions. 

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -267,6 +267,7 @@ namespace Dynamo.ViewModels
                 DisplayAutocompleteMLStaticPage = true;
                 AutocompleteMLTitle = Resources.LoginNeededTitle;
                 AutocompleteMLMessage = Resources.LoginNeededMessage;
+                Analytics.TrackEvent(Actions.View, Categories.NodeAutoCompleteOperations, "UnabletoFetch");
                 return;
             }
 
@@ -276,6 +277,7 @@ namespace Dynamo.ViewModels
                 DisplayAutocompleteMLStaticPage = true;
                 AutocompleteMLTitle = Resources.AutocompleteNoRecommendationsTitle;
                 AutocompleteMLMessage = Resources.AutocompleteNoRecommendationsMessage;
+                Analytics.TrackEvent(Actions.View, Categories.NodeAutoCompleteOperations, "NoRecommendation");
                 return;
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -476,7 +476,7 @@ namespace Dynamo.ViewModels
                 DisplayMachineLearningResults();
                 //Tracking Analytics when raising Node Autocomplete with the Recommended Nodes option selected (Machine Learning)
                 Analytics.TrackEvent(
-                    Actions.SelectMachineLearning,
+                    Actions.Select,
                     Categories.NodeAutoCompleteOperations,
                     "DisplayingMLRecommendations");
             }
@@ -484,7 +484,7 @@ namespace Dynamo.ViewModels
             {
                 //Tracking Analytics when raising Node Autocomplete with the Object Types option selected.
                 Analytics.TrackEvent(
-                    Actions.SelectObjectType,
+                    Actions.Select,
                     Categories.NodeAutoCompleteOperations,
                     "DisplayingObjectTypeRecomendations");
                 // Only call GetMatchingSearchElements() for object type match comparison

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -466,6 +466,9 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Key function to populate node autocomplete results to display
+        /// </summary>
         internal void PopulateAutoCompleteCandidates()
         {
             if (PortViewModel == null) return;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -10,6 +10,7 @@ using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Logging;
 using Dynamo.PackageManager;
 using Dynamo.Properties;
 using Dynamo.Search.SearchElements;
@@ -473,9 +474,19 @@ namespace Dynamo.ViewModels
             if (IsDisplayingMLRecommendation)
             {
                 DisplayMachineLearningResults();
+                //Tracking Analytics when raising Node Autocomplete with the Recommended Nodes option selected (Machine Learning)
+                Analytics.TrackEvent(
+                    Actions.SelectMachineLearning,
+                    Categories.NodeAutoCompleteOperations,
+                    "DisplayingMLRecommendations");
             }
             else
             {
+                //Tracking Analytics when raising Node Autocomplete with the Object Types option selected.
+                Analytics.TrackEvent(
+                    Actions.SelectObjectType,
+                    Categories.NodeAutoCompleteOperations,
+                    "DisplayingObjectTypeRecomendations");
                 // Only call GetMatchingSearchElements() for object type match comparison
                 var objectTypeMatchingElements = GetMatchingSearchElements().ToList();
                 // If node match searchElements found, use default suggestions. 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -467,7 +467,7 @@ namespace Dynamo.Wpf.Views
                         Wpf.Utilities.MessageBoxService.Show(
                             this, Res.ImportSettingsFailedMessage, Res.ImportSettingsDialogTitle, MessageBoxButton.OK, MessageBoxImage.Exclamation);
                     }
-                    Analytics.TrackEvent(Actions.ImportSettings, Categories.Preferences, isImported.ToString());
+                    Analytics.TrackEvent(Actions.Import, Categories.Preferences, isImported.ToString());
                 }
                 catch (Exception ex)
                 {
@@ -504,7 +504,7 @@ namespace Dynamo.Wpf.Views
                     File.Copy(dynViewModel.Model.PathManager.PreferenceFilePath, selectedPathFile);
                     string argument = "/select, \"" + selectedPathFile + "\"";
                     System.Diagnostics.Process.Start("explorer.exe", argument);
-                    Analytics.TrackEvent(Actions.ExportSettings, Categories.Preferences);
+                    Analytics.TrackEvent(Actions.Export, Categories.Preferences);
                 }
                 catch (Exception ex)
                 {
@@ -578,8 +578,8 @@ namespace Dynamo.Wpf.Views
             displayConfidenceLevel();
             //Tracking Analytics when changing the ML Confidence Level in the Preferences panel
             Analytics.TrackEvent(
-                    Actions.AdjustConfidenceLevel,
-                    Categories.NodeAutoCompleteOperations,
+                    Actions.Set,
+                    Categories.Preferences,
                     "ConfidendeLevel");
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -576,6 +576,11 @@ namespace Dynamo.Wpf.Views
         private void sliderConfidenceLevel_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             displayConfidenceLevel();
+            //Tracking Analytics when changing the ML Confidence Level in the Preferences panel
+            Analytics.TrackEvent(
+                    Actions.AdjustConfidenceLevel,
+                    Categories.NodeAutoCompleteOperations,
+                    "ConfidendeLevel");
         }
 
         private void displayConfidenceLevel()

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -155,7 +155,7 @@ namespace Dynamo.UI.Views
             {
                 SetImportStatus(ImportStatus.error);
             }
-            Analytics.TrackEvent(Actions.ImportSettings, Categories.SplashScreenOperations, isImported.ToString());
+            Analytics.TrackEvent(Actions.Import, Categories.SplashScreenOperations, isImported.ToString());
         }
 
         /// <summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -433,7 +433,27 @@ namespace Dynamo.Logging
         /// <summary>
         /// ExportSettings event, e.g. tracks the ExportSettings event
         /// </summary>
-        ExportSettings
+        ExportSettings,
+
+        /// <summary>
+        /// Ajusting the confidence level threshold in the Preferences panel
+        /// </summary>
+        AdjustConfidenceLevel,
+
+        /// <summary>
+        /// Click in the Low Confidence Level option will open the list of possible nodes
+        /// </summary>
+        ExpandConfidenceLevel,
+
+        /// <summary>
+        /// The user selected Object Type then it will affect the node autocomplete results
+        /// </summary>
+        SelectObjectType,
+
+        /// <summary>
+        /// The user selected Machine Learning then it will affect the node autocomplete results
+        /// </summary>
+        SelectMachineLearning
     }
 
     /// <summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -372,14 +372,17 @@ namespace Dynamo.Logging
         /// Hide event, e.g when a connection is hidden by user choice
         /// </summary>
         Hide,
+
         /// <summary>
         /// When a package conflict is encountered which involves at least one built-in package.
         /// </summary>
         BuiltInPackageConflict,
+
         /// <summary>
         /// Sort event, when user wants to sort some information
         /// </summary>
         Sort,
+
         /// <summary>
         /// View event, when user wants to see some information
         /// </summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -426,34 +426,14 @@ namespace Dynamo.Logging
         SignOut,
 
         /// <summary>
-        /// ImportSettings event, e.g. tracks the ImportSettings event
+        /// Import event, e.g. tracks the ImportSettings event
         /// </summary>
-        ImportSettings,
+        Import,
 
         /// <summary>
-        /// ExportSettings event, e.g. tracks the ExportSettings event
+        /// Export event, e.g. tracks the ExportSettings event
         /// </summary>
-        ExportSettings,
-
-        /// <summary>
-        /// Ajusting the confidence level threshold in the Preferences panel
-        /// </summary>
-        AdjustConfidenceLevel,
-
-        /// <summary>
-        /// Click in the Low Confidence Level option will open the list of possible nodes
-        /// </summary>
-        ExpandConfidenceLevel,
-
-        /// <summary>
-        /// The user selected Object Type then it will affect the node autocomplete results
-        /// </summary>
-        SelectObjectType,
-
-        /// <summary>
-        /// The user selected Machine Learning then it will affect the node autocomplete results
-        /// </summary>
-        SelectMachineLearning
+        Export
     }
 
     /// <summary>


### PR DESCRIPTION
### Purpose

Adding Analytics for ML Node Autocomplete
I added the code for TrackEvent in 4 places:
- NodeAutoCompleteSearchControl.xaml.cs - when clicking the Low Confidence combobox for displaying the list of nodes.
- NodeAutoCompleteSearchViewModel.cs - when the Node Autocomplete is raised using the Recommented nodes option or the Object Types option.
- PreferencesView.xaml.cs when the Slider Confidence Level is updated. And finally I've added additional Actions in IAnalyticsClient.cs
(I'm still missing local test)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Adding Analytics for ML Node Autocomplete


### Reviewers

@QilongTang 

### FYIs

@reddyashish 
