### PR TITLE
[Cherry-pick] Use IOAuth2AuthProvider interface for ML autocomplete authentication.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
@@ -15,6 +14,7 @@ using Dynamo.Properties;
 using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
 using Dynamo.Wpf.ViewModels;
+using Greg;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.Mirror;
@@ -382,31 +382,35 @@ namespace Dynamo.ViewModels
             MLNodeAutoCompletionResponse results = null;
             var authProvider = dynamoViewModel.Model.AuthenticationManager.AuthProvider;
 
-            if (authProvider is IDSDKManager manager)
+            if (authProvider is IOAuth2AuthProvider oauth2AuthProvider)
             {
-                var uri = DynamoUtilities.PathHelper.getServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
-                var client = new RestClient(uri);
-                var request = new RestRequest(Method.POST);
-
                 try
                 {
-                    manager.LoginRequest(ref request, client);
+                    // TODO: We need to implement something like GetToken() on the IOAuth2AuthProvider interface which will be used by all auth providers.
+                    // For now, we are mocking the RestSharpRequest object to set the IDSDK token and then update the header in actual RestRequest with that token.
+                    // LoginRequest() is also not available on RevitOAuth2Provider, so using the SignRequest() which will show the sign-in page when the user is logged out.
+                    RestRequest restSharpRequest = new RestRequest();
+                    RestClient restSharpClient = new RestClient();
+                    oauth2AuthProvider.SignRequest(ref restSharpRequest, restSharpClient);
+
+                    var uri = DynamoUtilities.PathHelper.getServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
+                    var client = new RestClient(uri);
+                    var request = new RestRequest(Method.POST);
+
+                    request.AddHeader("Authorization", restSharpRequest.Parameters.FirstOrDefault(n => n.Name.Equals("Authorization")).Value.ToString());
                     request = request.AddJsonBody(requestJSON) as RestRequest;
                     request.RequestFormat = DataFormat.Json;
                     RestResponse response = client.Execute(request) as RestResponse;
                     results = JsonConvert.DeserializeObject<MLNodeAutoCompletionResponse>(response.Content);
                 }
-                catch (Exception ex) {
+                catch (Exception ex)
+                {
                     dynamoViewModel.Model.Logger.Log(ex.Message);
                     throw new Exception("Authentication failed.");
                 }
+            }
 
-                return results;
-            }
-            else
-            {
-                throw new Exception("Failed to access IDSDK manager.");
-            }
+            return results;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Cherrypicking https://github.com/DynamoDS/Dynamo/pull/13579 into 2.17

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
[Cherry-pick] Use IOAuth2AuthProvider interface for ML autocomplete authentication …


### Reviewers
@QilongTang 

