### PR TITLE
Cherry pick 2.17: Don't throw if a package has dlls but no node libraries.

### DIFF
--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -692,15 +692,14 @@ namespace Dynamo.PackageManager
         /// </summary>
         /// <param name="packageDirectoryPath">path to package location</param>
         /// <param name="discoveredPkg">package object to check</param>
-        private static void CheckPackageNodeLibraryCertificates(string packageDirectoryPath, Package discoveredPkg)
+        private void CheckPackageNodeLibraryCertificates(string packageDirectoryPath, Package discoveredPkg)
         {
             var dllfiles = new System.IO.DirectoryInfo(discoveredPkg.BinaryDirectory).EnumerateFiles("*.dll");
             if (discoveredPkg.Header.node_libraries.Count() == 0 && dllfiles.Count() != 0)
             {
-                throw new LibraryLoadFailedException(packageDirectoryPath,
-                    String.Format(
-                        Resources.InvalidPackageNoNodeLibrariesDefinedInPackageJson,
-                        discoveredPkg.Name, discoveredPkg.RootDirectory));
+                Log(String.Format(
+                    String.Format(Resources.InvalidPackageNoNodeLibrariesDefinedInPackageJson,
+                    discoveredPkg.Name, discoveredPkg.RootDirectory)));
             }
 
             foreach (var nodeLibraryAssembly in discoveredPkg.Header.node_libraries)


### PR DESCRIPTION
### Purpose

* Cherry pick from master. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixes an issue where a notification is shown if a package has no node libraries in a protected location

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
