### PR TITLE
DYN-5844-ColorPicker-MarginIssues

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
+++ b/src/DynamoCoreWpf/Views/Core/CustomColorPicker.xaml
@@ -327,8 +327,8 @@
                         </Grid>
                         <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="420"/>
-                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="420" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -345,18 +345,18 @@
                                 <Canvas
                                     x:Name="PART_ColorShadingCanvas"
                                     Width="420"
-                                    Height="200"
+                                    MinHeight="120"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Top">
                                     <Rectangle
                                         x:Name="ColorShadingRectangle"
                                         Width="{Binding ElementName=PART_ColorShadingCanvas, Path=Width}"
-                                        Height="{Binding ElementName=PART_ColorShadingCanvas, Path=Height}"
+                                        MinHeight="120"
                                         Fill="{Binding SelectedColor, ElementName=PART_SpectrumSlider, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
                                     <Rectangle
                                         x:Name="WhiteGradient"
                                         Width="{Binding ElementName=PART_ColorShadingCanvas, Path=Width}"
-                                        Height="{Binding ElementName=PART_ColorShadingCanvas, Path=Height}">
+                                        MinHeight="120">
                                         <Rectangle.Fill>
                                             <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
                                                 <GradientStop Offset="0" Color="#ffffffff" />
@@ -367,7 +367,7 @@
                                     <Rectangle
                                         x:Name="BlackGradient"
                                         Width="{Binding ElementName=PART_ColorShadingCanvas, Path=Width}"
-                                        Height="{Binding ElementName=PART_ColorShadingCanvas, Path=Height}">
+                                        MinHeight="120">
                                         <Rectangle.Fill>
                                             <LinearGradientBrush StartPoint="0,1" EndPoint="0, 0">
                                                 <GradientStop Offset="0" Color="#ff000000" />
@@ -669,7 +669,7 @@
                                 FontSize="20"
                                 FontWeight="Bold"
                                 Foreground="Black"
-                                Text="{x:Static p:Resources.CustomColorPickerTitle}"/>
+                                Text="{x:Static p:Resources.CustomColorPickerTitle}" />
                             <Button
                                 Name="NormalColorsCloseButton"
                                 Grid.Column="1"
@@ -694,8 +694,8 @@
                                 Margin="0,10,0,0"
                                 Padding="2"
                                 Background="Transparent"
-                                FontSize="14"
                                 FontFamily="{StaticResource ArtifaktElementRegular}"
+                                FontSize="14"
                                 Foreground="Black"
                                 Text="{x:Static p:Resources.CustomColorPickerBasicColors}" />
 


### PR DESCRIPTION
### Purpose

Fixing height value for CustomColorPicker.
We have a Canvas inside a Grid but the Canvas doesn't support auto-size like other WPF controls then the only way to fix the problem of the CustomColorPicker appearing wrong under a 200% scale is to use a fixed height. In this way this fix will make the NormalColors window with the same height than the CustomColors window.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fixing height value for CustomColorPicker.


### Reviewers

@QilongTang 


### FYIs

