### PR TITLE
SPIKE: coercing arrays using linq functions

### DIFF
--- a/src/Engine/EmitMSIL/CodeGenIL.cs
+++ b/src/Engine/EmitMSIL/CodeGenIL.cs
@@ -305,18 +305,6 @@ namespace EmitMSIL
             var genericToList = toListMethod.MakeGenericMethod(typeof(Target));
             EmitOpCode(OpCodes.Call, genericToList);
             return typeof(List<Target>);
-
-            //if (typeof(IList).IsAssignableFrom(ienumerableParamType) ||
-            //    typeof(IList<Target>).IsAssignableFrom(ienumerableParamType))
-            //{
-            //    var requiredType = typeof(Target);
-            //    var toListMethod = typeof(Enumerable).GetMethod(nameof(Enumerable.ToList));
-            //    mInfo = toListMethod.MakeGenericMethod(requiredType);
-
-            //    EmitOpCode(OpCodes.Call, mInfo);
-            //    return typeof(List<Target>);
-            //}
-
         }
 
         private IEnumerable<ProtoCore.CLRFunctionEndPoint> FunctionLookup(IList args)

--- a/src/Engine/EmitMSIL/CodeGenIL.cs
+++ b/src/Engine/EmitMSIL/CodeGenIL.cs
@@ -6,10 +6,8 @@ using ProtoCore.Properties;
 using ProtoCore.Utils;
 using ProtoFFI;
 using System;
-using System.CodeDom;
 using System.Collections;
 using System.Collections.Generic;
-using System.Configuration.Assemblies;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -145,13 +143,11 @@ namespace EmitMSIL
                     DfsTraverse(ast);
                 }
                 EmitOpCode(OpCodes.Ret);
+
                 return (asm, type);
 #if DEBUG
             }
 #endif
-            EmitOpCode(OpCodes.Ret);
-
-            return (asm, type);
         }
 
         // Given a double value on the stack, emit call to Math.Round(arg, 0, MidpointRounding.AwayFromZero);

--- a/test/CodeGenILTests/MicroTests.cs
+++ b/test/CodeGenILTests/MicroTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace CodeGenILTests
+{
+    public class MicroTests
+    {
+        private ProtoScript.Runners.LiveRunner liveRunner = null;
+        private ProtoCore.MSILRuntimeCore runtimeCore = null;
+
+        protected EmitMSIL.CodeGenIL codeGen;
+        protected Dictionary<string, IList> inputs = new Dictionary<string, IList>();
+        protected string opCodeFilePath;
+
+        protected virtual void GetLibrariesToPreload(ref List<string> libraries)
+        {
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("FFITarget.dll");
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            //TODO_MSIL: remove the dependency on the old VM by implementing
+            //necesary Emit functions(ex mitFunctionDefinition and EmitImportStatements and all the preloading logic)
+            liveRunner = new ProtoScript.Runners.LiveRunner();
+
+            List<string> libraries = new List<string>();
+            GetLibrariesToPreload(ref libraries);
+
+            liveRunner.ResetVMAndResyncGraph(libraries);
+            runtimeCore = new ProtoCore.MSILRuntimeCore(liveRunner.RuntimeCore);
+
+            var assemblyPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            var outputpath = Path.Combine(assemblyPath, "MSILTestOutput");
+            System.IO.Directory.CreateDirectory(outputpath);
+            opCodeFilePath = Path.Combine(outputpath, $"OpCodesTEST{NUnit.Framework.TestContext.CurrentContext.Test.Name}.txt");
+            codeGen = new EmitMSIL.CodeGenIL(inputs, opCodeFilePath, runtimeCore);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            liveRunner.Dispose();
+            codeGen.Dispose();
+        }
+    }
+}

--- a/test/CodeGenILTests/RangeMicroTests.cs
+++ b/test/CodeGenILTests/RangeMicroTests.cs
@@ -22,6 +22,7 @@ namespace CodeGenILTests
         {
             libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSCoreNodes.dll");
+            libraries.Add("FFITarget.dll");
         }
 
         [SetUp]
