### PR TITLE
Do not force user login for package search operation

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -740,6 +740,9 @@ namespace Dynamo.PackageManager
 
         internal void RefreshInfectedPackages()
         {
+            //do not call a protected route, if user is not logged in already.
+            if (string.IsNullOrEmpty(PackageManagerClientViewModel.Username)) return;
+
             var infectedPkgs = PackageManagerClientViewModel.GetInfectedPackages();
             infectedPkgs.Sort((e1, e2) => e1.InfectedPackageCreationDate.CompareTo(e2.InfectedPackageCreationDate));
 


### PR DESCRIPTION
### Purpose

Do not initiate a login process when user opens the package search window.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### Reviewers

@DynamoDS/dynamo 

### FYIs

@Amoursol 
