### PR TITLE
Handle node overlay color specifical case

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -899,7 +899,14 @@ namespace Dynamo.ViewModels
             // 1. Compile-time warnings in CBNs
             // 2. Obsolete nodes with warnings
             // 3. Dummy or unresolved nodes
-            if (nodeLogic.State == ElementState.Error || nodeLogic.State == ElementState.PersistentWarning || ErrorBubble == null) return;
+            if (nodeLogic.State == ElementState.Error || nodeLogic.State == ElementState.PersistentWarning) return;
+
+            // For certain nodes without ErrorBubble in place, handle color overlay specifically
+            if (ErrorBubble == null)
+            {
+                HandleColorOverlayChange();
+                return;
+            }
 
             if (DynamoViewModel.UIDispatcher != null)
             {


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

A PR for discussion to handle https://jira.autodesk.com/browse/DYN-5553.

In short, we have strange cases for node model nodes without error bubble to handle node overlay changes to reflect the correct state. Currently, Dynamo relies on node state property change and event handle to update it (see https://github.com/DynamoDS/Dynamo/blob/master/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs#L1136) but PropertyChangeManager seems will mute events in certain cases https://github.com/DynamoDS/Dynamo/blob/master/src/DynamoCore/Core/PropertyChangeManager.cs#L50, @mjkkirschner you may know the reason?

The muting would fail in this case because the `File From Object` state changed from Active -> Warning -> Dead -> Active, multiple times during execution for some VM reason I am not aware, from Debugging, only the first Active -> Warning state change was captured to finish the overlay change, so the overlay was never turned back.

Here is a simple graph to reproduce the edge case:
![image](https://user-images.githubusercontent.com/3942418/225466791-bf58860b-5436-48e7-af39-54df048a54df.png)
![image](https://user-images.githubusercontent.com/3942418/225466804-65a3512a-aefd-4b12-9e2e-ad95d933a694.png)

After
![image](https://user-images.githubusercontent.com/3942418/225466852-e6dbd421-88f5-454e-a20e-e5d020342219.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

@RobertGlobant20 @mjkkirschner 