### PR TITLE
remove extra libg reference from dynamocorewpf

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -71,7 +71,6 @@
   </ItemGroup>
   <ItemGroup>
   <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.17.1.3967"/>
-  <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.16.0.3736" />
   <PackageReference Include="AvalonEdit" Version="4.3.1.9430" CopyXML="true" />
   <PackageReference Include="Greg" Version="2.3.0.2505" />
   <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />


### PR DESCRIPTION
existing problem on 2.17.2 and 2.17.3 branches but shouldn't be a problem to fix it.