### PR TITLE
DYN-5530 library slider tooltip

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -169,7 +169,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Indicates the zoom scale of the library
         /// </summary>
-        public float LibraryZoomScale { get; set; }
+        public int LibraryZoomScale { get; set; }
 
         /// <summary>
         /// The types of connector: Bezier or Polyline.

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -782,7 +782,7 @@ namespace Dynamo.Configuration
             BackupFilesCount = 1;
             BackupFiles = new List<string>();
 
-            LibraryZoomScale = 1;
+            LibraryZoomScale = 100;
 
             CustomPackageFolders = new List<string>();
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1937,6 +1937,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Library.
+        /// </summary>
+        public static string DynamoViewSettingLibraryZoomScale {
+            get {
+                return ResourceManager.GetString("DynamoViewSettingLibraryZoomScale", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Settings.
         /// </summary>
         public static string DynamoViewSettingMenu {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3494,4 +3494,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="PreferencesViewZoomScalingSettings" xml:space="preserve">
     <value>Zoom Scaling</value>
   </data>
+  <data name="DynamoViewSettingLibraryZoomScale" xml:space="preserve">
+    <value>Library</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3481,4 +3481,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="PreferencesViewZoomScalingSettings" xml:space="preserve">
     <value>Zoom Scaling</value>
   </data>
+  <data name="DynamoViewSettingLibraryZoomScale" xml:space="preserve">
+    <value>Library</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1273,7 +1273,7 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Margin="0,10,0,5" Grid.Row="0" Orientation="Horizontal">
-                                        <TextBlock  FontSize="12" VerticalAlignment="Center" Text="Library"></TextBlock>
+                                        <TextBlock  FontSize="12" VerticalAlignment="Center" Text="{x:Static p:Resources.DynamoViewSettingLibraryZoomScale}"></TextBlock>
                                         <Label HorizontalAlignment="Left"
                                                    Name="LibraryZoomScaleInfoLabel"
                                                    VerticalAlignment="Bottom"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1273,16 +1273,17 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Margin="0,10,0,5" Grid.Row="0" Orientation="Horizontal">
-                                        <TextBlock  FontSize="12" Text="Library"></TextBlock>
+                                        <TextBlock  FontSize="12" VerticalAlignment="Center" Text="Library"></TextBlock>
                                         <Label HorizontalAlignment="Left"
                                                    Name="LibraryZoomScaleInfoLabel"
-                                                   VerticalAlignment="Center" 
+                                                   VerticalAlignment="Bottom"
+                                                   Margin="0,2,0,0"
                                                    Height="26" 
                                                    Width="53">
                                             <Image
                                                Width="14"
                                                Height="14"
-                                               Margin="0,0,0,5"
+                                               Margin="0,0,0,0"
                                                Grid.Column="1"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1301,8 +1301,12 @@
                                             x:Name="LibraryZoomScalingSlider"
                                             Style="{StaticResource SliderStyle}"
                                             Width="440"
-                                            Minimum="0.1"
-                                            Maximum="3">
+                                            Minimum="10"
+                                            IsSnapToTickEnabled="True"
+                                            TickFrequency="1"
+                                            AutoToolTipPlacement="BottomRight"
+                                            AutoToolTipPrecision="0"
+                                            Maximum="300">
                                         </Slider>
                                     </StackPanel>
                                     <StackPanel Grid.Row="2" Width="550">

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1295,34 +1295,38 @@
                                             </Image>
                                         </Label>
                                     </StackPanel>
-                                   
-                                    <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,3">
-                                        
+
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1" Margin="0,0,0,3">
+                                        <TextBlock Text="10%"></TextBlock>
+
                                         <Slider
                                             x:Name="LibraryZoomScalingSlider"
                                             Style="{StaticResource SliderStyle}"
-                                            Width="440"
+                                            ValueChanged="zoomScaleLevel_ValueChanged"
+                                            Width="400"
+                                            Margin="5,0,5,0"
                                             Minimum="10"
                                             IsSnapToTickEnabled="True"
                                             TickFrequency="1"
-                                            AutoToolTipPlacement="BottomRight"
-                                            AutoToolTipPrecision="0"
                                             Maximum="300">
                                         </Slider>
+                                        <TextBlock Text="300%"></TextBlock>
+
                                     </StackPanel>
                                     <StackPanel Grid.Row="2" Width="550">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="125"></ColumnDefinition>
-                                                <ColumnDefinition Width="150"></ColumnDefinition>
-                                                <ColumnDefinition Width="135"></ColumnDefinition>
                                                 <ColumnDefinition Width="*"></ColumnDefinition>
                                             </Grid.ColumnDefinitions>
-                                            <TextBlock Text="10%" Grid.Column="0"></TextBlock>
-                                            <TextBlock Text="100%" Grid.Column="1"></TextBlock>
-                                            <TextBlock Text="200%" Grid.Column="2"></TextBlock>
-                                            <TextBlock Text="300%" Grid.Column="3"></TextBlock>
                                         </Grid>
+                                        <Label
+                                            Name="lblZoomScalingValue"
+                                            Width="50"
+                                            VerticalAlignment="Center"
+                                            HorizontalContentAlignment="Center"
+                                            Foreground="{StaticResource PreferencesWindowFontColor}"
+                                            FontWeight="Regular"/>
                                     </StackPanel>
                                 </Grid>
                             </Expander>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -535,7 +535,9 @@ namespace Dynamo.Wpf.Views
         {
             Slider slider = (Slider)sender;
 
+            //Since the percentage goes from 10 to 300, the value is decremented by 10 to standardize. 
             double percentage = slider.Value - 10;
+            //This is the relation between the margin in pixels and the value of the percentage
             double marginValue = (79 * percentage / 29) - 480;
             if (lblZoomScalingValue != null)
             {

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -530,5 +530,18 @@ namespace Dynamo.Wpf.Views
                 this.lblConfidenceLevel.Margin = new Thickness(left, -15, 0, 0);
             }
         }
+
+        private void zoomScaleLevel_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            Slider slider = (Slider)sender;
+
+            double percentage = slider.Value - 10;
+            double marginValue = (79 * percentage / 29) - 480;
+            if (lblZoomScalingValue != null)
+            {
+                lblZoomScalingValue.Margin = new Thickness(marginValue, 0, 0, 0);
+                lblZoomScalingValue.Content = slider.Value.ToString() + "%";
+            }
+        }
     }
 }

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -341,7 +341,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
             SetLibraryFontSize();
 
             //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
-            browser.ZoomFactor = dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100;
+            browser.ZoomFactor = (double)dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100;
             browser.ZoomFactorChanged += Browser_ZoomFactorChanged;
         }
 
