### PR TITLE
Service mode changes

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -63,6 +63,8 @@ namespace Dynamo.Applications
         public string SessionId { get; set; } = String.Empty;
         [Option("CERLocation", Required = false, HelpText = "Specify the crash error report tool location on disk.")]
         public string CERLocation { get; set; } = String.Empty;
+        [Option("ServiceMode", Required = false, HelpText = "Specify the service mode startup.")]
+        public bool ServiceMode { get; set; }
     }
 #endif
 
@@ -144,7 +146,8 @@ namespace Dynamo.Applications
                         CommonDataFolder = cmdArgs.CommonDataFolder,
                         DisableAnalytics = cmdArgs.DisableAnalytics,
                         AnalyticsInfo = new HostAnalyticsInfo() { HostName = cmdArgs.HostName, ParentId = cmdArgs.ParentId, SessionId = cmdArgs.SessionId },
-                        CERLocation = cmdArgs.CERLocation
+                        CERLocation = cmdArgs.CERLocation,
+                        ServiceMode = cmdArgs.ServiceMode
                     };
                 }, errs => new CommandLineArguments());
 #else

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1641,6 +1641,10 @@ namespace Dynamo.Models
             if (preferences != null) // If there is preference settings provided...
                 return preferences;
 
+            //Skip file handling in service mode.
+            if (IsServiceMode)
+                return new PreferenceSettings();
+
             // Is order for test cases not to interfere with the regular preference
             // settings xml file, a test case usually specify a temporary xml file
             // path from where preference settings are to be loaded. If that value

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -945,7 +945,7 @@ namespace Dynamo.Models
             DynamoModel.OnRequestUpdateLoadBarStatus(new SplashScreenLoadEventArgs(Resources.SplashScreenLoadNodeLibrary, 50));
             InitializeNodeLibrary();
 
-            if (!IsServiceMode && extensions.Any())
+            if (extensions.Any())
             {
                 var startupParams = new StartupParams(this);
 


### PR DESCRIPTION
### Purpose

Suggested additions and updates to the https://github.com/DynamoDS/Dynamo/pull/13659 PR which introduce service mode.

This PR adds:
* Add ServiceMode Configuration to the NETCore builds
* Ignores loading of preference file in service mode.  Instead it loads the default `PreferenceSettings`.  The XML read is prohibitively slow currently 

This PR removes
* No longer disable loading of extensions (including the package manger).  We want packages to load and can disable loading in other ways.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

### Reviewers

@QilongTang @mjkkirschner @BogdanZavu 

### FYIs
