### PR TITLE
Improve Package Manager search sort order

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -1019,7 +1019,7 @@ namespace Dynamo.PackageManager
                     results.Sort((e1, e2) => e1.Model.Downloads.CompareTo(e2.Model.Downloads));
                     break;
                 case PackageSortingKey.LastUpdate:
-                    results.Sort((e1, e2) => e1.Versions.FirstOrDefault().Item1.created.CompareTo(e2.Versions.FirstOrDefault().Item1.created));
+                    results.Sort((e1, e2) => e1.Versions.Last().Item1.created.CompareTo(e2.Versions.Last().Item1.created));
                     break;
                 case PackageSortingKey.Votes:
                     results.Sort((e1, e2) => e1.Model.Votes.CompareTo(e2.Model.Votes));

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -1019,7 +1019,7 @@ namespace Dynamo.PackageManager
                     results.Sort((e1, e2) => e1.Model.Downloads.CompareTo(e2.Model.Downloads));
                     break;
                 case PackageSortingKey.LastUpdate:
-                    results.Sort((e1, e2) => e1.Versions.Last().Item1.created.CompareTo(e2.Versions.Last().Item1.created));
+                    results.Sort((e1, e2) => e1.Versions.FirstOrDefault().Item1.created.CompareTo(e2.Versions.FirstOrDefault().Item1.created));
                     break;
                 case PackageSortingKey.Votes:
                     results.Sort((e1, e2) => e1.Model.Votes.CompareTo(e2.Model.Votes));

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -43,7 +43,8 @@ namespace Dynamo.PackageManager
             Downloads,
             Votes,
             Maintainers,
-            LastUpdate
+            LastUpdate,
+            Search
         };
 
         /// <summary>
@@ -365,7 +366,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         ///     Sort the search results
         /// </summary>
-        public DelegateCommand SortCommand { get; set; }
+        public DelegateCommand<object> SortCommand { get; set; }
 
         /// <summary>
         ///     Set the sorting key for search results and resort
@@ -417,7 +418,7 @@ namespace Dynamo.PackageManager
             MaxNumSearchResults = 35;
             SearchDictionary = new SearchDictionary<PackageManagerSearchElement>();
             ClearCompletedCommand = new DelegateCommand(ClearCompleted, CanClearCompleted);
-            SortCommand = new DelegateCommand(Sort, CanSort);
+            SortCommand = new DelegateCommand<object>(Sort, CanSort);
             SetSortingKeyCommand = new DelegateCommand<object>(SetSortingKey, CanSetSortingKey);
             SetSortingDirectionCommand = new DelegateCommand<object>(SetSortingDirection, CanSetSortingDirection);
             ViewPackageDetailsCommand = new DelegateCommand<object>(ViewPackageDetails);
@@ -442,14 +443,20 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Sort the search results in the view based on the sorting key and sorting direction.
         /// </summary>
-        public void Sort()
+        public void Sort(object searchQuery = null)
         {
             var list = this.SearchResults.AsEnumerable().ToList();
-            Sort(list, this.SortingKey);
-
-            if (SortingDirection == PackageSortingDirection.Descending)
+            if (searchQuery == null)
             {
-                list.Reverse();
+                Sort(list, this.SortingKey);
+
+                if (SortingDirection == PackageSortingDirection.Descending)
+                {
+                    list.Reverse();
+                }
+            }
+            else {
+                Sort(list, PackageSortingKey.Search, searchQuery.ToString());
             }
 
             Analytics.TrackEvent(Actions.Sort, Categories.PackageManagerOperations, $"{SortingDirection}");
@@ -487,7 +494,7 @@ namespace Dynamo.PackageManager
         /// Can search be performed.  Used by the associated command
         /// </summary>
         /// <returns></returns>
-        public bool CanSort()
+        public bool CanSort(object s)
         {
             return true;
         }
@@ -842,7 +849,7 @@ namespace Dynamo.PackageManager
                 this.AddToSearchResults(result);
             }
 
-            this.Sort();
+            this.Sort(query);
 
             SearchState = HasNoResults ? PackageSearchState.NoResults : PackageSearchState.Results;
         }
@@ -961,7 +968,7 @@ namespace Dynamo.PackageManager
         /// Sort a list of search results by the given key
         /// </summary>
         /// <param name="results"></param>
