### PR TITLE
use timespans to compare benchmarkdotnet results

### DIFF
--- a/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
+++ b/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
@@ -60,9 +60,9 @@ namespace DynamoPerformanceTests
             internal TimeSpan StdDev { get; set; }
 
             // Values + Units
-            internal string MeanString => Mean.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture);
-            internal string ErrorString => Error.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture);
-            internal string StdDevString => StdDev.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture);
+            internal string MeanString => Mean.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture) + "ms";
+            internal string ErrorString => Error.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture) + "ms";
+            internal string StdDevString => StdDev.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture) + "ms";
 
             /// <summary>
             /// Create a Benchmark result from values parsed from results csv
@@ -116,7 +116,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             internal double MeanDelta
             {
-                get { return Math.Round(100 * (NewResult.Mean.TotalMilliseconds - BaseResult.Mean.TotalMilliseconds) / BaseResult.Mean.TotalMilliseconds, 2); }
+                get { return Math.Round(100 * (NewResult.Mean.TotalMilliseconds - BaseResult.Mean.TotalMilliseconds) / BaseResult.Mean.TotalMilliseconds, 4); }
             }
 
             /// <summary>
@@ -124,7 +124,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             internal double ErrorDelta
             {
-                get { return Math.Round(100 * (NewResult.Error.TotalMilliseconds - BaseResult.Error.TotalMilliseconds) / BaseResult.Error.TotalMilliseconds, 2); }
+                get { return Math.Round(100 * (NewResult.Error.TotalMilliseconds - BaseResult.Error.TotalMilliseconds) / BaseResult.Error.TotalMilliseconds, 4); }
             }
 
             /// <summary>
@@ -132,7 +132,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             internal double StdDevDelta
             {
-                get { return Math.Round(100 * (NewResult.StdDev.TotalMilliseconds - BaseResult.StdDev.TotalMilliseconds) / BaseResult.StdDev.TotalMilliseconds, 2); }
+                get { return Math.Round(100 * (NewResult.StdDev.TotalMilliseconds - BaseResult.StdDev.TotalMilliseconds) / BaseResult.StdDev.TotalMilliseconds, 4); }
             }
 
             /// <summary>

