### PR TITLE
support serializing dynamic python engines

### DIFF
--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -54,6 +54,11 @@ namespace PythonNodeModels
                 if (!Enum.TryParse(engine, out PythonEngineVersion engineVersion) ||
                     engineVersion == PythonEngineVersion.Unspecified)
                 {
+                    //if this is a valid dynamically loaded engine, return unknown, and serialize the name.
+                    if (PythonEngineManager.Instance.AvailableEngines.Any(x=>x.Name == engine))
+                    {
+                        return PythonEngineVersion.Unknown;
+                    }
                     // This is a first-time case for newly created nodes only
                     SetEngineByDefault();
                 }

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -19,7 +19,8 @@ namespace PythonNodeModels
     {
         Unspecified,
         IronPython2,
-        CPython3
+        CPython3,
+        Unknown
     }
 }
 


### PR DESCRIPTION
### Purpose

while working on IronPython3 package recharge project I noticed that dynamic engine names were not serializing correctly because of an obsolete public API that requires returning an enum.. This PR works around that.

![Screen Shot 2023-03-21 at 3 21 18 PM](https://user-images.githubusercontent.com/508936/226719271-38f59ae0-ccc4-449e-8750-f76a737a66dc.png)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
