### PR TITLE
Splash screen should close as expected in DynamoRevit

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -37,7 +37,6 @@ using Dynamo.ViewModels;
 using Dynamo.Views;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Authentication;
-using Dynamo.Wpf.Controls;
 using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.UI.GuidedTour;
 using Dynamo.Wpf.Utilities;
@@ -1502,7 +1501,7 @@ namespace Dynamo.Controls
             newDialog.ShowDialog();
         }
 
-        private bool PerformShutdownSequenceOnViewModel()
+        internal bool PerformShutdownSequenceOnViewModel()
         {
             // Test cases that make use of views (e.g. recorded tests) have 
             // their own tear down logic as part of the test set-up (mainly 
@@ -1640,6 +1639,84 @@ namespace Dynamo.Controls
             this.Dispose();
             sharedViewExtensionLoadedParams?.Dispose();
         }
+
+        /*
+        internal void WindowClosed()
+        {
+            dynamoViewModel.Model.RequestLayoutUpdate -= vm_RequestLayoutUpdate;
+            dynamoViewModel.RequestViewOperation -= DynamoViewModelRequestViewOperation;
+
+            //PACKAGE MANAGER
+            dynamoViewModel.RequestPackagePublishDialog -= DynamoViewModelRequestRequestPackageManagerPublish;
+            dynamoViewModel.RequestPackageManagerSearchDialog -= DynamoViewModelRequestShowPackageManagerSearch;
+
+            //FUNCTION NAME PROMPT
+            dynamoViewModel.Model.RequestsFunctionNamePrompt -= DynamoViewModelRequestsFunctionNamePrompt;
+
+            //Preset Name Prompt
+            dynamoViewModel.Model.RequestPresetsNamePrompt -= DynamoViewModelRequestPresetNamePrompt;
+            dynamoViewModel.RequestPresetsWarningPrompt -= DynamoViewModelRequestPresetWarningPrompt;
+
+            dynamoViewModel.RequestClose -= DynamoViewModelRequestClose;
+            dynamoViewModel.RequestSaveImage -= DynamoViewModelRequestSaveImage;
+            dynamoViewModel.RequestSave3DImage -= DynamoViewModelRequestSave3DImage;
+
+            dynamoViewModel.SidebarClosed -= DynamoViewModelSidebarClosed;
+
+            DynamoSelection.Instance.Selection.CollectionChanged -= Selection_CollectionChanged;
+
+            dynamoViewModel.RequestUserSaveWorkflow -= DynamoViewModelRequestUserSaveWorkflow;
+            GuideFlowEvents.GuidedTourStart -= GuideFlowEvents_GuidedTourStart;
+
+            if (dynamoViewModel.Model != null)
+            {
+                dynamoViewModel.Model.RequestsCrashPrompt -= Controller_RequestsCrashPrompt;
+                dynamoViewModel.Model.RequestTaskDialog -= Controller_RequestTaskDialog;
+                dynamoViewModel.Model.ClipBoard.CollectionChanged -= ClipBoard_CollectionChanged;
+            }
+
+            //ABOUT WINDOW
+            dynamoViewModel.RequestAboutWindow -= DynamoViewModelRequestAboutWindow;
+
+            //first all view extensions have their shutdown methods called
+            //when this view is finally disposed, dispose will be called on them.
+            foreach (var ext in viewExtensionManager.ViewExtensions)
+            {
+                if (ext is ILogSource logSource)
+                {
+                    logSource.MessageLogged -= Log;
+                }
+
+                if (ext is INotificationSource notificationSource)
+                {
+                    notificationSource.NotificationLogged -= LogNotification;
+                }
+
+                try
+                {
+                    ext.Shutdown();
+                }
+                catch (Exception exc)
+                {
+                    Log($"{ext.Name} :  {exc.Message} during shutdown");
+                }
+            }
+
+
+            viewExtensionManager.MessageLogged -= Log;
+            BackgroundPreview = null;
+            background_grid.Children.Clear();
+
+            //COMMANDS
+            this.dynamoViewModel.RequestPaste -= OnRequestPaste;
+            this.dynamoViewModel.RequestReturnFocusToView -= OnRequestReturnFocusToView;
+            this.dynamoViewModel.Model.WorkspaceSaving -= OnWorkspaceSaving;
+            this.dynamoViewModel.Model.WorkspaceOpened -= OnWorkspaceOpened;
+            DynamoUtilities.DynamoFeatureFlagsManager.FlagsRetrieved -= CheckTestFlags;
+
+            this.Dispose();
+            sharedViewExtensionLoadedParams?.Dispose();
+        }*/
 
         // the key press event is being intercepted before it can get to
         // the active workspace. This code simply grabs the key presses and

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml
@@ -5,11 +5,9 @@
         Width="654"
         Height="452"
         WindowStartupLocation="CenterScreen"
-        WindowStyle="None"
-        AllowsTransparency="True"
+        Style="{DynamicResource DynamoWindowStyle}"
         Background="Transparent">
-
-    <Grid Margin="20" x:Name="ShadowGrid" Background="White">
+    <Grid x:Name="ShadowGrid" Background="White">
         <Grid.Effect>
             <DropShadowEffect BlurRadius="15" Direction="-90"
                               RenderingBias="Quality" ShadowDepth="2"/>

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -442,7 +442,19 @@ namespace Dynamo.UI.Views
                 Application.Current.Shutdown();
                 Analytics.TrackEvent(Actions.Close, Categories.SplashScreenOperations);
             }
+            else if (this is SplashScreen)
+            {
+                //dynamoView.Close();
+                //this.close();
+                dynamoView.PerformShutdownSequenceOnViewModel();
+            }
         }
+
+        /*
+        private void WindowClosing(object sender, CancelEventArgs e)
+        {
+            dynamoView.WindowClosed();
+        }*/
 
         protected override void OnClosed(EventArgs e)
         {


### PR DESCRIPTION
### Purpose

This is to address the splash screen closing issue in DynamoRevit.

All the following options I tried was disabling the Dynamo icon in DynamoRevit after the splash screen was closed. 
1) Closing the splash-screen window.
2) Closing Dynamo View.
3) Performing the shut down sequence on DynamoViewModel.
4) Unsubscribing all the events on DynamoViewModel that happen when you close the main Dynamo window. This would call all the dispose methods. 

I checked the processes and Dynamo is not running in the background. But I noticed that the OnApplicationIdle() on DynamoRevit is being called continuously.
https://github.com/DynamoDS/DynamoRevit/blob/master/src/DynamoRevit/DynamoRevitApp.cs#L221

Looking for suggestions.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@DynamoDS/dynamo