@@ -557,7 +557,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
         {
             Slider slider = (Slider)sender;
             //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
-            browser.ZoomFactor = slider.Value / 100;
+            browser.ZoomFactor = (double)slider.Value / 100;
             dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = ((int)slider.Value);
         }
 

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -88,7 +88,8 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
         private void Browser_ZoomFactorChanged(object sender, EventArgs e)
         {
-            dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = ((float)browser.ZoomFactor);
+            //Multiplies by 100 so the value can be saved as a percentage
+            dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = (float)browser.ZoomFactor * 100;
         }
 
         void PreferencesWindowChanged()
@@ -338,8 +339,9 @@ namespace Dynamo.LibraryViewExtensionWebView2
             }
 
             SetLibraryFontSize();
-            
-            browser.ZoomFactor = dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale;
+
+            //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
+            browser.ZoomFactor = dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100;
             browser.ZoomFactorChanged += Browser_ZoomFactorChanged;
         }
 
@@ -554,7 +556,8 @@ namespace Dynamo.LibraryViewExtensionWebView2
         private void DynamoSliderValueChanged(object sender, EventArgs e)
         {
             Slider slider = (Slider)sender;
-            browser.ZoomFactor = slider.Value;
+            //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
+            browser.ZoomFactor = slider.Value / 100;
             dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = ((float)slider.Value);
         }
 

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -89,7 +89,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
         private void Browser_ZoomFactorChanged(object sender, EventArgs e)
         {
             //Multiplies by 100 so the value can be saved as a percentage
-            dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = (float)browser.ZoomFactor * 100;
+            dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = (int)browser.ZoomFactor * 100;
         }
 
         void PreferencesWindowChanged()
@@ -558,7 +558,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
             Slider slider = (Slider)sender;
             //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
             browser.ZoomFactor = slider.Value / 100;
-            dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = ((float)slider.Value);
+            dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = ((int)slider.Value);
         }
 
         /// <summary>

--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -8,7 +8,7 @@
   <ShowCodeBlockLineNumber>false</ShowCodeBlockLineNumber>
   <ShowConnector>false</ShowConnector>
   <ShowConnectorToolTip>false</ShowConnectorToolTip>
-  <LibraryZoomScale>2.03</LibraryZoomScale>
+  <LibraryZoomScale>200</LibraryZoomScale>
   <ConnectorType>POLYLINE</ConnectorType>
   <BackgroundPreviews>
     <BackgroundPreviewActiveState>


### PR DESCRIPTION
### Purpose

It's included in this PR a tooltip to show the value of the library's zoom slider. Also, the fix for the help icon.

![sliderTooltip](https://user-images.githubusercontent.com/89042471/221000188-968a8400-77f4-498c-a473-0f7e21d79bd1.gif)


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### FYIs

@QilongTang @avidit 
