### PR TITLE
Handle null values in watch node/preview bubble

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -243,6 +243,9 @@ namespace Dynamo.ViewModels
 
         private static string GetStringFromObject(object obj)
         {
+            if (obj == null)
+                return Resources.NullString;
+
             TypeCode type = Type.GetTypeCode(obj.GetType());
             switch (type)
             {
@@ -285,6 +288,9 @@ namespace Dynamo.ViewModels
 
         private string GetDisplayType(object obj)
         {
+            if (obj == null)
+                return Resources.NullString;
+
             TypeCode typeCode = Type.GetTypeCode(obj.GetType());
             // returning a customized user friendly string instead of just returning the name of the type 
             switch (typeCode)

--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -1,17 +1,17 @@
-using Dynamo.Interfaces;
-using NUnit.Framework;
-using System.IO;
-using Dynamo.ViewModels;
-using ProtoCore.Mirror;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using CoreNodeModels;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Interfaces;
 using Dynamo.Tests;
+using Dynamo.ViewModels;
+using NUnit.Framework;
+using ProtoCore.Mirror;
 
 namespace DynamoCoreWpfTests 
 {

--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -1,4 +1,4 @@
-﻿using Dynamo.Interfaces;
+using Dynamo.Interfaces;
 using NUnit.Framework;
 using System.IO;
 using Dynamo.ViewModels;
@@ -254,6 +254,29 @@ namespace DynamoCoreWpfTests
 
             Assert.AreEqual(3, watchVM.Levels.ElementAt(0));
             Assert.AreEqual(2, watchVM.NumberOfItems);
+        }
+
+        [Test]
+        public void WatchDictionary()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\watch\WatchDictionary.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+            ViewModel.HomeSpace.Run();
+
+            var watchNode = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace("daa19ed1-36b0-4586-ae11-6470e7c196bd") as Watch;
+
+            var watchVM = GetWatchViewModel(watchNode);
+
+            Assert.AreEqual(3, watchVM.Children.Count);
+
+            Assert.AreEqual("1", watchVM.Children.ElementAt(0).NodeLabel);
+            Assert.AreEqual("Int64", watchVM.Children.ElementAt(0).ValueType);
+
+            Assert.AreEqual("null", watchVM.Children.ElementAt(1).NodeLabel);
+            Assert.AreEqual("null", watchVM.Children.ElementAt(1).ValueType);
+
+            Assert.AreEqual("null", watchVM.Children.ElementAt(2).NodeLabel);
+            Assert.AreEqual("String", watchVM.Children.ElementAt(2).ValueType);
         }
 
         [Test]

--- a/test/core/watch/WatchDictionary.dyn
+++ b/test/core/watch/WatchDictionary.dyn
@@ -1,0 +1,144 @@
+{
+  "Uuid": "b3971a38-9e42-4229-9ebd-7fa012a6ac9b",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "WatchDictionary",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "275d5ff387254cfa9ff92fac8f2d0e11",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1b7713c8f66d4e38933b4fb97acc7a28",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "{\"a\":1, \"b\": \"null\", \"c\": null};"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "Id": "daa19ed136b04586ae116470e7c196bd",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "7ce251e0efc946ce85c17be979c34247",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7cbf667c84fa4df3a7d6983d5a2e5825",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "1b7713c8f66d4e38933b4fb97acc7a28",
+      "End": "7ce251e0efc946ce85c17be979c34247",
+      "Id": "b903a06b6a534010862862dc48bd30b8",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.18",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.18.0.2986",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "275d5ff387254cfa9ff92fac8f2d0e11",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 220.5,
+        "Y": 325.0
+      },
+      {
+        "Id": "daa19ed136b04586ae116470e7c196bd",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 656.5,
+        "Y": 399.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-5740

Handle the Null values in a dict for watch node or preview bubble. The example provided in the above task has null values inside the dictionary and that was failing because we were not checking for null before checking the object type.

<img width="1325" alt="Screenshot 2023-03-28 at 2 58 34 AM" src="https://user-images.githubusercontent.com/43763136/228072178-43f624f6-7225-4d00-a8d9-bb67b8b4b593.png">

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes
Handle null values in watch node/preview bubble

### Reviewers
@QilongTang @mjkkirschner 

