### PR TITLE
wrap paths to files in quotes

### DIFF
--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -233,7 +233,7 @@ namespace Dynamo.Wpf.Utilities
                         filesToSend.Add(viewModel.DumpRecordedCommands());
                     }
 
-                    var extras = string.Join(" ", filesToSend.Select(f => "/EXTRA " + f));
+                    var extras = string.Join(" ", filesToSend.Select(f => "/EXTRA \"" + f + "\""));
 
                     string appConfig = "";
                     if (model != null)
@@ -254,7 +254,7 @@ namespace Dynamo.Wpf.Utilities
                     var miniDumpFilePath = CreateMiniDumpFile(cerDir.FullName);
                     var upiConfigFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "upiconfig.xml");
 
-                    var cerArgs = $"/UPITOKEN {upiConfigFilePath} /DMP {miniDumpFilePath} /APPXML \"{appConfig}\" {dynConfig} {extras} /USEEXCEPTIONTRACE";
+                    var cerArgs = $"/UPITOKEN \"{upiConfigFilePath}\" /DMP \"{miniDumpFilePath}\" /APPXML \"{appConfig}\" {dynConfig} {extras} /USEEXCEPTIONTRACE";
                     
                     Process.Start(new ProcessStartInfo(cerToolPath, cerArgs)).WaitForExit();
                     return true;


### PR DESCRIPTION
The crash error reporting tool is sometimes thrown off by special characters in some of the file paths we use.
This PR wraps those file paths in quotes so that the CER tool can properly process them