### PR TITLE
DYN-5742-AddGraphToWorkspace-UnitTest

### DIFF
--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -719,10 +719,10 @@ namespace DynamoCoreWpfTests
             //First check that the directory doesn't exist
             Assert.IsTrue(!Directory.Exists(tempDynDirectory));
 
-            //Creates a directory that use empty spaces in the name
+            //Creates a directory that has empty spaces in the name
             Directory.CreateDirectory(tempDynDirectory);
 
-            //Copy the dyn file to the Directory with empty spaces
+            //Copy the dyn file to the new directory with empty spaces
             File.Copy(dynFileName, insertDynFilePath);
 
             //Adds a Number node into the Current Workspace

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -708,6 +708,58 @@ namespace DynamoCoreWpfTests
             return GetSidebarDocsBrowserContents();
         }
 
+        [Test]
+        public void AddGraphInSpecificLocationToWorkspace()
+        {
+            var testDirectory = GetTestDirectory(ExecutingDirectory);
+            var tempDynDirectory = Path.Combine(testDirectory, "Temp Test Path");
+            var dynFileName = Path.Combine(testDirectory, @"UI\BasicAddition.dyn");
+            var insertDynFilePath = Path.Combine(tempDynDirectory, @"BasicAddition.dyn");
+
+            //First check that the directory doesn't exist
+            Assert.IsTrue(!Directory.Exists(tempDynDirectory));
+
+            //Creates a directory that use empty spaces in the name
+            Directory.CreateDirectory(tempDynDirectory);
+
+            //Copy the dyn file to the Directory with empty spaces
+            File.Copy(dynFileName, insertDynFilePath);
+
+            //Adds a Number node into the Current Workspace
+            var nodeName = "Number";
+            this.ViewModel.ExecuteCommand(
+            new DynamoModel.CreateNodeCommand(
+                Guid.NewGuid().ToString(), nodeName, 0, 0, false, false)
+            );
+
+            //Validates that we have just one node in the CurrentWorkspace
+            Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Nodes.Count(), 1);
+
+            var node = ViewModel.Model.CurrentWorkspace.Nodes.FirstOrDefault();
+            RequestNodeDocs(node);
+
+            // Show the DocumentationBrowser so we can get the DocumentationBrowserViewModel
+            ShowDocsBrowser();
+            var docsView = GetDocsTabItem().Content as DocumentationBrowserView;
+            var docsViewModel = docsView.DataContext as DocumentationBrowserViewModel;
+
+            //Using reflection change the path of the dyn file for using the created directory (which has empty spaces in the name)
+            FieldInfo fi = typeof(DocumentationBrowserViewModel).GetField("graphPath", BindingFlags.NonPublic | BindingFlags.Instance);
+            fi.SetValue(docsViewModel, insertDynFilePath);
+
+            //Insert the Graph into the current workspace
+            docsViewModel.InsertGraph();
+
+            //Deletes the Directory created previously
+            if (Directory.Exists(tempDynDirectory))
+            {
+                Directory.Delete(tempDynDirectory, true);
+            }
+
+            //Validates that we have 5 nodes the CurrentWorkspace (after the graph was added)
+            Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Nodes.Count(), 5);         
+        }
+
         #region Helpers
 
         private DocumentationBrowserViewExtension SetupNewViewExtension(bool runLoadedMethod = false)

--- a/test/UI/BasicAddition.dyn
+++ b/test/UI/BasicAddition.dyn
@@ -1,0 +1,234 @@
+{
+  "Uuid": "a017e1cc-8acd-45b5-af80-a2707ffa6d70",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "BasicAddition",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NumberType": "Double",
+      "Id": "6e203a8262af4517aedb4ede82263d71",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "366402b2b0ea4c5aac2f330d0fd01672",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number",
+      "InputValue": 3.0
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NumberType": "Double",
+      "Id": "51b008f74ae047b9b5df98eeaefc69a8",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "2e0d7fc44152457094191d6e4ea1e0fc",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number",
+      "InputValue": 5.0
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "6959553ac16f476d8ce1447bdf6321b3",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "fedf93f2920f4be6afc6ffa784e38235",
+          "Name": "x",
+          "Description": "Integer value, double value or string\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c06024131fb24cad95d6122756a81225",
+          "Name": "y",
+          "Description": "Integer value, double value or string\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "75cd3fd598024b42910c1d22f43d4022",
+          "Name": "var",
+          "Description": "The sum of two input numbers, or the concatenation of two strings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "+@var[]..[],var[]..[]",
+      "Replication": "Auto",
+      "Description": "Returns addition of x and y\n\n+ (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 28.0,
+      "WatchHeight": 38.0,
+      "Id": "5fc6a93162a849fb8357aa3a41f82cbf",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "c73afec16fe446f58e1fb89c95edd8ec",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "36dc4563eaa74ad5936d7fd79049f8b5",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "366402b2b0ea4c5aac2f330d0fd01672",
+      "End": "c06024131fb24cad95d6122756a81225",
+      "Id": "423b4c16f5a24e75a995213fae6cb4ba",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2e0d7fc44152457094191d6e4ea1e0fc",
+      "End": "fedf93f2920f4be6afc6ffa784e38235",
+      "Id": "c3f3ab6e84b7430fa54e0ae84eaab1fb",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "75cd3fd598024b42910c1d22f43d4022",
+      "End": "c73afec16fe446f58e1fb89c95edd8ec",
+      "Id": "a74cf41419474a54a3085e4317216f19",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.18",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.18.0.4645",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "6e203a8262af4517aedb4ede82263d71",
+        "Name": "Number",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 446.0,
+        "Y": 550.5
+      },
+      {
+        "Id": "51b008f74ae047b9b5df98eeaefc69a8",
+        "Name": "Number",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 452.0,
+        "Y": 316.5
+      },
+      {
+        "Id": "6959553ac16f476d8ce1447bdf6321b3",
+        "Name": "+",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 682.0,
+        "Y": 399.5
+      },
+      {
+        "Id": "5fc6a93162a849fb8357aa3a41f82cbf",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 977.0,
+        "Y": 398.5
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Adding unit test that will validate that a dyn file located in a folder with empty spaces can be added to the current workspace.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Adding unit test that will validate that a dyn file located in a folder with empty spaces can be added to the current workspace.


### Reviewers

@QilongTang 
@reddyashish 

### FYIs

