### PR TITLE
DYN-4308 Input and output port menu Y location

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -350,11 +350,9 @@ namespace Dynamo.ViewModels
             // The actual zoom here is confusing
             // What matters is the zoom factor measured from the scaled : unscaled node size
             var zoom = node.WorkspaceViewModel.Zoom;
-            var zoomFactor = targetSize.Height / node.ActualHeight;
 
             double x;
             var scaledWidth = autocompletePopupSpacing * targetSize.Width / node.ActualWidth;
-            var scaledHeight = targetSize.Height / node.ActualHeight;
 
             if (PortModel.PortType == PortType.Input)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -347,7 +347,10 @@ namespace Dynamo.ViewModels
 
         private CustomPopupPlacement[] PlacePortContextMenu(Size popupSize, Size targetSize, Point offset)
         {
+            // The actual zoom here is confusing
+            // What matters is the zoom factor measured from the scaled : unscaled node size
             var zoom = node.WorkspaceViewModel.Zoom;
+            var zoomFactor = targetSize.Height / node.ActualHeight;
 
             double x;
             var scaledWidth = autocompletePopupSpacing * targetSize.Width / node.ActualWidth;
@@ -363,10 +366,15 @@ namespace Dynamo.ViewModels
                 // Offset popup to the right by node width and spacing from left edge of node.
                 x = scaledWidth + targetSize.Width;
             }
-            // Offset popup down from the upper edge of the node by the node header and corresponding to the respective port.
-            // Scale the absolute heights by the target height (passed to the callback) and the actual height of the node.
-            var absoluteHeight = NodeModel.HeaderHeight + PortModel.Index * PortModel.Height;
-            var y = absoluteHeight * scaledHeight;
+            // Important - while zooming in and out, Node elements are scaled, while popup is not
+            // Calculate absolute popup halfheight to deduct from the overal y pos
+            // Then add the header, port height and port index position
+            var popupHeightOffset = - popupSize.Height * 0.5;
+            var headerHeightOffset = 2 * NodeModel.HeaderHeight * zoom;
+            var portHalfHeight = PortModel.Height * 0.5 * zoom;
+            var rowOffset = PortModel.Index * (1.5 * PortModel.Height) * zoom;
+
+            var y = popupHeightOffset + headerHeightOffset + portHalfHeight + rowOffset;
 
             var placement = new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None);
 


### PR DESCRIPTION
### Purpose

The PR solves an outstanding issue [DYN-4308](https://jira.autodesk.com/browse/DYN-4308) 'Input and output port menu is tiny when zoomed in and gets bigger when zoomed out'. The way the Y value of the popup context menu position was calculated did not take into account a few factors, which reflected in inaccurate position in different scale factors in relationship to the corresponding port.

#### Location after the solution
![popup_solution](https://user-images.githubusercontent.com/5354594/213021383-ab327835-b0d3-4570-b0ea-1f07691a7e8d.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User-facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes


- Complete rework of how the vertical position of the Popup was calculated 
- Now takes into account all relevant variables, including node header height, port height, port position, tooltip height
- Takes into account scalable vs non-scalable 


### Reviewers

@reddyashish 

### FYIs

@Amoursol 
@Jingyi-Wen 
