### PR TITLE
Insert Changes

### DIFF
--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -984,6 +984,24 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Insert Dynamo Definition....
+        /// </summary>
+        public static string InsertDialogBoxText {
+            get {
+                return ResourceManager.GetString("InsertDialogBoxText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Example file added to workspace. Run mode changed to Manual..
+        /// </summary>
+        public static string InsertGraphRunModeNotificationText {
+            get {
+                return ResourceManager.GetString("InsertGraphRunModeNotificationText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The folder &apos;{0}&apos; does not exist.
         /// </summary>
         public static string InvalidCustomNodeFolderWarning {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -893,4 +893,10 @@ This package likely contains an assembly that is blocked. You will need to load 
   <data name="FailedInsertFileNodeExistNotification" xml:space="preserve">
     <value>Failed to insert the file as some of the nodes already exist in the current worspace.</value>
   </data>
+  <data name="InsertDialogBoxText" xml:space="preserve">
+    <value>Insert Dynamo Definition...</value>
+  </data>
+  <data name="InsertGraphRunModeNotificationText" xml:space="preserve">
+    <value>Example file added to workspace. Run mode changed to Manual.</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -896,4 +896,10 @@ This package likely contains an assembly that is blocked. You will need to load 
   <data name="FailedInsertFileNodeExistNotification" xml:space="preserve">
     <value>Failed to insert the file as some of the nodes already exist in the current worspace.</value>
   </data>
+  <data name="InsertDialogBoxText" xml:space="preserve">
+    <value>Insert Dynamo Definition...</value>
+  </data>
+  <data name="InsertGraphRunModeNotificationText" xml:space="preserve">
+    <value>Example file added to workspace. Run mode changed to Manual.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1815,7 +1815,7 @@ namespace Dynamo.ViewModels
         /// <param name="notification"></param>
         private void model_RequestNotification(string notification)
         {
-            this.MainGuideManager.CreateRealTimeInfoWindow(notification, true);
+            this.MainGuideManager.CreateRealTimeInfoWindow(notification);
         }
 
         /// <summary>
@@ -1889,7 +1889,7 @@ namespace Dynamo.ViewModels
                 Filter = string.Format(Resources.FileDialogDynamoDefinitions,
                          BrandingResourceProvider.ProductName, fileExtensions) + "|" +
                          string.Format(Resources.FileDialogAllFiles, "*.*"),
-                Title = string.Format("Insert Title (Replace)", BrandingResourceProvider.ProductName)
+                Title = string.Format(Properties.Resources.InsertDialogBoxText, BrandingResourceProvider.ProductName)
             };
 
             // if you've got the current space path, use it as the inital dir
@@ -1917,17 +1917,17 @@ namespace Dynamo.ViewModels
                     _fileDialog.InitialDirectory = path;
             }
 
-            if (HomeSpace.RunSettings.RunType != RunType.Manual)
-            {
-                MainGuideManager.CreateRealTimeInfoWindow("Example file added to workspace. Run mode changed to Manual.", true);
-                HomeSpace.RunSettings.RunType = RunType.Manual;
-            }
-
             if (_fileDialog.ShowDialog() == DialogResult.OK)
             {
                 if (CanOpen(_fileDialog.FileName))
                 {
                     Insert(new Tuple<string, bool>(_fileDialog.FileName, _fileDialog.RunManualMode));
+
+                    if (HomeSpace.RunSettings.RunType != RunType.Manual)
+                    {
+                        MainGuideManager.CreateRealTimeInfoWindow(Properties.Resources.InsertGraphRunModeNotificationText);
+                        HomeSpace.RunSettings.RunType = RunType.Manual;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Purpose

A small PR addressing some outstanding resource issues to Insert functionality. Addresses [this](https://jira.autodesk.com/browse/DYN-5525) jira task. Changes toast notification behavior from user interactive to passively disappears on mouseclick.

#### behavior after changes
![insert_changes](https://user-images.githubusercontent.com/5354594/214363583-ca577460-8899-4bd2-88ac-f2d767f2603f.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- added Insert dialog box title to resources, changed the text
- added insert run mode change notification to resources
- change the Toast type (now disappears on the next mouseclick)
- change the order in which Insert is done and the mode is changed, i.e. mode would change only if a graph has been inserted


### Reviewers

@sm6srw 

### FYIs

@Amoursol 