### PR TITLE
don't require file extension for files to be copied

### DIFF
--- a/src/Libraries/CoreNodes/FileSystem.cs
+++ b/src/Libraries/CoreNodes/FileSystem.cs
@@ -110,7 +110,7 @@ namespace DSCore.IO
         {
             try
             {
-                if (Path.GetDirectoryName(destinationPath) != string.Empty && FileExtension(destinationPath) != string.Empty) 
+                if (Path.GetDirectoryName(destinationPath) != string.Empty) 
                 {
                     file.CopyTo(destinationPath, overwrite);
                 }


### PR DESCRIPTION
### Purpose


change was made here to require file paths, I'm not sure why. https://github.com/DynamoDS/Dynamo/pull/11798/
@QilongTang can you take a look too see if removing this check is ok?

see an issue here https://github.com/DynamoDS/Dynamo/issues/13617

I think the use case is definitely valid, many files don't have an extension.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
