### PR TITLE
Adding Unit Test for Search Node

### DIFF
--- a/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
@@ -355,13 +355,13 @@ namespace ViewExtensionLibraryTests
             SearchResultDataProvider searchResultDataProvider = new SearchResultDataProvider(nodeSearchModel, iconProvider);
 
             var extension = string.Empty;
-            var searchStream = searchResultDataProvider.GetResource("Code Block", out extension);
+            var searchResultStream = searchResultDataProvider.GetResource(nodeName, out extension);
 
-            var data = GetLoadedTypesFromJson(searchStream);
-            List<LoadedTypeItem> types = data.loadedTypes;
+            var searchResult = GetLoadedTypesFromJson(searchResultStream);
+            List<LoadedTypeItem> nodesResult = searchResult.loadedTypes;
 
-            Assert.AreEqual(types.Count, 1);
-            Assert.AreEqual(expectedQualifiedName, types[0].fullyQualifiedName);
+            Assert.AreEqual(nodesResult.Count, 1);
+            Assert.AreEqual(expectedQualifiedName, nodesResult[0].fullyQualifiedName);
         }
 
         private LoadedTypeData<LoadedTypeItem> GetLoadedTypesFromJson(Stream stream)


### PR DESCRIPTION
### Purpose
Adding a unit test for THE Search node feature https://jira.autodesk.com/browse/DYN-3910

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@mjkkirschner @reddyashish 

### FYIs
@QilongTang @RobertGlobant20 @filipeotero
