### PR TITLE
DYN-5782-ColorPicker-TriggerFix

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -30,6 +30,7 @@ namespace Dynamo.Wpf.Views
         private List<GroupStyleItem> originalCustomGroupStyles { get; set; }
 
         private Button colorButtonSelected;
+        private bool groupStyleItemExisting = false;
 
         // Used for tracking the manage package command event
         // This is not a command any more but we keep it
@@ -262,7 +263,35 @@ namespace Dynamo.Wpf.Views
             Logging.Analytics.TrackEvent(Actions.Delete, Categories.GroupStyleOperations, nameof(GroupStyleItem));
         }
 
+        private void ColorPicker_Closed(object sender, EventArgs e)
+        {
+            var colorPicker = sender as CustomColorPicker;
+            if (colorPicker == null) return;  
+            colorPicker.Closed -= ColorPicker_Closed;
+
+            if (colorButtonSelected != null)
+            {
+                var viewModel = colorPicker.DataContext as CustomColorPickerViewModel;
+                if (viewModel == null || viewModel.ColorPickerSelectedColor == null)
+                    return;
+                colorButtonSelected.Background = new SolidColorBrush(viewModel.ColorPickerSelectedColor.Value);
+
+                //In case we are editing a Custom Style color then groupStyleItemExisting will be true and we need to set the GroupStyleItem.HexColorString
+                if (groupStyleItemExisting == true)
+                {
+                    GroupStyleItem selectedGroupStyle = (GroupStyleItem)colorButtonSelected.DataContext;
+                    selectedGroupStyle.HexColorString = viewModel.ColorPickerSelectedColor.Value.R.ToString("X2") + viewModel.ColorPickerSelectedColor.Value.G.ToString("X2") + viewModel.ColorPickerSelectedColor.Value.B.ToString("X2");
+                }
+            }
+            groupStyleItemExisting = false;
+        }
+
         private void ButtonColorPicker_Click(object sender, RoutedEventArgs e)
+        {
+            ShowCustomColorPicker(sender);
+        }
+
+        private void ShowCustomColorPicker(object sender)
         {
             var colorPicker = new CustomColorPicker();
 
@@ -270,7 +299,7 @@ namespace Dynamo.Wpf.Views
             var customStylesColorsList = viewModel.StyleItemsList.Where(style => style.IsDefault == false);
             foreach (var styleItem in customStylesColorsList)
             {
-                Color color = (Color)ColorConverter.ConvertFromString("#"+styleItem.HexColorString);
+                Color color = (Color)ColorConverter.ConvertFromString("#" + styleItem.HexColorString);
                 var customColorItem = new CustomColorItem(color, string.Format("#{0},{1},{2}", color.R, color.G, color.B));
                 if (!stylesCustomColors.Contains(customColorItem))
                     stylesCustomColors.Add(customColorItem);
@@ -287,42 +316,17 @@ namespace Dynamo.Wpf.Views
             colorButtonSelected = sender as Button;
 
             var brushColor = (colorButtonSelected.Background as SolidColorBrush);
-            if(brushColor != null)
+            if (brushColor != null)
             {
                 //if the current color in the Group Style already exists in the CustomColorPicker then it will be selected
                 colorPicker.InitializeSelectedColor(brushColor.Color);
-            }         
-        }
-
-        private void ColorPicker_Closed(object sender, EventArgs e)
-        {
-            var colorPicker = sender as CustomColorPicker;
-            if(colorPicker == null) return;  
-            colorPicker.Closed -= ColorPicker_Closed;
-
-            if (colorButtonSelected != null)
-            {
-                var viewModel = colorPicker.DataContext as CustomColorPickerViewModel;
-                if (viewModel == null || viewModel.ColorPickerSelectedColor == null)
-                    return;
-                colorButtonSelected.Background = new SolidColorBrush(viewModel.ColorPickerSelectedColor.Value);
             }
         }
 
         private void onChangedGroupStyleColor_Click(object sender, RoutedEventArgs e)
         {
-            System.Windows.Forms.ColorDialog colorDialog = new System.Windows.Forms.ColorDialog();
-
-            if (colorDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-            {
-                Button colorButton = sender as Button;
-                
-                if (colorButton != null)
-                {
-                    GroupStyleItem selectedGroupStyle = (GroupStyleItem)colorButton.DataContext;
-                    selectedGroupStyle.HexColorString = colorDialog.Color.R.ToString("X2") + colorDialog.Color.G.ToString("X2") + colorDialog.Color.B.ToString("X2");
-                }                
-            }
+            groupStyleItemExisting = true;
+            ShowCustomColorPicker(sender);
         }
 
         private void Log(ILogMessage obj)


### PR DESCRIPTION
### Purpose

When editing a color in a custom Group Style was appearing the old ColorPicker, so with this fix it will show the new CustomColorPicker.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

When editing a color in a custom Group Style was appearing the old ColorPicker, so with this fix it will show the new CustomColorPicker.


### Reviewers

@QilongTang 

### FYIs

