### PR TITLE
Insert unique GUIDs update

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2530,7 +2530,7 @@ namespace Dynamo.Graph.Workspaces
                 var text = annotationViewInfo.Title;
 
                 var pinnedNode = this.Nodes.
-                    FirstOrDefault(x => x.GUID.ToString() == annotationViewInfo.PinnedNode);
+                    FirstOrDefault(x => x.GUID.ToString("N") == annotationViewInfo.PinnedNode);
 
                 NoteModel noteModel;
                 if (offsetX == 0.0 && offsetY == 0.0)

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2530,7 +2530,7 @@ namespace Dynamo.Graph.Workspaces
                 var text = annotationViewInfo.Title;
 
                 var pinnedNode = this.Nodes.
-                    FirstOrDefault(x => x.GUID.ToString("N") == annotationViewInfo.PinnedNode);
+                    FirstOrDefault(x => x.GUID.ToString() == annotationViewInfo.PinnedNode);
 
                 NoteModel noteModel;
                 if (offsetX == 0.0 && offsetY == 0.0)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1892,7 +1892,6 @@ namespace Dynamo.Models
             }
         }
 
-
         static private DynamoPreferencesData DynamoPreferencesDataFromJson(string json)
         {
             JsonReader reader = new JsonTextReader(new StringReader(json));

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1986,175 +1986,7 @@ namespace Dynamo.Models
                 throw e;
             }
         }
