### PR TITLE
Fix CustomNode view layout after it is saved.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2001,16 +2001,7 @@ namespace Dynamo.ViewModels
             try
             {
                 Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
-
-                // If the current workspace is a CustomNodeWorkspaceModel, then call the save method on it.
-                if (CurrentSpaceViewModel.Model is CustomNodeWorkspaceModel)
-                {
-                    CurrentSpaceViewModel.Model.Save(path, false, Model.EngineController);
-                }
-                else
-                {
-                    CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController, saveContext);
-                }
+                CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController, saveContext);
 
                 if (!isBackup) AddToRecentFiles(path);
             }
@@ -2339,7 +2330,8 @@ namespace Dynamo.ViewModels
                     _fileDialog.InitialDirectory = fi.DirectoryName;
                     _fileDialog.FileName = fi.Name;
                 }
-                else if (vm.Model.CurrentWorkspace is CustomNodeWorkspaceModel)
+
+                if (vm.Model.CurrentWorkspace is CustomNodeWorkspaceModel)
                 {
                     var pathManager = vm.model.PathManager;
                     _fileDialog.InitialDirectory = pathManager.DefaultUserDefinitions;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -20,7 +20,6 @@ using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Selection;
-using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.Wpf.ViewModels;
 using Dynamo.Wpf.ViewModels.Core;
@@ -610,6 +609,12 @@ namespace Dynamo.ViewModels
                 {
                     Model.FileName = filePath;
                     Model.OnSaved();
+                }
+
+                // If a new CustomNodeWorkspaceModel is created, store that info in CustomNodeManager without creating an instance of the custom node.
+                if (this.Model is CustomNodeWorkspaceModel customNodeWorkspaceModel)
+                {
+                    customNodeWorkspaceModel.SetInfo(Path.GetFileNameWithoutExtension(filePath));
                 }
             }
             catch (Exception ex)

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -1361,7 +1361,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void CustomNodeWorkspaceViewsTestAfterSaving()
+        public void CustomNodeWorkspaceViewTestAfterSaving()
         {
             ViewModel.Model.OpenFileFromPath(Path.Combine(TestDirectory, @"core\combine", "Sequence_Json.dyf"));
 

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -1,23 +1,23 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Dynamo.Graph;
+using Dynamo.Graph.Connectors;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
-using Dynamo.Search.SearchElements;
-using Dynamo.Wpf.ViewModels;
-
-using NUnit.Framework;
-using Dynamo.ViewModels;
-using Dynamo.Utilities;
-using CoreNodeModels.Input;
-using Dynamo.Graph.Connectors;
-using Dynamo.Graph.Nodes;
-using Dynamo.Wpf;
 using Dynamo.PackageManager;
+using Dynamo.Search.SearchElements;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using Dynamo.Wpf;
+using Dynamo.Wpf.ViewModels;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 
 namespace Dynamo.Tests
 {
@@ -1358,6 +1358,23 @@ namespace Dynamo.Tests
             Assert.AreEqual(oldNumPorts+1, nodeInstance.OutPorts.Count());
             Assert.IsTrue(nodeInstance.OutPorts.LastOrDefault().Name.StartsWith("anewoutput"));
 
+        }
+
+        [Test]
+        public void CustomNodeWorkspaceViewsTestAfterSaving()
+        {
+            ViewModel.Model.OpenFileFromPath(Path.Combine(TestDirectory, @"core\combine", "Sequence_Json.dyf"));
+
+            var newFilePath = GetNewFileNameOnTempPath("dyf");
+            ViewModel.SaveAs(newFilePath, SaveContext.SaveAs);
+
+            var oldJSON = File.ReadAllText(newFilePath);
+            var oldJObject = JObject.Parse(oldJSON);
+
+            var newJSON = File.ReadAllText(newFilePath);
+            var newJObject = JObject.Parse(newJSON);
+
+            Assert.AreEqual(oldJObject["View"], newJObject["View"]);
         }
         #endregion
     }


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5423. 

This PR is to fix the custom node layout by serializing the "Views" property when a new file is saved. This is done in the WorkspaceViewModel which will handle both the HomeWorkspaceModel and CustomNodeWorkspaceModel. 

![CN saving](https://user-images.githubusercontent.com/43763136/204782375-2b0a98e9-0aa6-486b-b5d6-f650244dde78.gif)

The previous check for CustomNodeWorkspaceModel is moved inside WorkspaceViewModel, where we will update the file path info in the custom node manager after a new custom node file is saved (related to the [PR](https://github.com/DynamoDS/Dynamo/pull/12687)).


### Declarations
Check these if you believe they are true
- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Fix CustomNode view layout after it is saved.

### Reviewers
@DynamoDS/dynamo 
