### PR TITLE
DYN-5640: fix List.AllIndicesOf node

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -1346,7 +1346,7 @@ namespace DSCore
             if (list == null)
                 return new List<int> { }; 
 
-            var indices = Enumerable.Range(0, list.Count).Where(i => list[i].Equals(item)).ToList();
+            var indices = Enumerable.Range(0, list.Count).Where(i => list[i] != null ? list[i].Equals(item) : item == null).ToList();
             return indices;
         }
 

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -946,6 +946,25 @@ namespace DSCoreNodesTests
 
             indices = List.AllIndicesOf(input, 21).Cast<int>();
             Assert.IsEmpty(indices);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void AllIndicesOfNullTest()
+        {
+            var input = new List<object> { true, false, null };
+
+            var indices = List.AllIndicesOf(input, true);
+            Assert.True(indices.Count == 1);
+            Assert.AreEqual(0, indices[0]);
+
+            indices = List.AllIndicesOf(input, false);
+            Assert.True(indices.Count == 1);
+            Assert.AreEqual(1, indices[0]);
+
+            indices = List.AllIndicesOf(input, null);
+            Assert.True(indices.Count == 1);
+            Assert.AreEqual(2, indices[0]);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

DYN-5640: Fix List.AllIndicesOf

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
