### PR TITLE
DYN-5657 - Insert shortcut change

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -113,7 +113,7 @@
                     Modifiers="Control"
                     Command="{Binding Path=DataContext.ShowOpenDialogAndOpenResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="I"
-                    Modifiers="Control"
+                    Modifiers="Control+Shift"
                     Command="{Binding Path=DataContext.ShowInsertDialogAndInsertResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="H"
                     Modifiers="Control"
@@ -344,11 +344,11 @@
                         <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuInsert}"
                                   Command="{Binding ShowInsertDialogAndInsertResultCommand}"
                                   Name="insertButton"
-                                  InputGestureText="Ctrl + I">
+                                  InputGestureText="Ctrl + Shift + I">
                         </MenuItem>
                         <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuRecentFiles}"
                                   ItemsSource="{Binding RecentFiles}">
-                            <MenuItem.ItemContainerStyle>
+                            <MenuItem.ItemContainerStyle>   
                                 <Style TargetType="MenuItem">
                                     <Setter Property="Header"
                                             Value="{Binding Converter={StaticResource FilePathDisplayConverter}}" />


### PR DESCRIPTION
### Purpose

A tiny PR changing the shortcut for `Insert` command. Ctrl + I has traditionally been used for the `Isolate` command. `Insert` now uses Ctrl + Shift + I instead. This [Jira ](https://jira.autodesk.com/browse/DYN-5657) task was dedicated on the issue.

![insert shortcut](https://github.com/DynamoDS/Dynamo/assets/5354594/ab089975-4de6-4f19-af29-158582ee34d9)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

- changed the shortcut combination for the Insert command
- now uses Ctrl + Shift + I instead of Ctrl + I

### Reviewers

@Amoursol 
@reddyashish 

### FYIs


