### PR TITLE
DYN-5674-CustomNode-Renamed

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -646,7 +646,9 @@ namespace Dynamo.ViewModels
                 // If a new CustomNodeWorkspaceModel is created, store that info in CustomNodeManager without creating an instance of the custom node.
                 if (this.Model is CustomNodeWorkspaceModel customNodeWorkspaceModel)
                 {
-                    customNodeWorkspaceModel.SetInfo(Path.GetFileNameWithoutExtension(filePath));
+                    //If the custom node Name is already set and the FileName is already set then we don't need to change the Name with "backup"
+                    if(string.IsNullOrEmpty(customNodeWorkspaceModel.Name) && string.IsNullOrEmpty(customNodeWorkspaceModel.FileName))
+                        customNodeWorkspaceModel.SetInfo(Path.GetFileNameWithoutExtension(filePath));
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
### Purpose

Fixing bug that was renaming Custom Nodes when auto-save functionality is automatically triggered.
After the auto-save functionality is triggered when we are located in the Custom Node edit tab when the node in the Home Workspace is being renamed to "backup". Then after my fix first is checking if it has a name and file associated (that usually happen when you create/edit a custom node) if that is the case then we don't execute the rename process. Also I added a test that will validate that the Save functionality doesn't rename the CustomNode name.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fixing bug that was renaming Custom Nodes when auto-save functionality is automatically triggered.


### Reviewers

@QilongTang 

### FYIs

@reddyashish 
