### PR TITLE
read scientific notation

### DIFF
--- a/src/Libraries/DSOffice/OpenXmlHelper.cs
+++ b/src/Libraries/DSOffice/OpenXmlHelper.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
-using ProtoCore.AST.AssociativeAST;
 
 namespace DSOffice
 {

--- a/src/Libraries/DSOffice/OpenXmlHelper.cs
+++ b/src/Libraries/DSOffice/OpenXmlHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using ProtoCore.AST.AssociativeAST;
 
 namespace DSOffice
 {
@@ -345,7 +346,7 @@ namespace DSOffice
                     else
                     {
                         // This is a number
-                        if (cell.CellValue.TryGetDouble(out var value))
+                        if (double.TryParse(cell.InnerText, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out var value))
                         {
                             if (readAsString)
                             {


### PR DESCRIPTION
### Purpose

The purpose of this PR is to fix scientific notation values that are read from Excel files.

![image](https://user-images.githubusercontent.com/89042471/212760745-16e56a3f-d626-4dd0-b9ce-1ba992a90ebf.png)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 
