### PR TITLE
DYN-5755 : restrict logging in service mode

### DIFF
--- a/src/DynamoCLI/Program.cs
+++ b/src/DynamoCLI/Program.cs
@@ -86,9 +86,9 @@ namespace DynamoCLI
                     Console.WriteLine("Press Enter to shutdown...");
                 }
             }
-            catch
+            catch(Exception ex)
             {
-                Console.WriteLine("Server is shutting down due to an error");
+                Console.WriteLine("Server is shutting down due to an error : " + ex.ToString());
             }
         }
 

--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -160,7 +160,7 @@ namespace Dynamo.Logging
         /// </summary>
         /// <param name="debugSettings">Debug settings</param>
         /// <param name="logDirectory">Directory path where log file will be written</param>
-        [Obsolete("This will be removed in 3.0, please use DynamoLogger(debugSettings, logDirectory, isTestMode) instead.")]
+        [Obsolete("This will be removed in 3.0, please use DynamoLogger(debugSettings, logDirectory, isTestMode, isCLIMode, isServiceMode) instead.")]
         public DynamoLogger(DebugSettings debugSettings, string logDirectory) : this(debugSettings, logDirectory, false)
         {
             
@@ -173,6 +173,7 @@ namespace Dynamo.Logging
         /// <param name="debugSettings">Debug settings</param>
         /// <param name="logDirectory">Directory path where log file will be written</param>
         /// <param name="isTestMode">Test mode is true or false.</param>
+        [Obsolete("This will be removed in 3.0, please use DynamoLogger(debugSettings, logDirectory, isTestMode, isCLIMode, isServiceMode) instead.")]
         public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean isTestMode)
         {
             lock (guardMutex)
@@ -204,6 +205,7 @@ namespace Dynamo.Logging
         /// <param name="logDirectory">Directory path where log file will be written</param>
         /// <param name="isTestMode">Test mode is true or false.</param>
         /// <param name="isCLIMode">We want to allow logging when CLI mode is true even if we are in test mode.</param>
+        [Obsolete("This will be removed in 3.0, please use DynamoLogger(debugSettings, logDirectory, isTestMode, isCLIMode, isServiceMode) instead.")]
         public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean isTestMode, Boolean isCLIMode)
             :this(debugSettings, logDirectory, isTestMode)
         {
@@ -223,6 +225,7 @@ namespace Dynamo.Logging
         /// <param name="isTestMode">Test mode is true or false.</param>
         /// <param name="isCLIMode">We want to allow logging when CLI mode is true even if we are in test mode.</param>
         /// <param name="isServiceMode">We want restrict logging in service mode to console only due to lambda limitations.</param>
+        /// TODO(DYN-5757): Review usage of isTestMode,isTestMode,isServiceMode across Dynamo and see how we can consildate all these flags.
         public DynamoLogger(DebugSettings debugSettings, string logDirectory, Boolean isTestMode, Boolean isCLIMode, Boolean isServiceMode)
             : this(debugSettings, logDirectory, isTestMode)
         {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -648,7 +648,7 @@ namespace Dynamo.Models
             IsHeadless = config.IsHeadless;
 
             DebugSettings = new DebugSettings();
-            Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory, IsTestMode, CLIMode);
+            Logger = new DynamoLogger(DebugSettings, pathManager.LogDirectory, IsTestMode, CLIMode, IsServiceMode);
 
             if (!IsServiceMode)
             {
@@ -2418,6 +2418,12 @@ namespace Dynamo.Models
         /// </summary>
         protected void SaveBackupFiles(object state)
         {
+            //No backup files in ServiceMode due to Lambda restrictions
+            if (IsServiceMode)
+            {
+                return;
+            }
+
             OnRequestDispatcherBeginInvoke(() =>
             {
                 // tempDict stores the list of backup files and their corresponding workspaces IDs


### PR DESCRIPTION
### Purpose
We have to deal with some limitations when we deploy Dynamo in service mode.
More precisely there are restrictions when running Dynamo in a Lambda and we can't create local files.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
