### PR TITLE
Dyn 4738 custom color picker

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -48,6 +48,7 @@
     <None Remove="Packages\SplashScreen\build\index.bundle.js" />
     <None Remove="Packages\SplashScreen\build\index.html" />
     <None Remove="UI\Images\Canvas\canvas-button-geometry-scaling.png" />
+    <None Remove="Views\Core\CustomColorPicker.xaml" />
     <None Remove="Views\Core\GeometryScalingPopup.xaml" />
     <None Remove="UI\Images\question-hover-blue-16px.png" />
     <None Remove="Views\SplashScreen\WebApp\splashScreenBackground.png" />
@@ -143,6 +144,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+	<PackageReference Include="Extended.Wpf.Toolkit" version="3.0.0">
+	  <GeneratePathProperty>true</GeneratePathProperty>
+    <!--Exclude copying the dll because we will handle it in the BinaryCompatibilityOps target -->
+    <ExcludeAssets>runtime</ExcludeAssets>
+	</PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controls\InstalledPackagesControl.xaml.cs">
@@ -337,6 +343,7 @@
     <Compile Include="Utilities\ResourceUtilities.cs" />
     <Compile Include="ViewModels\Core\Converters\DynamoPythonScriptEditorTextOptions.cs" />
     <Compile Include="ViewModels\Core\Converters\SerializationConverters.cs" />
+    <Compile Include="ViewModels\Core\CustomColorPickerViewModel.cs" />
     <Compile Include="ViewModels\Core\DynamoViewModelBranding.cs" />
     <Compile Include="ViewModels\Core\GeometryScalingViewModel.cs" />
     <Compile Include="ViewModels\Core\HomeWorkspaceViewModel.cs" />
@@ -385,6 +392,7 @@
     <Compile Include="Views\Core\ConnectorContextMenuView.xaml.cs">
       <DependentUpon>ConnectorContextMenuView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\Core\CustomColorPicker.xaml.cs" />
     <Compile Include="Views\Core\DynamoOpenFileDialog.cs" />
     <Compile Include="Views\Core\ConnectorPinView.xaml.cs">
       <DependentUpon>ConnectorPinView.xaml</DependentUpon>
@@ -551,6 +559,10 @@
     </Page>
     <Page Include="Controls\InPortContextMenu.xaml">
       <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Core\CustomColorPicker.xaml">
+      <CopyToOutputDirectory></CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\Core\GeometryScalingPopup.xaml">

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3641,4 +3641,57 @@ namespace Dynamo.Controls
             return 0.2126 * R + 0.7152 * G + 0.0722 * B;
         }
     }
+
+    public class AdditionConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if ((value != null) && (parameter != null))
+            {
+                var firstValue = System.Convert.ToDouble(value);
+                var secondValue = double.Parse(parameter as string);
+
+                return firstValue + secondValue;
+            }
+
+            return 0d;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class ColorToSolidColorBrushConverter : IValueConverter
+    {
+        /// <summary>
+        /// Converts a Color to a SolidColorBrush.
+        /// </summary>
+        /// <returns>
+        /// A converted SolidColorBrush. If the method returns null, the valid null value is used.
+        /// </returns>
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value != null)
+                return new SolidColorBrush((Color)value);
+
+            return value;
+        }
+
+
+        /// <summary>
+        /// Converts a SolidColorBrush to a Color.
+        /// </summary>
+        /// <returns>
+        /// A converted value. If the method returns null, the valid null value is used.
+        /// </returns>
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value != null)
+                return ((SolidColorBrush)value).Color;
+
+            return value;
+        }
+    }
 }

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3643,7 +3643,7 @@ namespace Dynamo.Controls
     }
 
     /// <summary>
