### PR TITLE
DYN-5676-ColorPicker-CustomColors-DefaultColor

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml.cs
@@ -96,6 +96,8 @@ namespace Dynamo.Controls
         private void DefineColorBtn_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             viewModel.IsCustomColorSelectionEnabled = true;
+            if(colorCanvasControl.SelectedColor == null)
+                colorCanvasControl.SelectedColor = Colors.Black;
         }
 
         private void CustomColorsCloseButton_Click(object sender, System.Windows.RoutedEventArgs e)


### PR DESCRIPTION
### Purpose

When there is no color selected and the custom colors Popup is opened and none color was selected the sliders are disabled. Now with this fix the default color when the custom colors Popup is opened will be black and sliders will be enabled by default.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Default color when  the custom colors Popup is opened will be black.


### Reviewers

@QilongTang 

### FYIs

@avidit 
