### PR TITLE
Workspace SaveAs Guids replacement

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -1991,7 +1990,7 @@ namespace Dynamo.Models
                 // Update (assign new) Guids for each node, connection, note and group
                 // The update of Guids is necessary to assure the insertion of dynamo graphs does not interfere with the current workspace
                 // This allows multiple inserts of the same or 'similar' graph to take place
-                fileContents = UpdateWorkspaceGUIDs(fileContents);
+                fileContents = GuidUtility.UpdateWorkspaceGUIDs(fileContents);
 
                 DynamoPreferencesData dynamoPreferences = DynamoPreferencesDataFromJson(fileContents);
                 if (dynamoPreferences != null)
@@ -3547,36 +3546,6 @@ namespace Dynamo.Models
             // If no nodes exist with the same GUID, then we are good to go
             return false;
         }
-        #endregion
-
-        #region Insert Private Methods
-
-        /// <summary>
-        /// Performs an update to all Guids inside the json string before deserialization.
-        /// Targets specifically Guids without the '-' hyphen, which are all the workspace elements.
-        /// Replacing all occurrences of each individual Guid guarantees that the relationships between the elements are retained.
-        /// </summary>
-        /// <param name="jsonData"></param>
-        /// <returns></returns>
-        private string UpdateWorkspaceGUIDs(string jsonData)
-        {
-            string pattern = @"([a-z0-9]{32})";
-            string updatedJsonData = jsonData;
-
-            // The unique collection of Guids
-            var mc = Regex.Matches(jsonData, pattern)
-                .Cast<Match>()
-                .Select(m => m.Value)
-                .Distinct();
-
-            foreach (var match in mc)
-            {
-                updatedJsonData = updatedJsonData.Replace(match, Guid.NewGuid().ToString("N"));
-            }
-
-            return updatedJsonData;
-        }
-
         #endregion
 
         #endregion

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -594,7 +594,9 @@ namespace Dynamo.ViewModels
         /// then adds a View property to serialized Workspace, and sets its value to the serialized ViewModel.
         /// </summary>
         /// <param name="filePath"></param>
+        /// <param name="isBackup"></param>
         /// <param name="engine"></param>
+        /// <param name="saveContext"></param>
         /// <exception cref="ArgumentNullException">Thrown when the file path is null.</exception>
         internal void Save(string filePath, bool isBackup = false, EngineController engine = null, SaveContext saveContext = SaveContext.None)
         {
@@ -620,7 +622,18 @@ namespace Dynamo.ViewModels
                 var jo = AddViewBlockToJSON(json_parsed);
 
                 // Stage 3: Save
-                File.WriteAllText(filePath, jo.ToString());
+                string saveContent;
+                if(saveContext == SaveContext.SaveAs && !isBackup)
+                {
+                    // For intentional SaveAs either through UI or API calls, replace workspace elements' Guids and workspace Id
+                    jo["Uuid"] = Guid.NewGuid().ToString();
+                    saveContent = GuidUtility.UpdateWorkspaceGUIDs(jo.ToString());
+                }
+                else
+                {
+                    saveContent = jo.ToString();
+                }
+                File.WriteAllText(filePath, saveContent);
 
                 // Handle Workspace or CustomNodeWorkspace related non-serialization internal logic
                 // Only for actual save, update file path and recent file list

--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -128,7 +128,7 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="jsonData"></param>
         /// <returns></returns>
-        public static string UpdateWorkspaceGUIDs(string jsonData)
+        internal static string UpdateWorkspaceGUIDs(string jsonData)
         {
             string pattern = @"([a-z0-9]{32})";
             string updatedJsonData = jsonData;

--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 // drawn from: https://github.com/LogosBible/Logos.Utility/blob/master/src/Logos.Utility/GuidUtility.cs
 namespace Dynamo.Utilities
@@ -117,6 +119,32 @@ namespace Dynamo.Utilities
             byte temp = guid[left];
             guid[left] = guid[right];
             guid[right] = temp;
+        }
+
+        /// <summary>
+        /// Performs an update to all Guids inside the json string before deserialization.
+        /// Targets specifically Guids without the '-' hyphen, which are all the workspace elements.
+        /// Replacing all occurrences of each individual Guid guarantees that the relationships between the elements are retained.
+        /// </summary>
+        /// <param name="jsonData"></param>
+        /// <returns></returns>
+        public static string UpdateWorkspaceGUIDs(string jsonData)
+        {
+            string pattern = @"([a-z0-9]{32})";
+            string updatedJsonData = jsonData;
+
+            // The unique collection of Guids
+            var mc = Regex.Matches(jsonData, pattern)
+                .Cast<Match>()
+                .Select(m => m.Value)
+                .Distinct();
+
+            foreach (var match in mc)
+            {
+                updatedJsonData = updatedJsonData.Replace(match, Guid.NewGuid().ToString("N"));
+            }
+
+            return updatedJsonData;
         }
     }
 }

