### PR TITLE
DYN-4490-PythonScriptFromString_NodeFix

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonStringNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Windows;
@@ -49,8 +49,17 @@ namespace PythonNodeModelsWpf
 
             nodeModel.Disposed += NodeModel_Disposed;
 
-            nodeView.PresentationGrid.Visibility = Visibility.Visible;
-            nodeView.PresentationGrid.Children.Add(new EngineLabel(pythonStringNodeModel));
+            var engineLabel = new EngineLabel(pythonStringNodeModel);
+            engineLabel.HorizontalAlignment = HorizontalAlignment.Left;
+            engineLabel.VerticalAlignment = VerticalAlignment.Bottom;
+            engineLabel.Margin = new Thickness(14, -4, -10, 4);
+            Canvas.SetZIndex(engineLabel, 5);
+
+            nodeView.grid.Visibility = Visibility.Visible;
+            nodeView.grid.Children.Add(engineLabel);
+
+            Grid.SetColumn(engineLabel, 0);
+            Grid.SetRow(engineLabel, 3);
         }
 
         private void NodeModel_Disposed(Dynamo.Graph.ModelBase obj)


### PR DESCRIPTION
### Purpose

Fixing the location of the engine label in the PythonScriptFromString node. 
I've used the normal nodeView.grid for addnig the engineLabel instead of the nodeView.PresentationGrid due that this last one is located in a different row, column.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fixing the location of the engine label in the PythonScriptFromString node. 


### Reviewers

@QilongTang 

### FYIs