-        private static void Sort(List<PackageManagerSearchElementViewModel> results, PackageSortingKey key)
+        private static void Sort(List<PackageManagerSearchElementViewModel> results, PackageSortingKey key, string query = null)
         {
             switch (key)
             {
@@ -972,13 +979,25 @@ namespace Dynamo.PackageManager
                     results.Sort((e1, e2) => e1.Model.Downloads.CompareTo(e2.Model.Downloads));
                     break;
                 case PackageSortingKey.LastUpdate:
-                    results.Sort((e1, e2) => e1.Versions.Last().Item1.created.CompareTo(e2.Versions.Last().Item1.created));
+                    results.Sort((e1, e2) => e1.Versions.FirstOrDefault().Item1.created.CompareTo(e2.Versions.FirstOrDefault().Item1.created));
                     break;
                 case PackageSortingKey.Votes:
                     results.Sort((e1, e2) => e1.Model.Votes.CompareTo(e2.Model.Votes));
                     break;
                 case PackageSortingKey.Maintainers:
                     results.Sort((e1, e2) => e1.Model.Maintainers.ToLower().CompareTo(e2.Model.Maintainers.ToLower()));
+                    break;
+                //This sorting key is applied to search results when user submits a search query on package manager search window,
+                //it sorts in the following order: Not Deprecated Packages > search query in Name > Recently Updated
+                case PackageSortingKey.Search:
+                    results.Sort((e1, e2) => {
+                        int ret = e1.Model.IsDeprecated.CompareTo(e2.Model.IsDeprecated);
+                        int i1 = e1.Model.Name.ToLower().IndexOf(query.ToLower(), StringComparison.InvariantCultureIgnoreCase);
+                        int i2 = e2.Model.Name.ToLower().IndexOf(query.ToLower(), StringComparison.InvariantCultureIgnoreCase);
+                        ret = ret != 0 ? ret : ((i1 == -1) ? int.MaxValue : i1).CompareTo((i2 == -1) ? int.MaxValue : i2);
+                        ret = ret != 0 ? ret : -e1.Versions.FirstOrDefault().Item1.created.CompareTo(e2.Versions.FirstOrDefault().Item1.created);
+                        return ret;
+                    });
                     break;
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -43,7 +43,8 @@ namespace Dynamo.PackageManager
             Downloads,
             Votes,
             Maintainers,
-            LastUpdate
+            LastUpdate,
+            Search
         };
 
         /// <summary>
@@ -363,9 +364,14 @@ namespace Dynamo.PackageManager
         public DelegateCommand ClearCompletedCommand { get; set; }
 
         /// <summary>
-        ///     Sort the search results
+        ///     Sort the default results
         /// </summary>
         public DelegateCommand SortCommand { get; set; }
+
+        /// <summary>
+        ///     Sort the search results
+        /// </summary>
+        public DelegateCommand<object> SearchSortCommand { get; set; }
 
         /// <summary>
         ///     Set the sorting key for search results and resort
@@ -418,6 +424,7 @@ namespace Dynamo.PackageManager
             SearchDictionary = new SearchDictionary<PackageManagerSearchElement>();
             ClearCompletedCommand = new DelegateCommand(ClearCompleted, CanClearCompleted);
             SortCommand = new DelegateCommand(Sort, CanSort);
+            SearchSortCommand = new DelegateCommand<object>(Sort, CanSort);
             SetSortingKeyCommand = new DelegateCommand<object>(SetSortingKey, CanSetSortingKey);
             SetSortingDirectionCommand = new DelegateCommand<object>(SetSortingDirection, CanSetSortingDirection);
             ViewPackageDetailsCommand = new DelegateCommand<object>(ViewPackageDetails);
@@ -440,7 +447,7 @@ namespace Dynamo.PackageManager
         }
         
         /// <summary>
-        /// Sort the search results in the view based on the sorting key and sorting direction.
+        /// Sort the default package results in the view based on the sorting key and sorting direction.
         /// </summary>
         public void Sort()
         {
@@ -451,8 +458,6 @@ namespace Dynamo.PackageManager
             {
                 list.Reverse();
             }
-
-            Analytics.TrackEvent(Actions.Sort, Categories.PackageManagerOperations, $"{SortingDirection}");
 
             // temporarily hide binding
             var temp = this.SearchResults;
@@ -466,6 +471,35 @@ namespace Dynamo.PackageManager
             }
 
             this.SearchResults = temp;
+        }
+
+        /// <summary>
+        /// Sort the package search results in the view based on the closest hit to the search key.
+        /// </summary>
+        private void Sort(object searchQuery = null)
+        {
+            if (searchQuery == null)
+            {
+                this.Sort();
+            }
+            else
+            {
+                var list = this.SearchResults.AsEnumerable().ToList();
+                Sort(list, PackageSortingKey.Search, searchQuery.ToString());
+
+                // temporarily hide binding
+                var temp = this.SearchResults;
+                this.SearchResults = null;
+
+                temp.Clear();
+
+                foreach (var ele in list)
+                {
+                    temp.Add(ele);
+                }
+
+                this.SearchResults = temp;
+            }
         }
 
         /// <summary>