@@ -237,6 +238,49 @@ y = DSCore.Math.Sum([1,2,3]);";
             var output = codeGen.EmitAndExecute(ast);
             Assert.IsNotEmpty(output);
             Assert.AreEqual(6, output["y"]);
+        }
+
+        [Test]
+        public void SumList_TypeCoercion_Works()
+        {
+            var code = @"
+import(""DesignScriptBuiltin.dll"");
+import(""FFITarget.dll"");
+y = FFITarget.AtLevelTestClass.Sum([1,2,3]);";
+
+            var ast = ParserUtils.Parse(code).Body;
+            var output = codeGen.EmitAndExecute(ast);
+            Assert.IsNotEmpty(output);
+            Assert.AreEqual(6, output["y"]);
+        }
+
+        [Test]
+        public void SumArray_TypeCoercion_Works()
+        {
+            var code = @"
+import(""DesignScriptBuiltin.dll"");
+import(""FFITarget.dll"");
+y = FFITarget.DummyCollection.MakeArray([1.0,2.3,3.1]);";
+
+            var ast = ParserUtils.Parse(code).Body;
+            var output = codeGen.EmitAndExecute(ast);
+            Assert.IsNotEmpty(output);
+            Assert.AreEqual(new[] { 1, 2, 3 }, output["y"]);
+        }
+
+        [Test]
+        public void SumVarArray_TypeCoercion_Works()
+        {
+            var code = @"
+import(""DesignScriptBuiltin.dll"");
+import(""FFITarget.dll"");
+x = [1.0,2.3,3.1];
+y = FFITarget.DummyCollection.MakeArray(x);";
+
+            var ast = ParserUtils.Parse(code).Body;
+            var output = codeGen.EmitAndExecute(ast);
+            Assert.IsNotEmpty(output);
+            Assert.AreEqual(new[] { 1, 2, 3 }, output["y"]);
         }
 
         [Test]

