### PR TITLE
DYN-4304-ContextMenu-Direction

### DIFF
--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System.Reflection;
+using System.Windows;
 using System.Windows.Controls.Primitives;
 
 namespace Dynamo.Notifications.View
@@ -17,6 +18,15 @@ namespace Dynamo.Notifications.View
             if (notificationsUIViewModel == null)
             {
                 notificationsUIViewModel = new NotificationsUIViewModel();
+            }
+
+            //When if the Windows Handedness parameter is set to Right-handed (True) then we need to set the _menuDropAlignment field to false otherwise the Notifications popup will be shown in a wrong Position
+            var ifLeft = SystemParameters.MenuDropAlignment;
+            if (ifLeft) //If MenuDropAlignment = Right-handed(True)
+            {
+                var t = typeof(SystemParameters);
+                var field = t.GetField("_menuDropAlignment", BindingFlags.NonPublic | BindingFlags.Static);
+                field.SetValue(null, false); //Set the field to Left-handed(false)
             }
 
             DataContext = notificationsUIViewModel;


### PR DESCRIPTION
### Purpose

Fixing Dynamo Popup Directions
When showing the NotificationsCenter popup and the Windows10 Handedness is Right-handed then the popup was shown in the wrong location then I implemented a fix that will be setting temporally the field _menuDropAlignment (this one modifies the Handedness) so in this way if the Handedness is Right-handed we will be setting this to Left-handed and the popup will be displayed in the right direction.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing Dynamo Popup Directions


### Reviewers
@QilongTang 


### FYIs