-
-        /// <summary>
-        /// Update inserted workspace elements GUIDs 
-        /// </summary>
-        /// <param name="viewInfo">viewInfo</param>
-        /// <param name="ws">workspace</param>
-        private void UpdateWorkspaceGUIDs(ref ExtraWorkspaceViewInfo viewInfo, ref WorkspaceModel ws)
-        {
-            var nodes = ws.Nodes;
-            var connectors = ws.Connectors;
-            var notes = viewInfo?.Annotations;
-            
-            var nodesGuids = UpdateNodeGUIDs(ref nodes);
-            var connectorsGuids = UpdateConnectorGUIDs(ref connectors);
-            var notesGuids = UpdateNoteGUIDs(nodesGuids, ref notes);
-            
-            // Now propagate these changes to the viewInfo object
-            if (viewInfo == null) return;
-
-            PropagateUpdatesToViewInfo(viewInfo, nodesGuids, notesGuids, connectorsGuids);
-        }
-
-        private Dictionary<string, string> UpdateNoteGUIDs(Dictionary<Guid, Guid> nodesGuids, ref IEnumerable<ExtraAnnotationViewInfo> notes)
-        {
-            Dictionary<string, string> notesGuids = new Dictionary<string, string>();
-
-            // Assign new annotation models new GUIDs
-            // We need two separate runs to first create the new GUIDs and second work with the new GUIDS
-            if (notes != null)
-            {
-                foreach (var note in notes)
-                {
-                    string id = Guid.NewGuid().ToString();
-                    notesGuids[note.Id] = id;
-                    note.Id = id;
-
-                    // Reassign the pinned node Id
-                    if (note.PinnedNode != null)
-                    {
-                        if (nodesGuids.TryGetValue(new Guid(note.PinnedNode), out var guid))
-                        {
-                            note.PinnedNode = guid.ToString();
-                        }
-                    }
-                }
-
-                foreach (var note in notes)
-                {
-                    // Repopulate the group elements
-                    if (note.Nodes != null)
-                    {
-                        var updatedNodes = new List<string>();
-
-                        foreach (var node in note.Nodes)
-                        {
-                            // In case it's a node
-                            if (nodesGuids.TryGetValue(new Guid(node), out var guid))
-                            {
-                                updatedNodes.Add(guid.ToString());
-                            }
-                            // In case it's a group or a note
-                            else if (notesGuids.TryGetValue(node, out var id))
-                            {
-                                updatedNodes.Add(id);
-                            }
-                        }
-
-                        note.Nodes = updatedNodes;
-                    }
-                }
-            }
-
-            return notesGuids;
-        }
-
-        private Dictionary<Guid, Guid> UpdateNodeGUIDs(ref IEnumerable<NodeModel> nodes)
-        {
-            Dictionary<Guid, Guid> nodesGuids = new Dictionary<Guid, Guid>();
-
-            // Assign new GUIDs
-            foreach (var node in nodes)
-            {
-                var newGuid = Guid.NewGuid();
-                nodesGuids[node.GUID] = newGuid;
-                node.GUID = newGuid;
-            }
-
-            return nodesGuids;
-        }
-
-        private Dictionary<Guid, Guid> UpdateConnectorGUIDs(ref IEnumerable<ConnectorModel> connectors)
-        {
-            Dictionary<Guid, Guid> connectorsGuids = new Dictionary<Guid, Guid>();
-
-            foreach (var connector in connectors)
-            {
-                var newGuid = Guid.NewGuid();
-                connectorsGuids[connector.GUID] = newGuid;
-                connector.GUID = newGuid;
-
-                // Assign new pin GUIDs
-                foreach (var pin in connector.ConnectorPinModels)
-                {
-                    newGuid = Guid.NewGuid();
-                    pin.GUID = newGuid;
-                }
-            }
-
-            return connectorsGuids;
-        }
-
-        /// <summary>
-        /// Update GUIDs inside ExtraWorskapceViewInfo
-        /// </summary>
-        /// <param name="viewInfo">ViewInfo object containing information allowing to recreate the workspace</param>
-        /// <param name="nodesGuids">Nodes [old,new] GUID values</param>
-        /// <param name="notesGuids">Annotations [old,new] GUID values</param>
-        /// <param name="connectorsGuids">Connectors [old,new] GUID values</param>
-        private void PropagateUpdatesToViewInfo(ExtraWorkspaceViewInfo viewInfo,
-            Dictionary<Guid, Guid> nodesGuids,
-            Dictionary<string, string> notesGuids,
-            Dictionary<Guid, Guid> connectorsGuids)
-        {
-            if (viewInfo.NodeViews != null)
-            {
-                foreach (var node in viewInfo.NodeViews)
-                {
-                    if (nodesGuids.TryGetValue(new Guid(node.Id), out var guid))
-                    {
-                        node.Id = guid.ToString();
-                    }
-                }
-            }
-
-            if (viewInfo.Notes != null)
-            {
-                foreach (var note in viewInfo.Notes)
-                {
-                    if (notesGuids.TryGetValue(note.Id, out var guid))
-                    {
-                        note.Id = guid;
-                    }
-                }
-            }
-
-            if (viewInfo.Annotations != null)
-            {
-                foreach (var note in viewInfo.Annotations)
-                {
-                    if (notesGuids.TryGetValue(note.Id, out var guid))
-                    {
-                        note.Id = guid;
-                    }
-                }
-            }
-
-            if (viewInfo.ConnectorPins != null)
-            {
-                foreach (var pin in viewInfo.ConnectorPins)
-                {
-                    if (connectorsGuids.TryGetValue(new Guid(pin.ConnectorGuid), out var guid))
-                    {
-                        pin.ConnectorGuid = guid.ToString();
-                    }
-                }
-            }
-        }
-
-
+        
         /// <summary>
         /// Opens a Dynamo workspace from a path to an Xml file on disk.
         /// </summary>
@@ -3700,6 +3532,177 @@ namespace Dynamo.Models
             // If no nodes exist with the same GUID, then we are good to go
             return false;
         }
