### PR TITLE
Correct version in license.rtf

### DIFF
--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -2,7 +2,7 @@
 {\colortbl ;\red165\green165\blue165;\red109\green210\blue255;\red0\green0\blue255;\red70\green70\blue70;\red253\green253\blue253;\red74\green74\blue74;\red255\green255\blue255;\red5\green99\blue193;\red36\green41\blue47;}
 {\stylesheet{ Normal;}{\s1 heading 1;}{\s2 heading 2;}{\s3 heading 3;}{\s4 heading 4;}}
 {\*\generator Riched20 10.0.19041}{\*\mmathPr\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
-\pard\nowidctlpar\sb240\sl276\slmult1\cf1\b\f0\fs22\lang2057 @DYNAMO v.2.19.0 \'a9 2023 Autodesk, Inc.  All rights reserved.\par
+\pard\nowidctlpar\sb240\sl276\slmult1\cf1\b\f0\fs22\lang2057 @DYNAMO v.2.18.0 \'a9 2023 Autodesk, Inc.  All rights reserved.\par
 Dynamo License\par
 
 \pard\widctlpar\b0\par


### PR DESCRIPTION
### Purpose

Somehow the version in license rtf wasn't corrected for 2.18.4827 which was the release version. Not sure if other integrators picked up that build number but just making a PR in-case we decide to go with a different build.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes
Correct version in license.rtf

### Reviewers
@QilongTang @zeusongit 
