### PR TITLE
DYN-5611-Attempt2Fix-Flaky-Test

### DIFF
--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -1153,7 +1153,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
 
             //Wait 3 seconds until the Click Right context menu is opened
-            Task.WaitAll(new Task[] { Task.Delay(3000) });
+            Task.WaitAll(new Task[] { Task.Delay(2000) });
         }
 
 

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
@@ -1150,6 +1151,9 @@ namespace DynamoCoreWpfTests
             });
 
             DispatcherUtil.DoEvents();
+
+            //Wait 3 seconds until the Click Right context menu is opened
+            Task.WaitAll(new Task[] { Task.Delay(3000) });
         }
 
 


### PR DESCRIPTION
### Purpose

Trying to fix flaky test (issue not 100% reproducible).
After opening the workspace ContextMenu we are validating if the Popup is opened but sometimes the validation fails meaning that the Popup is not opened yet, so I added a 3 seconds delay after the Right Click is executed so we can be sure that the Context Menu is opened (this behavior hasn't been reproduced in my local environment).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Trying to fix flaky test (issue not 100% reproducible).


### Reviewers

@QilongTang @zeusongit 

### FYIs
