### PR TITLE
Doc browser homepage update

### DIFF
--- a/src/DocumentationBrowserViewExtension/Docs/NoContent.html
+++ b/src/DocumentationBrowserViewExtension/Docs/NoContent.html
@@ -2,49 +2,97 @@
 
 
 <head>
-  
-  <meta charset="UTF-8" />
+
+    <meta charset="UTF-8" />
 </head>
 
 <style>
-  body {
-      color: white;
-      font-size: 14px;
-      font-family: "Artifakt Element", "Open Sans", sans-serif;
-      src: url("fonts/ArtifaktElement-Regular.woff") format("woff");
-      background-color: #353535;
-      padding: 1%;
-  }
-  
-  a {
-      color: lightgray;
-      cursor: pointer;
-      background-color: transparent;
-  }
+    body {
+        color: white;
+        font-size: 14px;
+        font-family: "Artifakt Element", "Open Sans", sans-serif;
+        src: url("fonts/ArtifaktElement-Regular.woff") format("woff");
+        background-color: #353535;
+        padding: 1%;
+    }
 
-  hr { 
-    border: none; 
-    border-bottom: 1px solid #545454;
-  } 
+    a {
+        color: lightgray;
+        cursor: pointer;
+        background-color: transparent;
+    }
 
-  </style>
-  
-  <!-- Use inline styles to keep Dynamo Dictionary styling in the dictionary -->
-  <!-- and custom styling in Dynamo sidepanel. -->
-  <body>
-  
+    hr {
+        border: none;
+        border-bottom: 1px solid #545454;
+    }
+
+    * {
+        box-sizing: border-box;
+    }
+
+    .flex-container {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .flex-child1 {
+        background-color: transparent;
+        flex-basis: 10%;
+    }
+
+    .flex-child2 {
+        background-color: transparent;
+        flex-basis: 90%;
+    }
+
+    div {
+        color: #f5f5f5;
+    }
+
+    h2 {
+        color: #f5f5f5;
+    }
+
+    body {
+        background-color: #2a2a2a;
+    }
+
+    a:link {
+        color: #6dd3ff;
+        background-color: transparent;
+        text-decoration: none;
+    }
+
+    a:visited {
+        color: pink;
+        background-color: transparent;
+        text-decoration: none;
+    }
+
+    a:hover {
+        color: red;
+        background-color: transparent;
+        text-decoration: underline;
+    }
+
+    a:active {
+        color: #6dd3ff;
+        background-color: transparent;
+        text-decoration: underline;
+    }
+</style>
+
+<!-- Use inline styles to keep Dynamo Dictionary styling in the dictionary -->
+<!-- and custom styling in Dynamo sidepanel. -->
+<body>
+
     <h2>Dynamo Documentation Browser</h2>
-    <hr >
-    <p>This sidebar will display any available documentation for the error selected.</p>
+    <hr>
+    <p>Welcome to the Documentation Browser! Here, you can find out more about nodes, settings, features, and errors—without having to leave Dynamo.</p>
+    <h3>What can I find in the Documentation Browser?</h3>
+    <p><b>Node information</b>: Want to learn more about a node? Select the node in the workspace and hit F1. This panel will show you information about how the node works, its inputs and outputs, and more. For several nodes, you can also interact with a sample graph showcasing use of the node in context.
     <br />
-    <br />
-    <h4>How do you select an error to view its documentation ?</h4>
-    <p>Click the "Read more..." link in the info bubble above a node that has a warning or error.</p>
-    <br />
-    <h4>No "Read more" link visible?</h4>
-    <p>This means the developers of the node (Dynamo team or third parties) have not included a documentation link for that error.</p>
-    <br />
-    <h4>Clicked "Read more" but still seeing this?</h4>
-    <p>This can happen if the documentation content was empty.</p>
-  
-  </body>
+    <p><b>Node issue documentation</b>: Did you come across an unfamiliar node error or warning? Click the Learn More link in the error/warning tooltip to access more information, instructions to fix the issue, and links to forum discussions. If you don’t see a Learn More link, documentation is not yet available for that issue.</p>
+    <p><b>Information about features and settings</b>: Several Dynamo dialogs include question mark icons that you can click to learn more about the feature or setting.</p>
+</body>


### PR DESCRIPTION
### Purpose

Replacing content on the Documentation Browser homepage (or No Content page) to more accurately describe what users can find there.

![Doc browser homepage](https://user-images.githubusercontent.com/84459986/226898953-44c4cc5d-fa2f-4fa7-ab27-34dc2358b87a.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Updated the Documentation Browser homepage to include a description about the types of content that can be found there: node information, issue documentation, and information about settings.


### Reviewers

@QilongTang 



### FYIs

@Amoursol 
