### PR TITLE
Adjust minimum percentage of the Library zoom scale

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1297,7 +1297,7 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1" Margin="0,0,0,3">
-                                        <TextBlock Text="10%"></TextBlock>
+                                        <TextBlock Text="25%"></TextBlock>
 
                                         <Slider
                                             x:Name="LibraryZoomScalingSlider"
@@ -1305,7 +1305,7 @@
                                             ValueChanged="zoomScaleLevel_ValueChanged"
                                             Width="400"
                                             Margin="5,0,5,0"
-                                            Minimum="10"
+                                            Minimum="25"
                                             IsSnapToTickEnabled="True"
                                             TickFrequency="1"
                                             Maximum="300">

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -84,6 +84,7 @@ namespace Dynamo.Wpf.Views
             viewModel.RequestShowFileDialog += OnRequestShowFileDialog;
 
             LibraryZoomScalingSlider.Value = dynViewModel.Model.PreferenceSettings.LibraryZoomScale;
+            updateLibraryZoomScaleValueLabel(LibraryZoomScalingSlider);
         }
 
         /// <summary>
@@ -535,10 +536,19 @@ namespace Dynamo.Wpf.Views
         {
             Slider slider = (Slider)sender;
 
-            //Since the percentage goes from 10 to 300, the value is decremented by 10 to standardize. 
-            double percentage = slider.Value - 10;
+            updateLibraryZoomScaleValueLabel(slider);            
+        }
+
+        private void updateLibraryZoomScaleValueLabel(Slider slider)
+        {
+            //Since the percentage goes from 25 to 300, the value is decremented by 25 to standardize. 
+            double percentage = slider.Value - 25;
+
+            //The margin value for the label goes from - 480 to 310, resulting in 790 pixels from the starting point to the end.
+            //We also standardized the values ​​of the percentage(from 0 to 275).
+            //The value is decreased to 480 because the margin begins at - 480
             //This is the relation between the margin in pixels and the value of the percentage
-            double marginValue = (79 * percentage / 29) - 480;
+            double marginValue = (790 * percentage / 275) - 480;
             if (lblZoomScalingValue != null)
             {
                 lblZoomScalingValue.Margin = new Thickness(marginValue, 0, 0, 0);

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -55,7 +55,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
         private const int standardFontSize = 14;
         private const int standardScreenHeight = 1080;
         private double libraryFontSize;
-
+        private const double minimumZoomScale = 0.25;
 
         /// <summary>
         /// Creates a LibraryViewController.
@@ -339,9 +339,14 @@ namespace Dynamo.LibraryViewExtensionWebView2
             }
 
             SetLibraryFontSize();
+            //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent            
+            double zoomFactor = (dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100);
 
-            //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
-            browser.ZoomFactor = (double)dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100;
+            //To avoid an invalid value for the zoom factor
+            if (zoomFactor < minimumZoomScale)
+                zoomFactor = minimumZoomScale;
+
+            browser.ZoomFactor = zoomFactor;
             browser.ZoomFactorChanged += Browser_ZoomFactorChanged;
         }
 
@@ -557,7 +562,13 @@ namespace Dynamo.LibraryViewExtensionWebView2
         {
             Slider slider = (Slider)sender;
             //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
-            browser.ZoomFactor = (double)slider.Value / 100;
+            double zoomFactor = slider.Value / 100;
+
+            //To avoid an invalid value for the zoom factor
+            if (zoomFactor < minimumZoomScale)
+                zoomFactor = minimumZoomScale;
+
+            browser.ZoomFactor = zoomFactor;
             dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale = ((int)slider.Value);
         }
 


### PR DESCRIPTION
### Purpose

* Minimum value of the Zoom Scale for the Library is set to 25%
* Added an if before setting the zoomFactor to avoid an exception

![zoomScaleMinimumValue](https://user-images.githubusercontent.com/89042471/222183272-8159c3a2-5ed6-4feb-abe2-ed024ae7e1ff.gif)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@QilongTang 