-    /// This converter is used to add margin/Padding from Popup in the CustomColorPicker
+    /// This converter is used to add extra space between the ListBox and the CustomColorPicker border
     /// </summary>
     public class AdditionConverter : IValueConverter
     {

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3642,6 +3642,9 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
+    /// This converter is used to add margin/Padding from Popup in the CustomColorPicker
+    /// </summary>
     public class AdditionConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -187,4 +187,6 @@
     <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
     <controls:ObjectTypeConverter x:Key="ObjectTypeConverter" />
     <controls:TextForegroundSaturationColorConverter x:Key="TextForegroundSaturationColorConverter" />
+    <controls:AdditionConverter x:Key="AdditionConverter" />
+    <controls:ColorToSolidColorBrushConverter x:Key="ColorToSolidColorBrushConverter" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -6,6 +6,8 @@
                     xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"
                     xmlns:dynui="clr-namespace:Dynamo.UI.Controls;assembly=DynamoCoreWpf"
                     xmlns:fa="clr-namespace:FontAwesome.WPF;assembly=FontAwesome.WPF"
+                    xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib"
                     xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
                     xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf">
 
@@ -5557,5 +5559,134 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+
+    <DataTemplate x:Key="ColorItemTemplate">
+        <Grid>
+            <Border Background="White"
+                    BorderBrush="LightGray"
+                    BorderThickness="1"
+                    Margin="1">
+                <Rectangle Width="26"
+                           Height="26">
+                    <Rectangle.Style>
+                        <Style TargetType="Rectangle">
+                            <Setter Property="Fill"
+                                    Value="{Binding Color, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
+                        </Style>
+                    </Rectangle.Style>
+                </Rectangle>
+            </Border>
+        </Grid>
+    </DataTemplate>
+
+    <Style x:Key="ColorDisplayStyle"
+           TargetType="ContentControl">
+        <Setter Property="Focusable"
+                Value="False" />
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <Border Background="{StaticResource CheckerBrush}">
+                        <Rectangle Fill="{Binding SelectedColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=xctk:ColorPicker}, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
+                    </Border>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding SelectedColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=xctk:ColorPicker}}"
+                         Value="{x:Null}">
+                <Setter Property="Visibility"
+                        Value="Collapsed" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="ColorItemContainerStyle"
+           TargetType="{x:Type ListBoxItem}">
+        <Setter Property="ToolTip"
+                Value="{Binding Name}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                    <Grid x:Name="mainGrid"
+                          ToolTip="{Binding Name}">
+                        <Grid.Resources>
+                            <Style TargetType="ToolTip">
+                                <Style.Triggers>
+                                    <Trigger Property="Content"
+                                             Value="{x:Static sys:String.Empty}">
+                                        <Setter Property="Visibility"
+                                                Value="Collapsed" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Resources>
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                        <Border BorderThickness="2"
+                                Background="Transparent"
+                                BorderBrush="{StaticResource PreferencesWindowButtonColor}"
+                                x:Name="_outerBorder"
+                                Visibility="{Binding Path=IsColorItemSelected,Converter={StaticResource BooleanToVisibilityConverter}}"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch">
+                        </Border>
+                        <Border Background="Transparent"
+                                BorderThickness="1"
+                                BorderBrush="Transparent"
+                                x:Name="_innerBorder"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch">
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver"
+                                 Value="True">
+                            <Setter TargetName="_outerBorder"
+                                    Property="BorderBrush"
+                                    Value="{StaticResource PreferencesWindowButtonColor}" />
+                            <Setter TargetName="_innerBorder"
+                                    Property="BorderBrush"
+                                    Value="{StaticResource PreferencesWindowButtonColor}" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding DisplayColorTooltip, RelativeSource={RelativeSource AncestorType={x:Type xctk:ColorPicker}}}"
+                                     Value="False">
+                            <Setter Property="ToolTip"
+                                    Value="{x:Static sys:String.Empty}"
+                                    TargetName="mainGrid" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ColorListStyle"
+           TargetType="ListBox">
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="MaxHeight"
+                Value="300" />
+        <!-- ConverterParameter is margin/Padding from Popup-->
+        <Setter Property="Width"
+                Value="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type xctk:ColorPicker}}, Converter={StaticResource AdditionConverter}, ConverterParameter=-18}" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <WrapPanel Width="{Binding ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBox}, Converter={StaticResource AdditionConverter}, ConverterParameter=-4}" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ItemContainerStyle"
+                Value="{StaticResource ColorItemContainerStyle}" />
+        <Setter Property="ItemTemplate"
+                Value="{StaticResource ColorItemTemplate}" />
+        <Setter Property="SelectionMode"
+                Value="Single" />
+    </Style>
+
+    
 
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
@@ -11,6 +11,9 @@ namespace Dynamo.ViewModels
 {
     internal class CustomColorItem : ColorItem, INotifyPropertyChanged
     {
+        /// <summary>
+        /// This event will help to execute the method  OnPropertyChanged used for xaml bindings (NotificationObject class cannot be used due that we already derive from ColorItem)
+        /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
         private bool isColorItemSelected = false;
@@ -27,6 +30,11 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Constructor that initialize the base class with the values passed as paramters
+        /// </summary>
+        /// <param name="color">color that will be displayed in the ColorPicker list</param>
+        /// <param name="name">description or color name that will be displayed as tooltip when mouse hover a specific color</param>
         public CustomColorItem(Color? color, string name) : base(color, name)
         {
 
@@ -106,7 +114,8 @@ namespace Dynamo.ViewModels
 
         private static ObservableCollection<CustomColorItem> CreateBasicColorsCollection()
         {
-
+            //This list of colors were taken from the design created by the UX team in the Jira task (based from the Weave component).
+            //Also you can find more details of the colors used in the next link:  https://weave.autodesk.com/web/basics/colors-data-viz
             ObservableCollection<CustomColorItem> observableCollection = new ObservableCollection<CustomColorItem>();
 
             List<(int R, int G, int B)> colors = new List<(int, int, int)>()

--- a/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Media;
+using Dynamo.Core;
+using Xceed.Wpf.Toolkit;
+
+namespace Dynamo.ViewModels
+{
+    internal class CustomColorItem : ColorItem, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private bool isColorItemSelected = false;
+        public bool IsColorItemSelected
+        {
+            get
+            {
+                return isColorItemSelected;
+            }
+            set
+            {
+                isColorItemSelected = value;
+                OnPropertyChanged(nameof(IsColorItemSelected));
+            }
+        }
+
+        public CustomColorItem(Color? color, string name) : base(color, name)
+        {
+
+        }
+        // Create the OnPropertyChanged method to raise the event
+        // The calling member's name will be used as the parameter.
+        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+    internal class CustomColorPickerViewModel : NotificationObject
+    {
+        private Color? colorPickerFinalSelectedColor;
+        public Color? ColorPickerFinalSelectedColor
+        {
+            get
+            {
+                return colorPickerFinalSelectedColor;
+            }
+            set
+            {
+                colorPickerFinalSelectedColor = value;
+                RaisePropertyChanged(nameof(ColorPickerFinalSelectedColor));
+            }
+        }
+
+        private ObservableCollection<CustomColorItem> customAvailableColors;
+
+        public ObservableCollection<CustomColorItem> CustomAvailableColors
+        {
+            get
+            {
+                return customAvailableColors;
+            }
+            set
+            {
+                customAvailableColors = value;
+                RaisePropertyChanged(nameof(CustomAvailableColors));
+            }
+        }
+
+        public CustomColorPickerViewModel()
+        {
+            CustomAvailableColors = new ObservableCollection<CustomColorItem>();
+            CustomAvailableColors = CreateCustomAvailableColors();
+        }
+
+        private static ObservableCollection<CustomColorItem> CreateCustomAvailableColors()
+        {
+            double R = 0;
+            double G = 0;
+            double B = 0;
+            const int rows = 5;
+            const int columns = 16;
+            const int offset = 51;
+            var random = new Random();
+
+            ObservableCollection<CustomColorItem> observableCollection = new ObservableCollection<CustomColorItem>();
+
+            List<(int R, int G, int B)> colors = new List<(int, int, int)>()
+            {
+                (77, 0, 0),
+                (77, 19, 0),
+                (77, 38, 0),
+                (77, 58, 0),
+                (77, 77, 1),
+                (58, 76, 2),
+                (37, 76, 2),
+                (19, 77, 1),
+                (0, 77, 1),
+                (0, 77, 20),
+                (0, 77, 38),
+                (0, 77, 57),
+                (0, 76, 76),
+                (0, 58, 76),
+                (0, 39, 76),
+                (0, 21, 76),
+                (129, 0, 1),
+                (129, 31, 1),
+                (129, 63, 0),
+                (128, 95, 1),
+                (128, 127, 5),
+                (95, 127, 4),
+                (63, 126, 3),
+                (30, 127, 2),
+                (0, 127, 2),
+                (0, 127, 32),
+                (0, 128, 63),
+                (0, 127, 95),
+                (0, 127, 127),
+                (0, 95, 127),
+                (0, 64, 127),
+                (0, 32, 127),
+                (155, 0, 2),
+                (155, 38, 2),
+                (155, 76, 3),
+                (154, 114, 3),
+                (154, 153, 3),
+                (114, 153, 5),
+                (77, 153, 3),
+                (35, 153, 3),
+                (0, 153, 4),
+                (0, 153, 38),
+                (0, 153, 76),
+                (0, 154, 113),
+                (0, 153, 153),
+                (0, 114, 153),
+                (0, 78, 153),
+                (0, 39, 153),
+                (206, 1, 1),
+                (206, 51, 3),
+                (206, 101, 4),
+                (206, 153, 3),
+                (205, 204, 0),
+                (153, 205, 6),
+                (100, 205, 7),
+                (46, 204, 3),
+                (0, 204, 5),
+                (0, 204, 51),
+                (0, 204, 102),
+                (0, 204, 153),
+                (0, 204, 204),
+                (0, 154, 204),
+                (0, 102, 204),
+                (0, 53, 204),
+                (255, 0, 0),
+                (255, 64, 0),
+                (255, 127, 1),
+                (255, 192, 0),
+                (255, 255, 0),
+                (190, 254, 5),
+                (125, 255, 2),
+                (59, 254, 5),
+                (0, 254, 1),
+                (0, 254, 63),
+                (0, 255, 127),
+                (0, 255, 191),
+                (0, 255, 255),
+                (0, 192, 255),
+                (0, 128, 254),
+                (0, 67, 255)
+            };
+
+
+            foreach (var color in colors)
+            {
+                var colorItem = Color.FromRgb((byte)color.R, (byte)color.G, (byte)color.B);
+                observableCollection.Add(new CustomColorItem(colorItem, string.Format("#{0},{1},{2}", color.R, color.G, color.B)));
+            }
+
+            return observableCollection;
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
@@ -54,36 +54,47 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private ObservableCollection<CustomColorItem> customAvailableColors;
+        private ObservableCollection<CustomColorItem> basicColors;
 
-        public ObservableCollection<CustomColorItem> CustomAvailableColors
+        public ObservableCollection<CustomColorItem> BasicColors
         {
             get
             {
-                return customAvailableColors;
+                return basicColors;
             }
             set
             {
-                customAvailableColors = value;
-                RaisePropertyChanged(nameof(CustomAvailableColors));
+                basicColors = value;
+                RaisePropertyChanged(nameof(BasicColors));
+            }
+        }
+
+        private ObservableCollection<CustomColorItem> customColors;
+
+        public ObservableCollection<CustomColorItem> CustomColors
+        {
+            get
+            {
+                return customColors;
+            }
+            set
+            {
+                customColors = value;
+                RaisePropertyChanged(nameof(CustomColors));
             }
         }
 
         public CustomColorPickerViewModel()
         {
-            CustomAvailableColors = new ObservableCollection<CustomColorItem>();
-            CustomAvailableColors = CreateCustomAvailableColors();
+            BasicColors = new ObservableCollection<CustomColorItem>();
+            BasicColors = CreateBasicColorsCollection();
+
+            CustomColors = new ObservableCollection<CustomColorItem>();
+            CustomColors = CreateCustomColorsCollection();
         }
 
-        private static ObservableCollection<CustomColorItem> CreateCustomAvailableColors()
+        private static ObservableCollection<CustomColorItem> CreateBasicColorsCollection()
         {
-            double R = 0;
-            double G = 0;
-            double B = 0;
-            const int rows = 5;
-            const int columns = 16;
-            const int offset = 51;
-            var random = new Random();
 
             ObservableCollection<CustomColorItem> observableCollection = new ObservableCollection<CustomColorItem>();
 
@@ -178,6 +189,14 @@ namespace Dynamo.ViewModels
                 observableCollection.Add(new CustomColorItem(colorItem, string.Format("#{0},{1},{2}", color.R, color.G, color.B)));
             }
 
+            return observableCollection;
+        }
+
+        private static ObservableCollection<CustomColorItem> CreateCustomColorsCollection()
+        {
+            ObservableCollection<CustomColorItem> observableCollection = new ObservableCollection<CustomColorItem>();
+            var colorItem = Color.FromRgb(0, 255, 0);
+            observableCollection.Add(new CustomColorItem(colorItem, string.Format("#{0},{1},{2}", 0, 255, 0)));
             return observableCollection;
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/CustomColorPickerViewModel.cs
@@ -31,6 +31,7 @@ namespace Dynamo.ViewModels
         {
 
         }
+
         // Create the OnPropertyChanged method to raise the event
         // The calling member's name will be used as the parameter.
         protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -38,9 +39,17 @@ namespace Dynamo.ViewModels
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
     }
+
     internal class CustomColorPickerViewModel : NotificationObject
     {
         private Color? colorPickerFinalSelectedColor;
+        private ObservableCollection<CustomColorItem> basicColors;
+        private ObservableCollection<CustomColorItem> customColors;
+
+
+        /// <summary>
+        /// Color Selected in the ColorPicker
+        /// </summary>
         public Color? ColorPickerFinalSelectedColor
         {
             get
@@ -52,10 +61,11 @@ namespace Dynamo.ViewModels
                 colorPickerFinalSelectedColor = value;
                 RaisePropertyChanged(nameof(ColorPickerFinalSelectedColor));
             }
-        }
+        }      
 
-        private ObservableCollection<CustomColorItem> basicColors;
-
+        /// <summary>
+        /// List of Basic Colors that will be displayed in the CustomColorPicker
+        /// </summary>
         public ObservableCollection<CustomColorItem> BasicColors
         {
             get
@@ -69,8 +79,9 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private ObservableCollection<CustomColorItem> customColors;
-
+        /// <summary>
+        /// List of Custom Colors that will be displayed in the CustomColorPicker
+        /// </summary>
         public ObservableCollection<CustomColorItem> CustomColors
         {
             get
@@ -192,6 +203,10 @@ namespace Dynamo.ViewModels
             return observableCollection;
         }
 
+        /// <summary>
+        /// Creates de default List of Custom Colors (this will be modified by the user
+        /// </summary>
+        /// <returns></returns>
         private static ObservableCollection<CustomColorItem> CreateCustomColorsCollection()
         {
             ObservableCollection<CustomColorItem> observableCollection = new ObservableCollection<CustomColorItem>();

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
@@ -4,7 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-       xmlns:converters="clr-namespace:Dynamo.Controls"
         xmlns:ui="clr-namespace:Dynamo.UI"
         mc:Ignorable="d" 
         d:DesignHeight="780" d:DesignWidth="860">
@@ -14,8 +13,7 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-            
+
             <Style x:Key="CustomColorPicker"
                    TargetType="{x:Type xctk:ColorPicker}">
                 <Setter Property="Template">
@@ -142,10 +140,6 @@
                                                         Padding="10"
                                                         HorizontalAlignment="Left"
                                                         MaxWidth="200">
-                                                    <Button.ToolTip>
-                                                        <ToolTip Content="Custom Button Style"
-                                                                 Style="{StaticResource GenericToolTipLight}" />
-                                                    </Button.ToolTip>
                                                     <Button.Style>
                                                         <Style BasedOn="{StaticResource SolidButtonStyle}"
                                                                TargetType="{x:Type Button}">
@@ -189,10 +183,6 @@
                                                             Padding="10,5,10,5"
                                                             Grid.Column="1"
                                                             Content="Apply">
-                                                        <Button.ToolTip>
-                                                            <ToolTip Content="Custom Button Style"
-                                                                     Style="{StaticResource GenericToolTipLight}" />
-                                                        </Button.ToolTip>
                                                         <Button.Style>
                                                             <Style BasedOn="{StaticResource SolidButtonStyle}"
                                                                    TargetType="{x:Type Button}">
@@ -215,17 +205,16 @@
         </ResourceDictionary>
     </Popup.Resources>
     <Grid>
-        <xctk:ColorPicker 
-            Name="xceedColorPickerControl" 
-            HorizontalAlignment="Center" 
-            VerticalAlignment="Center" 
-            AvailableColorsHeader="Basic colors:"
-            StandardColorsHeader="Custom colors:"
-            ShowStandardColors="False" 
-            ShowRecentColors="True"
-            Width="520"
-            Style="{StaticResource CustomColorPicker}"
-            RecentColorsHeader="Test">
+        <xctk:ColorPicker   Name="xceedColorPickerControl" 
+                            HorizontalAlignment="Center" 
+                            VerticalAlignment="Center" 
+                            AvailableColorsHeader="Basic colors:"
+                            StandardColorsHeader="Custom colors:"
+                            ShowStandardColors="False" 
+                            ShowRecentColors="True"
+                            Width="520"
+                            Style="{StaticResource CustomColorPicker}"
+                            RecentColorsHeader="Test">
         </xctk:ColorPicker>
     </Grid>
 </Popup>

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
@@ -38,7 +38,29 @@
                     </Border>
                 </Grid>
             </DataTemplate>
-            
+
+            <Style x:Key="ColorDisplayStyle"
+         TargetType="ContentControl">
+                <Setter Property="Focusable"
+            Value="False" />
+                <Setter Property="ContentTemplate">
+                    <Setter.Value>
+                        <DataTemplate>
+                            <Border Background="{StaticResource CheckerBrush}">
+                                <Rectangle Fill="{Binding SelectedColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=xctk:ColorPicker}, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
+                            </Border>
+                        </DataTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding SelectedColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=xctk:ColorPicker}}"
+                   Value="{x:Null}">
+                        <Setter Property="Visibility"
+                Value="Collapsed" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
             <Style x:Key="ColorItemContainerStyle"
                 TargetType="{x:Type ListBoxItem}">
                 <Setter Property="ToolTip"
@@ -61,9 +83,9 @@
                                 </Grid.Resources>
                                 <ContentPresenter HorizontalAlignment="Center"
                                                VerticalAlignment="Center" />
-                                <Border BorderThickness="1"
+                                <Border BorderThickness="2"
                                         Background="Transparent"
-                                        BorderBrush="Red"
+                                        BorderBrush="{StaticResource PreferencesWindowButtonColor}"
                                         x:Name="_outerBorder"
                                         Visibility="{Binding Path=IsColorItemSelected,Converter={StaticResource BooleanToVisibilityConverter}}"
                                         HorizontalAlignment="Stretch"
@@ -174,14 +196,14 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type xctk:ColorPicker}">
                             <Popup x:Name="PART_ColorPickerPalettePopup"
-                               VerticalAlignment="Bottom"
-                               IsOpen="True"
-                               StaysOpen="False"
-                               Focusable="False"
-                               AllowsTransparency="True"
-                               Width="550"
-                               Height="490"
-                               PopupAnimation="Slide">
+                                   VerticalAlignment="Bottom"
+                                   IsOpen="True"
+                                   StaysOpen="False"
+                                   Focusable="False"
+                                   AllowsTransparency="True"
+                                   Width="550"
+                                   Height="Auto"
+                                   PopupAnimation="Slide">
                                 <Border BorderBrush="Transparent" 
                                     BorderThickness="10" 
                                     CornerRadius="10" 
@@ -252,16 +274,17 @@
                                                                Padding="2"/>
 
                                                     <ListBox x:Name="PART_AvailableColors"
-                                                         Margin="0, 5, 0, 5"
-                                                       Grid.Row="1"
-                                                       ItemsSource="{Binding CustomAvailableColors}"
-                                                       Style="{StaticResource ColorListStyle}"/>
+                                                             Margin="0, 5, 0, 5"
+                                                             Grid.Row="1"
+                                                             SelectionChanged="PART_BasicColors_SelectionChanged"
+                                                             ItemsSource="{Binding BasicColors}"
+                                                             Style="{StaticResource ColorListStyle}"/>
 
                                                 </Grid>
                                             </Grid>
 
                                             <!-- Custom Colors-->
-                                            <Grid Grid.Row="2">
+                                            <Grid Grid.Row="2" Visibility="Hidden">
                                                 <Grid>
                                                     <Grid.RowDefinitions>
                                                         <RowDefinition Height="Auto" />
@@ -273,19 +296,20 @@
                                                                 Foreground="Black"
                                                                 Padding="2"/>
 
-                                                    <ListBox x:Name="PART_StandardColors"
-                                                       Grid.Row="1"
-                                                       Margin="0, 5, 0, 5"
-                                                       ItemsSource="{Binding StandardColors, RelativeSource={RelativeSource TemplatedParent}}"
-                                                       Style="{StaticResource ColorListStyle}"/>
+                                                    <ListBox x:Name="PART_CustomColors"
+                                                             Grid.Row="1"
+                                                             Margin="0, 5, 0, 5"
+                                                             SelectionChanged="PART_CustomColors_SelectionChanged"
+                                                             ItemsSource="{Binding CustomColors, RelativeSource={RelativeSource TemplatedParent}}"
+                                                             Style="{StaticResource ColorListStyle}"/>
 
                                                 </Grid>
                                             </Grid>
 
                                             <!-- Define Colors-->
-                                            <Grid Grid.Row="3">
+                                            <Grid Grid.Row="3" Visibility="Hidden">
                                                 <Button x:Name="DefineColorBtn" 
-                                                    Content="Define Custom Colors"
+                                                        Content="Define Custom Colors"
                                                         Margin="5"
                                                     Padding="10"
                                                     HorizontalAlignment="Left"
@@ -365,7 +389,6 @@
             ShowStandardColors="False" 
             ShowRecentColors="True"
             Width="520"
-            SelectedColorChanged="xceedColorPickerControl_SelectedColorChanged"
             Style="{StaticResource CustomColorPicker}"
             RecentColorsHeader="Test">
         </xctk:ColorPicker>

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
@@ -1,0 +1,373 @@
+<Popup x:Class="Dynamo.Controls.CustomColorPicker"
+       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        xmlns:converters="clr-namespace:Dynamo.Controls"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:ui="clr-namespace:Dynamo.UI"
+        mc:Ignorable="d" 
+        d:DesignHeight="780" d:DesignWidth="860">
+    <Popup.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <converters:AdditionConverter x:Key="AdditionConverter" />
+            <converters:ColorToSolidColorBrushConverter x:Key="ColorToSolidColorBrushConverter" />
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            
+            <DataTemplate x:Key="ColorItemTemplate">
+                <Grid>
+                    <Border Background="White"
+                          BorderBrush="LightGray"
+                          BorderThickness="1"
+                          Margin="1">
+                        <Rectangle Width="26"
+                               Height="26">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle">
+                                    <Setter Property="Fill"
+                                            Value="{Binding Color, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
+                                </Style>
+                            </Rectangle.Style>
+                        </Rectangle>
+                    </Border>
+                </Grid>
+            </DataTemplate>
+            
+            <Style x:Key="ColorItemContainerStyle"
+                TargetType="{x:Type ListBoxItem}">
+                <Setter Property="ToolTip"
+                    Value="{Binding Name}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                            <Grid x:Name="mainGrid"
+                             ToolTip="{Binding Name}">
+                                <Grid.Resources>
+                                    <Style TargetType="ToolTip">
+                                        <Style.Triggers>
+                                            <Trigger Property="Content"
+                                                Value="{x:Static sys:String.Empty}">
+                                                <Setter Property="Visibility"
+                                                    Value="Collapsed" />
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Resources>
+                                <ContentPresenter HorizontalAlignment="Center"
+                                               VerticalAlignment="Center" />
+                                <Border BorderThickness="1"
+                                        Background="Transparent"
+                                        BorderBrush="Red"
+                                        x:Name="_outerBorder"
+                                        Visibility="{Binding Path=IsColorItemSelected,Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch">
+                                </Border>
+                                <Border Background="Transparent"
+                                        BorderThickness="1"
+                                        BorderBrush="Transparent"
+                                        x:Name="_innerBorder"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch">
+                                </Border>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver"
+                                    Value="True">
+                                    <Setter TargetName="_outerBorder"
+                                              Property="BorderBrush"
+                                              Value="{StaticResource PreferencesWindowButtonColor}" />
+                                    <Setter TargetName="_innerBorder"
+                                              Property="BorderBrush"
+                                              Value="{StaticResource PreferencesWindowButtonColor}" />
+                                </Trigger>
+                                <DataTrigger Binding="{Binding DisplayColorTooltip, RelativeSource={RelativeSource AncestorType={x:Type xctk:ColorPicker}}}"
+                                         Value="False">
+                                    <Setter Property="ToolTip"
+                                        Value="{x:Static sys:String.Empty}"
+                                        TargetName="mainGrid" />
+                                </DataTrigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="ColorListStyle"
+                TargetType="ListBox">
+                <Setter Property="Background"
+                    Value="Transparent" />
+                <Setter Property="BorderThickness"
+                    Value="0" />
+                <Setter Property="MaxHeight"
+                    Value="300" />
+                <!-- ConverterParameter is margin/Padding from Popup-->
+                <Setter Property="Width"
+                    Value="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type xctk:ColorPicker}}, Converter={StaticResource AdditionConverter}, ConverterParameter=-18}" />
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <WrapPanel Width="{Binding ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBox}, Converter={StaticResource AdditionConverter}, ConverterParameter=-4}" />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="ItemContainerStyle"
+                    Value="{StaticResource ColorItemContainerStyle}" />
+                <Setter Property="ItemTemplate"
+                    Value="{StaticResource ColorItemTemplate}" />
+                <Setter Property="SelectionMode"
+                    Value="Single" />
+            </Style>
+
+            <!--  Style for the close popup button in a Tooltip part of the Dynamo Guided Tours  -->
+            <Style x:Key="PopupCloseButtonStyle" TargetType="{x:Type Button}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type Button}">
+                            <Border x:Name="CloseButtonBorder"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            BorderThickness="0">
+                                <Canvas Margin="0,0,0,0">
+                                    <Line x:Name="line1"
+                                  Stroke="#808080"
+                                  StrokeThickness="1"
+                                  X1="0"
+                                  X2="13"
+                                  Y1="0"
+                                  Y2="13" />
+                                    <Line x:Name="line2"
+                                  Stroke="#808080"
+                                  StrokeThickness="1"
+                                  X1="0"
+                                  X2="13"
+                                  Y1="13"
+                                  Y2="0" />
+                                </Canvas>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="line1" Property="Stroke" Value="Red" />
+                                    <Setter TargetName="line2" Property="Stroke" Value="Red" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="line1" Property="Stroke" Value="{StaticResource PreferencesWindowButtonColor}" />
+                                    <Setter TargetName="line2" Property="Stroke" Value="{StaticResource PreferencesWindowButtonColor}" />
+                                    <Setter Property="Cursor" Value="Hand" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+
+
+            <Style x:Key="CustomColorPicker" TargetType="{x:Type xctk:ColorPicker}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type xctk:ColorPicker}">
+                            <Popup x:Name="PART_ColorPickerPalettePopup"
+                               VerticalAlignment="Bottom"
+                               IsOpen="True"
+                               StaysOpen="False"
+                               Focusable="False"
+                               AllowsTransparency="True"
+                               Width="550"
+                               Height="490"
+                               PopupAnimation="Slide">
+                                <Border BorderBrush="Transparent" 
+                                    BorderThickness="10" 
+                                    CornerRadius="10" 
+                                    Background="Transparent">
+                                    <Border BorderBrush="Transparent" 
+                                        BorderThickness="4" 
+                                        CornerRadius="10" 
+                                        Name = "MainBorder" 
+                                        Background="White">
+                                        <Border.Effect>
+                                            <DropShadowEffect BlurRadius="15" 
+                                                          Direction ="-90" 
+                                                          RenderingBias ="Quality" 
+                                                          ShadowDepth ="2" 
+                                                          Color ="LightGray" />
+                                        </Border.Effect>
+
+                                        <Grid x:Name="_colorPaletteHost"
+                                          HorizontalAlignment="Left"
+                                          Margin="20"
+                                          Background="Transparent">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+
+                                            <!--Title-->
+                                            <Grid Grid.Row="0">
+                                                <Grid x:Name="titleGrid">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="10*"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Color"
+                                                           Background="Transparent"
+                                                           Foreground="Black"
+                                                           FontSize="20"
+                                                           Margin="0, 10, 0, 10"
+                                                           FontWeight="Bold"
+                                                           Padding="2"/>
+                                                    <Button Name="CloseButton"
+                                                        Height="12.8"  
+                                                        Width="12.8"
+                                                        Grid.Column="1"
+                                                        Style="{StaticResource PopupCloseButtonStyle}"
+                                                        Click="CloseButton_Click">
+                                                    </Button>
+                                                </Grid>
+
+                                            </Grid>
+
+                                            <!-- Basic Colors -->
+                                            <Grid Grid.Row="1" >
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition />
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Text="{TemplateBinding AvailableColorsHeader}"
+                                                               Grid.Row="0"
+                                                               Margin="0, 5, 0, 5"
+                                                               Background="Transparent"
+                                                               Foreground="Black"
+                                                               Padding="2"/>
+
+                                                    <ListBox x:Name="PART_AvailableColors"
+                                                         Margin="0, 5, 0, 5"
+                                                       Grid.Row="1"
+                                                       ItemsSource="{Binding CustomAvailableColors}"
+                                                       Style="{StaticResource ColorListStyle}"/>
+
+                                                </Grid>
+                                            </Grid>
+
+                                            <!-- Custom Colors-->
+                                            <Grid Grid.Row="2">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition Height="Auto" />
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Text="{TemplateBinding StandardColorsHeader}"
+                                                                Background="Transparent"
+                                                                Margin="0, 5, 0, 5"
+                                                                Foreground="Black"
+                                                                Padding="2"/>
+
+                                                    <ListBox x:Name="PART_StandardColors"
+                                                       Grid.Row="1"
+                                                       Margin="0, 5, 0, 5"
+                                                       ItemsSource="{Binding StandardColors, RelativeSource={RelativeSource TemplatedParent}}"
+                                                       Style="{StaticResource ColorListStyle}"/>
+
+                                                </Grid>
+                                            </Grid>
+
+                                            <!-- Define Colors-->
+                                            <Grid Grid.Row="3">
+                                                <Button x:Name="DefineColorBtn" 
+                                                    Content="Define Custom Colors"
+                                                        Margin="5"
+                                                    Padding="10"
+                                                    HorizontalAlignment="Left"
+                                                    MaxWidth="200">
+                                                    <Button.ToolTip>
+                                                        <ToolTip Content="Custom Button Style" Style="{StaticResource GenericToolTipLight}"/>
+                                                    </Button.ToolTip>
+                                                    <Button.Style>
+                                                        <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
+                                                            <Setter Property="IsEnabled" Value="True"/>
+                                                        </Style>
+                                                    </Button.Style>
+                                                </Button>
+                                            </Grid>
+
+                                            <!--Separator-->
+                                            <Grid Grid.Row="4">
+                                                <Separator Margin="5,5,0,5"/>
+                                            </Grid>
+
+                                            <!-- Buttons-->
+                                            <Grid Grid.Row="5" 
+                                              HorizontalAlignment="Right">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Button x:Name="CancelBtn" 
+                                                            Click="CancelBtn_Click"
+                                                            Margin="10"
+                                                            Padding="10,5,10,5"
+                                                            Grid.Column="0" 
+                                                            Content="Cancel">
+                                                        <Button.Style>
+                                                            <Style BasedOn="{StaticResource OutlinedButtonStyleInverted}" TargetType="{x:Type Button}">
+                                                                <Setter Property="IsEnabled" Value="True"/>
+                                                            </Style>
+                                                        </Button.Style>
+                                                    </Button>
+                                                    <Button x:Name="Apply" 
+                                                        Click="Apply_Click"
+                                                        Margin="10"
+                                                        Padding="10,5,10,5"
+                                                        Grid.Column="1" 
+                                                        Content="Apply">
+                                                        <Button.ToolTip>
+                                                            <ToolTip Content="Custom Button Style" Style="{StaticResource GenericToolTipLight}"/>
+                                                        </Button.ToolTip>
+                                                        <Button.Style>
+                                                            <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
+                                                                <Setter Property="IsEnabled" Value="True"/>
+                                                            </Style>
+                                                        </Button.Style>
+                                                    </Button>
+                                                </Grid>
+                                            </Grid>
+
+                                        </Grid>
+                                    </Border>
+                                </Border>
+                            </Popup>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
+    </Popup.Resources>
+    <Grid>
+        <xctk:ColorPicker 
+            Name="xceedColorPickerControl" 
+            HorizontalAlignment="Center" 
+            Margin="0,0,0,0" 
+            VerticalAlignment="Center" 
+            AvailableColorsHeader="Basic colors:"
+            StandardColorsHeader="Custom colors:"
+            ShowStandardColors="False" 
+            ShowRecentColors="True"
+            Width="520"
+            SelectedColorChanged="xceedColorPickerControl_SelectedColorChanged"
+            Style="{StaticResource CustomColorPicker}"
+            RecentColorsHeader="Test">
+        </xctk:ColorPicker>
+    </Grid>
+</Popup>

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
@@ -2,10 +2,9 @@
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-        xmlns:converters="clr-namespace:Dynamo.Controls"
-        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+       xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+       xmlns:converters="clr-namespace:Dynamo.Controls"
         xmlns:ui="clr-namespace:Dynamo.UI"
         mc:Ignorable="d" 
         d:DesignHeight="780" d:DesignWidth="860">
@@ -15,183 +14,10 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-
-            <converters:AdditionConverter x:Key="AdditionConverter" />
-            <converters:ColorToSolidColorBrushConverter x:Key="ColorToSolidColorBrushConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             
-            <DataTemplate x:Key="ColorItemTemplate">
-                <Grid>
-                    <Border Background="White"
-                          BorderBrush="LightGray"
-                          BorderThickness="1"
-                          Margin="1">
-                        <Rectangle Width="26"
-                               Height="26">
-                            <Rectangle.Style>
-                                <Style TargetType="Rectangle">
-                                    <Setter Property="Fill"
-                                            Value="{Binding Color, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
-                                </Style>
-                            </Rectangle.Style>
-                        </Rectangle>
-                    </Border>
-                </Grid>
-            </DataTemplate>
-
-            <Style x:Key="ColorDisplayStyle"
-         TargetType="ContentControl">
-                <Setter Property="Focusable"
-            Value="False" />
-                <Setter Property="ContentTemplate">
-                    <Setter.Value>
-                        <DataTemplate>
-                            <Border Background="{StaticResource CheckerBrush}">
-                                <Rectangle Fill="{Binding SelectedColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=xctk:ColorPicker}, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
-                            </Border>
-                        </DataTemplate>
-                    </Setter.Value>
-                </Setter>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding SelectedColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=xctk:ColorPicker}}"
-                   Value="{x:Null}">
-                        <Setter Property="Visibility"
-                Value="Collapsed" />
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-
-            <Style x:Key="ColorItemContainerStyle"
-                TargetType="{x:Type ListBoxItem}">
-                <Setter Property="ToolTip"
-                    Value="{Binding Name}" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                            <Grid x:Name="mainGrid"
-                             ToolTip="{Binding Name}">
-                                <Grid.Resources>
-                                    <Style TargetType="ToolTip">
-                                        <Style.Triggers>
-                                            <Trigger Property="Content"
-                                                Value="{x:Static sys:String.Empty}">
-                                                <Setter Property="Visibility"
-                                                    Value="Collapsed" />
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Grid.Resources>
-                                <ContentPresenter HorizontalAlignment="Center"
-                                               VerticalAlignment="Center" />
-                                <Border BorderThickness="2"
-                                        Background="Transparent"
-                                        BorderBrush="{StaticResource PreferencesWindowButtonColor}"
-                                        x:Name="_outerBorder"
-                                        Visibility="{Binding Path=IsColorItemSelected,Converter={StaticResource BooleanToVisibilityConverter}}"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch">
-                                </Border>
-                                <Border Background="Transparent"
-                                        BorderThickness="1"
-                                        BorderBrush="Transparent"
-                                        x:Name="_innerBorder"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch">
-                                </Border>
-                            </Grid>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsMouseOver"
-                                    Value="True">
-                                    <Setter TargetName="_outerBorder"
-                                              Property="BorderBrush"
-                                              Value="{StaticResource PreferencesWindowButtonColor}" />
-                                    <Setter TargetName="_innerBorder"
-                                              Property="BorderBrush"
-                                              Value="{StaticResource PreferencesWindowButtonColor}" />
-                                </Trigger>
-                                <DataTrigger Binding="{Binding DisplayColorTooltip, RelativeSource={RelativeSource AncestorType={x:Type xctk:ColorPicker}}}"
-                                         Value="False">
-                                    <Setter Property="ToolTip"
-                                        Value="{x:Static sys:String.Empty}"
-                                        TargetName="mainGrid" />
-                                </DataTrigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <Style x:Key="ColorListStyle"
-                TargetType="ListBox">
-                <Setter Property="Background"
-                    Value="Transparent" />
-                <Setter Property="BorderThickness"
-                    Value="0" />
-                <Setter Property="MaxHeight"
-                    Value="300" />
-                <!-- ConverterParameter is margin/Padding from Popup-->
-                <Setter Property="Width"
-                    Value="{Binding Width, RelativeSource={RelativeSource AncestorType={x:Type xctk:ColorPicker}}, Converter={StaticResource AdditionConverter}, ConverterParameter=-18}" />
-                <Setter Property="ItemsPanel">
-                    <Setter.Value>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Width="{Binding ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListBox}, Converter={StaticResource AdditionConverter}, ConverterParameter=-4}" />
-                        </ItemsPanelTemplate>
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="ItemContainerStyle"
-                    Value="{StaticResource ColorItemContainerStyle}" />
-                <Setter Property="ItemTemplate"
-                    Value="{StaticResource ColorItemTemplate}" />
-                <Setter Property="SelectionMode"
-                    Value="Single" />
-            </Style>
-
-            <!--  Style for the close popup button in a Tooltip part of the Dynamo Guided Tours  -->
-            <Style x:Key="PopupCloseButtonStyle" TargetType="{x:Type Button}">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type Button}">
-                            <Border x:Name="CloseButtonBorder"
-                            Background="Transparent"
-                            BorderBrush="Transparent"
-                            BorderThickness="0">
-                                <Canvas Margin="0,0,0,0">
-                                    <Line x:Name="line1"
-                                  Stroke="#808080"
-                                  StrokeThickness="1"
-                                  X1="0"
-                                  X2="13"
-                                  Y1="0"
-                                  Y2="13" />
-                                    <Line x:Name="line2"
-                                  Stroke="#808080"
-                                  StrokeThickness="1"
-                                  X1="0"
-                                  X2="13"
-                                  Y1="13"
-                                  Y2="0" />
-                                </Canvas>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsPressed" Value="True">
-                                    <Setter TargetName="line1" Property="Stroke" Value="Red" />
-                                    <Setter TargetName="line2" Property="Stroke" Value="Red" />
-                                </Trigger>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="line1" Property="Stroke" Value="{StaticResource PreferencesWindowButtonColor}" />
-                                    <Setter TargetName="line2" Property="Stroke" Value="{StaticResource PreferencesWindowButtonColor}" />
-                                    <Setter Property="Cursor" Value="Hand" />
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-
-
-            <Style x:Key="CustomColorPicker" TargetType="{x:Type xctk:ColorPicker}">
+            <Style x:Key="CustomColorPicker"
+                   TargetType="{x:Type xctk:ColorPicker}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type xctk:ColorPicker}">
@@ -204,27 +30,27 @@
                                    Width="550"
                                    Height="Auto"
                                    PopupAnimation="Slide">
-                                <Border BorderBrush="Transparent" 
-                                    BorderThickness="10" 
-                                    CornerRadius="10" 
-                                    Background="Transparent">
-                                    <Border BorderBrush="Transparent" 
-                                        BorderThickness="4" 
-                                        CornerRadius="10" 
-                                        Name = "MainBorder" 
-                                        Background="White">
+                                <Border BorderBrush="Transparent"
+                                        BorderThickness="10"
+                                        CornerRadius="10"
+                                        Background="Transparent">
+                                    <Border BorderBrush="Transparent"
+                                            BorderThickness="4"
+                                            CornerRadius="10"
+                                            Name="MainBorder"
+                                            Background="White">
                                         <Border.Effect>
-                                            <DropShadowEffect BlurRadius="15" 
-                                                          Direction ="-90" 
-                                                          RenderingBias ="Quality" 
-                                                          ShadowDepth ="2" 
-                                                          Color ="LightGray" />
+                                            <DropShadowEffect BlurRadius="15"
+                                                              Direction="-90"
+                                                              RenderingBias="Quality"
+                                                              ShadowDepth="2"
+                                                              Color="LightGray" />
                                         </Border.Effect>
 
                                         <Grid x:Name="_colorPaletteHost"
-                                          HorizontalAlignment="Left"
-                                          Margin="20"
-                                          Background="Transparent">
+                                              HorizontalAlignment="Left"
+                                              Margin="20"
+                                              Background="Transparent">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="Auto" />
@@ -238,29 +64,29 @@
                                             <Grid Grid.Row="0">
                                                 <Grid x:Name="titleGrid">
                                                     <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="10*"/>
-                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="10*" />
+                                                        <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock Text="Color"
-                                                           Background="Transparent"
-                                                           Foreground="Black"
-                                                           FontSize="20"
-                                                           Margin="0, 10, 0, 10"
-                                                           FontWeight="Bold"
-                                                           Padding="2"/>
+                                                               Background="Transparent"
+                                                               Foreground="Black"
+                                                               FontSize="20"
+                                                               Margin="0, 10, 0, 10"
+                                                               FontWeight="Bold"
+                                                               Padding="2" />
                                                     <Button Name="CloseButton"
-                                                        Height="12.8"  
-                                                        Width="12.8"
-                                                        Grid.Column="1"
-                                                        Style="{StaticResource PopupCloseButtonStyle}"
-                                                        Click="CloseButton_Click">
+                                                            Height="12.8"
+                                                            Width="12.8"
+                                                            Grid.Column="1"
+                                                            Style="{StaticResource PopupCloseButtonStyle}"
+                                                            Click="CloseButton_Click">
                                                     </Button>
                                                 </Grid>
 
                                             </Grid>
 
                                             <!-- Basic Colors -->
-                                            <Grid Grid.Row="1" >
+                                            <Grid Grid.Row="1">
                                                 <Grid>
                                                     <Grid.RowDefinitions>
                                                         <RowDefinition Height="Auto" />
@@ -271,55 +97,60 @@
                                                                Margin="0, 5, 0, 5"
                                                                Background="Transparent"
                                                                Foreground="Black"
-                                                               Padding="2"/>
+                                                               Padding="2" />
 
                                                     <ListBox x:Name="PART_AvailableColors"
                                                              Margin="0, 5, 0, 5"
                                                              Grid.Row="1"
                                                              SelectionChanged="PART_BasicColors_SelectionChanged"
                                                              ItemsSource="{Binding BasicColors}"
-                                                             Style="{StaticResource ColorListStyle}"/>
+                                                             Style="{StaticResource ColorListStyle}" />
 
                                                 </Grid>
                                             </Grid>
 
                                             <!-- Custom Colors-->
-                                            <Grid Grid.Row="2" Visibility="Hidden">
+                                            <Grid Grid.Row="2"
+                                                  Visibility="Collapsed">
                                                 <Grid>
                                                     <Grid.RowDefinitions>
                                                         <RowDefinition Height="Auto" />
                                                         <RowDefinition Height="Auto" />
                                                     </Grid.RowDefinitions>
                                                     <TextBlock Text="{TemplateBinding StandardColorsHeader}"
-                                                                Background="Transparent"
-                                                                Margin="0, 5, 0, 5"
-                                                                Foreground="Black"
-                                                                Padding="2"/>
+                                                               Background="Transparent"
+                                                               Margin="0, 5, 0, 5"
+                                                               Foreground="Black"
+                                                               Padding="2" />
 
                                                     <ListBox x:Name="PART_CustomColors"
                                                              Grid.Row="1"
                                                              Margin="0, 5, 0, 5"
                                                              SelectionChanged="PART_CustomColors_SelectionChanged"
                                                              ItemsSource="{Binding CustomColors, RelativeSource={RelativeSource TemplatedParent}}"
-                                                             Style="{StaticResource ColorListStyle}"/>
+                                                             Style="{StaticResource ColorListStyle}" />
 
                                                 </Grid>
                                             </Grid>
 
                                             <!-- Define Colors-->
-                                            <Grid Grid.Row="3" Visibility="Hidden">
-                                                <Button x:Name="DefineColorBtn" 
+                                            <Grid Grid.Row="3"
+                                                  Visibility="Collapsed">
+                                                <Button x:Name="DefineColorBtn"
                                                         Content="Define Custom Colors"
                                                         Margin="5"
-                                                    Padding="10"
-                                                    HorizontalAlignment="Left"
-                                                    MaxWidth="200">
+                                                        Padding="10"
+                                                        HorizontalAlignment="Left"
+                                                        MaxWidth="200">
                                                     <Button.ToolTip>
-                                                        <ToolTip Content="Custom Button Style" Style="{StaticResource GenericToolTipLight}"/>
+                                                        <ToolTip Content="Custom Button Style"
+                                                                 Style="{StaticResource GenericToolTipLight}" />
                                                     </Button.ToolTip>
                                                     <Button.Style>
-                                                        <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
-                                                            <Setter Property="IsEnabled" Value="True"/>
+                                                        <Style BasedOn="{StaticResource SolidButtonStyle}"
+                                                               TargetType="{x:Type Button}">
+                                                            <Setter Property="IsEnabled"
+                                                                    Value="True" />
                                                         </Style>
                                                     </Button.Style>
                                                 </Button>
@@ -327,41 +158,46 @@
 
                                             <!--Separator-->
                                             <Grid Grid.Row="4">
-                                                <Separator Margin="5,5,0,5"/>
+                                                <Separator Margin="5,5,0,5" />
                                             </Grid>
 
                                             <!-- Buttons-->
-                                            <Grid Grid.Row="5" 
-                                              HorizontalAlignment="Right">
+                                            <Grid Grid.Row="5"
+                                                  HorizontalAlignment="Right">
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto" />
                                                     </Grid.ColumnDefinitions>
-                                                    <Button x:Name="CancelBtn" 
+                                                    <Button x:Name="CancelBtn"
                                                             Click="CancelBtn_Click"
                                                             Margin="10"
                                                             Padding="10,5,10,5"
-                                                            Grid.Column="0" 
+                                                            Grid.Column="0"
                                                             Content="Cancel">
                                                         <Button.Style>
-                                                            <Style BasedOn="{StaticResource OutlinedButtonStyleInverted}" TargetType="{x:Type Button}">
-                                                                <Setter Property="IsEnabled" Value="True"/>
+                                                            <Style BasedOn="{StaticResource OutlinedButtonStyleInverted}"
+                                                                   TargetType="{x:Type Button}">
+                                                                <Setter Property="IsEnabled"
+                                                                        Value="True" />
                                                             </Style>
                                                         </Button.Style>
                                                     </Button>
-                                                    <Button x:Name="Apply" 
-                                                        Click="Apply_Click"
-                                                        Margin="10"
-                                                        Padding="10,5,10,5"
-                                                        Grid.Column="1" 
-                                                        Content="Apply">
+                                                    <Button x:Name="Apply"
+                                                            Click="Apply_Click"
+                                                            Margin="10"
+                                                            Padding="10,5,10,5"
+                                                            Grid.Column="1"
+                                                            Content="Apply">
                                                         <Button.ToolTip>
-                                                            <ToolTip Content="Custom Button Style" Style="{StaticResource GenericToolTipLight}"/>
+                                                            <ToolTip Content="Custom Button Style"
+                                                                     Style="{StaticResource GenericToolTipLight}" />
                                                         </Button.ToolTip>
                                                         <Button.Style>
-                                                            <Style BasedOn="{StaticResource SolidButtonStyle}" TargetType="{x:Type Button}">
-                                                                <Setter Property="IsEnabled" Value="True"/>
+                                                            <Style BasedOn="{StaticResource SolidButtonStyle}"
+                                                                   TargetType="{x:Type Button}">
+                                                                <Setter Property="IsEnabled"
+                                                                        Value="True" />
                                                             </Style>
                                                         </Button.Style>
                                                     </Button>
@@ -382,7 +218,6 @@
         <xctk:ColorPicker 
             Name="xceedColorPickerControl" 
             HorizontalAlignment="Center" 
-            Margin="0,0,0,0" 
             VerticalAlignment="Center" 
             AvailableColorsHeader="Basic colors:"
             StandardColorsHeader="Custom colors:"

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
@@ -38,23 +38,20 @@ namespace Dynamo.Controls
         }
 
         private void PART_BasicColors_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            var listbox = sender as ListBox;
