### PR TITLE
Fix Civil3D hostname to fix psuedo warning for package users

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -14,6 +14,7 @@ namespace Dynamo.PackageManager
         #region Properties/Fields
 
         public const string PackageEngineName = "dynamo";
+        private IEnumerable<string> cachedHosts;
 
         // These were used early on in order to identify packages with binaries and python scripts
         // This is now a bona fide field in the DB so they are obsolete. 
@@ -179,12 +180,16 @@ namespace Dynamo.PackageManager
         /// </summary>
         internal virtual IEnumerable<string> GetKnownHosts()
         {
-            return FailFunc.TryExecute(() =>
+            if (cachedHosts == null)
             {
-                var hosts = new Hosts();
-                var hostsResponse = this.client.ExecuteAndDeserializeWithContent<List<String>>(hosts);
-                return hostsResponse.content;
-            }, new List<string>());
+                cachedHosts = FailFunc.TryExecute(() =>
+                {
+                    var hosts = new Hosts();
+                    var hostsResponse = this.client.ExecuteAndDeserializeWithContent<List<String>>(hosts);
+                    return hostsResponse.content;
+                }, new List<string>());
+            }
+            return cachedHosts;
         }
 
         internal bool GetTermsOfUseAcceptanceStatus()

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -44,14 +44,6 @@ namespace Dynamo.PackageManager
         /// </summary>
         private Dictionary<string, List<PackageInfo>> NodePackageDictionary;
 
-        // TODO : Update all packages to use this hostname and replace the hostname in package manager as well.
-        /// <summary>
-        /// This will be used to match Civil 3D specific packages,
-        /// as there is a mismatch between the host dependency name in packages and the host name used by Civil 3D for Dynamo.
-        /// </summary>
-        private readonly string Civil3DHostName = "Dynamo Civil 3D";
-        private readonly string oldCivil3DHostName = "Civil 3D";
-
         public string Name { get { return "DynamoPackageManager"; } }
 
         public string UniqueId
@@ -359,20 +351,20 @@ namespace Dynamo.PackageManager
             }
             else
             {
-                string currentHost = Host;
-                if (Host.ToLower().Equals(Civil3DHostName.ToLower()))
+                bool civilflag = false;
+                if (Host.ToLower().Contains("civil"))
                 {
                     //To mitigate the mismatch between Dynamo Civil3D hostname and Dynamo Packages Host dependency name,
-                    //setting the current host name as the one used by package authors to mark their package Civil3D dependent.
-                    currentHost = oldCivil3DHostName;
+                    //setting the civil flag to true in case of Civil3D host.
+                    civilflag = true;
                 }
                 // Warn if there are packages targeting other hosts but not our host
-                var otherHosts = knownHosts.Except(new List<string>() { currentHost });
+                var otherHosts = knownHosts.Except(new List<string>() { Host });
                 containsPackagesThatTargetOtherHosts = newPackageHeaders.Any(x =>
                 {
                     // Is our host in the list?
                     // If not, is any other host in the list?
-                    return x.host_dependencies != null && !x.host_dependencies.Contains(currentHost) && otherHosts.Any(y => x.host_dependencies.Contains(y));
+                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && !(civilflag && x.host_dependencies.Any(y => y.Contains("civil"))) && otherHosts.Any(y => x.host_dependencies.Contains(y));
                 });
             }
 

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Reflection;
-using Dynamo.Configuration;
 using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