--- a/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
+++ b/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
@@ -88,7 +88,9 @@ namespace DynamoPerformanceTests
             {
                 if(unitString.ToLowerInvariant().Contains("us"))
                 {
-                    return TimeSpan.FromMilliseconds(val* 0.001);
+                    const long TicksPerMicrosecond = 10;
+                    long microseconds = (long)(val / TicksPerMicrosecond);
+                    return TimeSpan.FromTicks(microseconds);
                 }
                 if (unitString.ToLowerInvariant().Contains("ms"))
                 {

--- a/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
+++ b/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
@@ -88,9 +88,9 @@ namespace DynamoPerformanceTests
             {
                 if(unitString.ToLowerInvariant().Contains("us"))
                 {
-                    const long TicksPerMicrosecond = 10;
-                    long microseconds = (long)(val / TicksPerMicrosecond);
-                    return TimeSpan.FromTicks(microseconds);
+                    const long ticksPerMicrosecond = 10;
+                    long ticks = (long)(val * ticksPerMicrosecond);
+                    return TimeSpan.FromTicks(ticks);
                 }
                 if (unitString.ToLowerInvariant().Contains("ms"))
                 {

--- a/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
+++ b/tools/Performance/DynamoPerformanceTests/ResultsComparer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -38,7 +38,7 @@ namespace DynamoPerformanceTests
             //EX. test with runtime of 1000ms will yeild fuzz factor of 10 + 1000/1000 = 11%
             //This attempts to deal with test failures that have very small runtimes which are 
             //more susceptible to uncontrollable operating system or machine workloads.
-            if (comparisonData.MeanDelta > (10 + (1000/comparisonData.BaseResult.Mean)))
+            if (comparisonData.MeanDelta > (10 + (1000/comparisonData.BaseResult.Mean.TotalMilliseconds)))
             {
                 return ComparisonResultState.FAIL;
             }
@@ -55,19 +55,14 @@ namespace DynamoPerformanceTests
             // Values
             internal string Method { get; set; }
             internal string Graph { get; set; }
-            internal double Mean { get; set; }
-            internal double Error { get; set; }
-            internal double StdDev { get; set; }
-
-            // Units
-            internal string MeanUnits { get; set; }
-            internal string ErrorUnits { get; set; }
-            internal string StdDevUnits { get; set; }
+            internal TimeSpan Mean { get; set; }
+            internal TimeSpan Error { get; set; }
+            internal TimeSpan StdDev { get; set; }
 
             // Values + Units
-            internal string MeanString { get { return Mean.ToString("N", CultureInfo.InvariantCulture) + " " + MeanUnits; } }
-            internal string ErrorString { get { return Error.ToString("N", CultureInfo.InvariantCulture) + " " + ErrorUnits; } }
-            internal string StdDevString { get { return StdDev.ToString("N", CultureInfo.InvariantCulture) + " " + StdDevUnits; } }
+            internal string MeanString => Mean.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture);
+            internal string ErrorString => Error.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture);
+            internal string StdDevString => StdDev.TotalMilliseconds.ToString("N", CultureInfo.InvariantCulture);
 
             /// <summary>
             /// Create a Benchmark result from values parsed from results csv
@@ -84,12 +79,23 @@ namespace DynamoPerformanceTests
             {
                 Method = method;
                 Graph = graph;
-                Mean = mean;
-                MeanUnits = meanUnits;
-                Error = error;
-                ErrorUnits = errorUnits;
-                StdDev = stdDev;
-                StdDevUnits = stdDevUnits;
+                Mean = ParseUnitToTimeSpan(mean, meanUnits);
+                Error = ParseUnitToTimeSpan(error, errorUnits);
+                StdDev = ParseUnitToTimeSpan(stdDev, stdDevUnits);
+            }
+
+            private TimeSpan ParseUnitToTimeSpan(double val, string unitString)
+            {
+                if(unitString.ToLowerInvariant().Contains("us"))
+                {
+                    return TimeSpan.FromMilliseconds(val* 0.001);
+                }
+                if (unitString.ToLowerInvariant().Contains("ms"))
+                {
+                    return TimeSpan.FromMilliseconds(val);
+                }
+
+                throw new Exception("unknown unit");
             }
         }
 
@@ -110,7 +116,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             internal double MeanDelta
             {
-                get { return Math.Round(100 * (NewResult.Mean - BaseResult.Mean) / BaseResult.Mean, 2); }
+                get { return Math.Round(100 * (NewResult.Mean.TotalMilliseconds - BaseResult.Mean.TotalMilliseconds) / BaseResult.Mean.TotalMilliseconds, 2); }
             }
 
             /// <summary>
@@ -118,7 +124,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             internal double ErrorDelta
             {
-                get { return Math.Round(100 * (NewResult.Error - BaseResult.Error) / BaseResult.Error, 2); }
+                get { return Math.Round(100 * (NewResult.Error.TotalMilliseconds - BaseResult.Error.TotalMilliseconds) / BaseResult.Error.TotalMilliseconds, 2); }
             }
 
             /// <summary>
@@ -126,7 +132,7 @@ namespace DynamoPerformanceTests
             /// </summary>
             internal double StdDevDelta
             {
-                get { return Math.Round(100 * (NewResult.StdDev - BaseResult.StdDev) / BaseResult.StdDev, 2); }
+                get { return Math.Round(100 * (NewResult.StdDev.TotalMilliseconds - BaseResult.StdDev.TotalMilliseconds) / BaseResult.StdDev.TotalMilliseconds, 2); }
             }
 
             /// <summary>
@@ -158,14 +164,6 @@ namespace DynamoPerformanceTests
                 if (BaseResult.Method != NewResult.Method || BaseResult.Graph != NewResult.Graph)
                 {
                     throw new Exception("Non-matching benchmarks provided for comparison");
-                }
-                
-                if (BaseResult.MeanUnits != NewResult.MeanUnits || BaseResult.ErrorUnits != NewResult.ErrorUnits || BaseResult.StdDevUnits != NewResult.StdDevUnits)
-                {
-                    var fc = Console.ForegroundColor;
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine("Units do not match beween base and new results.");
-                    Console.ForegroundColor = fc;
                 }
                 this.ResultState = comparisonFunction(this);
 


### PR DESCRIPTION
### Purpose

sometimes results from benchmarkdotnet are in ms, and sometimes they are in us. Use timespans to compare them.

I'm currently running this branch on the perf ci job.

This still needs work, the comparison makes more sense, but it yields NAN and some divide by zero errors, I guess we need more precision when converting us to ms. Looks like we are rounding somewhere to 2 decimals.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes


### Reviewers