@@ -484,10 +518,19 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// Can search be performed.  Used by the associated command
+        /// Can search be performed.  Used by the associated command : SortCommand
         /// </summary>
         /// <returns></returns>
         public bool CanSort()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Can search be performed.  Used by the associated command : SearchSortCommand
+        /// </summary>
+        /// <returns></returns>
+        private bool CanSort(object s)
         {
             return true;
         }
@@ -618,6 +661,8 @@ namespace Dynamo.PackageManager
             {
                 this.SortingKey = (PackageSortingKey)sortingKey;
             }
+
+            Analytics.TrackEvent(Actions.Sort, Categories.PackageManagerOperations, $"{sortingKey}");
 
             this.Sort();
         }
@@ -842,7 +887,7 @@ namespace Dynamo.PackageManager
                 this.AddToSearchResults(result);
             }
 
-            this.Sort();
+            this.Sort(query);
 
             SearchState = HasNoResults ? PackageSearchState.NoResults : PackageSearchState.Results;
         }
@@ -961,7 +1006,9 @@ namespace Dynamo.PackageManager
         /// Sort a list of search results by the given key
         /// </summary>
         /// <param name="results"></param>
-        private static void Sort(List<PackageManagerSearchElementViewModel> results, PackageSortingKey key)
+        /// <param name="key"></param>
+        /// <param name="query"></param>
+        private static void Sort(List<PackageManagerSearchElementViewModel> results, PackageSortingKey key, string query = null)
         {
             switch (key)
             {
@@ -972,13 +1019,25 @@ namespace Dynamo.PackageManager
                     results.Sort((e1, e2) => e1.Model.Downloads.CompareTo(e2.Model.Downloads));
                     break;
                 case PackageSortingKey.LastUpdate:
-                    results.Sort((e1, e2) => e1.Versions.Last().Item1.created.CompareTo(e2.Versions.Last().Item1.created));
+                    results.Sort((e1, e2) => e1.Versions.FirstOrDefault().Item1.created.CompareTo(e2.Versions.FirstOrDefault().Item1.created));
                     break;
                 case PackageSortingKey.Votes:
                     results.Sort((e1, e2) => e1.Model.Votes.CompareTo(e2.Model.Votes));
                     break;
                 case PackageSortingKey.Maintainers:
                     results.Sort((e1, e2) => e1.Model.Maintainers.ToLower().CompareTo(e2.Model.Maintainers.ToLower()));
+                    break;
+                //This sorting key is applied to search results when user submits a search query on package manager search window,
+                //it sorts in the following order: Not Deprecated Packages > search query in Name > Recently Updated
+                case PackageSortingKey.Search:
+                    results.Sort((e1, e2) => {
+                        int ret = e1.Model.IsDeprecated.CompareTo(e2.Model.IsDeprecated);
+                        int i1 = e1.Model.Name.ToLower().IndexOf(query.ToLower(), StringComparison.InvariantCultureIgnoreCase);
+                        int i2 = e2.Model.Name.ToLower().IndexOf(query.ToLower(), StringComparison.InvariantCultureIgnoreCase);
+                        ret = ret != 0 ? ret : ((i1 == -1) ? int.MaxValue : i1).CompareTo((i2 == -1) ? int.MaxValue : i2);
+                        ret = ret != 0 ? ret : -e1.Versions.FirstOrDefault().Item1.created.CompareTo(e2.Versions.FirstOrDefault().Item1.created);
+                        return ret;
+                    });
                     break;
             }
         }


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-4732

Improve package manager search sorting order.
Most recently updated packages are given higher priority than newly created packages, for the default order.

New Sort order for search results, after user has entered a search query will be in the following priority from most to least:

- Non-Deprecated packages are given highest priority
- Packages with the search term in their names
- Most recently updated
- Description, Maintainers and Keywords

Before: 
![clockworkHits](https://user-images.githubusercontent.com/32665108/213828178-13eff0b3-6c9b-4d9b-ba74-e676458de286.jpg)

After:
![DynamoSandbox_UjJermrr38](https://user-images.githubusercontent.com/32665108/213828201-a0bbbbc0-1936-409c-9069-99565fbc63eb.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- Improve package manager search sorting order.


### Reviewers

@DynamoDS/dynamo 