-            if (listbox == null) return;
-            
-            SelectColor(listbox);
+        {         
+            SelectColor(sender);
         }
 
         private void PART_CustomColors_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            SelectColor(sender);
+        }
+
+        private void SelectColor(object sender)
+        {
             var listbox = sender as ListBox;
             if (listbox == null) return;
 
-            SelectColor(listbox);
-        }
-
-        private void SelectColor(ListBox listbox)
-        {
             var customColorItemSelected = listbox.SelectedItem as CustomColorItem;
             if (customColorItemSelected == null) return;
 

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Dynamo.ViewModels;
+using Xceed.Wpf.Toolkit;
+
+namespace Dynamo.Controls
+{
+    public partial class CustomColorPicker : Popup
+    {
+        CustomColorPickerViewModel viewModel;
+        public CustomColorPicker()
+        {
+            InitializeComponent();
+            if (viewModel == null)
+            {
+                viewModel = new CustomColorPickerViewModel();
+            }
+            this.DataContext = viewModel;
+        }
+
+        private void Apply_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            viewModel.ColorPickerFinalSelectedColor = xceedColorPickerControl.SelectedColor;
+            this.IsOpen = false;
+        }
+
+        private void CancelBtn_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            viewModel.ColorPickerFinalSelectedColor = null;
+            this.IsOpen = false;
+        }
+
+        private void CloseButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            viewModel.ColorPickerFinalSelectedColor = null;
+            this.IsOpen = false;
+        }
+
+        private void xceedColorPickerControl_SelectedColorChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<System.Windows.Media.Color?> e)
+        {
+            //Cast to ColorPicker so we can use ColorPicker.Template
+            var colorPicker = (sender as ColorPicker);
+
+            //Get the ListBox for BasicColors
+            var basicColorsListBox = colorPicker.Template.FindName("PART_AvailableColors", colorPicker) as ListBox;
+            if (basicColorsListBox == null) return;
+
+            basicColorsListBox.Items.Cast<CustomColorItem>().ToList().ForEach(color => color.IsColorItemSelected = false);
+
+            //Find the color clicked in the ListBox.Items so we can put the IsColorItemSelected to true
+            var customColorItemSelected = basicColorsListBox.Items.Cast<CustomColorItem>().Where(item => item.Color.Value == e.NewValue.Value).FirstOrDefault();
+            if (customColorItemSelected == null) return;
+            customColorItemSelected.IsColorItemSelected = true;
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
@@ -2,13 +2,13 @@ using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Dynamo.ViewModels;
-using Xceed.Wpf.Toolkit;
 
 namespace Dynamo.Controls
 {
     public partial class CustomColorPicker : Popup
     {
-        CustomColorPickerViewModel viewModel;
+        private CustomColorPickerViewModel viewModel;
+
         public CustomColorPicker()
         {
             InitializeComponent();

--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
@@ -37,20 +37,28 @@ namespace Dynamo.Controls
             this.IsOpen = false;
         }
 
-        private void xceedColorPickerControl_SelectedColorChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<System.Windows.Media.Color?> e)
+        private void PART_BasicColors_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            //Cast to ColorPicker so we can use ColorPicker.Template
-            var colorPicker = (sender as ColorPicker);
+            var listbox = sender as ListBox;
+            if (listbox == null) return;
+            
+            SelectColor(listbox);
+        }
 
-            //Get the ListBox for BasicColors
-            var basicColorsListBox = colorPicker.Template.FindName("PART_AvailableColors", colorPicker) as ListBox;
-            if (basicColorsListBox == null) return;
+        private void PART_CustomColors_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var listbox = sender as ListBox;
+            if (listbox == null) return;
 
-            basicColorsListBox.Items.Cast<CustomColorItem>().ToList().ForEach(color => color.IsColorItemSelected = false);
+            SelectColor(listbox);
+        }
 
