### PR TITLE
Fix startup crash and remove start tab on start-up page.

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.UI.Controls.StartPageView"
+<UserControl x:Class="Dynamo.UI.Controls.StartPageView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -32,46 +32,8 @@
 
         <!-- Begin top part (i.e. the "Start" tab) -->
         <Border HorizontalAlignment="Stretch" Background="#3C3C3C" Margin="220,-40,0,49"></Border>
-        
-        <Border Margin="218,-39,0,49"
-            HorizontalAlignment="Left"
-            Background="#2A2A2A"
-            BorderThickness="0,0,0,5"
-            BorderBrush="#ADE4DE">
-            <Grid Margin="10" Width="212">
-                <TextBlock Margin="3,2,0,-2"
-                           FontSize="16px"
-                           FontFamily="{StaticResource ArtifaktElementRegular}"
-                           Text="{x:Static p:Resources.StartPageStart}"
-                           Foreground="#EEEEEE"
-                           VerticalAlignment="Center" />
-                <Image Width="16px"
-                       Height="16px"
-                       Margin="0,1,0,0"
-                       HorizontalAlignment="Right"
-                       MouseLeftButtonUp="OnCloseStartPageClicked">
-                <Image.Style>
-                    <Style TargetType="{x:Type Image}">
-                        <Style.Triggers>
-                            <Trigger Property="IsMouseOver"
-                                     Value="False">
-                                <Setter Property="Source"
-                                        Value="/DynamoCoreWpf;component/UI/Images/closetab_normal.png" />
-                            </Trigger>
-                            <Trigger Property="IsMouseOver"
-                                     Value="True">
-                                <Setter Property="Source"
-                                        Value="/DynamoCoreWpf;component/UI/Images/closetab_hover.png" />
-                            </Trigger>
-                        </Style.Triggers>
-                    </Style>
-                </Image.Style>
-            </Image>
-            </Grid>
-        </Border>
-
+  
         <!-- Begin Dynamo logo -->
-
         <Image Name="StartPageLogo"
                Grid.Row="1"
                Width="250"
@@ -79,7 +41,6 @@
                HorizontalAlignment="Center"/>
 
         <!-- Begin inner grid control for all other list boxes -->
-
         <ScrollViewer HorizontalScrollBarVisibility="Hidden"
                       HorizontalAlignment="Stretch"
                       Grid.Row="2">
@@ -93,7 +54,6 @@
                 </Grid.ColumnDefinitions>
 
                 <!-- Left rows of list boxes -->
-
                 <StackPanel Name="leftPanel"
                             Grid.Column="0"
                             Orientation="Vertical">
@@ -130,8 +90,6 @@
                              SelectionChanged="OnItemSelectionChanged">
                     </ListBox>
 
-
-
                     <Border BorderThickness="0,0,0,1"
                             BorderBrush="#dfd8cf">
                         <TextBlock Text="{Binding Path=BackupTitle}"
@@ -154,19 +112,17 @@
                           HorizontalAlignment="Stretch">
 
                         <Label Grid.Column="0"
-                           Name ="backupLocation"
-                           FontFamily="{StaticResource ArtifaktElementRegular}"
-                           Margin="0,0,0,0"
-                           HorizontalAlignment="Right"
-                           Style="{StaticResource StartPageLabel}"
-                           Content="{x:Static p:Resources.StartPageBackupLocation}"
-                           MouseLeftButtonUp="ShowBackupFilesInFolder" />
+                               Name="backupLocation"
+                               FontFamily="{StaticResource ArtifaktElementRegular}"
+                               Margin="0,0,0,0"
+                               HorizontalAlignment="Right"
+                               Style="{StaticResource StartPageLabel}"
+                               Content="{x:Static p:Resources.StartPageBackupLocation}"
+                               MouseLeftButtonUp="ShowBackupFilesInFolder" />
                     </Grid>
-
                 </StackPanel>
 
                 <!-- Right rows of list boxes -->
-
                 <StackPanel Name="rightPanel"
                             Grid.Column="2"
                             Orientation="Vertical">
@@ -253,11 +209,8 @@
                            Style="{StaticResource StartPageLabel}"
                            Content="{x:Static p:Resources.StartPageShowSamples}"
                            MouseLeftButtonUp="ShowSamplesInFolder" />
-                    
                 </StackPanel>
-
             </Grid>
         </ScrollViewer>
-
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -482,13 +482,6 @@ namespace Dynamo.UI.Controls
             listBox.SelectedIndex = -1;
         }
 
