### PR TITLE
DYN-5782-PrePopulate-CustomColorPicker

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -265,6 +265,17 @@ namespace Dynamo.Wpf.Views
         private void ButtonColorPicker_Click(object sender, RoutedEventArgs e)
         {
             var colorPicker = new CustomColorPicker();
+
+            //This section populate the CustomColorPicker custom colors with the colors defined in the custom GroupStyles
+            var customStylesColorsList = viewModel.StyleItemsList.Where(style => style.IsDefault == false);
+            foreach (var styleItem in customStylesColorsList)
+            {
+                Color color = (Color)ColorConverter.ConvertFromString("#"+styleItem.HexColorString);
+                var customColorItem = new CustomColorItem(color, string.Format("#{0},{1},{2}", color.R, color.G, color.B));
+                if (!stylesCustomColors.Contains(customColorItem))
+                    stylesCustomColors.Add(customColorItem);
+            }
+
             //This will set the custom colors list so the custom colors will remain the same for the Preferences panel (no matter if preferences is closed the list will remain).
             colorPicker.SetCustomColors(stylesCustomColors);
             if (colorPicker == null) return;

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -37,7 +37,7 @@ namespace Dynamo.Wpf.Views
         private IDisposable managePackageCommandEvent;
 
         //This list will be passed everytime that we create a new GroupStyle so the custom colors can remain
-        private ObservableCollection<CustomColorItem> stylesCustomColors;
+        internal ObservableCollection<CustomColorItem> stylesCustomColors;
 
         /// <summary>
         /// Storing the original custom styles before the user could update them

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -33,8 +34,9 @@ namespace CoreNodeModelsWpf.Controls
         }
 
         private ColorPaletteViewModel viewModel = null;
+        private DynamoViewModel dynViewModel = null;
 
-        public ColorPaletteUI()
+        public ColorPaletteUI(DynamoViewModel dynViewM)
         {
             InitializeComponent();
             if(viewModel == null)
@@ -42,6 +44,7 @@ namespace CoreNodeModelsWpf.Controls
                 viewModel = new ColorPaletteViewModel();
             }
             this.DataContext = viewModel;
+            dynViewModel = dynViewM;
 
             //By default the ToggleButton will contain the Black color
             viewModel.SelectedColor = new SolidColorBrush(Colors.Black);
@@ -64,6 +67,20 @@ namespace CoreNodeModelsWpf.Controls
         private void ColorToggleButton_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var colorPickerPopup = new CustomColorPicker();
+
+            if (dynViewModel != null)
+            {
+                //This section populate the CustomColorPicker custom colors with the colors defined in the custom GroupStyles
+                var customStylesColorsList = dynViewModel.PreferencesViewModel.StyleItemsList.Where(style => style.IsDefault == false);
+                foreach (var styleItem in customStylesColorsList)
+                {
+                    Color color = (Color)ColorConverter.ConvertFromString("#" + styleItem.HexColorString);
+                    var customColorItem = new CustomColorItem(color, string.Format("#{0},{1},{2}", color.R, color.G, color.B));
+                    if (!nodeCustomColors.Contains(customColorItem))
+                        nodeCustomColors.Add(customColorItem);
+                }
+            }
+
             //This will set the custom colors list so the custom colors will remain the same just for this node.
             colorPickerPopup.SetCustomColors(nodeCustomColors);
             colorPickerPopup.Placement = PlacementMode.Bottom;

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -31,7 +31,8 @@ namespace CoreNodeModelsWpf.Nodes
             viewNode = nodeView;
             colorPaletteNode = model;
             converter = new Converters.MediatoDSColorConverter();
-            ColorPaletteUINode = new ColorPaletteUI();
+           
+            ColorPaletteUINode = new ColorPaletteUI(viewNode.ViewModel.DynamoViewModel);
             colorPaletteViewModel = ColorPaletteUINode.DataContext as ColorPaletteViewModel;
             if(colorPaletteNode == null ) return;
 

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -119,6 +119,61 @@ namespace DynamoCoreWpfTests
             //Check that the GroupStyles in the AnnotationView match the ones in the PreferencesView
             Assert.AreEqual(annotationViewModel.GroupStyleList.OfType<GroupStyleItem>().Count(), currentGroupStylesCounter);
 
+        }
+
+        [Test]
+        public void CustomColorPicker_PrePopulateDefaultColors()
+        {
+            Open(@"UI\GroupTest.dyn");
+            var tabName = "Visual Settings";
+            var expanderName = "Group Styles";
+
+            var preferencesSettings = (View.DataContext as DynamoViewModel).PreferenceSettings;
+
+            //Creates the Preferences dialog 
+            var preferencesWindow = new PreferencesView(View);
+            
+            //Validate the 4 default existing styles list
+            Assert.AreEqual(preferencesSettings.GroupStyleItemsList.Count, 4);
+
+            //Adds two Custom Group Styles to the PreferencesView
+            preferencesSettings.GroupStyleItemsList.Add(new GroupStyleItem { Name = "Custom 1", HexColorString = "FFFF00", IsDefault = false });
+            preferencesSettings.GroupStyleItemsList.Add(new GroupStyleItem { Name = "Custom 2", HexColorString = "FF00FF", IsDefault = false });
+
+            //Finds the Visual Settings tab and open it
+            var tabControl = preferencesWindow.preferencesTabControl;
+            if (tabControl == null) return;
+            var preferencesTab = (from TabItem tabItem in tabControl.Items
+                                    where tabItem.Header.ToString().Equals(tabName)
+                                    select tabItem).FirstOrDefault();
+            if (preferencesTab == null) return;
+            tabControl.SelectedItem = preferencesTab;
+
+            //Finds the Group Styles section and open it 
+            var listExpanders = WpfUtilities.ChildrenOfType<Expander>(preferencesTab.Content as Grid);
+            var tabExpander = (from expander in listExpanders
+                                where expander.Header.ToString().Equals(expanderName)
+                                select expander).FirstOrDefault();
+            if (tabExpander == null) return;
+            tabExpander.IsExpanded = true;
+                   
+                 
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            //Click the AddStyle button
+            preferencesWindow.AddStyleButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            //The custom Colors list used by ColorPicker is empty
+            Assert.AreEqual(preferencesWindow.stylesCustomColors.Count, 0);
+
+            //Clicks the color button, this will populate the custom Colors list with the style colors added in Group Styles
+            preferencesWindow.buttonColorPicker.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            //Validates that the 3 added custom colors are present in the custom Colors list
+            Assert.AreEqual(preferencesWindow.stylesCustomColors.Count, 2);
         }
     }
 }


### PR DESCRIPTION
### Purpose

This fix will be pre-populating the custom colors in CustomColorPicker with the colors added in the Preferences->GroupStyles section (just for custom Styles). This fix is not applicable for the Color Palette node.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Pre-populating the custom colors in CustomColorPicker with the colors added in the Preferences->GroupStyles section.

### Reviewers

@QilongTang 

### FYIs

