### PR TITLE
[Cherry-pick] Fix Civil3D hostname to fix psuedo warning for package users (#13910)

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -14,6 +14,7 @@ namespace Dynamo.PackageManager
         #region Properties/Fields
 
         public const string PackageEngineName = "dynamo";
+        private IEnumerable<string> cachedHosts;
 
         // These were used early on in order to identify packages with binaries and python scripts
         // This is now a bona fide field in the DB so they are obsolete. 
@@ -179,12 +180,16 @@ namespace Dynamo.PackageManager
         /// </summary>
         internal virtual IEnumerable<string> GetKnownHosts()
         {
-            return FailFunc.TryExecute(() =>
+            if (cachedHosts == null)
             {
-                var hosts = new Hosts();
-                var hostsResponse = this.client.ExecuteAndDeserializeWithContent<List<String>>(hosts);
-                return hostsResponse.content;
-            }, new List<string>());
+                cachedHosts = FailFunc.TryExecute(() =>
+                {
+                    var hosts = new Hosts();
+                    var hostsResponse = this.client.ExecuteAndDeserializeWithContent<List<String>>(hosts);
+                    return hostsResponse.content;
+                }, new List<string>());
+            }
+            return cachedHosts;
         }
 
         internal bool GetTermsOfUseAcceptanceStatus()

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -1,9 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Reflection;
-using Dynamo.Configuration;
 using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
@@ -357,7 +355,8 @@ namespace Dynamo.PackageManager
                 {
                     // Is our host in the list?
                     // If not, is any other host in the list?
-                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && otherHosts.Any(y => x.host_dependencies.Contains(y));
+                    // Also, check if any dependency contains the hostname or vice-versa.
+                    return x.host_dependencies != null && !x.host_dependencies.Contains(Host) && !x.host_dependencies.Any(y => Host.Contains(y)) && otherHosts.Any(y => x.host_dependencies.Contains(y));
                 });
             }
 


### PR DESCRIPTION
### Purpose

cherry pick #13910

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- Fix Civil3D hostname to fix psuedo warning for package users


### Reviewers

@reddyashish @QilongTang 
