### PR TITLE
DYN-4810_Dots in Preview Bubble and Watch sublists are rendered off-axis

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Controls.WatchTree"
+<UserControl x:Class="Dynamo.Controls.WatchTree"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:Dynamo.Controls"
@@ -163,12 +163,13 @@
                                     <!--  Vertical line  -->
 
                                     <Rectangle x:Name="VerLn"
-                                               Grid.RowSpan="2"
+                                               Grid.RowSpan="1"
                                                Width="1"
-                                               Margin="9,0,0,0"
+                                               Margin="9,0,0,3"
                                                HorizontalAlignment="Center"
                                                Fill="Black"
-                                               SnapsToDevicePixels="true"
+                                               SnapsToDevicePixels="True"
+                                               UseLayoutRounding="True"
                                                Stroke="#959595" />
 
                                     <!--  Draw Ellipse at the bottom of each vertical line  -->
@@ -176,11 +177,12 @@
                                     <Ellipse x:Name="LnEnd"
                                              Width="5"
                                              Height="5"
-                                             Margin="8,0,0,0"
+                                             Margin="9,0,0,0"
                                              HorizontalAlignment="Center"
                                              VerticalAlignment="Bottom"
                                              Fill="#959595"
                                              SnapsToDevicePixels="True"
+                                             UseLayoutRounding="True"
                                              Stroke="#959595" />
 
                                 </Grid>


### PR DESCRIPTION
### Purpose

This is a bug-fix to the [Dots in Preview Bubble and Watch sublists are rendered off-axis](https://jira.autodesk.com/browse/DYN-4810) issue. It fixes the misalignment of the dots in the sub-list node menu.

<img src="https://user-images.githubusercontent.com/5354594/205932758-accdf0ac-5ced-4863-b51f-c5caf9199989.png" width="400">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- fix to the misalignment of the sub-list dots


### Reviewers

@reddyashish 

### FYIs

@Amoursol 