--- a/test/CodeGenILTests/RangeMicroTests.cs
+++ b/test/CodeGenILTests/RangeMicroTests.cs
@@ -9,50 +9,6 @@ using System;
 
 namespace CodeGenILTests
 {
-    public class MicroTests
-    {
-        private ProtoScript.Runners.LiveRunner liveRunner = null;
-        private ProtoCore.MSILRuntimeCore runtimeCore = null;
-
-        protected EmitMSIL.CodeGenIL codeGen;
-        protected Dictionary<string, IList> inputs = new Dictionary<string, IList>();
-        protected string opCodeFilePath;
-
-        protected virtual void GetLibrariesToPreload(ref List<string> libraries)
-        {
-            libraries.Add("DesignScriptBuiltin.dll");
-            libraries.Add("DSCoreNodes.dll");
-            libraries.Add("FFITarget.dll");
-        }
-
-        [SetUp]
-        public void Setup()
-        {
-            //TODO_MSIL: remove the dependency on the old VM by implementing
-            //necesary Emit functions(ex mitFunctionDefinition and EmitImportStatements and all the preloading logic)
-            liveRunner = new ProtoScript.Runners.LiveRunner();
-
-            List<string> libraries = new List<string>();
-            GetLibrariesToPreload(ref libraries);
-
-            liveRunner.ResetVMAndResyncGraph(libraries);
-            runtimeCore = new ProtoCore.MSILRuntimeCore(liveRunner.RuntimeCore);
-
-            var assemblyPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-            var outputpath = Path.Combine(assemblyPath, "MSILTestOutput");
-            System.IO.Directory.CreateDirectory(outputpath);
-            opCodeFilePath = Path.Combine(outputpath, $"OpCodesTEST{NUnit.Framework.TestContext.CurrentContext.Test.Name}.txt");
-            codeGen = new EmitMSIL.CodeGenIL(inputs, opCodeFilePath, runtimeCore);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            liveRunner.Dispose();
-            codeGen.Dispose();
-        }
-    }
-
     [TestFixture]
     public class RangeMicroTests : MicroTests
     {

--- a/test/CodeGenILTests/RangeMicroTests.cs
+++ b/test/CodeGenILTests/RangeMicroTests.cs
@@ -197,6 +197,21 @@ y = DSCore.Math.Sum([1,2,3]);";
         }
 
         [Test]
+        //'Object of type 'System.int64[]' can be converted to type 'System.Collections.Generic.IEnumerable`1[System.Double]'.'
+        public void SumArray_TypeCoerNeeded()
+        {
+            var dscode = @"
+import(""DesignScriptBuiltin.dll"");
+import(""DSCoreNodes.dll"");
+y = DSCore.Math.Sum(1..100000000);";
+
+            var ast = ParserUtils.Parse(dscode).Body;
+            var output = codeGen.EmitAndExecute(ast);
+            Assert.IsNotEmpty(output);
+            //Assert.AreEqual(6, output["y"]);
+        }
+
+        [Test]
         public void SumList_TypeCoercion_Works()
         {
             var code = @"

--- a/test/DynamoCoreTests/Performance/PerformanceTests.cs
+++ b/test/DynamoCoreTests/Performance/PerformanceTests.cs
@@ -11,7 +11,8 @@ namespace Dynamo.Tests
     [TestFixture, Category("Performance")]
     public class PerformanceTests : DynamoModelTestBase
     {
-        private List<(string graph, TimeSpan oldEngineCompileTime, TimeSpan oldEngineExecutionTime, TimeSpan newEngineCompileTime, TimeSpan newEngineExecutionTime)> executionData;
+        private List<(string graph, TimeSpan oldEngineCompileTime, TimeSpan oldEngineExecutionTime,
+            TimeSpan newEngineCompileTime, TimeSpan newEngineExecutionTime)> executionData;
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {


### PR DESCRIPTION
### Purpose

This PR attempts at emitting collection coercion code using Linq expressions. E.g. conversion from long[] to IEnumerable<double>:
```
var arr = new long[] { x, y, z };
var coerced_arr = arr.Select(Convert.ToDouble);  
var res = Math.Sum(coerced_arr);    // Math.Sum() takes in an IEnumerable<double>
```
The emitted MSIL for the above conversion looks like:
```
ldnull      
ldftn       System.Convert.ToDouble
newobj  System.Func<System.Int64,System.Double>..ctor
call         System.Linq.Enumerable.Select<Int64,Double>
call        ToList or ToArray
```

Blocker:
~~I'm seeing the returned `IEnumerable` as a `WhereSelectArrayIterator ` when it is wrapped in an `object[]` and passed to `ReplicationLogic`, in other words when it's wrapped in a `CLRStackValue`.~~

Performance measurements:
It was found that even for a large array of 100 million elements (array_coercion.dyn), there was a negligible change (in compilation time) but a significant change in (execution) performance between using the linq approach and the current coercion using for loops.

Before:
![image](https://user-images.githubusercontent.com/5710686/214068766-5466f890-ea7a-4435-ade0-b2217a01d0fd.png)

After:
![image](https://user-images.githubusercontent.com/5710686/214068065-730f2f6f-48c8-4015-aa90-bf2fa4ac638b.png)

Observations:
As seen above, even though this approach doesn't offer any performance benefits, it reduces the complexity of the codegen logic and that of the MSIL being emitted. Previously there were errors reported in the MSIL that was being generated for coercion (using `for ` and `foreach` loops), which although can be fixed, is hard to do. Now the emitted code is so simple and concise that the decompiler doesn't report any errors in the generated MSIL when decompiling the resulting assembly.
Note that the overall compilation and execution times are almost comparable in most cases except for the last graph, which contains an array of 100 million elements, in which case the execution time is more than double what it was before.
In summary, it can be said that in most common workflows, this approach will not have any significant positive or negative impact but for certain, isolated cases involving large arrays could have a performance hit. Being able to generate error-free MSIL is an added advantage as it avoids more serious errors that can accumulate with large graphs.

TODO:
The last call to `ToList` or `ToArray ` was found to be required only in the case of replicated calls to workaround the `WhereSelectArrayIterator` issue. The `WhereSelectIterator ` is returned from the call to `Enumerable.Select` and didn't pose to be an issue for direct function calls (non-replicated) case. There are 2 things that still could be figured out here:
- Why is this iterator returned instead of an `IEnumerable<T>`?
- Can we somehow use this iterator to still properly marshal it to a `CLRStackValue `in the replication case and thereby achieve some sort of deferred execution?

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