--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -126,8 +126,8 @@ namespace Dynamo.Utilities
         /// Targets specifically Guids without the '-' hyphen, which are all the workspace elements.
         /// Replacing all occurrences of each individual Guid guarantees that the relationships between the elements are retained.
         /// </summary>
-        /// <param name="jsonData"></param>
-        /// <returns></returns>
+        /// <param name="jsonData">Json representation of workspace.</param>
+        /// <returns>String representation of workspace after all elements' Guids replaced.</returns>
         internal static string UpdateWorkspaceGUIDs(string jsonData)
         {
             string pattern = @"([a-z0-9]{32})";

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -619,10 +619,11 @@ namespace Dynamo.Tests
             ViewModel.OpenCommand.Execute(examplePath);
             var legacyWorkspaceGuid = ViewModel.Model.CurrentWorkspace.Guid;
             var legacyNodeGuid = ViewModel.Model.CurrentWorkspace.Nodes.FirstOrDefault().GUID;
-            var legacyGroupGuid = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GUID;
-            var legacyGroupStyleId = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GroupStyleId;
+            var legacyGroupGuid = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault().AnnotationModel.GUID;
+            var legacyGroupStyleId = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault().GroupStyleId;
             var legacyNoteId = ViewModel.Model.CurrentWorkspace.Notes.FirstOrDefault().GUID;
             var legacyConnectorId = ViewModel.Model.CurrentWorkspace.Connectors.FirstOrDefault().GUID;
+            var legacyLinterId = ViewModel.CurrentSpaceViewModel.Model.linterManager.ActiveLinter.Id;
 
             // Save As a new workspace
             string fn = "ruthlessTurtles.dyn";
@@ -631,18 +632,19 @@ namespace Dynamo.Tests
             ViewModel.OpenCommand.Execute(path);
             var newWorkspaceGuid = ViewModel.Model.CurrentWorkspace.Guid;
             var newNodeGuid = ViewModel.Model.CurrentWorkspace.Nodes.FirstOrDefault().GUID;
-
-            var newGroupGuid = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GUID;
-            var newGroupStyleId = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GroupStyleId;
+            var newGroupGuid = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault().AnnotationModel.GUID;
+            var newGroupStyleId = ViewModel.CurrentSpaceViewModel.Annotations.FirstOrDefault().GroupStyleId;
             var newNoteId = ViewModel.Model.CurrentWorkspace.Notes.FirstOrDefault().GUID;
             var newConnectorId = ViewModel.Model.CurrentWorkspace.Connectors.FirstOrDefault().GUID;
+            var newLinterId = ViewModel.CurrentSpaceViewModel.Model.linterManager.ActiveLinter.Id;
 
             Assert.AreNotEqual(legacyWorkspaceGuid, newWorkspaceGuid);
             Assert.AreNotEqual(legacyNodeGuid, newNodeGuid);
             Assert.AreNotEqual(legacyGroupGuid, newGroupGuid);
-            Assert.AreEqual(legacyGroupStyleId, newGroupStyleId);
             Assert.AreNotEqual(legacyNoteId, newNoteId);
             Assert.AreNotEqual(legacyConnectorId, newConnectorId);
+            Assert.AreEqual(legacyGroupStyleId, newGroupStyleId);
+            Assert.AreEqual(legacyLinterId, newLinterId);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -613,6 +613,39 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CanSaveAsNewWorkspaceWithNewGuids()
+        {
+            string examplePath = Path.Combine(TestDirectory, (@"UI\GroupStyleTest.dyn"));
+            ViewModel.OpenCommand.Execute(examplePath);
+            var legacyWorkspaceGuid = ViewModel.Model.CurrentWorkspace.Guid;
+            var legacyNodeGuid = ViewModel.Model.CurrentWorkspace.Nodes.FirstOrDefault().GUID;
+            var legacyGroupGuid = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GUID;
+            var legacyGroupStyleId = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GroupStyleId;
+            var legacyNoteId = ViewModel.Model.CurrentWorkspace.Notes.FirstOrDefault().GUID;
+            var legacyConnectorId = ViewModel.Model.CurrentWorkspace.Connectors.FirstOrDefault().GUID;
+
+            // Save As a new workspace
+            string fn = "ruthlessTurtles.dyn";
+            string path = Path.Combine(TempFolder, fn);
+            ViewModel.CurrentSpaceViewModel.Save(path, false, null, SaveContext.SaveAs);
+            ViewModel.OpenCommand.Execute(path);
+            var newWorkspaceGuid = ViewModel.Model.CurrentWorkspace.Guid;
+            var newNodeGuid = ViewModel.Model.CurrentWorkspace.Nodes.FirstOrDefault().GUID;
+
+            var newGroupGuid = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GUID;
+            var newGroupStyleId = ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().GroupStyleId;
+            var newNoteId = ViewModel.Model.CurrentWorkspace.Notes.FirstOrDefault().GUID;
+            var newConnectorId = ViewModel.Model.CurrentWorkspace.Connectors.FirstOrDefault().GUID;
+
+            Assert.AreNotEqual(legacyWorkspaceGuid, newWorkspaceGuid);
+            Assert.AreNotEqual(legacyNodeGuid, newNodeGuid);
+            Assert.AreNotEqual(legacyGroupGuid, newGroupGuid);
+            Assert.AreEqual(legacyGroupStyleId, newGroupStyleId);
+            Assert.AreNotEqual(legacyNoteId, newNoteId);
+            Assert.AreNotEqual(legacyConnectorId, newConnectorId);
+        }
+
+        [Test]
         [Category("UnitTests")]
         public void BackUpSaveDoesNotChangeName()
         {

--- a/test/UI/GroupStyleTest.dyn
+++ b/test/UI/GroupStyleTest.dyn
@@ -1,7 +1,7 @@
 {
   "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
   "IsCustomNode": false,
-  "Description": "",
+  "Description": "Group Style Test",
   "Name": "GroupStyleTest",
   "ElementResolver": {
     "ResolutionMap": {
@@ -74,7 +74,7 @@
   ],
   "Dependencies": [],
   "NodeLibraryDependencies": [],
-  "Thumbnail": null,
+  "Thumbnail": "",
   "GraphDocumentationURL": null,
   "ExtensionWorkspaceData": [
     {
@@ -84,7 +84,7 @@
       "Data": {}
     }
   ],
-  "Author": "None provided",
+  "Author": "Dynamo Team",
   "Linting": {
     "activeLinter": "None",
     "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
@@ -155,7 +155,7 @@
         "FontSize": 36.0,
         "GroupStyleId": "00000000-0000-0000-0000-000000000000",
         "InitialTop": 201.66666666666666,
-        "InitialHeight": 161.2,
+        "InitialHeight": 144.99999999999997,
         "TextblockHeight": 106.66666666666667,
         "Background": "#FFC98132"
       },

--- a/test/UI/GroupStyleTest.dyn
+++ b/test/UI/GroupStyleTest.dyn
@@ -1,0 +1,188 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "GroupStyleTest",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "189b1e12ef5449239af879fa1fd7a523",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "592e20a0243843f1b3b4e39fda1009c3",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "Point.ByCoordinates(1,1,1);"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "Id": "a388045e9fcc44ca88e25b43f51bfc1b",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "61971d7fed9b4551ba5dc8ffc31e425e",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7481964b63074ea981e3a2d33c03f016",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "592e20a0243843f1b3b4e39fda1009c3",
+      "End": "61971d7fed9b4551ba5dc8ffc31e425e",
+      "Id": "45b96ddbe908478b96099cc485abfdae",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": null,
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.18",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.18.0.2986",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "189b1e12ef5449239af879fa1fd7a523",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 53.333333333333258,
+        "Y": 201.66666666666666
+      },
+      {
+        "Id": "a388045e9fcc44ca88e25b43f51bfc1b",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 443.33333333333343,
+        "Y": 215.17249999999999
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "a432d63f7a3645adb30a7924beb20e90",
+        "Title": "<Click here to edit the group title>",
+        "DescriptionText": "<Double click here to edit group description>",
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [
+          "189b1e12ef5449239af879fa1fd7a523"
+        ],
+        "HasNestedGroups": false,
+        "Left": 43.333333333333258,
+        "Top": 84.999999999999986,
+        "Width": 316.0,
+        "Height": 261.0,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 201.66666666666666,
+        "InitialHeight": 161.2,
+        "TextblockHeight": 106.66666666666667,
+        "Background": "#FFC98132"
+      },
+      {
+        "Id": "a42c4389353d4648ac308e9f86ee6bf0",
+        "Title": "New Note",
+        "DescriptionText": null,
+        "IsExpanded": true,
+        "WidthAdjustment": 0.0,
+        "HeightAdjustment": 0.0,
+        "Nodes": [],
+        "HasNestedGroups": false,
+        "Left": 468.33333333333343,
+        "Top": 164.5058333333333,
+        "Width": 0.0,
+        "Height": 0.0,
+        "FontSize": 36.0,
+        "GroupStyleId": "00000000-0000-0000-0000-000000000000",
+        "InitialTop": 0.0,
+        "InitialHeight": 0.0,
+        "TextblockHeight": 0.0,
+        "Background": "#FFC1D676",
+        "PinnedNode": "a388045e9fcc44ca88e25b43f51bfc1b"
+      }
+    ],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per https://jira.autodesk.com/browse/DYN-5626, as a follow-up of https://github.com/DynamoDS/Dynamo/pull/13751, moving the Guids replacement function to be a utility method and also make it part of workspace SaveAs call.

Example:
![image](https://user-images.githubusercontent.com/3942418/220413578-db5f137f-32c3-42c3-9d9b-4ebce1743256.png)

Guids not updating:

- `ExtensionGuid` under `ExtensionWorkspaceData`
- `activeLinterId` under `Linting`
- `GroupStyleId` under `Annotations`

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

For workspace SaveAs, update all Guids required


### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