+        #endregion
+
+        #region Insert Private Methods
+
+        /// <summary>
+        /// Update inserted workspace elements GUIDs 
+        /// </summary>
+        /// <param name="viewInfo">viewInfo</param>
+        /// <param name="ws">workspace</param>
+        private void UpdateWorkspaceGUIDs(ref ExtraWorkspaceViewInfo viewInfo, ref WorkspaceModel ws)
+        {
+            var nodes = ws.Nodes;
+            var connectors = ws.Connectors;
+            var notes = viewInfo?.Annotations;
+
+            var nodesGuids = UpdateNodeGUIDs(ref nodes);
+            var connectorsGuids = UpdateConnectorGUIDs(ref connectors);
+            var notesGuids = UpdateNoteGUIDs(nodesGuids, ref notes);
+
+            // Now propagate these changes to the viewInfo object
+            if (viewInfo == null) return;
+
+            PropagateUpdatesToViewInfo(viewInfo, nodesGuids, notesGuids, connectorsGuids);
+        }
+
+        private Dictionary<string, string> UpdateNoteGUIDs(Dictionary<Guid, Guid> nodesGuids, ref IEnumerable<ExtraAnnotationViewInfo> notes)
+        {
+            Dictionary<string, string> notesGuids = new Dictionary<string, string>();
+
+            // Assign new annotation models new GUIDs
+            // We need two separate runs to first create the new GUIDs and second work with the new GUIDS
+            if (notes != null)
+            {
+                foreach (var note in notes)
+                {
+                    string id = Guid.NewGuid().ToString();
+                    notesGuids[note.Id] = id;
+                    note.Id = id;
+
+                    // Reassign the pinned node Id
+                    if (note.PinnedNode != null)
+                    {
+                        if (nodesGuids.TryGetValue(new Guid(note.PinnedNode), out var guid))
+                        {
+                            note.PinnedNode = guid.ToString();
+                        }
+                    }
+                }
+
+                foreach (var note in notes)
+                {
+                    // Repopulate the group elements
+                    if (note.Nodes != null)
+                    {
+                        var updatedNodes = new List<string>();
+
+                        foreach (var node in note.Nodes)
+                        {
+                            // In case it's a node
+                            if (nodesGuids.TryGetValue(new Guid(node), out var guid))
+                            {
+                                updatedNodes.Add(guid.ToString());
+                            }
+                            // In case it's a group or a note
+                            else if (notesGuids.TryGetValue(node, out var id))
+                            {
+                                updatedNodes.Add(id);
+                            }
+                        }
+
+                        note.Nodes = updatedNodes;
+                    }
+                }
+            }
+
+            return notesGuids;
+        }
+
+        private Dictionary<Guid, Guid> UpdateNodeGUIDs(ref IEnumerable<NodeModel> nodes)
+        {
+            Dictionary<Guid, Guid> nodesGuids = new Dictionary<Guid, Guid>();
+
+            // Assign new GUIDs
+            foreach (var node in nodes)
+            {
+                var newGuid = Guid.NewGuid();
+                nodesGuids[node.GUID] = newGuid;
+                node.GUID = newGuid;
+            }
+
+            return nodesGuids;
+        }
+
+        private Dictionary<Guid, Guid> UpdateConnectorGUIDs(ref IEnumerable<ConnectorModel> connectors)
+        {
+            Dictionary<Guid, Guid> connectorsGuids = new Dictionary<Guid, Guid>();
+
+            foreach (var connector in connectors)
+            {
+                var newGuid = Guid.NewGuid();
+                connectorsGuids[connector.GUID] = newGuid;
+                connector.GUID = newGuid;
+
+                // Assign new pin GUIDs
+                foreach (var pin in connector.ConnectorPinModels)
+                {
+                    newGuid = Guid.NewGuid();
+                    pin.GUID = newGuid;
+                }
+            }
+
+            return connectorsGuids;
+        }
+
+        /// <summary>
+        /// Update GUIDs inside ExtraWorskapceViewInfo
+        /// </summary>
+        /// <param name="viewInfo">ViewInfo object containing information allowing to recreate the workspace</param>
+        /// <param name="nodesGuids">Nodes [old,new] GUID values</param>
+        /// <param name="notesGuids">Annotations [old,new] GUID values</param>
+        /// <param name="connectorsGuids">Connectors [old,new] GUID values</param>
+        private void PropagateUpdatesToViewInfo(ExtraWorkspaceViewInfo viewInfo,
+            Dictionary<Guid, Guid> nodesGuids,
+            Dictionary<string, string> notesGuids,
+            Dictionary<Guid, Guid> connectorsGuids)
+        {
+            if (viewInfo.NodeViews != null)
+            {
+                foreach (var node in viewInfo.NodeViews)
+                {
+                    if (nodesGuids.TryGetValue(new Guid(node.Id), out var guid))
+                    {
+                        node.Id = guid.ToString();
+                    }
+                }
+            }
+
+            if (viewInfo.Notes != null)
+            {
+                foreach (var note in viewInfo.Notes)
+                {
+                    if (notesGuids.TryGetValue(note.Id, out var guid))
+                    {
+                        note.Id = guid;
+                    }
+                }
+            }
+
+            if (viewInfo.Annotations != null)
+            {
+                foreach (var note in viewInfo.Annotations)
+                {
+                    if (notesGuids.TryGetValue(note.Id, out var guid))
+                    {
+                        note.Id = guid;
+                    }
+                }
+            }
+
+            if (viewInfo.ConnectorPins != null)
+            {
+                foreach (var pin in viewInfo.ConnectorPins)
+                {
+                    if (connectorsGuids.TryGetValue(new Guid(pin.ConnectorGuid), out var guid))
+                    {
+                        pin.ConnectorGuid = guid.ToString();
+                    }
+                }
+            }
+        }
+
         #endregion
 
         #endregion

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2121,8 +2121,6 @@ namespace Dynamo.Models
 
             CurrentWorkspace.UpdateWithExtraWorkspaceViewInfo(viewInfo, offsetX, offsetY);
 
