### PR TITLE
[Cherry-pick] Splash screen should close as expected for Revit and other integrators

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -703,8 +703,20 @@ namespace Dynamo.Models
             // or the feature flags client.
             if (!areAnalyticsDisabledFromConfig && !Dynamo.Logging.Analytics.DisableAnalytics)
             {
-                AnalyticsService.Start(this, IsHeadless, IsTestMode);
-
+                // Start the Analytics service only when a session is not present.
+                // In an integrator host, as splash screen can be closed without shutting down the ViewModel, the analytics service is not stopped.
+                // So we don't want to start it when splash screen or dynamo window is launched again.
+                if (Analytics.client == null)
+                {
+                    AnalyticsService.Start(this, IsHeadless, IsTestMode);
+                }
+                else if (Analytics.client is DynamoAnalyticsClient dac)
+                {
+                    if (dac.Session == null)
+                    {
+                        AnalyticsService.Start(this, IsHeadless, IsTestMode);
+                    }
+                }
 
                 //run process startup/reading on another thread so we don't block dynamo startup.
                 //if we end up needing to control aspects of dynamo model or view startup that we can't make

--- a/src/DynamoCoreWpf/Services/UsageReportingManager.cs
+++ b/src/DynamoCoreWpf/Services/UsageReportingManager.cs
@@ -159,7 +159,8 @@ namespace Dynamo.Services
         {
             resourceProvider = resource;
             // First run of Dynamo
-            if (dynamoViewModel.Model.PreferenceSettings.IsFirstRun
+            if (dynamoViewModel != null
+                && dynamoViewModel.Model.PreferenceSettings.IsFirstRun
                 && !dynamoViewModel.HideReportOptions
                 && !Analytics.DisableAnalytics
                 && !DynamoModel.IsTestMode)

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -63,6 +63,8 @@ namespace Dynamo.UI.Views
             {
                 dynamoView = value;
                 viewModel = value.DataContext as DynamoViewModel;
+                // When view model is closed, we need to close the splash screen if it is displayed.
+                viewModel.RequestClose += SplashScreenRequestClose;
                 authManager = viewModel.Model.AuthenticationManager;
             }
         }
@@ -141,6 +143,15 @@ namespace Dynamo.UI.Views
         }
 
         /// <summary>
+        /// Request to close SplashScreen.
+        /// </summary>
+        private void SplashScreenRequestClose(object sender, EventArgs e)
+        {
+            CloseWindow();
+            viewModel.RequestClose -= SplashScreenRequestClose;
+        }
+
+        /// <summary>
         /// Import setting file from chosen path
         /// </summary>
         /// <param name="fileContent"></param>
@@ -188,7 +199,6 @@ namespace Dynamo.UI.Views
         private void LaunchDynamo(bool isCheckboxChecked)
         {
             viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
-            DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             StaticSplashScreenReady -= OnStaticScreenReady;
             Close();
             dynamoView.Show();
@@ -202,7 +212,6 @@ namespace Dynamo.UI.Views
         {
             // Stop the timer in any case
             loadingTimer.Stop();
-            loadingTimer = null;
 
             //When a xml preferences settings file is located at C:\ProgramData\Dynamo will be read and deserialized so the settings can be set correctly.
             LoadPreferencesFileAtStartup();
@@ -444,12 +453,21 @@ namespace Dynamo.UI.Views
                 Application.Current.Shutdown();
                 Analytics.TrackEvent(Actions.Close, Categories.SplashScreenOperations);
             }
+            // If Dynamo is launched from an integrator host, user should be able to close the splash screen window.
+            // Additionally, we will have to shutdown the ViewModel which will close all the services and dispose the events.
+            // RequestUpdateLoadBarStatus event needs to be unsubscribed when the splash screen window is closed, to avoid populating the info on splash screen.
+            else if (this is SplashScreen)
+            {
+                this.Close();
+                viewModel.Model.ShutDown(false);
+            }
         }
 
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);
 
+            DynamoModel.RequestUpdateLoadBarStatus -= DynamoModel_RequestUpdateLoadBarStatus;
             webView.Dispose();
             webView = null;
 


### PR DESCRIPTION
### Purpose

Cherrypicking https://github.com/DynamoDS/Dynamo/pull/13614 into 2.17

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Cherrypicking https://github.com/DynamoDS/Dynamo/pull/13614 into 2.17

### Reviewers
@QilongTang 