-            //Find the color clicked in the ListBox.Items so we can put the IsColorItemSelected to true
-            var customColorItemSelected = basicColorsListBox.Items.Cast<CustomColorItem>().Where(item => item.Color.Value == e.NewValue.Value).FirstOrDefault();
+        private void SelectColor(ListBox listbox)
+        {
+            var customColorItemSelected = listbox.SelectedItem as CustomColorItem;
             if (customColorItemSelected == null) return;
+
+            listbox.Items.Cast<CustomColorItem>().ToList().ForEach(color => color.IsColorItemSelected = false);
             customColorItemSelected.IsColorItemSelected = true;
         }
     }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -1079,10 +1079,5 @@ namespace Dynamo.Views
             }
             GeoScalingPopup.IsOpen = true;
         }
-
-        private void InCanvasSearchBar_Opened(object sender, EventArgs e)
-        {
-            int i = 0;
-        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -1079,5 +1079,10 @@ namespace Dynamo.Views
             }
             GeoScalingPopup.IsOpen = true;
         }
+
+        private void InCanvasSearchBar_Opened(object sender, EventArgs e)
+        {
+            int i = 0;
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -256,14 +256,6 @@ namespace Dynamo.Wpf.Views
 
         private void ButtonColorPicker_Click(object sender, RoutedEventArgs e)
         {
-            //System.Windows.Forms.ColorDialog colorDialog = new System.Windows.Forms.ColorDialog();
-
-            //if (colorDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-            //{
-            //    Button colorButton = sender as Button;
-            //    if (colorButton != null)
-            //        colorButton.Background = new SolidColorBrush(Color.FromRgb(colorDialog.Color.R, colorDialog.Color.G, colorDialog.Color.B));
-            //}
             var colorPicker = new CustomColorPicker();
             if (colorPicker == null) return;
 
@@ -277,15 +269,15 @@ namespace Dynamo.Wpf.Views
         private void ColorPicker_Closed(object sender, EventArgs e)
         {
             var colorPicker = sender as CustomColorPicker;
-            if(colorPicker== null) return;  
+            if(colorPicker == null) return;  
             colorPicker.Closed -= ColorPicker_Closed;
 
             if (colorButtonSelected != null)
             {
                 var viewModel = colorPicker.DataContext as CustomColorPickerViewModel;
-                if (viewModel == null || viewModel.ColorPickerFinalSelectedColor == null) return;
+                if (viewModel == null || viewModel.ColorPickerFinalSelectedColor == null)
+                    return;
                 colorButtonSelected.Background = new SolidColorBrush(viewModel.ColorPickerFinalSelectedColor.Value);
-                colorButtonSelected = null;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -30,6 +30,8 @@ namespace Dynamo.Wpf.Views
         private readonly DynamoViewModel dynViewModel;
         private List<GroupStyleItem> originalCustomGroupStyles { get; set; }
 
+        private Button colorButtonSelected;
+
         // Used for tracking the manage package command event
         // This is not a command any more but we keep it
         // around in a compatible way for now
@@ -254,13 +256,36 @@ namespace Dynamo.Wpf.Views
 
         private void ButtonColorPicker_Click(object sender, RoutedEventArgs e)
         {
-            System.Windows.Forms.ColorDialog colorDialog = new System.Windows.Forms.ColorDialog();
+            //System.Windows.Forms.ColorDialog colorDialog = new System.Windows.Forms.ColorDialog();
 
-            if (colorDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            //if (colorDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            //{
+            //    Button colorButton = sender as Button;
+            //    if (colorButton != null)
+            //        colorButton.Background = new SolidColorBrush(Color.FromRgb(colorDialog.Color.R, colorDialog.Color.G, colorDialog.Color.B));
+            //}
+            var colorPicker = new CustomColorPicker();
+            if (colorPicker == null) return;
+
+            colorPicker.Placement = PlacementMode.Top;
+            colorPicker.PlacementTarget = sender as UIElement;
+            colorPicker.IsOpen = true;
+            colorPicker.Closed += ColorPicker_Closed;
+            colorButtonSelected = sender as Button;
+        }
+
+        private void ColorPicker_Closed(object sender, EventArgs e)
+        {
+            var colorPicker = sender as CustomColorPicker;
+            if(colorPicker== null) return;  
+            colorPicker.Closed -= ColorPicker_Closed;
+
+            if (colorButtonSelected != null)
             {
-                Button colorButton = sender as Button;
-                if (colorButton != null)
-                    colorButton.Background = new SolidColorBrush(Color.FromRgb(colorDialog.Color.R, colorDialog.Color.G, colorDialog.Color.B));
+                var viewModel = colorPicker.DataContext as CustomColorPickerViewModel;
+                if (viewModel == null || viewModel.ColorPickerFinalSelectedColor == null) return;
+                colorButtonSelected.Background = new SolidColorBrush(viewModel.ColorPickerFinalSelectedColor.Value);
+                colorButtonSelected = null;
             }
         }
 

--- a/src/Libraries/CoreNodeModelsWpf/ColorPaletteViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/ColorPaletteViewModel.cs
@@ -1,0 +1,23 @@
+using System.Windows.Media;
+using Dynamo.Core;
+
+namespace Dynamo.Wpf
+{
+    internal class ColorPaletteViewModel : NotificationObject
+    {
+        private SolidColorBrush selectedColor;
+
+        public SolidColorBrush SelectedColor
+        {
+            get
+            {
+                return selectedColor;
+            }
+            set
+            {
+                selectedColor = value;
+                RaisePropertyChanged(nameof(SelectedColor));
+            }
+        }
+    }
+}

--- a/src/Libraries/CoreNodeModelsWpf/ColorPaletteViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/ColorPaletteViewModel.cs
@@ -7,6 +7,9 @@ namespace Dynamo.Wpf
     {
         private SolidColorBrush selectedColor;
 
+        /// <summary>
+        /// This Property will contain the selected color in the CustomColorPicker popup
+        /// </summary>
         public SolidColorBrush SelectedColor
         {
             get

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
@@ -3,83 +3,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="90">
     <UserControl.Resources>
-        <!--Control colors.-->
-        <Color x:Key="WindowColor">#FFE8EDF9</Color>
-        <Color x:Key="ContentAreaColorLight">#FFC5CBF9</Color>
-        <Color x:Key="ContentAreaColorDark">#FF7381F9</Color>
-
-        <Color x:Key="DisabledControlLightColor">#FFE8EDF9</Color>
-        <Color x:Key="DisabledControlDarkColor">#FFC5CBF9</Color>
-        <Color x:Key="DisabledForegroundColor">#FF888888</Color>
-
-        <Color x:Key="SelectedBackgroundColor">#FFC5CBF9</Color>
-        <Color x:Key="SelectedUnfocusedColor">#FFDDDDDD</Color>
-
-        <Color x:Key="ControlLightColor">White</Color>
-        <Color x:Key="ControlMediumColor">#FF7381F9</Color>
-        <Color x:Key="ControlDarkColor">#FF211AA9</Color>
-
-        <Color x:Key="ControlMouseOverColor">#FF3843C4</Color>
-        <Color x:Key="ControlPressedColor">#FF211AA9</Color>
-
-
-        <Color x:Key="GlyphColor">#FF444444</Color>
-        <Color x:Key="GlyphMouseOver">sc#1, 0.004391443, 0.002428215, 0.242281124</Color>
-
-        <!--Border colors-->
-        <Color x:Key="BorderLightColor">#FFCCCCCC</Color>
-        <Color x:Key="BorderMediumColor">#FF888888</Color>
-        <Color x:Key="BorderDarkColor">#FF444444</Color>
-
-        <Color x:Key="PressedBorderLightColor">#FF888888</Color>
-        <Color x:Key="PressedBorderDarkColor">#FF444444</Color>
-
-        <Color x:Key="DisabledBorderLightColor">#FFAAAAAA</Color>
-        <Color x:Key="DisabledBorderDarkColor">#FF888888</Color>
-
-        <Color x:Key="DefaultBorderBrushDarkColor">Black</Color>
-
-        <!--Control-specific resources.-->
-        <Color x:Key="HeaderTopColor">#FFC5CBF9</Color>
-        <Color x:Key="DatagridCurrentCellBorderColor">Black</Color>
-        <Color x:Key="SliderTrackDarkColor">#FFC5CBF9</Color>
-
-        <Color x:Key="NavButtonFrameColor">#FF3843C4</Color>
-
-        <LinearGradientBrush x:Key="MenuPopupBrush"
-                             EndPoint="0.5,1"
-                             StartPoint="0.5,0">
-            <GradientStop Color="{DynamicResource ControlLightColor}"
-                          Offset="0" />
-            <GradientStop Color="{DynamicResource ControlMediumColor}"
-                          Offset="0.5" />
-            <GradientStop Color="{DynamicResource ControlLightColor}"
-                          Offset="1" />
-        </LinearGradientBrush>
-
-        <LinearGradientBrush x:Key="ProgressBarIndicatorAnimatedFill"
-                             StartPoint="0,0"
-                             EndPoint="1,0">
-            <LinearGradientBrush.GradientStops>
-                <GradientStopCollection>
-                    <GradientStop Color="#000000FF"
-                                  Offset="0" />
-                    <GradientStop Color="#600000FF"
-                                  Offset="0.4" />
-                    <GradientStop Color="#600000FF"
-                                  Offset="0.6" />
-                    <GradientStop Color="#000000FF"
-                                  Offset="1" />
-                </GradientStopCollection>
-            </LinearGradientBrush.GradientStops>
-        </LinearGradientBrush>
-
-        <Style x:Key="CustomColorPicker"
+        <Style x:Key="CustomColorToggle"
                TargetType="{x:Type ToggleButton}">
             <Setter Property="Template">
                 <Setter.Value>
@@ -89,87 +16,28 @@
                                 <ColumnDefinition />
                                 <ColumnDefinition Width="20" />
                             </Grid.ColumnDefinitions>
-                            <VisualStateManager.VisualStateGroups>
-                                <VisualStateGroup x:Name="CommonStates">
-                                    <VisualState x:Name="Normal" />
-                                    <VisualState x:Name="MouseOver">
-                                        <Storyboard>
-                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
-                                                                          Storyboard.TargetName="Border">
-                                                <EasingColorKeyFrame KeyTime="0"
-                                                                     Value="{StaticResource ControlMouseOverColor}" />
-                                            </ColorAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </VisualState>
-                                    <VisualState x:Name="Pressed" />
-                                    <VisualState x:Name="Disabled">
-                                        <Storyboard>
-                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
-                                                                          Storyboard.TargetName="Border">
-                                                <EasingColorKeyFrame KeyTime="0"
-                                                                     Value="{StaticResource DisabledControlDarkColor}" />
-                                            </ColorAnimationUsingKeyFrames>
-                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
-                                                                          Storyboard.TargetName="Arrow">
-                                                <EasingColorKeyFrame KeyTime="0"
-                                                                     Value="{StaticResource DisabledForegroundColor}" />
-                                            </ColorAnimationUsingKeyFrames>
-                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Border.BorderBrush).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
-                                                                          Storyboard.TargetName="Border">
-                                                <EasingColorKeyFrame KeyTime="0"
-                                                                     Value="{StaticResource DisabledBorderDarkColor}" />
-                                            </ColorAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </VisualState>
-                                </VisualStateGroup>
-                                <VisualStateGroup x:Name="CheckStates">
-                                    <VisualState x:Name="Checked">
-                                        <Storyboard>
-                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
-                                                                          Storyboard.TargetName="Border">
-                                                <EasingColorKeyFrame KeyTime="0"
-                                                                     Value="{StaticResource ControlPressedColor}" />
-                                            </ColorAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </VisualState>
-                                    <VisualState x:Name="Unchecked" />
-                                    <VisualState x:Name="Indeterminate" />
-                                </VisualStateGroup>
-                            </VisualStateManager.VisualStateGroups>
                             <Border x:Name="Border"
+                                    Grid.Column="0"
+                                    Background="LightGray"
+                                    BorderBrush="Gray"
                                     Grid.ColumnSpan="2"
                                     CornerRadius="2"
-                                    BorderThickness="1">
-                                <Border.BorderBrush>
-                                    <LinearGradientBrush EndPoint="0,1"
-                                                         StartPoint="0,0">
-                                        <GradientStop Color="{DynamicResource BorderLightColor}"
-                                                      Offset="0" />
-                                        <GradientStop Color="{DynamicResource BorderDarkColor}"
-                                                      Offset="1" />
-                                    </LinearGradientBrush>
-                                </Border.BorderBrush>
-                                <Border.Background>
-
-                                    <LinearGradientBrush StartPoint="0,0"
-                                                         EndPoint="0,1">
-                                        <LinearGradientBrush.GradientStops>
-                                            <GradientStopCollection>
-                                                <GradientStop Color="{DynamicResource ControlLightColor}" />
-                                                <GradientStop Color="{DynamicResource ControlMediumColor}"
-                                                              Offset="1.0" />
-                                            </GradientStopCollection>
-                                        </LinearGradientBrush.GradientStops>
-                                    </LinearGradientBrush>
-
-                                </Border.Background>
+                                    BorderThickness="2">
                             </Border>
                             <Border Grid.Column="0"
+                                    BorderThickness="2"
+                                    BorderBrush="Gray"
                                     CornerRadius="2,0,0,2"
-                                    Margin="1">
+                                    Margin="0,0,0,0">
                                 <Border.Background>
-                                    <SolidColorBrush Color="{DynamicResource ControlLightColor}" />
+                                    <SolidColorBrush Color="White" />
                                 </Border.Background>
+                                <Border x:Name="CurrentColor"
+                                        Margin="2,2,2,2"
+                                        BorderBrush="Transparent"
+                                        Background="{Binding SelectedColor}">
+
+                                </Border>
                             </Border>
                             <Path x:Name="Arrow"
                                   Grid.Column="1"
@@ -177,7 +45,7 @@
                                   VerticalAlignment="Center"
                                   Data="M 0 0 L 4 4 L 8 0 Z">
                                 <Path.Fill>
-                                    <SolidColorBrush Color="{DynamicResource GlyphColor}" />
+                                    <SolidColorBrush Color="Black" />
                                 </Path.Fill>
                             </Path>
                         </Grid>
@@ -187,22 +55,11 @@
         </Style>
     </UserControl.Resources>
 
-    <Grid>
-        <!--<ToggleButton x:Name="xceedColorPickerControl"
-                      Width="100"
-                      Height="40"
-                      Click="xceedColorPickerControl_Click"
-                      Style="{StaticResource CustomColorPicker}" />-->
-        <xctk:ColorPicker Name="xceedColorPickerControl"
-                          HorizontalAlignment="Center"
-                          Margin="0,0,0,0"
-                          VerticalAlignment="Center"
-                          Width="80"
-                          AvailableColorsHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIStandardColors}"
-                          ShowStandardColors="False"
-                          ShowRecentColors="True"
-                          StandardButtonHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIStandardButtonHeader}"
-                          AdvancedButtonHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIAdvancedButtonHeader}"
-                          RecentColorsHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIRecentColors}" />
+    <Grid x:Name="mainGrid">
+        <ToggleButton x:Name="ColorToggleButton"
+                      Width="80"
+                      Height="25"
+                      Click="ColorToggleButton_Click"
+                      Style="{StaticResource CustomColorToggle}" />
     </Grid>
 </UserControl>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
@@ -1,25 +1,208 @@
-﻿<UserControl x:Class="CoreNodeModelsWpf.Controls.ColorPaletteUI"
+<UserControl x:Class="CoreNodeModelsWpf.Controls.ColorPaletteUI"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="90">
+    <UserControl.Resources>
+        <!--Control colors.-->
+        <Color x:Key="WindowColor">#FFE8EDF9</Color>
+        <Color x:Key="ContentAreaColorLight">#FFC5CBF9</Color>
+        <Color x:Key="ContentAreaColorDark">#FF7381F9</Color>
+
+        <Color x:Key="DisabledControlLightColor">#FFE8EDF9</Color>
+        <Color x:Key="DisabledControlDarkColor">#FFC5CBF9</Color>
+        <Color x:Key="DisabledForegroundColor">#FF888888</Color>
+
+        <Color x:Key="SelectedBackgroundColor">#FFC5CBF9</Color>
+        <Color x:Key="SelectedUnfocusedColor">#FFDDDDDD</Color>
+
+        <Color x:Key="ControlLightColor">White</Color>
+        <Color x:Key="ControlMediumColor">#FF7381F9</Color>
+        <Color x:Key="ControlDarkColor">#FF211AA9</Color>
+
+        <Color x:Key="ControlMouseOverColor">#FF3843C4</Color>
+        <Color x:Key="ControlPressedColor">#FF211AA9</Color>
+
+
+        <Color x:Key="GlyphColor">#FF444444</Color>
+        <Color x:Key="GlyphMouseOver">sc#1, 0.004391443, 0.002428215, 0.242281124</Color>
+
+        <!--Border colors-->
+        <Color x:Key="BorderLightColor">#FFCCCCCC</Color>
+        <Color x:Key="BorderMediumColor">#FF888888</Color>
+        <Color x:Key="BorderDarkColor">#FF444444</Color>
+
+        <Color x:Key="PressedBorderLightColor">#FF888888</Color>
+        <Color x:Key="PressedBorderDarkColor">#FF444444</Color>
+
+        <Color x:Key="DisabledBorderLightColor">#FFAAAAAA</Color>
+        <Color x:Key="DisabledBorderDarkColor">#FF888888</Color>
+
+        <Color x:Key="DefaultBorderBrushDarkColor">Black</Color>
+
+        <!--Control-specific resources.-->
+        <Color x:Key="HeaderTopColor">#FFC5CBF9</Color>
+        <Color x:Key="DatagridCurrentCellBorderColor">Black</Color>
+        <Color x:Key="SliderTrackDarkColor">#FFC5CBF9</Color>
+
+        <Color x:Key="NavButtonFrameColor">#FF3843C4</Color>
+
+        <LinearGradientBrush x:Key="MenuPopupBrush"
+                             EndPoint="0.5,1"
+                             StartPoint="0.5,0">
+            <GradientStop Color="{DynamicResource ControlLightColor}"
+                          Offset="0" />
+            <GradientStop Color="{DynamicResource ControlMediumColor}"
+                          Offset="0.5" />
+            <GradientStop Color="{DynamicResource ControlLightColor}"
+                          Offset="1" />
+        </LinearGradientBrush>
+
+        <LinearGradientBrush x:Key="ProgressBarIndicatorAnimatedFill"
+                             StartPoint="0,0"
+                             EndPoint="1,0">
+            <LinearGradientBrush.GradientStops>
+                <GradientStopCollection>
+                    <GradientStop Color="#000000FF"
+                                  Offset="0" />
+                    <GradientStop Color="#600000FF"
+                                  Offset="0.4" />
+                    <GradientStop Color="#600000FF"
+                                  Offset="0.6" />
+                    <GradientStop Color="#000000FF"
+                                  Offset="1" />
+                </GradientStopCollection>
+            </LinearGradientBrush.GradientStops>
+        </LinearGradientBrush>
+
+        <Style x:Key="CustomColorPicker"
+               TargetType="{x:Type ToggleButton}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ToggleButton}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="20" />
+                            </Grid.ColumnDefinitions>
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="MouseOver">
+                                        <Storyboard>
+                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                          Storyboard.TargetName="Border">
+                                                <EasingColorKeyFrame KeyTime="0"
+                                                                     Value="{StaticResource ControlMouseOverColor}" />
+                                            </ColorAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Pressed" />
+                                    <VisualState x:Name="Disabled">
+                                        <Storyboard>
+                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                          Storyboard.TargetName="Border">
+                                                <EasingColorKeyFrame KeyTime="0"
+                                                                     Value="{StaticResource DisabledControlDarkColor}" />
+                                            </ColorAnimationUsingKeyFrames>
+                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                                                          Storyboard.TargetName="Arrow">
+                                                <EasingColorKeyFrame KeyTime="0"
+                                                                     Value="{StaticResource DisabledForegroundColor}" />
+                                            </ColorAnimationUsingKeyFrames>
+                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Border.BorderBrush).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                          Storyboard.TargetName="Border">
+                                                <EasingColorKeyFrame KeyTime="0"
+                                                                     Value="{StaticResource DisabledBorderDarkColor}" />
+                                            </ColorAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                </VisualStateGroup>
+                                <VisualStateGroup x:Name="CheckStates">
+                                    <VisualState x:Name="Checked">
+                                        <Storyboard>
+                                            <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                          Storyboard.TargetName="Border">
+                                                <EasingColorKeyFrame KeyTime="0"
+                                                                     Value="{StaticResource ControlPressedColor}" />
+                                            </ColorAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Unchecked" />
+                                    <VisualState x:Name="Indeterminate" />
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                            <Border x:Name="Border"
+                                    Grid.ColumnSpan="2"
+                                    CornerRadius="2"
+                                    BorderThickness="1">
+                                <Border.BorderBrush>
+                                    <LinearGradientBrush EndPoint="0,1"
+                                                         StartPoint="0,0">
+                                        <GradientStop Color="{DynamicResource BorderLightColor}"
+                                                      Offset="0" />
+                                        <GradientStop Color="{DynamicResource BorderDarkColor}"
+                                                      Offset="1" />
+                                    </LinearGradientBrush>
+                                </Border.BorderBrush>
+                                <Border.Background>
+
+                                    <LinearGradientBrush StartPoint="0,0"
+                                                         EndPoint="0,1">
+                                        <LinearGradientBrush.GradientStops>
+                                            <GradientStopCollection>
+                                                <GradientStop Color="{DynamicResource ControlLightColor}" />
+                                                <GradientStop Color="{DynamicResource ControlMediumColor}"
+                                                              Offset="1.0" />
+                                            </GradientStopCollection>
+                                        </LinearGradientBrush.GradientStops>
+                                    </LinearGradientBrush>
+
+                                </Border.Background>
+                            </Border>
+                            <Border Grid.Column="0"
+                                    CornerRadius="2,0,0,2"
+                                    Margin="1">
+                                <Border.Background>
+                                    <SolidColorBrush Color="{DynamicResource ControlLightColor}" />
+                                </Border.Background>
+                            </Border>
+                            <Path x:Name="Arrow"
+                                  Grid.Column="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Data="M 0 0 L 4 4 L 8 0 Z">
+                                <Path.Fill>
+                                    <SolidColorBrush Color="{DynamicResource GlyphColor}" />
+                                </Path.Fill>
+                            </Path>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
 
     <Grid>
-        <xctk:ColorPicker 
-            Name="xceedColorPickerControl" 
-            HorizontalAlignment="Center" 
-            Margin="0,0,0,0" 
-            VerticalAlignment="Center" 
-            Width="80"  
-            AvailableColorsHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIStandardColors}" 
-            ShowStandardColors="False" 
-            ShowRecentColors="True"
-            StandardButtonHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIStandardButtonHeader}"
-            AdvancedButtonHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIAdvancedButtonHeader}"
-            RecentColorsHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIRecentColors}" />
+        <!--<ToggleButton x:Name="xceedColorPickerControl"
+                      Width="100"
+                      Height="40"
+                      Click="xceedColorPickerControl_Click"
+                      Style="{StaticResource CustomColorPicker}" />-->
+        <xctk:ColorPicker Name="xceedColorPickerControl"
+                          HorizontalAlignment="Center"
+                          Margin="0,0,0,0"
+                          VerticalAlignment="Center"
+                          Width="80"
+                          AvailableColorsHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIStandardColors}"
+                          ShowStandardColors="False"
+                          ShowRecentColors="True"
+                          StandardButtonHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIStandardButtonHeader}"
+                          AdvancedButtonHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIAdvancedButtonHeader}"
+                          RecentColorsHeader="{x:Static p:CoreNodeModelWpfResources.ColorPaletteUIRecentColors}" />
     </Grid>
 </UserControl>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Controls;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Dynamo.Controls;
 
 namespace CoreNodeModelsWpf.Controls
 {
@@ -10,6 +12,14 @@ namespace CoreNodeModelsWpf.Controls
         public ColorPaletteUI()
         {
             InitializeComponent();
+        }
+
+        private void xceedColorPickerControl_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var colorPickerPopup = new CustomColorPicker();
+            colorPickerPopup.Placement = PlacementMode.Bottom;
+            colorPickerPopup.PlacementTarget = xceedColorPickerControl;
+            colorPickerPopup.IsOpen = true;
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -20,6 +18,9 @@ namespace CoreNodeModelsWpf.Controls
         /// </summary>
         public delegate void ColorPickerSelectedColorHandler();
 
+        /// <summary>
+        /// Event that will be raised when the user selected a color in the CustomColorPicker popup and then the popup is closed
+        /// </summary>
         public event ColorPickerSelectedColorHandler ColorPickerSelectedColor;
 
         public void OnColorPickerSelectedColor()

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
@@ -1,6 +1,11 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Media;
 using Dynamo.Controls;
+using Dynamo.ViewModels;
+using Dynamo.Wpf;
 
 namespace CoreNodeModelsWpf.Controls
 {
@@ -9,17 +14,52 @@ namespace CoreNodeModelsWpf.Controls
     /// </summary>
     public partial class ColorPaletteUI : UserControl
     {
+
+        /// <summary>
+        /// Delegate that will be used for manage the event when a color was selected from the Color Picker
+        /// </summary>
+        public delegate void ColorPickerSelectedColorHandler();
+
+        public event ColorPickerSelectedColorHandler ColorPickerSelectedColor;
+
+        public void OnColorPickerSelectedColor()
+        {
+            this.ColorPickerSelectedColor?.Invoke();
+        }
+
+        private ColorPaletteViewModel viewModel = null;
+
         public ColorPaletteUI()
         {
             InitializeComponent();
+            if(viewModel == null)
+            {
+                viewModel = new ColorPaletteViewModel();
+            }
+            this.DataContext = viewModel;
+
+            //By default the ToggleButton will contain the Black color
+            viewModel.SelectedColor = new SolidColorBrush(Colors.Black);
         }
 
-        private void xceedColorPickerControl_Click(object sender, System.Windows.RoutedEventArgs e)
+        private void ColorPickerPopup_Closed(object sender, System.EventArgs e)
+        {
+            var colorPickerPopupClosed = sender as CustomColorPicker;
+            colorPickerPopupClosed.Closed -= ColorPickerPopup_Closed;
+            var colorPickerViewModel = colorPickerPopupClosed.DataContext as CustomColorPickerViewModel;
+            if (colorPickerViewModel == null || colorPickerViewModel.ColorPickerFinalSelectedColor == null) return;
+
+            viewModel.SelectedColor = new SolidColorBrush(colorPickerViewModel.ColorPickerFinalSelectedColor.Value);
+            OnColorPickerSelectedColor();
+        }
+
+        private void ColorToggleButton_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var colorPickerPopup = new CustomColorPicker();
             colorPickerPopup.Placement = PlacementMode.Bottom;
-            colorPickerPopup.PlacementTarget = xceedColorPickerControl;
+            colorPickerPopup.PlacementTarget = ColorToggleButton;
             colorPickerPopup.IsOpen = true;
+            colorPickerPopup.Closed += ColorPickerPopup_Closed;
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/CoreNodeModelsWpf.csproj
+++ b/src/Libraries/CoreNodeModelsWpf/CoreNodeModelsWpf.csproj
@@ -35,11 +35,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-	<PackageReference Include="Extended.Wpf.Toolkit" version="3.0.0">
-	  <GeneratePathProperty>true</GeneratePathProperty>
-    <!--Exclude copying the dll because we will handle it in the BinaryCompatibilityOps target -->
-    <ExcludeAssets>runtime</ExcludeAssets>
-	</PackageReference>
 	<PackageReference Include="LiveCharts" Version="0.9.7" />
 	<PackageReference Include="LiveCharts.Wpf" Version="0.9.7" />
 	<Reference Include="Xceed.Wpf.Toolkit, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">


### PR DESCRIPTION
### Purpose

Replacing the current ColorPicker and ColorPalette used for GroupStyles and for the Color Palette node.
Currently in Dynamo the GroupStyles are using the System.Windows.Forms.ColorDialog control for selecting the color and the Color Palette node is using the WPF Extended Toolkit ColorPicker, now with this change in both places we will be using the CustomColorPicker (based in WPF Extended Toolkit ColorPicker).

Basically I did the next tasks:
- Remove WPF Extended Toolkit 3.0.0 from CoreNodeModelsWpf project.
- Add WPF Extended Toolkit 3.0.0 to DynamoCoreWpf project
- Create a new ColorPicker named CustomColorPicker (based in WPF Extended Toolkit ColorPicker).
- Use the new ColorPicker in Color Palette node.
- Use the new ColorPicker for selecting the color when creating new styles (Preferences -> GroupStyles).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Replacing the current ColorPicker and ColorPalette used for GroupStyles and for the Color Palette node.


### Reviewers

@QilongTang 

### FYIs

@zeusongit 
