### PR TITLE
Edit Python Port Properties - bugfix

### DIFF
--- a/src/DynamoCoreWpf/Controls/InPortContextMenu.xaml
+++ b/src/DynamoCoreWpf/Controls/InPortContextMenu.xaml
@@ -128,8 +128,8 @@
                         HorizontalAlignment="Left"
                         Command="{Binding Path=EditPortPropertiesCommand}"
                         Content="{x:Static p:Resources.RenamePortPopupMenuItem}"
-                        IsEnabled="{Binding RenameNodeButtonEnabled, UpdateSourceTrigger=PropertyChanged}"
-                        Visibility="{Binding RenameNodeButtonEnabled, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                        IsEnabled="{Binding IsPythonNodePort, UpdateSourceTrigger=PropertyChanged}"
+                        Visibility="{Binding IsPythonNodePort, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
                         Style="{StaticResource PopupButtonStyle}" />
 
             </StackPanel>


### PR DESCRIPTION
### Purpose

A small bugfix to Edit Port Properties inport context menu. Used to be displayed for any Node, now only shows for Python nodes, as required. 

#### Changes
![inport-before-after](https://user-images.githubusercontent.com/5354594/233153180-8417ec5f-d2e5-46b9-9d39-70209a8bdbce.png)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- fixed the condition in which the Edit Port Properties will be visible for all Nodes

### Reviewers

@reddyashish 
@Amoursol 

