### PR TITLE
Enabling the Dynamo Environment

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1999,11 +1999,7 @@ namespace Dynamo.Controls
 
         public void EnableEnvironment(bool isEnabled)
         {
-            this.titleBarGrid.IsEnabled = isEnabled;
-            this.shortcutBarGrid.IsEnabled = isEnabled;
-            this.sidebarGrid.IsEnabled = isEnabled;
-            this.WorkspaceTabs.IsEnabled = isEnabled;
-            this.bottomBarGrid.IsEnabled = isEnabled;
+            this.mainGrid.IsEnabled = isEnabled;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -140,6 +140,7 @@ namespace Dynamo.Controls
 
             SizeChanged += DynamoView_SizeChanged;
             LocationChanged += DynamoView_LocationChanged;
+            MouseLeftButtonDown += DynamoView_MouseLeftButtonDown;
 
             // Apply appropriate expand/collapse library button state depending on initial width
             UpdateLibraryCollapseIcon();
@@ -243,6 +244,14 @@ namespace Dynamo.Controls
             if (!DynamoModel.IsTestMode && Application.Current != null)
             {
                 Application.Current.MainWindow = this;
+            }
+        }
+
+        void DynamoView_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (PreferencesWindow != null && PreferencesWindow.IsLoaded)
+            {
+                dynamoViewModel.MainGuideManager?.CreateRealTimeInfoWindow(Res.PreferencesMustBeClosedMessage, true);
             }
         }
 
@@ -1603,6 +1612,7 @@ namespace Dynamo.Controls
                 //Shutdown wasn't cancelled
                 SizeChanged -= DynamoView_SizeChanged;
                 LocationChanged -= DynamoView_LocationChanged;
+                MouseLeftButtonDown -= DynamoView_MouseLeftButtonDown;
                 return true;
             }
             else
@@ -1984,7 +1994,16 @@ namespace Dynamo.Controls
             preferencesWindow = new PreferencesView(this);
             dynamoViewModel.OnPreferencesWindowChanged(preferencesWindow);
             preferencesWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
-            preferencesWindow.ShowDialog();
+            preferencesWindow.Show();
+        }
+
+        public void EnableEnvironment(bool isEnabled)
+        {
+            this.titleBarGrid.IsEnabled = isEnabled;
+            this.shortcutBarGrid.IsEnabled = isEnabled;
+            this.sidebarGrid.IsEnabled = isEnabled;
+            this.WorkspaceTabs.IsEnabled = isEnabled;
+            this.bottomBarGrid.IsEnabled = isEnabled;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1997,7 +1997,7 @@ namespace Dynamo.Controls
             preferencesWindow.Show();
         }
 
-        public void EnableEnvironment(bool isEnabled)
+        internal void EnableEnvironment(bool isEnabled)
         {
             this.mainGrid.IsEnabled = isEnabled;
         }

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -31,7 +31,6 @@ namespace Dynamo.Wpf.Views
 
         private Button colorButtonSelected;
         private bool groupStyleItemExisting = false;
-        private bool closingWindow = false;
 
         // Used for tracking the manage package command event
         // This is not a command any more but we keep it
@@ -96,7 +95,7 @@ namespace Dynamo.Wpf.Views
             stylesCustomColors = new ObservableCollection<CustomColorItem>();
             UpdateZoomScaleValueLabel(LibraryZoomScalingSlider, lblZoomScalingValue);
             UpdateZoomScaleValueLabel(PythonZoomScalingSlider, lblPythonScalingValue);
-            this.Deactivated += PreferencesView_Deactivated;
+            dynamoView.EnableEnvironment(false);
         }
 
         /// <summary>
@@ -170,8 +169,7 @@ namespace Dynamo.Wpf.Views
 
             dynViewModel.PreferencesViewModel.TrustedPathsViewModel.PropertyChanged -= TrustedPathsViewModel_PropertyChanged;
             dynViewModel.CheckCustomGroupStylesChanges(originalCustomGroupStyles);
-            closingWindow = true;
-            this.Deactivated -= PreferencesView_Deactivated;
+            (this.Owner as DynamoView).EnableEnvironment(true);
 
             Close();
         }
@@ -643,14 +641,6 @@ namespace Dynamo.Wpf.Views
             {
                 label.Margin = new Thickness(marginValue, 0, 0, 0);
                 label.Content = slider.Value.ToString() + "%";
-            }
-        }
-
-        private void PreferencesView_Deactivated(object sender, EventArgs e)
-        {
-            if (!closingWindow)
-            {
-                dynViewModel.MainGuideManager?.CreateRealTimeInfoWindow(Res.PreferencesMustBeClosedMessage, true);
             }
         }
     }


### PR DESCRIPTION

### Purpose

Enabling the Dynamo Environment based on the IsEnabled properties of their main components instead of the Preferences Deactivated Event for the implementation of the improvement https://jira.autodesk.com/browse/DYN-5656.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@RobertGlobant20 
@Enzo707 
