### PR TITLE
AGD-2857 : cache adp analytics optin

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -55,6 +55,8 @@ namespace Dynamo.Configuration
         private bool isNotificationCenterEnabled;
         private bool isStaticSplashScreenEnabled;
         private bool isCreatedFromValidFile = true;
+        private bool isADPChecked = false;
+        private bool isADPOptedIn = false;
 
         #region Constants
         /// <summary>
@@ -115,7 +117,16 @@ namespace Dynamo.Configuration
         [Obsolete("Setter is obsolete - ADP consent should not be set directly, it should be set using the consent dialog.")]
         public bool IsADPAnalyticsReportingApproved
         {
-            get { return Logging.AnalyticsService.IsADPOptedIn; }
+            get
+            {
+                if (!isADPChecked)
+                {
+                    isADPChecked = true;
+                    isADPOptedIn = AnalyticsService.IsADPOptedIn;
+                }
+
+                return isADPOptedIn;
+            }
             set { throw new Exception("do not use"); }
         }
         #endregion

--- a/src/DynamoCore/Logging/AnalyticsService.cs
+++ b/src/DynamoCore/Logging/AnalyticsService.cs
@@ -1,4 +1,4 @@
-﻿using Dynamo.Graph.Workspaces;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Autodesk.Analytics.ADP;
 using Autodesk.Analytics.Core;
@@ -66,7 +66,7 @@ namespace Dynamo.Logging
                 {
                     return false;
                 }
-                return adpAnalyticsUI.IsOptedIn(150,200);
+                return adpAnalyticsUI.IsOptedIn(5,500);
             }
             
             set


### PR DESCRIPTION
### Purpose
Avoid hang or long startup times when there are issues with ADP connection.
The number of retries in Analytics.NET IsOptedIn. is too high and it takes a failed call 30s to conclude.
In my case the return code was 11 but there could be other codes as well.
On Dynamo startup there is a high number of track event calls which can easily add up to a lot of time.
I believe this is the reason for other reports that we have with Dynamo or Player starting slowly when startup sequence takes too long.
Imho one quick possible solution for this release R2024 is to interrogate once per session for IsOptedIn value and cache it. Also limit the number of retries and overall isOpt check should not tale longer than 3s or other value.
While this will prevent the analytics behavior to be changed during the same session I think we can live with that.
This is somewhat already happening when you are set to false since trackers are only registered on startup if set to true.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs
