### PR TITLE
Make Linter Extension and API public (WIP)

### DIFF
--- a/src/DynamoCore/Extensions/LinterExtensionBase.cs
+++ b/src/DynamoCore/Extensions/LinterExtensionBase.cs
@@ -26,9 +26,12 @@ namespace Dynamo.Extensions
         private LinterManager linterManager;
         private HomeWorkspaceModel currentWorkspace;
 
-        internal ReadyParams ReadyParamsRef { get; set; }
+        public ReadyParams ReadyParamsRef { get; private set; }
 
-        internal bool IsActive => this.linterManager?.IsExtensionActive(UniqueId) ?? false;
+        /// <summary>
+        /// Is this linter currently active for the active workspace.
+        /// </summary>
+        public bool IsActive => this.linterManager?.IsExtensionActive(UniqueId) ?? false;
 
         internal bool SetupComplete { get; set; } = false;
   

--- a/src/DynamoCore/Extensions/LinterExtensionBase.cs
+++ b/src/DynamoCore/Extensions/LinterExtensionBase.cs
@@ -106,7 +106,7 @@ namespace Dynamo.Extensions
         internal void Deactivate()
         {
             //Nothing to deactivate if we have not setup everything properly
-            //yet or we alreay deativated this linter extension
+            //yet or we already deactivated this linter extension
             if (!SetupComplete)
             {
                 return;


### PR DESCRIPTION
### Purpose

Expose the LinterExtensionBase as a public base class so that user can create linter extensions to create rule sets for Dynamo graphs beyond the GenerativeDesign type.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@BogdanZavu .

### FYIs

@mjkkirschner @twastvedt 
