### PR TITLE
DYN-4513 Improvement: Allow pin note to node via drag, hover and release

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -61,6 +61,7 @@ namespace Dynamo.ViewModels
         private bool isRenamed = false;
         private bool isNodeInCollapsedGroup = false;
         private const string WatchNodeName = "Watch";
+        private bool nodeHoveringState;
         #endregion
 
         #region public members
@@ -541,6 +542,28 @@ namespace Dynamo.ViewModels
                 }
 
                 return PreviewState.None;
+            }
+        }
+
+        /// <summary>
+        /// This is used to determine if there is
+        /// a node hovering over this group.
+        /// When this is true the views nodeHoveringStateBorder
+        /// is activated.
+        /// </summary>
+        [JsonIgnore]
+        public bool NodeHoveringState
+        {
+            get => nodeHoveringState;
+            set
+            {
+                if (nodeHoveringState == value)
+                {
+                    return;
+                }
+
+                nodeHoveringState = value;
+                RaisePropertyChanged(nameof(NodeHoveringState));
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Selection;
@@ -857,49 +858,11 @@ namespace Dynamo.ViewModels
                     // Update the dragged nodes (note: this isn't recorded).
                     owningWorkspace.UpdateDraggedSelection(mouseCursor.AsDynamoType());
 
-                    var draggedNodes = DynamoSelection.Instance.Selection.OfType<NodeModel>();
+                    // Perform drag&drop for notes
+                    // terminate early if this was successful 
+                    if(PerformDropNotes(mouseCursor)) return false;
+
                     var draggedGroups = DynamoSelection.Instance.Selection.OfType<AnnotationModel>();
-
-                    // Here we check if the mouse cursor is inside any Nodes
-                    var dropNodes = owningWorkspace.Nodes
-                        .Where(x =>
-                        !draggedNodes.Select(a => a.GUID).Contains(x.NodeModel.GUID) &&
-                        x.NodeModel.Rect.Contains(mouseCursor.X, mouseCursor.Y));
-
-                    var dropNode = dropNodes.FirstOrDefault();
-                    if (dropNode is null)
-                    {
-                        // Reset the workspace from hovered nodes
-                        owningWorkspace.Nodes
-                            .Where(x => x.NodeHoveringState)
-                            .ToList()
-                            .ForEach(x => x.NodeHoveringState = false);
-                    }
-                    else if (!dropNode.NodeHoveringState)
-                    {
-                        // make sure there are no other node
-                        // set to NodeHoveringState before setting
-                        // the current node.
-                        // If we dont do this there are scenarios where
-                        // two nodes are very close and a note is dragged
-                        // quickly between the two where the hovering state
-                        // is not reset.
-                        owningWorkspace.Nodes
-                            .Where(x => x.NodeHoveringState)
-                            .ToList()
-                            .ForEach(x => x.NodeHoveringState = false);
-
-                        // also make sure no Annotation groups are marked as hovered
-                        // in case the Note is being dropped over a Node inside a Group
-                        owningWorkspace.Annotations
-                            .Where(x => x.NodeHoveringState)
-                            .ToList()
-                            .ForEach(x => x.NodeHoveringState = false);
-
-                        dropNode.NodeHoveringState = true;
-
-                        return false;   // Mouse event has not been handled
-                    }
 
                     // Terminate early if a Note is being hovered over a Node
                     if (owningWorkspace.Nodes.Any(x => x.NodeHoveringState)) return false;
@@ -975,6 +938,67 @@ namespace Dynamo.ViewModels
                 }
 
                 return false; // Mouse event not handled.
+            }
+
+            /// <summary>
+            /// Handles the drag & drop for Notes over Nodes
+            /// </summary>
+            /// <param name="mouseCursor">The current location of the mouse cursor</param>
+            /// <returns></returns>
+            private bool PerformDropNotes(Point mouseCursor)
+            {
+                // If the selected element is not a Note
+                // we don't need to keep going
+                var draggedNotes = DynamoSelection.Instance.Selection.OfType<NoteModel>();
+                if (!draggedNotes.Any())
+                {
+                    return false;
+                }
+
+                var draggedNodes = DynamoSelection.Instance.Selection.OfType<NodeModel>();
+
+                // Here we check if the mouse cursor is inside any Nodes
+                var dropNodes = owningWorkspace.Nodes
+                    .Where(x =>
+                    !draggedNodes.Select(a => a.GUID).Contains(x.NodeModel.GUID) &&
+                    x.NodeModel.Rect.Contains(mouseCursor.X, mouseCursor.Y));
+
+                var dropNode = dropNodes.FirstOrDefault();
+                if (dropNode is null)
+                {
+                    // Reset the workspace from hovered nodes
+                    owningWorkspace.Nodes
+                        .Where(x => x.NodeHoveringState)
+                        .ToList()
+                        .ForEach(x => x.NodeHoveringState = false);
+                }
+                else if (!dropNode.NodeHoveringState)
+                {
+                    // make sure there are no other node
+                    // set to NodeHoveringState before setting
+                    // the current node.
+                    // If we dont do this there are scenarios where
+                    // two nodes are very close and a note is dragged
+                    // quickly between the two where the hovering state
+                    // is not reset.
+                    owningWorkspace.Nodes
+                        .Where(x => x.NodeHoveringState)
+                        .ToList()
+                        .ForEach(x => x.NodeHoveringState = false);
+
+                    // also make sure no Annotation groups are marked as hovered
+                    // in case the Note is being dropped over a Node inside a Group
+                    owningWorkspace.Annotations
+                        .Where(x => x.NodeHoveringState)
+                        .ToList()
+                        .ForEach(x => x.NodeHoveringState = false);
+
+                    dropNode.NodeHoveringState = true;
+
+                    return true;   // Mouse event has not been handled
+                }
+
+                return false;
             }
 
             internal bool HandleMouseMove(object sender, MouseEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -686,6 +686,30 @@
             </Border.Visibility>
         </Border>
 
+        <!--
+        If a note is dragged over this group
+        this border is activated, indicating that the node can be dropped into the group.
+        The visibility of this is controlled by the NodeViewModel property 'NodeHoveringState'
+        which is set in the StateMachine.
+        -->
+        <Border x:Name="nodeHoveringStateBorder"
+                Grid.Row="1"
+                Grid.RowSpan="4"
+                Grid.ColumnSpan="3"
+                Margin="-3"
+                Background="Transparent"
+                IsHitTestVisible="False"
+                Canvas.ZIndex="41"
+                CornerRadius="10,10,0,0"
+                BorderBrush="#CCCCCC"
+                BorderThickness="6px"
+                Visibility="{Binding NodeHoveringState,
+                    Converter={StaticResource BooleanToVisibilityConverter},
+                    Mode=OneWay,
+                    UpdateSourceTrigger=PropertyChanged}"
+                >
+        </Border>
+
         <!--  DO NOT ERASE. THIS IS FOR DEBUGGING  -->
         <!--<Rectangle Name="ForceReexecBorder"
                    Grid.Row="1"


### PR DESCRIPTION
### Purpose

An improvement allowing the user to drag-&-drop a Note over a Node, pinning it down. Below is the description of the task as set in the brief: 

- a. When dragging and hovering a note over a node, border on node appears and release of note will cause note to be pinned to node.
- b. Refer to https://github.com/DynamoDS/Dynamo/pull/12571 as precedent.


#### pin note to node 
![pin note drag   drop](https://user-images.githubusercontent.com/5354594/236257251-f6165800-a91a-4800-bc60-c7679e76cd8e.gif)

#### border update on hover state
![hover note over node](https://user-images.githubusercontent.com/5354594/236243943-7528bfb3-ce0b-4578-923b-5a9aea1e8309.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

The steps taken to create the new functionality are as follows:

- created new graphic affordances to show a hover state over a Node
- created the logic inside the StateMachine that handles the case of Note being hovered over a Node
- successfully pins the note when the mouse is released and the note is over the node
- will skip highlighting Nodes that already have a Note pinned (consistent with current behavior to not allow more than 1 pinned Note)


### Reviewers

@reddyashish 
@Amoursol 

### FYIs

