### PR TITLE
Set Server when switching Auth environment

### DIFF
--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -227,6 +227,7 @@ namespace Dynamo.Core
                         if (ret) 
                         {
                             ret = SetProductConfigs("Dynamo", server, client_id);
+                            Client.SetServer(server);
                             return ret;
                         }
                     }


### PR DESCRIPTION
### Purpose

After setting the product config we have to set the server as well, this was set to prod by default, therefore when switching to staging client we were getting an error.
There are other steps involved in switching environment that will be covered in an internal wiki.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated


### Reviewers

@DynamoDS/dynamo 