-        private void OnCloseStartPageClicked(object sender, MouseButtonEventArgs e)
-        {
-            this.dynamoViewModel.ShowStartPage = false;
-        }
-
-        #endregion
-
         private void OnSampleFileSelected(object sender, RoutedEventArgs e)
         {
             var dp = e.OriginalSource as DependencyObject;
@@ -546,6 +539,7 @@ namespace Dynamo.UI.Controls
 
             }
         }
+        #endregion
     }
 
     public class SampleFileEntry

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -8353,15 +8353,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start.
-        /// </summary>
-        public static string StartPageStart {
-            get {
-                return ResourceManager.GetString("StartPageStart", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Video Tutorials.
         /// </summary>
         public static string StartPageVideoTutorials {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1975,9 +1975,6 @@ Want to publish a different package?</value>
   <data name="StartPageShowSamples" xml:space="preserve">
     <value>Show Samples In Folder</value>
   </data>
-  <data name="StartPageStart" xml:space="preserve">
-    <value>Start</value>
-  </data>
   <data name="StartPageVideoTutorials" xml:space="preserve">
     <value>Video Tutorials</value>
     <comment>Start page | Link to videos</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -836,9 +836,6 @@
   <data name="StartPageShowSamples" xml:space="preserve">
     <value>Show Samples In Folder</value>
   </data>
-  <data name="StartPageStart" xml:space="preserve">
-    <value>Start</value>
-  </data>
   <data name="StartPageVideoTutorials" xml:space="preserve">
     <value>Video Tutorials</value>
     <comment>Start page | Link to videos</comment>

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -293,7 +293,7 @@ namespace Dynamo.UI.Views
             var elapsedTime = loadingTimer.ElapsedMilliseconds;
             totalLoadingTime += elapsedTime;
             loadingTimer = Stopwatch.StartNew();
-            if (webView.CoreWebView2 != null)
+            if (webView != null && webView.CoreWebView2 != null)
             {
                 await webView.CoreWebView2.ExecuteScriptAsync($"window.setBarProperties(\"{version}\",\"{loadingDescription}\", \"{barSize}%\", \"{Wpf.Properties.Resources.SplashScreenLoadingTimeLabel}: {elapsedTime}ms\")");
             }

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -293,7 +293,7 @@ namespace Dynamo.UI.Views
             var elapsedTime = loadingTimer.ElapsedMilliseconds;
             totalLoadingTime += elapsedTime;
             loadingTimer = Stopwatch.StartNew();
-            if (webView != null && webView.CoreWebView2 != null)
+            if (webView?.CoreWebView2 != null)
             {
                 await webView.CoreWebView2.ExecuteScriptAsync($"window.setBarProperties(\"{version}\",\"{loadingDescription}\", \"{barSize}%\", \"{Wpf.Properties.Resources.SplashScreenLoadingTimeLabel}: {elapsedTime}ms\")");
             }
@@ -301,7 +301,7 @@ namespace Dynamo.UI.Views
 
         internal async void SetLoadingDone()
         {
-            if (webView.CoreWebView2 != null)
+            if (webView?.CoreWebView2 != null)
             {
                 await webView.CoreWebView2.ExecuteScriptAsync($"window.setLoadingDone()");
                 await webView.CoreWebView2.ExecuteScriptAsync($"window.setTotalLoadingTime(\"{Wpf.Properties.Resources.SplashScreenTotalLoadingTimeLabel} {totalLoadingTime}ms\")");
@@ -352,7 +352,7 @@ namespace Dynamo.UI.Views
         /// </summary>
         internal async void SetSignInStatus(bool status)
         {
-            if (webView.CoreWebView2 != null)
+            if (webView?.CoreWebView2 != null)
             {
                 await webView.CoreWebView2.ExecuteScriptAsync("window.setSignInStatus({" +
                 $"signInTitle: \"" + (status ? Wpf.Properties.Resources.SplashScreenSignOut : Wpf.Properties.Resources.SplashScreenSignIn).ToString() + "\"," +


### PR DESCRIPTION
### Purpose

This PR to fix a specific crash that can happen during splash-screen startup.

When you try to close Dynamo from the windows taskbar while the splash-screen is loading node libraries, it crashes because webView2 is not loaded yet.

![crash](https://user-images.githubusercontent.com/43763136/205327600-fa7d680f-9fc6-4e80-888c-cdab8ee62deb.gif)

Also removing the startup tab that is shown on the startup page. It is causing confusion as it opens the home when you click on the close button.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Fix startup crash and remove start tab on start-up page.

### Reviewers
@QilongTang @filipeotero 