@@ -351,21 +349,14 @@ namespace Dynamo.PackageManager
             }
             else
             {
-                string civilStr = "civil";
-                bool civilFlag = false;
-                if (Host.ToLower().Contains(civilStr))
-                {
-                    //To mitigate the mismatch between Dynamo Civil3D hostname and Dynamo Packages Host dependency name,
-                    //setting the civil flag to true in case of Civil3D host.
-                    civilFlag = true;
-                }
                 // Warn if there are packages targeting other hosts but not our host
                 var otherHosts = knownHosts.Except(new List<string>() { Host });
                 containsPackagesThatTargetOtherHosts = newPackageHeaders.Any(x =>
                 {
                     // Is our host in the list?
                     // If not, is any other host in the list?
-                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && !(civilFlag && x.host_dependencies.Any(y => y.Contains(civilStr))) && otherHosts.Any(y => x.host_dependencies.Contains(y));
+                    // Also, check if any dependency contains the hostname or vice-versa.
+                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && !x.host_dependencies.Any(y => Host.Contains(y)) && otherHosts.Any(y => x.host_dependencies.Contains(y));
                 });
             }
 

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -351,12 +351,13 @@ namespace Dynamo.PackageManager
             }
             else
             {
-                bool civilflag = false;
-                if (Host.ToLower().Contains("civil"))
+                string civilStr = "civil";
+                bool civilFlag = false;
+                if (Host.ToLower().Contains(civilStr))
                 {
                     //To mitigate the mismatch between Dynamo Civil3D hostname and Dynamo Packages Host dependency name,
                     //setting the civil flag to true in case of Civil3D host.
-                    civilflag = true;
+                    civilFlag = true;
                 }
                 // Warn if there are packages targeting other hosts but not our host
                 var otherHosts = knownHosts.Except(new List<string>() { Host });
@@ -364,7 +365,7 @@ namespace Dynamo.PackageManager
                 {
                     // Is our host in the list?
                     // If not, is any other host in the list?
-                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && !(civilflag && x.host_dependencies.Any(y => y.Contains("civil"))) && otherHosts.Any(y => x.host_dependencies.Contains(y));
+                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && !(civilFlag && x.host_dependencies.Any(y => y.Contains(civilStr))) && otherHosts.Any(y => x.host_dependencies.Contains(y));
                 });
             }
 

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -50,6 +50,7 @@ namespace Dynamo.PackageManager
         /// as there is a mismatch between the host dependency name in packages and the host name used by Civil 3D for Dynamo.
         /// </summary>
         private readonly string Civil3DHostName = "Dynamo Civil 3D";
+        private readonly string oldCivil3DHostName = "Civil 3D";
 
         public string Name { get { return "DynamoPackageManager"; } }
 
@@ -363,7 +364,7 @@ namespace Dynamo.PackageManager
                 {
                     //To mitigate the mismatch between Dynamo Civil3D hostname and Dynamo Packages Host dependency name,
                     //setting the current host name as the one used by package authors to mark their package Civil3D dependent.
-                    currentHost = "Civil 3D";
+                    currentHost = oldCivil3DHostName;
                 }
                 // Warn if there are packages targeting other hosts but not our host
                 var otherHosts = knownHosts.Except(new List<string>() { currentHost });

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -362,7 +362,7 @@ namespace Dynamo.PackageManager
                 if (Host.ToLower().Equals(Civil3DHostName.ToLower()))
                 {
                     //To mitigate the mismatch between Dynamo Civil3D hostname and Dynamo Packages Host dependency name,
-                    //setting the current host name as the one used by package autors to mark their package Civil3D dependent.
+                    //setting the current host name as the one used by package authors to mark their package Civil3D dependent.
                     currentHost = "Civil 3D";
                 }
                 // Warn if there are packages targeting other hosts but not our host

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
@@ -43,6 +43,13 @@ namespace Dynamo.PackageManager
         /// Used for package dependency serialization.
         /// </summary>
         private Dictionary<string, List<PackageInfo>> NodePackageDictionary;
+
+        // TODO : Update all packages to use this hostname and replace the hostname in package manager as well.
+        /// <summary>
+        /// This will be used to match Civil 3D specific packages,
+        /// as there is a mismatch between the host dependency name in packages and the host name used by Civil 3D for Dynamo.
+        /// </summary>
+        private readonly string Civil3DHostName = "Dynamo Civil 3D";
 
         public string Name { get { return "DynamoPackageManager"; } }
 
@@ -351,13 +358,20 @@ namespace Dynamo.PackageManager
             }
             else
             {
+                string currentHost = Host;
+                if (Host.ToLower().Equals(Civil3DHostName.ToLower()))
+                {
+                    //To mitigate the mismatch between Dynamo Civil3D hostname and Dynamo Packages Host dependency name,
+                    //setting the current host name as the one used by package autors to mark their package Civil3D dependent.
+                    currentHost = "Civil 3D";
+                }
                 // Warn if there are packages targeting other hosts but not our host
-                var otherHosts = knownHosts.Except(new List<string>() { Host });
+                var otherHosts = knownHosts.Except(new List<string>() { currentHost });
                 containsPackagesThatTargetOtherHosts = newPackageHeaders.Any(x =>
                 {
                     // Is our host in the list?
                     // If not, is any other host in the list?
-                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && otherHosts.Any(y => x.host_dependencies.Contains(y));
+                    return x.host_dependencies != null && !x.host_dependencies.Contains(currentHost) && otherHosts.Any(y => x.host_dependencies.Contains(y));
                 });
             }
 


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-5470
Added `Dynamo Civil 3D` as the hostname for Civil 3D packages that have `Civil 3D` as the host dependency.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes


### Reviewers

@DynamoDS/dynamo 
