### PR TITLE
DYN-5742 add workspace

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -1,18 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Web;
 using System.Windows;
-using System.Windows.Markup;
 using Dynamo.Core;
 using Dynamo.DocumentationBrowser.Properties;
 using Dynamo.Logging;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
-using Dynamo.Wpf.Extensions;
 
 namespace Dynamo.DocumentationBrowser
 {

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Web;
 using System.Windows;
 using System.Windows.Markup;
 using Dynamo.Core;
@@ -436,7 +437,10 @@ namespace Dynamo.DocumentationBrowser
                 }
                 else
                 {
-                    raiseInsertGraph(this, new InsertDocumentationLinkEventArgs(Resources.FileNotFoundFailureMessage, DynamoGraphFromMDFilePath(this.Link.AbsolutePath)));
+                    string fileAbsolutePath = this.Link.AbsolutePath;
+                    if(fileAbsolutePath.Contains("%20"))
+                        fileAbsolutePath = HttpUtility.UrlDecode(this.Link.AbsolutePath);
+                    raiseInsertGraph(this, new InsertDocumentationLinkEventArgs(Resources.FileNotFoundFailureMessage, DynamoGraphFromMDFilePath(fileAbsolutePath)));
                     return;
                 }
             }

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Web;
 using System.Windows;
 using Dynamo.Core;
 using Dynamo.DocumentationBrowser.Properties;
@@ -444,8 +445,8 @@ namespace Dynamo.DocumentationBrowser
 
         private string DynamoGraphFromMDFilePath(string path)
         {
-            var dynPath = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path).Replace("%20", " ")) + ".dyn";
-            return dynPath.Replace("%20", " ");
+            path = HttpUtility.UrlDecode(path);
+            return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path)) + ".dyn";
         }
 
 

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -437,10 +437,7 @@ namespace Dynamo.DocumentationBrowser
                 }
                 else
                 {
-                    string fileAbsolutePath = this.Link.AbsolutePath;
-                    if(fileAbsolutePath.Contains("%20"))
-                        fileAbsolutePath = HttpUtility.UrlDecode(this.Link.AbsolutePath);
-                    raiseInsertGraph(this, new InsertDocumentationLinkEventArgs(Resources.FileNotFoundFailureMessage, DynamoGraphFromMDFilePath(fileAbsolutePath)));
+                    raiseInsertGraph(this, new InsertDocumentationLinkEventArgs(Resources.FileNotFoundFailureMessage, DynamoGraphFromMDFilePath(this.Link.AbsolutePath)));
                     return;
                 }
             }
@@ -452,8 +449,7 @@ namespace Dynamo.DocumentationBrowser
         private string DynamoGraphFromMDFilePath(string path)
         {
             var dynPath = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path).Replace("%20", " ")) + ".dyn";
-            return dynPath;
-            return path.Replace("%20", " ").Replace(".md", ".dyn");
+            return dynPath.Replace("%20", " ");
         }
 
 


### PR DESCRIPTION
### Purpose

Graph is not being added in the workspace because dyn file was not found.
The problem is that when executing DynamoSandbox from a path that contain empty spaces the URI.AbsolutePath is converting them to "%20" so the dyn file is not found.
Then with this fix I'm removing the "%20" from the string path and is found correctly when inserting the graph in the workspace.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Graph is not being added in the workspace because dyn file was not found.

### Reviewers

@QilongTang 

### FYIs

@reddyashish 
