### PR TITLE
use another target to generate resources

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)Config\CS_SDK.props" />
   </ImportGroup>
@@ -183,7 +183,9 @@
         <GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
             <Output TaskParameter="Assemblies" ItemName="DynamoCoreInfo" />
         </GetAssemblyIdentity>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+        <Message Text="Project taret = $(TargetFramework)" Importance="high" />
+  </Target>
+    <Target AfterTargets="AfterBuildOps" Name="gen_resources" Condition=" '$(OS)' != 'Unix' ">
         <!-- Generate customization dll for DynamoCore -->
         <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)DynamoCoreImages.resx" OutputResources="$(ProjectDir)DynamoCoreImages.resources" References="$(SystemDrawingDllPath)" />
         <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)DynamoCoreImages.resources" OutputAssembly="$(OutDir)DynamoCore.customization.dll" Version="%(DynamoCoreInfo.Version)" />
@@ -193,6 +195,5 @@
         <!-- Generate customization dll for BuiltIn -->
         <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)/BuiltInAndOperators/BuiltInImages.resx" OutputResources="$(ProjectDir)/BuiltInAndOperators/BuiltInImages.resources" References="$(SystemDrawingDllPath)" />
         <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)/BuiltInAndOperators/BuiltInImages.resources" OutputAssembly="$(OutDir)BuiltIn.customization.dll" Version="%(DynamoCoreInfo.Version)" />
-    </ItemGroup>
-  </Target>
+    </Target>
 </Project>


### PR DESCRIPTION
### Purpose

@QilongTang reported that dynamocore.customization.dll was not being produced, and he was correct!

It seems that `ItemGroups` - are great for grouping items, but they do not actually run the tasks they contain, instead a target should be used... seems obvious now.

* use a target with a condition
* change the condition to match the more general check that @pinzart90 used which uses `OS != unix` instead of the target framework - this now matches the other csproj files which need to generate resource dlls.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

fix build

### Reviewers

