### PR TITLE
Markdown procedural image location

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -9,6 +9,7 @@ using Dynamo.DocumentationBrowser.Properties;
 using Dynamo.Logging;
 using Dynamo.ViewModels;
 using SharpDX.DXGI;
+using Dynamo.Utilities;
 
 namespace Dynamo.DocumentationBrowser
 {
@@ -119,8 +120,10 @@ namespace Dynamo.DocumentationBrowser
 
             StringBuilder sb = new StringBuilder();
 
-            var mkArray = mkDown.Split(new string[] {"\r\n", "\r", "\n"}, StringSplitOptions.None).Where(s => !string.IsNullOrEmpty(s)).ToArray();
-            var imageRow = mkArray.Last();
+            var mkArray = mkDown.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+            var imageRow = mkArray.First(x => x.Contains("img"));
+            var index = mkArray.IndexOf(imageRow);
+
             if (!imageRow.Contains("img"))
             {
                 sb.AppendLine(mkArray.First());
@@ -130,16 +133,19 @@ namespace Dynamo.DocumentationBrowser
             imageRow = imageRow.Replace("<p>", "").Replace("</p>", "");
             imageRow = imageRow.Insert(4, @" id='drag--img' class='resizable--img' ");
 
-            sb.AppendLine(string.Join(Environment.NewLine, mkArray.Take(mkArray.Count() - 1).ToArray()));
+            var rowsBeforeImage = string.Join(Environment.NewLine, mkArray.Take(index).ToArray());
+            var rowsAfterImage = string.Join(Environment.NewLine, mkArray.Skip(index + 1).ToArray());
+
+            sb.AppendLine(rowsBeforeImage);
             sb.AppendLine("<div class=\"container\" id=\"img--container\">");
             sb.AppendLine(imageRow);
             sb.AppendLine("<div class=\"btn--container\">");
             sb.AppendLine(
-                $"<button type=\"button\" id=\"zoomfit\" class=\"button fitIcon\"  title=\"{Resources.ImageFitToolTip}\" ></button>");
-            sb.AppendLine(
                 $"<button type=\"button\" id=\"zoomin\" class=\"button plusIcon\" title=\"{Resources.ImageZoomInToolTip}\" ></button>\r\n");
             sb.AppendLine(
                 $"<button type=\"button\" id=\"zoomout\" class=\"button minusIcon\" title=\"{Resources.ImageZoomOutToolTip}\" ></button>\r\n");
+            sb.AppendLine(
+                $"<button type=\"button\" id=\"zoomfit\" class=\"button fitIcon\"  title=\"{Resources.ImageFitToolTip}\" ></button>");
             sb.AppendLine(@"</div>");
             sb.AppendLine("<div class=\"btn--insert--container\">");
 
@@ -148,6 +154,7 @@ namespace Dynamo.DocumentationBrowser
                 $"<button type=\"button\" id=\"insert\" class=\"button insertIcon\" title=\"{tooltip}\" ></button>\r\n");
             sb.AppendLine(@"</div>");
             sb.AppendLine(@"</div>");
+            sb.AppendLine(rowsAfterImage);
 
             return sb.ToString();
         }

--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -121,7 +121,9 @@ namespace Dynamo.DocumentationBrowser
             StringBuilder sb = new StringBuilder();
 
             var mkArray = mkDown.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).Where(s => !string.IsNullOrEmpty(s)).ToArray();
-            var imageRow = mkArray.First(x => x.Contains("img"));
+            var imageRow = mkArray.FirstOrDefault(x => x.Contains("img"));
+            if(imageRow == null) return mkDown;
+
             var index = mkArray.IndexOf(imageRow);
 
             if (!imageRow.Contains("img"))


### PR DESCRIPTION
### Purpose

A small PR with changes to the NodeDocumentationHtmlGenerator. Now identifies the location of the <img> tag inside markdown help files and correctly injects HTML code for that row.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- fixed hard-coded image location
- now identifies image location


### Reviewers

@reddyashish 
@RobertGlobant20 

### FYIs

@Amoursol 
