### PR TITLE
Cherry-picking into 2.18.1

### DIFF
--- a/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
+++ b/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
@@ -43,10 +43,10 @@
         <Key word="local" />
         <Key word="static" />
         <Key word="this" />
-      </KeyWords>
-      <KeyWords name="ClassStatement" color="#F2A9F2">
-        <Key word="class" />
         <Key word="extends" />
+      </KeyWords>
+      <KeyWords name="ClassStatement" color="#6AC0E7">
+        <Key word="class" />
       </KeyWords>
       <KeyWords name="ExceptionHandlingStatements" color="#F2A9F2">
         <Key word="throw" />

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -113,7 +113,7 @@
                     Modifiers="Control"
                     Command="{Binding Path=DataContext.ShowOpenDialogAndOpenResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="I"
-                    Modifiers="Control"
+                    Modifiers="Control+Shift"
                     Command="{Binding Path=DataContext.ShowInsertDialogAndInsertResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="H"
                     Modifiers="Control"
@@ -344,11 +344,11 @@
                         <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuInsert}"
                                   Command="{Binding ShowInsertDialogAndInsertResultCommand}"
                                   Name="insertButton"
-                                  InputGestureText="Ctrl + I">
+                                  InputGestureText="Ctrl + Shift + I">
                         </MenuItem>
                         <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuRecentFiles}"
                                   ItemsSource="{Binding RecentFiles}">
-                            <MenuItem.ItemContainerStyle>
+                            <MenuItem.ItemContainerStyle>   
                                 <Style TargetType="MenuItem">
                                     <Setter Property="Header"
                                             Value="{Binding Converter={StaticResource FilePathDisplayConverter}}" />


### PR DESCRIPTION
### Purpose

A couple of minor changes regressed in 2.18 version and including them as part of 2.18.1 hotfix.
1) https://github.com/DynamoDS/Dynamo/pull/13995
2) https://github.com/DynamoDS/Dynamo/pull/13998

One more crash fix related to the python script editor will be coming in from @dnenov. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers
@QilongTang @Amoursol  
