### PR TITLE
[Cherry-pick] Handle tabfolding edge-case inside python editor. (#14004)

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/TabFoldingStrategy.cs
+++ b/src/Libraries/PythonNodeModelsWpf/TabFoldingStrategy.cs
@@ -1,11 +1,8 @@
-using Dynamo.UI.Controls;
-using ICSharpCode.AvalonEdit.Document;
-using ICSharpCode.AvalonEdit.Folding;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Windows.Media.Animation;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Folding;
 
 namespace PythonNodeModelsWpf
 {
@@ -73,7 +70,7 @@ namespace PythonNodeModelsWpf
                     }
                     else if (tabLevel != currentTabLevel && currentTabLevel < tabLevel)
                     {
-                        while (currentTabLevel < tabLevel)
+                        while (currentTabLevel < tabLevel && startOffsets.Any())
                         {
                             // we close all nested tabs
                             var tempFolding = new NewFolding();
@@ -92,7 +89,7 @@ namespace PythonNodeModelsWpf
                 }
                 else if (whiteSpaces == 0 && tabLevel > 0)
                 {
-                    while(tabLevel> 0)
+                    while(tabLevel> 0 && startOffsets.Any())
                     { 
                         // we close all nested tabs
                         var tempFolding = new NewFolding();


### PR DESCRIPTION
### Purpose

Cherrypicking https://github.com/DynamoDS/Dynamo/pull/14004

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes
[Cherry-pick] Handle tabfolding edge-case inside python editor. (#14004)

### Reviewers
@QilongTang @Amoursol 