-            //InsertAnnotations(viewInfo.Annotations, offsetX, offsetY);
-
             List<NoteModel> insertedNotes = GetInsertedNotes(viewInfo.Annotations);
 
             DynamoSelection.Instance.Selection.AddRange(nodes);
@@ -3355,18 +3353,6 @@ namespace Dynamo.Models
         }
 
         #region insert private methods
-        private void InsertAnnotations(IEnumerable<ExtraAnnotationViewInfo> viewInfoAnnotations, double offsetX, double offsetY)
-        {
-            List<ConnectorModel> newConnectors = new List<ConnectorModel>();
-
-            foreach (var annotation in viewInfoAnnotations)
-            {
-                if (annotation.Nodes.Any() || annotation.PinnedNode != null) continue;
-
-                var guidValue = WorkspaceModel.IdToGuidConverter(annotation.Id);
-                var matchingNote = CurrentWorkspace.Notes.FirstOrDefault(x => x.GUID == guidValue);
-            }
-        }
 
         private void InsertNodes(IEnumerable<NodeModel> nodes, double offsetX, double offsetY)
         {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -1960,6 +1961,9 @@ namespace Dynamo.Models
         {
             try
             {
+                // Update (assign new) GUIDs for each node, connection, note and group
+                fileContents = UpdateWorkspaceGUIDs(fileContents);
+
                 DynamoPreferencesData dynamoPreferences = DynamoPreferencesDataFromJson(fileContents);
                 if (dynamoPreferences != null)
                 {
@@ -1969,10 +1973,7 @@ namespace Dynamo.Models
                         if (OpenJsonFile(filePath, fileContents, dynamoPreferences, forceManualExecutionMode, out ws))
                         {
                             ExtraWorkspaceViewInfo viewInfo = ExtraWorkspaceViewInfoFromJson(fileContents);
-
-                            // Update (assign new) GUIDs for each node, connection, note and group
-                            UpdateWorkspaceGUIDs(ref viewInfo, ref ws);
-
+                            
                             InsertWorkspace(ws, viewInfo);
                         }
                     }
@@ -3522,170 +3523,29 @@ namespace Dynamo.Models
         #region Insert Private Methods
 
         /// <summary>
-        /// Update inserted workspace elements GUIDs 
+        /// Performs an update to all Guids inside the json string before deserialization.
+        /// Targets specifically Guids without the '-' hyphen, which are all the workspace elements.
+        /// Replacing all occurrences of each individual Guid guarantees that the relationships between the elements are retained.
         /// </summary>
-        /// <param name="viewInfo">viewInfo</param>
-        /// <param name="ws">workspace</param>
-        private void UpdateWorkspaceGUIDs(ref ExtraWorkspaceViewInfo viewInfo, ref WorkspaceModel ws)
+        /// <param name="jsonData"></param>
+        /// <returns></returns>
+        private string UpdateWorkspaceGUIDs(string jsonData)
         {
-            var nodes = ws.Nodes;
-            var connectors = ws.Connectors;
-            var notes = viewInfo?.Annotations;
+            string pattern = @"([a-z0-9]{32})";
+            string updatedJsonData = jsonData;
 
-            var nodesGuids = UpdateNodeGUIDs(ref nodes);
-            var connectorsGuids = UpdateConnectorGUIDs(ref connectors);
-            var notesGuids = UpdateNoteGUIDs(nodesGuids, ref notes);
+            // The unique collection of Guids
+            var mc = Regex.Matches(jsonData, pattern)
+                .Cast<Match>()
+                .Select(m => m.Value)
+                .Distinct();
 
-            // Now propagate these changes to the viewInfo object
-            if (viewInfo == null) return;
-
-            PropagateUpdatesToViewInfo(viewInfo, nodesGuids, notesGuids, connectorsGuids);
-        }
-
-        private Dictionary<string, string> UpdateNoteGUIDs(Dictionary<Guid, Guid> nodesGuids, ref IEnumerable<ExtraAnnotationViewInfo> notes)
-        {
-            Dictionary<string, string> notesGuids = new Dictionary<string, string>();
-
-            // Assign new annotation models new GUIDs
-            // We need two separate runs to first create the new GUIDs and second work with the new GUIDS
-            if (notes != null)
+            foreach (var match in mc)
             {
-                foreach (var note in notes)
-                {
-                    string id = Guid.NewGuid().ToString();
-                    notesGuids[note.Id] = id;
-                    note.Id = id;
-
-                    // Reassign the pinned node Id
-                    if (note.PinnedNode != null)
-                    {
-                        if (nodesGuids.TryGetValue(new Guid(note.PinnedNode), out var guid))
-                        {
-                            note.PinnedNode = guid.ToString();
-                        }
-                    }
-                }
-
-                foreach (var note in notes)
-                {
-                    // Repopulate the group elements
-                    if (note.Nodes != null)
-                    {
-                        var updatedNodes = new List<string>();
-
-                        foreach (var node in note.Nodes)
-                        {
-                            // In case it's a node
-                            if (nodesGuids.TryGetValue(new Guid(node), out var guid))
-                            {
-                                updatedNodes.Add(guid.ToString());
-                            }
-                            // In case it's a group or a note
-                            else if (notesGuids.TryGetValue(node, out var id))
-                            {
-                                updatedNodes.Add(id);
-                            }
-                        }
-
-                        note.Nodes = updatedNodes;
-                    }
-                }
+                updatedJsonData = updatedJsonData.Replace(match, Guid.NewGuid().ToString("N"));
             }
 
-            return notesGuids;
-        }
-
-        private Dictionary<Guid, Guid> UpdateNodeGUIDs(ref IEnumerable<NodeModel> nodes)
-        {
-            Dictionary<Guid, Guid> nodesGuids = new Dictionary<Guid, Guid>();
-
-            // Assign new GUIDs
-            foreach (var node in nodes)
-            {
-                var newGuid = Guid.NewGuid();
-                nodesGuids[node.GUID] = newGuid;
-                node.GUID = newGuid;
-            }
-
-            return nodesGuids;
-        }
-
-        private Dictionary<Guid, Guid> UpdateConnectorGUIDs(ref IEnumerable<ConnectorModel> connectors)
-        {
-            Dictionary<Guid, Guid> connectorsGuids = new Dictionary<Guid, Guid>();
-
-            foreach (var connector in connectors)
-            {
-                var newGuid = Guid.NewGuid();
-                connectorsGuids[connector.GUID] = newGuid;
-                connector.GUID = newGuid;
-
-                // Assign new pin GUIDs
-                foreach (var pin in connector.ConnectorPinModels)
-                {
-                    newGuid = Guid.NewGuid();
-                    pin.GUID = newGuid;
-                }
-            }
-
-            return connectorsGuids;
-        }
-
-        /// <summary>
-        /// Update GUIDs inside ExtraWorskapceViewInfo
-        /// </summary>
-        /// <param name="viewInfo">ViewInfo object containing information allowing to recreate the workspace</param>
-        /// <param name="nodesGuids">Nodes [old,new] GUID values</param>
-        /// <param name="notesGuids">Annotations [old,new] GUID values</param>
-        /// <param name="connectorsGuids">Connectors [old,new] GUID values</param>
-        private void PropagateUpdatesToViewInfo(ExtraWorkspaceViewInfo viewInfo,
-            Dictionary<Guid, Guid> nodesGuids,
-            Dictionary<string, string> notesGuids,
-            Dictionary<Guid, Guid> connectorsGuids)
-        {
-            if (viewInfo.NodeViews != null)
-            {
-                foreach (var node in viewInfo.NodeViews)
-                {
-                    if (nodesGuids.TryGetValue(new Guid(node.Id), out var guid))
-                    {
-                        node.Id = guid.ToString();
-                    }
-                }
-            }
-
-            if (viewInfo.Notes != null)
-            {
-                foreach (var note in viewInfo.Notes)
-                {
-                    if (notesGuids.TryGetValue(note.Id, out var guid))
-                    {
-                        note.Id = guid;
-                    }
-                }
-            }
-
-            if (viewInfo.Annotations != null)
-            {
-                foreach (var note in viewInfo.Annotations)
-                {
-                    if (notesGuids.TryGetValue(note.Id, out var guid))
-                    {
-                        note.Id = guid;
-                    }
-                }
-            }
-
-            if (viewInfo.ConnectorPins != null)
-            {
-                foreach (var pin in viewInfo.ConnectorPins)
-                {
-                    if (connectorsGuids.TryGetValue(new Guid(pin.ConnectorGuid), out var guid))
-                    {
-                        pin.ConnectorGuid = guid.ToString();
-                    }
-                }
-            }
+            return updatedJsonData;
         }
 
         #endregion

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1961,7 +1961,9 @@ namespace Dynamo.Models
         {
             try
             {
-                // Update (assign new) GUIDs for each node, connection, note and group
+                // Update (assign new) Guids for each node, connection, note and group
+                // The update of Guids is necessary to assure the insertion of dynamo graphs does not interfere with the current workspace
+                // This allows multiple inserts of the same or 'similar' graph to take place
                 fileContents = UpdateWorkspaceGUIDs(fileContents);
 
                 DynamoPreferencesData dynamoPreferences = DynamoPreferencesDataFromJson(fileContents);

--- a/test/DynamoCoreTests/Models/OpenFileCommandTest.cs
+++ b/test/DynamoCoreTests/Models/OpenFileCommandTest.cs
@@ -116,12 +116,53 @@ namespace Dynamo.Tests.ModelsTest
             currentCount = this.CurrentDynamoModel.CurrentWorkspace.Nodes.Count();
             Assert.AreNotEqual(0, currentCount);
 
-            //If we try to insert the same graph, currently Dynamo should not allow us
-            // TODO - this part of the test might change if we include a logic
-            // to recreate the GUIDs of the 'same' nodes to allow for duplicate or partial duplicate insertions
+            //Assert 2x
             this.CurrentDynamoModel.InsertFileFromPath(wspath);
             var updatedCount = this.CurrentDynamoModel.CurrentWorkspace.Nodes.Count();
-            Assert.AreEqual(currentCount, updatedCount);
+            Assert.AreEqual(currentCount * 2, updatedCount);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestInsertNotes()
+        {
+            // Home space contains 0 nodes
+            var currentCount = this.CurrentDynamoModel.CurrentWorkspace.Notes.Count();
+            Assert.AreEqual(0, currentCount);
+
+            //Act
+            string wspath = Path.Combine(TestDirectory, @"core\callsite\insert_annotations.dyn");
+            this.CurrentDynamoModel.InsertFileFromPath(wspath);
+
+            //Assert
+            currentCount = this.CurrentDynamoModel.CurrentWorkspace.Notes.Count();
+            Assert.AreNotEqual(0, currentCount);
+
+            //Assert pinned/unpinned notes
+            var pinnedNotesCount = this.CurrentDynamoModel.CurrentWorkspace.Notes.Count(x => x.PinnedNode != null);
+            var unpinnedNotesCount = this.CurrentDynamoModel.CurrentWorkspace.Notes.Count(x => x.PinnedNode == null);
+            Assert.AreEqual(1, pinnedNotesCount, unpinnedNotesCount);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestInsertAnnotations()
+        {
+            // Home space contains 0 nodes
+            var currentCount = this.CurrentDynamoModel.CurrentWorkspace.Annotations.Count();
+            Assert.AreEqual(0, currentCount);
+
+            //Act
+            string wspath = Path.Combine(TestDirectory, @"core\callsite\insert_annotations.dyn");
+            this.CurrentDynamoModel.InsertFileFromPath(wspath);
+
+            //Assert
+            currentCount = this.CurrentDynamoModel.CurrentWorkspace.Notes.Count();
+            Assert.AreEqual(2, currentCount);
+
+            //Assert nested groups
+            var nestedGroupsCount = this.CurrentDynamoModel.CurrentWorkspace.Annotations.Count(x => x.Nodes.Count(y => y is Dynamo.Graph.Annotations.AnnotationModel) > 0);
+            Assert.AreEqual(1, nestedGroupsCount);
         }
     }
     

--- a/test/core/callsite/insert_annotations.dyn
+++ b/test/core/callsite/insert_annotations.dyn
@@ -1,0 +1,245 @@
+{
+  "Uuid": "52110831-593d-4fd9-a6d1-f140fd89e2f7",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "pinned groups simple",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "f5f3698cf7dc405e998fbfaa46dde290",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [
+        {
+          "Id": "4e049cd065864402b53cb94831d0d9ff",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "31ecfa3826b447b58ef9da753b506412",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "x;"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "7636c3b513dd410e8c922959f852ed14",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [
+        {
+          "Id": "2d612be32257494daf57727b2b4fd85e",
+          "Name": "y",
+          "Description": "y",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f85e7b48ece74f87a4a3b9ac5a124bbd",
+          "Name": "",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "x = y;"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "31ecfa3826b447b58ef9da753b506412",
+      "End": "2d612be32257494daf57727b2b4fd85e",
+      "Id": "496d8b5344c6449c8762423d6b21c555",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.18",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.18.0.2986",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [
+      {
+        "Left": 446.66666666666663,
+        "Top": 270.0001,
+        "IsHidden": false,
+        "ConnectorGuid": "496d8b53-44c6-449c-8762-423d6b21c555"
+      }
+    ],
+    "NodeViews": [
+      {
+        "Id": "f5f3698cf7dc405e998fbfaa46dde290",
+        "Name": "nested node",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 92.370245501596173,
+        "Y": 207.45313531945578
+      },
+      {
+        "Id": "7636c3b513dd410e8c922959f852ed14",
+        "Name": "root node",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 724.43103352560468,
+        "Y": 441.9194789720317
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "9d272dab44b24f9e8586362d9e809ecb",
+        "Title": "Nested group",
+        "DescriptionText": "<Double click here to edit group description>",
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [
+          "f5f3698cf7dc405e998fbfaa46dde290"
+        ],
+        "HasNestedGroups": false,
+        "Left": 82.370245501596173,
+        "Top": 82.11980198612244,
+        "Width": 185.33333333333337,
+        "Height": 257.66666666666663,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 207.45313531945578,
+        "InitialHeight": 162.33333333333334,
+        "TextblockHeight": 115.33333333333334,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "cab1676718344715a98796af4355cef6",
+        "Title": "Root group",
+        "DescriptionText": "<Double click here to edit group description>",
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [
+          "7636c3b513dd410e8c922959f852ed14",
+          "9d272dab44b24f9e8586362d9e809ecb",
+          "54f04e9cff7d47f3b7e84dbf09f89c9a"
+        ],
+        "HasNestedGroups": true,
+        "Left": 72.370245501596173,
+        "Top": 8.7864686527891038,
+        "Width": 823.39412135734187,
+        "Height": 565.46634365257592,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 82.11980198612244,
+        "InitialHeight": 662.27581038265168,
+        "TextblockHeight": 63.333333333333336,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "b5ebc382d67a46748daaca25f9fc16ff",
+        "Title": "Unpinned note",
+        "DescriptionText": null,
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [],
+        "HasNestedGroups": false,
+        "Left": 99.4115405817468,
+        "Top": -209.99587727481452,
+        "Width": 0.0,
+        "Height": 0.0,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 0.0,
+        "InitialHeight": 0.0,
+        "TextblockHeight": 0.0,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "54f04e9cff7d47f3b7e84dbf09f89c9a",
+        "Title": "Pinned note",
+        "DescriptionText": null,
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [],
+        "HasNestedGroups": false,
+        "Left": 761.0977001922713,
+        "Top": 391.25281230536507,
+        "Width": 0.0,
+        "Height": 0.0,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 0.0,
+        "InitialHeight": 0.0,
+        "TextblockHeight": 0.0,
+        "Background": "#FFC1D676",
+        "PinnedNode": "7636c3b513dd410e8c922959f852ed14"
+      }
+    ],
+    "X": 135.71234475519236,
+    "Y": 301.06851218357639,
+    "Zoom": 0.565293988808902
+  }
+}


### PR DESCRIPTION
### Purpose

This PR addresses an outstanding issue with the Insert functionality introduced a while back. Previously, it wasn't possible for users to insert the same graph or derivatives of the same graph inside the workspace. That was due to the identical GUIDs present in the graphs (attached current state of affairs comparison between 3 derivative dynamo graphs). 

Logic to recreate all element GUIDs that make up the workspace prior to inserting them into the current workspace is introduced with this PR to handle these cases.

#### Side-by-side derivative comparison
![Insert](https://user-images.githubusercontent.com/5354594/219113211-f18cbabd-c0bd-43b9-b7e4-7cc6219d3e48.png)

#### Insert multiple of the same
![insert_multiple](https://user-images.githubusercontent.com/5354594/219113610-5f55110b-7957-4dce-8565-39caff89b8a4.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

- assign new GUIDs for all workspace elements
- now correctly inserts groups and notes
- now correctly inserts pinned notes
- added new tests for Insert functionality
- change to old test to account for the ability to insert multiple of the same graph

### Reviewers

@QilongTang 
@mjkkirschner 
@Amoursol 

### FYIs

@sm6srw 
