### PR TITLE
Get Dynamo Window to the foreground after login

### DIFF
--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Autodesk.IDSDK;
 using Greg;
 using Greg.AuthProviders;
@@ -207,17 +208,31 @@ namespace Dynamo.Core
 
         private bool Initialize()
         {
+            if (Client.IsInitialized()) return true;
             idsdk_status_code bRet = Client.Init();
 
             if (Client.IsSuccess(bRet))
             {
                 if (Client.IsInitialized())
                 {
-                    bool ret = GetClientIDAndServer(out idsdk_server server, out string client_id);
-                    if (ret)
+                    try
                     {
-                        ret = SetProductConfigs("Dynamo", server, client_id);
-                        return ret;
+                        IntPtr hWnd = Process.GetCurrentProcess().MainWindowHandle;
+                        if (hWnd != null)
+                        {
+                            Client.SetHost(hWnd);
+                        }
+
+                        bool ret = GetClientIDAndServer(out idsdk_server server, out string client_id);
+                        if (ret) 
+                        {
+                            ret = SetProductConfigs("Dynamo", server, client_id);
+                            return ret;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        return false;
                     }
                 }
             }


### PR DESCRIPTION
### Purpose

Bring dynamo window forward after login

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@DynamoDS/dynamo 
