### PR TITLE
Splash screen should close as expected for Revit and other integrators.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -703,8 +703,16 @@ namespace Dynamo.Models
             // or the feature flags client.
             if (!areAnalyticsDisabledFromConfig && !Dynamo.Logging.Analytics.DisableAnalytics)
             {
-                AnalyticsService.Start(this, IsHeadless, IsTestMode);
-
+                // Start the Analytics service only when a current session is not present.
+                // In an integrator host, as splash screen can be closed without shutting down the ViewModel, the analytics service is not stopped.
+                // So we don't want to start it when splash screen or dynamo window is launched again.
+                if (Analytics.client is DynamoAnalyticsClient dac)
+                {
+                    if (dac.Session == null)
+                    {
+                        AnalyticsService.Start(this, IsHeadless, IsTestMode);
+                    }
+                }
 
                 //run process startup/reading on another thread so we don't block dynamo startup.
                 //if we end up needing to control aspects of dynamo model or view startup that we can't make

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -703,10 +703,14 @@ namespace Dynamo.Models
             // or the feature flags client.
             if (!areAnalyticsDisabledFromConfig && !Dynamo.Logging.Analytics.DisableAnalytics)
             {
-                // Start the Analytics service only when a current session is not present.
+                // Start the Analytics service only when a session is not present.
                 // In an integrator host, as splash screen can be closed without shutting down the ViewModel, the analytics service is not stopped.
                 // So we don't want to start it when splash screen or dynamo window is launched again.
-                if (Analytics.client is DynamoAnalyticsClient dac)
+                if (Analytics.client == null)
+                {
+                    AnalyticsService.Start(this, IsHeadless, IsTestMode);
+                }
+                else if (Analytics.client is DynamoAnalyticsClient dac)
                 {
                     if (dac.Session == null)
                     {

--- a/src/DynamoCoreWpf/Services/UsageReportingManager.cs
+++ b/src/DynamoCoreWpf/Services/UsageReportingManager.cs
@@ -159,7 +159,8 @@ namespace Dynamo.Services
         {
             resourceProvider = resource;
             // First run of Dynamo
-            if (dynamoViewModel.Model.PreferenceSettings.IsFirstRun
+            if (dynamoViewModel != null
+                && dynamoViewModel.Model.PreferenceSettings.IsFirstRun
                 && !dynamoViewModel.HideReportOptions
                 && !Analytics.DisableAnalytics
                 && !DynamoModel.IsTestMode)

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -202,7 +202,6 @@ namespace Dynamo.UI.Views
         {
             // Stop the timer in any case
             loadingTimer.Stop();
-            loadingTimer = null;
 
             //When a xml preferences settings file is located at C:\ProgramData\Dynamo will be read and deserialized so the settings can be set correctly.
             LoadPreferencesFileAtStartup();
@@ -443,6 +442,12 @@ namespace Dynamo.UI.Views
             {
                 Application.Current.Shutdown();
                 Analytics.TrackEvent(Actions.Close, Categories.SplashScreenOperations);
+            }
+            else if (this is SplashScreen)
+            {
+                this.Close();
+                viewModel.Model.ShutDown(false);
+                DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -148,6 +148,7 @@ namespace Dynamo.UI.Views
         private void SplashScreenRequestClose(object sender, EventArgs e)
         {
             CloseWindow();
+            viewModel.RequestClose -= SplashScreenRequestClose;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -443,6 +443,9 @@ namespace Dynamo.UI.Views
                 Application.Current.Shutdown();
                 Analytics.TrackEvent(Actions.Close, Categories.SplashScreenOperations);
             }
+            // If Dynamo is launched from an integrator host, user should be able to close the splash screen window.
+            // Additionally, we will have to shutdown the ViewModel which will close all the services and dispose the events.
+            // RequestUpdateLoadBarStatus event needs to be unsubscribed when the splash screen window is closed, to avoid populating the info on splash screen.
             else if (this is SplashScreen)
             {
                 this.Close();

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -63,6 +63,8 @@ namespace Dynamo.UI.Views
             {
                 dynamoView = value;
                 viewModel = value.DataContext as DynamoViewModel;
+                // When view model is closed, we need to close the splash screen if it is displayed.
+                viewModel.RequestClose += SplashScreenRequestClose;
                 authManager = viewModel.Model.AuthenticationManager;
             }
         }
@@ -141,6 +143,14 @@ namespace Dynamo.UI.Views
         }
 
         /// <summary>
+        /// Request to close SplashScreen.
+        /// </summary>
+        private void SplashScreenRequestClose(object sender, EventArgs e)
+        {
+            CloseWindow();
+        }
+
+        /// <summary>
         /// Import setting file from chosen path
         /// </summary>
         /// <param name="fileContent"></param>
@@ -188,7 +198,6 @@ namespace Dynamo.UI.Views
         private void LaunchDynamo(bool isCheckboxChecked)
         {
             viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
-            DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             StaticSplashScreenReady -= OnStaticScreenReady;
             Close();
             dynamoView.Show();
@@ -450,7 +459,6 @@ namespace Dynamo.UI.Views
             {
                 this.Close();
                 viewModel.Model.ShutDown(false);
-                DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             }
         }
 
@@ -458,6 +466,7 @@ namespace Dynamo.UI.Views
         {
             base.OnClosed(e);
 
+            DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             webView.Dispose();
             webView = null;
 


### PR DESCRIPTION
### Purpose

Splash screen should close as expected for Revit and other integrators.

When the splash screen is closed, the model needs to be shutdown and the event to update the splash screen info needs to be unsubscribed. This was the missing part, as Analytics service needed to be closed when the splash screen is closed.

Relevant PR on the DynamoRevit repo: https://github.com/DynamoDS/DynamoRevit/pull/2886

![splash screen](https://user-images.githubusercontent.com/43763136/206177827-720146cf-582d-4cff-9f8b-7bb0a0ada4bb.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Splash screen should close as expected for Revit and other integrators.

### Reviewers
@QilongTang @mjkkirschner 

### FYIs
@DynamoDS/dynamo 
