### PR TITLE
AGD-9999 : allow extension to load in service mode

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -876,11 +876,8 @@ namespace Dynamo.Models
             //Initialize the ExtensionManager with the CommonDataDirectory so that extensions found here are checked first for dll's with signed certificates
             extensionManager = new ExtensionManager(new[] { PathManager.CommonDataDirectory });
             extensionManager.MessageLogged += LogMessage;
-            var extensions = config.Extensions ?? new List<IExtension>();
-            if (!extensions.Any() && !IsServiceMode)
-            {
-                extensions = LoadExtensions();
-            }
+            var extensions = config.Extensions ?? LoadExtensions();
+
             if (!IsServiceMode)
             {
                 LinterManager = new LinterManager(this.ExtensionManager);


### PR DESCRIPTION
### Purpose
Allow extension to load in service mode.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers
@QilongTang @saintentropy 

