### PR TITLE
class keyword designscript align

### DIFF
--- a/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
+++ b/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
@@ -43,10 +43,10 @@
         <Key word="local" />
         <Key word="static" />
         <Key word="this" />
-      </KeyWords>
-      <KeyWords name="ClassStatement" color="#F2A9F2">
-        <Key word="class" />
         <Key word="extends" />
+      </KeyWords>
+      <KeyWords name="ClassStatement" color="#6AC0E7">
+        <Key word="class" />
       </KeyWords>
       <KeyWords name="ExceptionHandlingStatements" color="#F2A9F2">
         <Key word="throw" />


### PR DESCRIPTION
### Purpose

Small PR restyling the `class` keyword in design script editor. Now aligns to Python editor styling.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/567adede-4960-4c3f-a384-c53b101b5856)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

- aligned class keyword color to python

### Reviewers

@Amoursol 
@reddyashish 

### FYIs

@QilongTang 
