### PR TITLE
Adding a GitHub action to perform a Binary Diff job on each PR/push event

### DIFF
--- a/.github/scripts/bin_diff.ps1
+++ b/.github/scripts/bin_diff.ps1
@@ -1,0 +1,225 @@
+#########################################################################
+### USAGE: rdiff path/to/left,path/to/right [-s path/to/summary/dir]  ###
+### ADD LOCATION OF THIS SCRIPT TO PATH                               ###
+#########################################################################
+[CmdletBinding()]
+param (
+  [parameter(HelpMessage="Stores the execution working directory.")]
+  [string]$ExecutionDirectory=$PWD,
+
+  [parameter(Position=0,HelpMessage="Compare two directories recursively for differences.")]
+  [alias("c")]
+  [string[]]$Compare,
+
+  [parameter(HelpMessage="Export a summary to path.")]
+  [alias("s")]
+  [string]$ExportSummary
+)
+
+### FUNCTION DEFINITIONS ###
+
+# SETS WORKING DIRECTORY FOR .NET #
+function SetWorkDir($PathName, $TestPath) {
+  $AbsPath = NormalizePath $PathName $TestPath
+  Set-Location $AbsPath
+  [System.IO.Directory]::SetCurrentDirectory($AbsPath)
+}
+
+# RESTORES THE EXECUTION WORKING DIRECTORY AND EXITS #
+function SafeExit() {
+  SetWorkDir /path/to/execution/directory $ExecutionDirectory
+  Exit
+}
+
+function Print {
+  [CmdletBinding()]
+  param (
+    [parameter(Mandatory=$TRUE,Position=0,HelpMessage="Message to print.")]
+    [string]$Message,
+
+    [parameter(HelpMessage="Specifies a success.")]
+    [alias("s")]
+    [switch]$SuccessFlag,
+
+    [parameter(HelpMessage="Specifies a warning.")]
+    [alias("w")]
+    [switch]$WarningFlag,
+
+    [parameter(HelpMessage="Specifies an error.")]
+    [alias("e")]
+    [switch]$ErrorFlag,
+
+    [parameter(HelpMessage="Specifies a fatal error.")]
+    [alias("f")]
+    [switch]$FatalFlag,
+
+    [parameter(HelpMessage="Specifies a info message.")]
+    [alias("i")]
+    [switch]$InfoFlag = !$SuccessFlag -and !$WarningFlag -and !$ErrorFlag -and !$FatalFlag,
+
+    [parameter(HelpMessage="Specifies blank lines to print before.")]
+    [alias("b")]
+    [int]$LinesBefore=0,
+
+    [parameter(HelpMessage="Specifies blank lines to print after.")]
+    [alias("a")]
+    [int]$LinesAfter=0,
+
+    [parameter(HelpMessage="Specifies if program should exit.")]
+    [alias("x")]
+    [switch]$ExitAfter
+  )
+  PROCESS {
+    if($LinesBefore -ne 0) {
+      foreach($i in 0..$LinesBefore) { Write-Host "" }
+    }
+    if($InfoFlag) { Write-Host "$Message" }
+    if($SuccessFlag) { Write-Host "$Message" -ForegroundColor "Green" }
+    if($WarningFlag) { Write-Host "$Message" -ForegroundColor "Orange" }
+    if($ErrorFlag) { Write-Host "$Message" -ForegroundColor "Red" }
+    if($FatalFlag) { Write-Host "$Message" -ForegroundColor "Red" -BackgroundColor "Black" }
+    if($LinesAfter -ne 0) {
+      foreach($i in 0..$LinesAfter) { Write-Host "" }
+    }
+    if($ExitAfter) { SafeExit }
+  }
+}
+
+# VALIDATES STRING MIGHT BE A PATH #
+function ValidatePath($PathName, $TestPath) {
+  If([string]::IsNullOrWhiteSpace($TestPath)) {
+    Print -x -f "$PathName is not a path"
+  }
+}
+
+# NORMALIZES RELATIVE OR ABSOLUTE PATH TO ABSOLUTE PATH #
+function NormalizePath($PathName, $TestPath) {
+  ValidatePath "$PathName" "$TestPath"
+  $TestPath = [System.IO.Path]::Combine((pwd).Path, $TestPath)
+  $NormalizedPath = [System.IO.Path]::GetFullPath($TestPath)
+  return $NormalizedPath
+}
+
+
+# VALIDATES STRING MIGHT BE A PATH AND RETURNS ABSOLUTE PATH #
+function ResolvePath($PathName, $TestPath) {
+  ValidatePath "$PathName" "$TestPath"
+  $ResolvedPath = NormalizePath $PathName $TestPath
+  return $ResolvedPath
+}
+
+# VALIDATES STRING RESOLVES TO A PATH AND RETURNS ABSOLUTE PATH #
+function RequirePath($PathName, $TestPath, $PathType) {
+  ValidatePath $PathName $TestPath
+  If(!(Test-Path $TestPath -PathType $PathType)) {
+    Print -x -f "$PathName ($TestPath) does not exist as a $PathType"
+  }
+  $ResolvedPath = Resolve-Path $TestPath
+  return $ResolvedPath
+}
+
+# Like mkdir -p -> creates a directory recursively if it doesn't exist #
+function MakeDirP {
+  [CmdletBinding()]
+  param (
+    [parameter(Mandatory=$TRUE,Position=0,HelpMessage="Path create.")]
+    [string]$Path
+  )
+  PROCESS {
+    New-Item -path $Path -itemtype Directory -force | Out-Null
+  }
+}
+
+# GETS ALL FILES IN A PATH RECURSIVELY #
+function GetFiles {
+  [CmdletBinding()]
+  param (
+    [parameter(Mandatory=$TRUE,Position=0,HelpMessage="Path to get files for.")]
+    [string]$Path
+  )
+  PROCESS {
+    ls $Path -r | where { !$_.PSIsContainer }
+  }
+}
+
+# GETS ALL FILES WITH CALCULATED HASH PROPERTY RELATIVE TO A ROOT DIRECTORY RECURSIVELY #
+# RETURNS LIST OF @{RelativePath, Hash, FullName}
+function GetFilesWithHash {
+  [CmdletBinding()]
+  param (
+    [parameter(Mandatory=$TRUE,Position=0,HelpMessage="Path to get directories for.")]
+    [string]$Path,
+
+    [parameter(HelpMessage="The hash algorithm to use.")]
+    [string]$Algorithm="MD5"
+  )
+  PROCESS {
+    $OriginalPath = $PWD
+    SetWorkDir path/to/diff $Path
+    GetFiles $Path | select @{N="RelativePath";E={$_.FullName | Resolve-Path -Relative}},
+                            @{N="Hash";E={(Get-FileHash $_.FullName -Algorithm $Algorithm | select Hash).Hash}},
+                            FullName
+    SetWorkDir path/to/original $OriginalPath
+  }
+}
+
+# COMPARE TWO DIRECTORIES RECURSIVELY #
+# RETURNS LIST OF @{RelativePath, Hash, FullName}
+function DiffDirectories {
+  [CmdletBinding()]
+  param (
+    [parameter(Mandatory=$TRUE,Position=0,HelpMessage="Directory to compare left.")]
+    [alias("l")]
+    [string]$LeftPath,
+
+    [parameter(Mandatory=$TRUE,Position=1,HelpMessage="Directory to compare right.")]
+    [alias("r")]
+    [string]$RightPath
+  )
+  PROCESS {
+    $LeftHash = GetFilesWithHash $LeftPath
+    $RightHash = GetFilesWithHash $RightPath
+    diff -ReferenceObject $LeftHash -DifferenceObject $RightHash -Property RelativePath,Hash
+  }
+}
+
+### END FUNCTION DEFINITIONS ###
+
+### PROGRAM LOGIC ###
+
+if($Compare.length -ne 2) {
+  Print -x "Compare requires passing exactly 2 path parameters separated by comma, you passed $($Compare.length)." -f
+}
+Print "Comparing $($Compare[0]) to $($Compare[1])..." -a 1
+$LeftPath   = RequirePath path/to/left $Compare[0] container
+$RightPath  = RequirePath path/to/right $Compare[1] container
+$Diff       = DiffDirectories $LeftPath $RightPath
+$LeftDiff   = $Diff | where {$_.SideIndicator -eq "<="} | select RelativePath,Hash
+$RightDiff   = $Diff | where {$_.SideIndicator -eq "=>"} | select RelativePath,Hash
+if($ExportSummary) {
+  $ExportSummary = ResolvePath path/to/summary/dir $ExportSummary
+  MakeDirP $ExportSummary
+  $SummaryPath = Join-Path $ExportSummary summary.txt
+  $LeftCsvPath = Join-Path $ExportSummary left.csv
+  $RightCsvPath = Join-Path $ExportSummary right.csv
+
+  $LeftMeasure = $LeftDiff | measure
+  $RightMeasure = $RightDiff | measure
+
+  "== DIFF SUMMARY ==" > $SummaryPath
+  "" >> $SummaryPath
+  "-- DIRECTORIES --" >> $SummaryPath
+  "`tLEFT -> $LeftPath" >> $SummaryPath
+  "`tRIGHT -> $RightPath" >> $SummaryPath
+  "" >> $SummaryPath
+  "-- DIFF COUNT --" >> $SummaryPath
+  "`tLEFT -> $($LeftMeasure.Count)" >> $SummaryPath
+  "`tRIGHT -> $($RightMeasure.Count)" >> $SummaryPath
+  "" >> $SummaryPath
+  $Diff | Format-Table >> $SummaryPath
+
+  $LeftDiff | Export-Csv $LeftCsvPath -f
+  $RightDiff | Export-Csv $RightCsvPath -f
+}
+$Diff
+SafeExit

--- a/.github/scripts/bin_diff.ps1
+++ b/.github/scripts/bin_diff.ps1
@@ -152,7 +152,7 @@ function GetFilesWithHash {
     [string]$Path,
 
     [parameter(HelpMessage="The hash algorithm to use.")]
-    [string]$Algorithm="MD5"
+    [string]$Algorithm="SHA256"
   )
   PROCESS {
     $OriginalPath = $PWD

--- a/.github/scripts/bin_diff.ps1
+++ b/.github/scripts/bin_diff.ps1
@@ -208,7 +208,7 @@ function DiffDirectories {
     $LeftHash = GetFilesWithHash $LeftPath
     $RightHash = GetFilesWithHash $RightPath
     diff -ReferenceObject $LeftHash -DifferenceObject $RightHash -Property RelativePath,Hash | 
-    Select-Object *, @{
+    Select-Object RelativePath, @{
     Name = 'Status'
     Expression = {
         if ($_.SideIndicator -eq "=>") {

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -67,13 +67,13 @@ jobs:
       uses: actions/cache/restore@v3
       with:
         fail-on-cache-miss: true
-        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+        path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Restore Master Build
       uses: actions/cache/restore@v3
       with:
         fail-on-cache-miss: true
-        path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Run Binary Diff Job
       run: |

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -16,72 +16,67 @@ jobs:
       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
     - name: Test var
       run: echo "${{ github.workspace }}"
+    - name: Build Dynamo current branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (current)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after current build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
     - name: Cache Current Build
       uses: actions/cache/save@v3
       with:
-        path: ${{ github.workspace }}
+        path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-#     - name: Build Dynamo current branch with MSBuild
-#       run: |
-#         echo "***Continue with the build, Good luck developer!***"
-#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-#     - name: Confirm Dynamo Build (current)
-#       run: |
-#         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
-#         echo "***Locating DynamoSandbox after current build!***"
-#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-#     - name: Cache Current Build
-#       uses: actions/cache/save@v3
-#       with:
-#         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
-#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-#  build-master:
-#   runs-on: windows-2022
-#   steps:
-#     - name: Checkout Dynamo Repo master branch
-#       uses: actions/checkout@v3
-#       with:
-#         ref: master
-#         path: master_Dynamo
-#         repository: DynamoDS/Dynamo
-#     - name: Setup Nuget.exe to use on VM (master)
-#       uses: nuget/setup-nuget@v1
-#     - name: Nuget Restore in Dynamo solution (master)
-#       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-#     - name: Build Dynamo master branch with MSBuild
-#       run: |
-#         echo "***Continue with the build, Good luck developer!***"
-#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-#     - name: Confirm Dynamo Build (master)
-#       run: |
-#         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
-#         echo "***Locating DynamoSandbox after master build!***"
-#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-#     - name: Cache Master Build
-#       uses: actions/cache/save@v3
-#       with:
-#         path: ${GITHUB_WORKSPACE}\Dynamo\bin\AnyCPU\Debug
-#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-#  run-bin-diff:
-#   needs: [build-current, build-master]
-#   runs-on: windows-2022
-#   steps:
-#     - name: Restore Current Build
-#       uses: actions/cache/restore@v3
-#       with:
-#         fail-on-cache-miss: true
-#         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
-#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-#     - name: Restore Master Build
-#       uses: actions/cache/restore@v3
-#       with:
-#         fail-on-cache-miss: true
-#         path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
-#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-#     - name: Run Binary Diff Job
-#       run: |
-#           echo "***Running the binary diff job between the current branch and the master branch!***"
-#           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-#             .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+ build-master:
+  runs-on: windows-2022
+  steps:
+    - name: Checkout Dynamo Repo master branch
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        path: master_Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM (master)
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution (master)
+      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Build Dynamo master branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (master)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after master build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Master Build
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+ run-bin-diff:
+  needs: [build-current, build-master]
+  runs-on: windows-2022
+  steps:
+    - name: Restore Current Build
+      uses: actions/cache/restore@v3
+      with:
+        fail-on-cache-miss: true
+        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Restore Master Build
+      uses: actions/cache/restore@v3
+      with:
+        fail-on-cache-miss: true
+        path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Run Binary Diff Job
+      run: |
+          echo "***Running the binary diff job between the current branch and the master branch!***"
+          cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
+            .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -83,6 +83,8 @@ jobs:
           cd
           dir
           dir D:/a/Dynamo/Dynamo
+          dir D:/a/Dynamo/Dynamo/Dynamo
+          dir D:/a/Dynamo/Dynamo/master_Dynamo
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
     - name: Cleanup Caches

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -82,11 +82,9 @@ jobs:
     - name: Run Binary Diff Job
       run: |
           echo "***Running the binary diff job between the current branch and the master branch!***"
-          dir D:/a/Dynamo/Dynamo/Dynamo
-          dir D:/a/Dynamo/Dynamo/master_Dynamo
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
     - name: Cleanup Caches
-      run: gh actions-cache delete cache-master-${{ github.run_id }}-${{ github.run_attempt }} && gh actions-cache delete cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+      run: gh extension install actions/gh-actions-cache && gh actions-cache delete cache-master-${{ github.run_id }}-${{ github.run_attempt }} && gh actions-cache delete cache-current-${{ github.run_id }}-${{ github.run_attempt }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Cache Master Build
       uses: actions/cache/save@v3
       with:
-        path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
  run-bin-diff:
   needs: [build-current, build-master]

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -2,7 +2,7 @@
 name: Dynamo-BinDiff
 on: [push,pull_request]
 jobs:
- build:
+ run-bin-diff:
   runs-on: windows-2022
   steps:
     - name: Checkout Dynamo Repo current branch
@@ -42,3 +42,8 @@ jobs:
         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
         echo "***Locating DynamoSandbox after master build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Run Binary Diff Job
+      run: |
+          echo "***Running the binary diff job between the current branch and the master branch!***"
+          cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
+            .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -2,7 +2,7 @@
 name: Dynamo-BinDiff
 on: [push,pull_request]
 jobs:
- run-bin-diff:
+ build-current:
   runs-on: windows-2022
   steps:
     - name: Checkout Dynamo Repo current branch
@@ -10,7 +10,7 @@ jobs:
       with:
         path: Dynamo
         repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM
+    - name: Setup Nuget.exe to use on VM (current)
       uses: nuget/setup-nuget@v1
     - name: Nuget Restore in Dynamo solution (current)
       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
@@ -24,12 +24,22 @@ jobs:
         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
         echo "***Locating DynamoSandbox after current build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Current Build
+      uses: actions/cache@v3
+      with:
+        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+ build-master:
+  runs-on: windows-2022
+  steps:
     - name: Checkout Dynamo Repo master branch
       uses: actions/checkout@v3
       with:
         ref: master
         path: master_Dynamo
         repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM (master)
+      uses: nuget/setup-nuget@v1
     - name: Nuget Restore in Dynamo solution (master)
       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
     - name: Build Dynamo master branch with MSBuild
@@ -42,8 +52,27 @@ jobs:
         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
         echo "***Locating DynamoSandbox after master build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Current Build
+      uses: actions/cache@v3
+      with:
+        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+ run-bin-diff:
+  needs: [build-current, build-master]
+  runs-on: windows-2022
+  steps:
+    - name: Restore Current Build
+      uses: actions/cache@v3
+      with:
+        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Restore Master Build
+      uses: actions/cache@v3
+      with:
+        path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Run Binary Diff Job
       run: |
           echo "***Running the binary diff job between the current branch and the master branch!***"
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-            .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
+            .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -1,0 +1,46 @@
+# Build Dynamo using latest VS and DotNET and perform a Bin Diff
+name: Dynamo-BinDiff
+on: [push,pull_request]
+jobs:
+ build:
+  runs-on: windows-2022
+  steps:
+    - name: Checkout Dynamo Repo current branch
+      uses: actions/checkout@v3
+      with:
+        path: Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution
+      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Build Dynamo current branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (current)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after current build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Checkout Dynamo Repo master
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        path: master_Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution (master)
+      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Build Dynamo master branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (master)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after master build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -2,87 +2,86 @@
 name: Dynamo-BinDiff
 on: [push,pull_request]
 jobs:
-#  build-current:
-#   runs-on: windows-2022
-#   steps:
-#     - name: Checkout Dynamo Repo current branch
-#       uses: actions/checkout@v3
-#       with:
-#         path: Dynamo
-#         repository: DynamoDS/Dynamo
-#     - name: Setup Nuget.exe to use on VM (current)
-#       uses: nuget/setup-nuget@v1
-#     - name: Nuget Restore in Dynamo solution (current)
-#       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-#     - name: Test var
-#       run: echo "${{ github.workspace }}"
-#     - name: Build Dynamo current branch with MSBuild
-#       run: |
-#         echo "***Continue with the build, Good luck developer!***"
-#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-#     - name: Confirm Dynamo Build (current)
-#       run: |
-#         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
-#         echo "***Locating DynamoSandbox after current build!***"
-#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-#     - name: Cache Current Build
-#       uses: actions/cache/save@v3
-#       with:
-#         path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-#  build-master:
-#   runs-on: windows-2022
-#   steps:
-#     - name: Checkout Dynamo Repo master branch
-#       uses: actions/checkout@v3
-#       with:
-#         ref: master
-#         path: master_Dynamo
-#         repository: DynamoDS/Dynamo
-#     - name: Setup Nuget.exe to use on VM (master)
-#       uses: nuget/setup-nuget@v1
-#     - name: Nuget Restore in Dynamo solution (master)
-#       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-#     - name: Build Dynamo master branch with MSBuild
-#       run: |
-#         echo "***Continue with the build, Good luck developer!***"
-#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-#     - name: Confirm Dynamo Build (master)
-#       run: |
-#         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
-#         echo "***Locating DynamoSandbox after master build!***"
-#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-#     - name: Cache Master Build
-#       uses: actions/cache/save@v3
-#       with:
-#         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+ build-current:
+  runs-on: windows-2022
+  steps:
+    - name: Checkout Dynamo Repo current branch
+      uses: actions/checkout@v3
+      with:
+        path: Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM (current)
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution (current)
+      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Test var
+      run: echo "${{ github.workspace }}"
+    - name: Build Dynamo current branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (current)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after current build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Current Build
+      uses: actions/cache/save@v3
+      with:
+        path: |
+           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+           ${{ github.workspace }}\Dynamo\.github\scripts
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+ build-master:
+  runs-on: windows-2022
+  steps:
+    - name: Checkout Dynamo Repo master branch
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        path: master_Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM (master)
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution (master)
+      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Build Dynamo master branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (master)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after master build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Master Build
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
  run-bin-diff:
-  # needs: [build-current, build-master]
+  needs: [build-current, build-master]
   runs-on: windows-2022
   steps:
     - name: Restore Current Build
       uses: actions/cache/restore@v3
       with:
         fail-on-cache-miss: true
-        path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-        #key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-        key: cache-current-5020929388-1
+        path: |
+          ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+          ${{ github.workspace }}\Dynamo\.github\scripts
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Restore Master Build
       uses: actions/cache/restore@v3
       with:
         fail-on-cache-miss: true
         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-        #key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-        key: cache-master-5020929388-1
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Run Binary Diff Job
       run: |
           echo "***Running the binary diff job between the current branch and the master branch!***"
-          cd
-          dir
-          dir D:/a/Dynamo/Dynamo
           dir D:/a/Dynamo/Dynamo/Dynamo
           dir D:/a/Dynamo/Dynamo/master_Dynamo
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -25,7 +25,7 @@ jobs:
         echo "***Locating DynamoSandbox after current build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
     - name: Cache Current Build
-      uses: actions/cache@v3
+      uses: actions/cache/save@v3
       with:
         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
@@ -52,8 +52,8 @@ jobs:
         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
         echo "***Locating DynamoSandbox after master build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Cache Current Build
-      uses: actions/cache@v3
+    - name: Cache Master Build
+      uses: actions/cache/save@v3
       with:
         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
@@ -62,13 +62,15 @@ jobs:
   runs-on: windows-2022
   steps:
     - name: Restore Current Build
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
+        fail-on-cache-miss: true
         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Restore Master Build
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
+        fail-on-cache-miss: true
         path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Run Binary Diff Job

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -5,86 +5,87 @@ jobs:
  build-current:
   runs-on: windows-2022
   steps:
-    - name: Checkout Dynamo Repo current branch
-      uses: actions/checkout@v3
-      with:
-        path: Dynamo
-        repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM (current)
-      uses: nuget/setup-nuget@v1
-    - name: Nuget Restore in Dynamo solution (current)
-      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-    - name: Test var
-      run: echo "${{ github.workspace }}"
-    - name: Build Dynamo current branch with MSBuild
-      run: |
-        echo "***Continue with the build, Good luck developer!***"
-        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-    - name: Confirm Dynamo Build (current)
-      run: |
-        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
-        echo "***Locating DynamoSandbox after current build!***"
-        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Cache Current Build
-      uses: actions/cache/save@v3
-      with:
-        path: |
-           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-           ${{ github.workspace }}\Dynamo\.github\scripts
-        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
- build-master:
-  runs-on: windows-2022
-  steps:
-    - name: Checkout Dynamo Repo master branch
-      uses: actions/checkout@v3
-      with:
-        ref: master
-        path: master_Dynamo
-        repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM (master)
-      uses: nuget/setup-nuget@v1
-    - name: Nuget Restore in Dynamo solution (master)
-      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-    - name: Build Dynamo master branch with MSBuild
-      run: |
-        echo "***Continue with the build, Good luck developer!***"
-        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-    - name: Confirm Dynamo Build (master)
-      run: |
-        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
-        echo "***Locating DynamoSandbox after master build!***"
-        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Cache Master Build
-      uses: actions/cache/save@v3
-      with:
-        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
- run-bin-diff:
-  needs: [build-current, build-master]
-  runs-on: windows-2022
-  steps:
-    - name: Restore Current Build
-      uses: actions/cache/restore@v3
-      with:
-        fail-on-cache-miss: true
-        path: |
-          ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-          ${{ github.workspace }}\Dynamo\.github\scripts
-        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-    - name: Restore Master Build
-      uses: actions/cache/restore@v3
-      with:
-        fail-on-cache-miss: true
-        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-    - name: Run Binary Diff Job
-      run: |
-          echo "***Running the binary diff job between the current branch and the master branch!***"
-          cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-          .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+#     - name: Checkout Dynamo Repo current branch
+#       uses: actions/checkout@v3
+#       with:
+#         path: Dynamo
+#         repository: DynamoDS/Dynamo
+#     - name: Setup Nuget.exe to use on VM (current)
+#       uses: nuget/setup-nuget@v1
+#     - name: Nuget Restore in Dynamo solution (current)
+#       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+#     - name: Test var
+#       run: echo "${{ github.workspace }}"
+#     - name: Build Dynamo current branch with MSBuild
+#       run: |
+#         echo "***Continue with the build, Good luck developer!***"
+#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+#     - name: Confirm Dynamo Build (current)
+#       run: |
+#         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+#         echo "***Locating DynamoSandbox after current build!***"
+#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+#     - name: Cache Current Build
+#       uses: actions/cache/save@v3
+#       with:
+#         path: |
+#            ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+#            ${{ github.workspace }}\Dynamo\.github\scripts
+#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+#  build-master:
+#   runs-on: windows-2022
+#   steps:
+#     - name: Checkout Dynamo Repo master branch
+#       uses: actions/checkout@v3
+#       with:
+#         ref: master
+#         path: master_Dynamo
+#         repository: DynamoDS/Dynamo
+#     - name: Setup Nuget.exe to use on VM (master)
+#       uses: nuget/setup-nuget@v1
+#     - name: Nuget Restore in Dynamo solution (master)
+#       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+#     - name: Build Dynamo master branch with MSBuild
+#       run: |
+#         echo "***Continue with the build, Good luck developer!***"
+#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+#     - name: Confirm Dynamo Build (master)
+#       run: |
+#         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+#         echo "***Locating DynamoSandbox after master build!***"
+#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+#     - name: Cache Master Build
+#       uses: actions/cache/save@v3
+#       with:
+#         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+#  run-bin-diff:
+#   needs: [build-current, build-master]
+#   runs-on: windows-2022
+#   steps:
+#     - name: Restore Current Build
+#       uses: actions/cache/restore@v3
+#       with:
+#         fail-on-cache-miss: true
+#         path: |
+#           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+#           ${{ github.workspace }}\Dynamo\.github\scripts
+#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+#     - name: Restore Master Build
+#       uses: actions/cache/restore@v3
+#       with:
+#         fail-on-cache-miss: true
+#         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+#     - name: Run Binary Diff Job
+#       run: |
+#           echo "***Running the binary diff job between the current branch and the master branch!***"
+#           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
+#           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
     - name: Cleanup Caches
-      run: gh extension install actions/gh-actions-cache && gh actions-cache delete cache-master-${{ github.run_id }}-${{ github.run_attempt }} && gh actions-cache delete cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+      run: |
+          curl.exe -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -12,7 +12,7 @@ jobs:
         repository: DynamoDS/Dynamo
     - name: Setup Nuget.exe to use on VM
       uses: nuget/setup-nuget@v1
-    - name: Nuget Restore in Dynamo solution
+    - name: Nuget Restore in Dynamo solution (current)
       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
     - name: Build Dynamo current branch with MSBuild
       run: |
@@ -24,16 +24,14 @@ jobs:
         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
         echo "***Locating DynamoSandbox after current build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Checkout Dynamo Repo master
+    - name: Checkout Dynamo Repo master branch
       uses: actions/checkout@v3
       with:
         ref: master
         path: master_Dynamo
         repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM
-      uses: nuget/setup-nuget@v1
     - name: Nuget Restore in Dynamo solution (master)
-      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
     - name: Build Dynamo master branch with MSBuild
       run: |
         echo "***Continue with the build, Good luck developer!***"

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -113,7 +113,9 @@ jobs:
     - name: Cache Current NET6 Windows Build
       uses: actions/cache/save@v3
       with:
-        path: ${{ github.workspace }}\net60_Win_Dynamo\bin\NET60_Windows\Release
+        path: |
+          ${{ github.workspace }}\net60_Win_Dynamo\bin\NET60_Windows\Release
+          ${{ github.workspace }}\net60_Win_Dynamo\.github\scripts
         key: cache-net60Win-current-${{ github.run_id }}-${{ github.run_attempt }}
  build-dotnet-windows-master:
   runs-on: windows-latest

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -78,5 +78,12 @@ jobs:
     - name: Run Binary Diff Job
       run: |
           echo "***Running the binary diff job between the current branch and the master branch!***"
+          pwd
+          ls -al
+          ls -al D:/a/Dynamo/Dynamo
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-            .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+          .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+    - name: Cleanup Caches
+      run: gh actions-cache delete cache-master-${{ github.run_id }}-${{ github.run_attempt }} && gh actions-cache delete cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -84,7 +84,3 @@ jobs:
           echo "***Running the binary diff job between the current branch and the master branch!***"
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
-    - name: Cleanup Caches
-      run: |
-          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-current-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -3,7 +3,7 @@ name: Dynamo-BinDiff
 on: [push,pull_request]
 jobs:
  build-current:
-  runs-on: windows-2022
+  runs-on: windows-latest
   steps:
     - name: Checkout Dynamo Repo current branch
       uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
            ${{ github.workspace }}\Dynamo\.github\scripts
         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
  build-master:
-  runs-on: windows-2022
+  runs-on: windows-latest
   steps:
     - name: Checkout Dynamo Repo master branch
       uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
  run-bin-diff:
   needs: [build-current, build-master]
-  runs-on: windows-2022
+  runs-on: windows-latest
   steps:
     - name: Restore Current Build
       uses: actions/cache/restore@v3
@@ -84,3 +84,89 @@ jobs:
           echo "***Running the binary diff job between the current branch and the master branch!***"
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+ build-dotnet-windows-current:
+  runs-on: windows-latest
+  steps:
+    - name: Checkout Dynamo Repo
+      uses: actions/checkout@v3
+      with:
+        path: net60_Win_Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '6.0.x'
+    - name: Disable problem matcher
+      run: echo "::remove-matcher owner=csc::"
+    - name: Install dependencies for windows runtime
+      run: dotnet restore $Env:GITHUB_WORKSPACE\net60_Win_Dynamo\src\DynamoCore.net6.sln -p:Platform=NET60_Windows --runtime=win10-x64
+    - name: Build Dynamo current branch with MSBuild for NET60-Windows
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\"
+            .\MSBuild.exe $Env:GITHUB_WORKSPACE\net60_Win_Dynamo\src\DynamoCore.net6.sln /p:Configuration=Release  /p:Platform=NET60_Windows
+    - name: Navigate to Dynamo DotNet6 Windows Folder
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\net60_Win_Dynamo\bin\NET60_Windows\Release"
+        echo "***Locating DynamoCLI for Windows!***"
+        test ".\DynamoCLI.exe" && echo "DynamoCLI exists!"
+    - name: Cache Current NET6 Windows Build
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ github.workspace }}\net60_Win_Dynamo\bin\NET60_Windows\Release
+        key: cache-net60Win-current-${{ github.run_id }}-${{ github.run_attempt }}
+ build-dotnet-windows-master:
+  runs-on: windows-latest
+  steps:
+    - name: Checkout Dynamo Repo
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        path: master_net60_Win_Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '6.0.x'
+    - name: Disable problem matcher
+      run: echo "::remove-matcher owner=csc::"
+    - name: Install dependencies for windows runtime
+      run: dotnet restore $Env:GITHUB_WORKSPACE\master_net60_Win_Dynamo\src\DynamoCore.net6.sln -p:Platform=NET60_Windows --runtime=win10-x64
+    - name: Build Dynamo master branch with MSBuild for NET60-Windows
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\"
+            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_net60_Win_Dynamo\src\DynamoCore.net6.sln /p:Configuration=Release  /p:Platform=NET60_Windows
+    - name: Navigate to Dynamo DotNet6 Windows Folder
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\master_net60_Win_Dynamo\bin\NET60_Windows\Release"
+        echo "***Locating DynamoCLI for Windows!***"
+        test ".\DynamoCLI.exe" && echo "DynamoCLI exists!"
+    - name: Cache Current NET6 Windows Build
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ github.workspace }}\master_net60_Win_Dynamo\bin\NET60_Windows\Release
+        key: cache-net60Win-master-${{ github.run_id }}-${{ github.run_attempt }}
+ run-bin-diff-net60-windows:
+  needs: [build-dotnet-windows-current, build-dotnet-windows-master]
+  runs-on: windows-latest
+  steps:
+    - name: Restore Current Net60 Windows Build
+      uses: actions/cache/restore@v3
+      with:
+        fail-on-cache-miss: true
+        path: |
+          ${{ github.workspace }}\net60_Win_Dynamo\bin\NET60_Windows\Release
+          ${{ github.workspace }}\net60_Win_Dynamo\.github\scripts
+        key: cache-net60Win-current-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Restore Master Net60 Windows Build
+      uses: actions/cache/restore@v3
+      with:
+        fail-on-cache-miss: true
+        path: ${{ github.workspace }}\master_net60_Win_Dynamo\bin\NET60_Windows\Release
+        key: cache-net60Win-master-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Run Binary Diff Job
+      run: |
+          echo "***Running the binary diff job between the current branch and the master branch of NET60-Windows Config!***"
+          cd "$Env:GITHUB_WORKSPACE\net60_Win_Dynamo\.github\scripts"
+          .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_net60_Win_Dynamo\bin\NET60_Windows\Release,$Env:GITHUB_WORKSPACE\net60_Win_Dynamo\bin\NET60_Windows\Release

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -14,67 +14,74 @@ jobs:
       uses: nuget/setup-nuget@v1
     - name: Nuget Restore in Dynamo solution (current)
       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-    - name: Build Dynamo current branch with MSBuild
-      run: |
-        echo "***Continue with the build, Good luck developer!***"
-        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-    - name: Confirm Dynamo Build (current)
-      run: |
-        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
-        echo "***Locating DynamoSandbox after current build!***"
-        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Test var
+      run: echo "${{ github.workspace }}"
     - name: Cache Current Build
       uses: actions/cache/save@v3
       with:
-        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+        path: ${{ github.workspace }}
         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
- build-master:
-  runs-on: windows-2022
-  steps:
-    - name: Checkout Dynamo Repo master branch
-      uses: actions/checkout@v3
-      with:
-        ref: master
-        path: master_Dynamo
-        repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM (master)
-      uses: nuget/setup-nuget@v1
-    - name: Nuget Restore in Dynamo solution (master)
-      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-    - name: Build Dynamo master branch with MSBuild
-      run: |
-        echo "***Continue with the build, Good luck developer!***"
-        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-    - name: Confirm Dynamo Build (master)
-      run: |
-        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
-        echo "***Locating DynamoSandbox after master build!***"
-        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Cache Master Build
-      uses: actions/cache/save@v3
-      with:
-        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
-        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
- run-bin-diff:
-  needs: [build-current, build-master]
-  runs-on: windows-2022
-  steps:
-    - name: Restore Current Build
-      uses: actions/cache/restore@v3
-      with:
-        fail-on-cache-miss: true
-        path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
-        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-    - name: Restore Master Build
-      uses: actions/cache/restore@v3
-      with:
-        fail-on-cache-miss: true
-        path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
-        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-    - name: Run Binary Diff Job
-      run: |
-          echo "***Running the binary diff job between the current branch and the master branch!***"
-          cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-            .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+#     - name: Build Dynamo current branch with MSBuild
+#       run: |
+#         echo "***Continue with the build, Good luck developer!***"
+#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+#     - name: Confirm Dynamo Build (current)
+#       run: |
+#         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+#         echo "***Locating DynamoSandbox after current build!***"
+#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+#     - name: Cache Current Build
+#       uses: actions/cache/save@v3
+#       with:
+#         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+#  build-master:
+#   runs-on: windows-2022
+#   steps:
+#     - name: Checkout Dynamo Repo master branch
+#       uses: actions/checkout@v3
+#       with:
+#         ref: master
+#         path: master_Dynamo
+#         repository: DynamoDS/Dynamo
+#     - name: Setup Nuget.exe to use on VM (master)
+#       uses: nuget/setup-nuget@v1
+#     - name: Nuget Restore in Dynamo solution (master)
+#       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+#     - name: Build Dynamo master branch with MSBuild
+#       run: |
+#         echo "***Continue with the build, Good luck developer!***"
+#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+#     - name: Confirm Dynamo Build (master)
+#       run: |
+#         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+#         echo "***Locating DynamoSandbox after master build!***"
+#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+#     - name: Cache Master Build
+#       uses: actions/cache/save@v3
+#       with:
+#         path: ${GITHUB_WORKSPACE}\Dynamo\bin\AnyCPU\Debug
+#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+#  run-bin-diff:
+#   needs: [build-current, build-master]
+#   runs-on: windows-2022
+#   steps:
+#     - name: Restore Current Build
+#       uses: actions/cache/restore@v3
+#       with:
+#         fail-on-cache-miss: true
+#         path: $Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+#     - name: Restore Master Build
+#       uses: actions/cache/restore@v3
+#       with:
+#         fail-on-cache-miss: true
+#         path: $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug
+#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+#     - name: Run Binary Diff Job
+#       run: |
+#           echo "***Running the binary diff job between the current branch and the master branch!***"
+#           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
+#             .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -86,6 +86,7 @@ jobs:
 #           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
     - name: Cleanup Caches
       run: |
-          curl.exe -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches
+          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-master-5021203829-1
+          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-current-5021203829-1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -5,88 +5,86 @@ jobs:
  build-current:
   runs-on: windows-2022
   steps:
-#     - name: Checkout Dynamo Repo current branch
-#       uses: actions/checkout@v3
-#       with:
-#         path: Dynamo
-#         repository: DynamoDS/Dynamo
-#     - name: Setup Nuget.exe to use on VM (current)
-#       uses: nuget/setup-nuget@v1
-#     - name: Nuget Restore in Dynamo solution (current)
-#       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-#     - name: Test var
-#       run: echo "${{ github.workspace }}"
-#     - name: Build Dynamo current branch with MSBuild
-#       run: |
-#         echo "***Continue with the build, Good luck developer!***"
-#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-#     - name: Confirm Dynamo Build (current)
-#       run: |
-#         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
-#         echo "***Locating DynamoSandbox after current build!***"
-#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-#     - name: Cache Current Build
-#       uses: actions/cache/save@v3
-#       with:
-#         path: |
-#            ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-#            ${{ github.workspace }}\Dynamo\.github\scripts
-#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-#  build-master:
-#   runs-on: windows-2022
-#   steps:
-#     - name: Checkout Dynamo Repo master branch
-#       uses: actions/checkout@v3
-#       with:
-#         ref: master
-#         path: master_Dynamo
-#         repository: DynamoDS/Dynamo
-#     - name: Setup Nuget.exe to use on VM (master)
-#       uses: nuget/setup-nuget@v1
-#     - name: Nuget Restore in Dynamo solution (master)
-#       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-#     - name: Build Dynamo master branch with MSBuild
-#       run: |
-#         echo "***Continue with the build, Good luck developer!***"
-#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-#     - name: Confirm Dynamo Build (master)
-#       run: |
-#         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
-#         echo "***Locating DynamoSandbox after master build!***"
-#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-#     - name: Cache Master Build
-#       uses: actions/cache/save@v3
-#       with:
-#         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-#  run-bin-diff:
-#   needs: [build-current, build-master]
-#   runs-on: windows-2022
-#   steps:
-#     - name: Restore Current Build
-#       uses: actions/cache/restore@v3
-#       with:
-#         fail-on-cache-miss: true
-#         path: |
-#           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-#           ${{ github.workspace }}\Dynamo\.github\scripts
-#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
-#     - name: Restore Master Build
-#       uses: actions/cache/restore@v3
-#       with:
-#         fail-on-cache-miss: true
-#         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
-#     - name: Run Binary Diff Job
-#       run: |
-#           echo "***Running the binary diff job between the current branch and the master branch!***"
-#           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-#           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
+    - name: Checkout Dynamo Repo current branch
+      uses: actions/checkout@v3
+      with:
+        path: Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM (current)
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution (current)
+      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Test var
+      run: echo "${{ github.workspace }}"
+    - name: Build Dynamo current branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (current)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after current build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Current Build
+      uses: actions/cache/save@v3
+      with:
+        path: |
+           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+           ${{ github.workspace }}\Dynamo\.github\scripts
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+ build-master:
+  runs-on: windows-2022
+  steps:
+    - name: Checkout Dynamo Repo master branch
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        path: master_Dynamo
+        repository: DynamoDS/Dynamo
+    - name: Setup Nuget.exe to use on VM (master)
+      uses: nuget/setup-nuget@v1
+    - name: Nuget Restore in Dynamo solution (master)
+      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Build Dynamo master branch with MSBuild
+      run: |
+        echo "***Continue with the build, Good luck developer!***"
+        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+    - name: Confirm Dynamo Build (master)
+      run: |
+        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+        echo "***Locating DynamoSandbox after master build!***"
+        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+    - name: Cache Master Build
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+ run-bin-diff:
+  needs: [build-current, build-master]
+  runs-on: windows-2022
+  steps:
+    - name: Restore Current Build
+      uses: actions/cache/restore@v3
+      with:
+        fail-on-cache-miss: true
+        path: |
+          ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+          ${{ github.workspace }}\Dynamo\.github\scripts
+        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Restore Master Build
+      uses: actions/cache/restore@v3
+      with:
+        fail-on-cache-miss: true
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Run Binary Diff Job
+      run: |
+          echo "***Running the binary diff job between the current branch and the master branch!***"
+          cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
+          .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
     - name: Cleanup Caches
       run: |
-          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-master-5021203829-1
-          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-current-5021203829-1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+          curl.exe -L -X DELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/DynamoDS/Dynamo/actions/caches?key=cache-current-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -2,65 +2,65 @@
 name: Dynamo-BinDiff
 on: [push,pull_request]
 jobs:
- build-current:
-  runs-on: windows-2022
-  steps:
-    - name: Checkout Dynamo Repo current branch
-      uses: actions/checkout@v3
-      with:
-        path: Dynamo
-        repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM (current)
-      uses: nuget/setup-nuget@v1
-    - name: Nuget Restore in Dynamo solution (current)
-      run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-    - name: Test var
-      run: echo "${{ github.workspace }}"
-    - name: Build Dynamo current branch with MSBuild
-      run: |
-        echo "***Continue with the build, Good luck developer!***"
-        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
-    - name: Confirm Dynamo Build (current)
-      run: |
-        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
-        echo "***Locating DynamoSandbox after current build!***"
-        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Cache Current Build
-      uses: actions/cache/save@v3
-      with:
-        path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
- build-master:
-  runs-on: windows-2022
-  steps:
-    - name: Checkout Dynamo Repo master branch
-      uses: actions/checkout@v3
-      with:
-        ref: master
-        path: master_Dynamo
-        repository: DynamoDS/Dynamo
-    - name: Setup Nuget.exe to use on VM (master)
-      uses: nuget/setup-nuget@v1
-    - name: Nuget Restore in Dynamo solution (master)
-      run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-    - name: Build Dynamo master branch with MSBuild
-      run: |
-        echo "***Continue with the build, Good luck developer!***"
-        cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
-    - name: Confirm Dynamo Build (master)
-      run: |
-        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
-        echo "***Locating DynamoSandbox after master build!***"
-        test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
-    - name: Cache Master Build
-      uses: actions/cache/save@v3
-      with:
-        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+#  build-current:
+#   runs-on: windows-2022
+#   steps:
+#     - name: Checkout Dynamo Repo current branch
+#       uses: actions/checkout@v3
+#       with:
+#         path: Dynamo
+#         repository: DynamoDS/Dynamo
+#     - name: Setup Nuget.exe to use on VM (current)
+#       uses: nuget/setup-nuget@v1
+#     - name: Nuget Restore in Dynamo solution (current)
+#       run: nuget restore $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+#     - name: Test var
+#       run: echo "${{ github.workspace }}"
+#     - name: Build Dynamo current branch with MSBuild
+#       run: |
+#         echo "***Continue with the build, Good luck developer!***"
+#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+#     - name: Confirm Dynamo Build (current)
+#       run: |
+#         cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+#         echo "***Locating DynamoSandbox after current build!***"
+#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+#     - name: Cache Current Build
+#       uses: actions/cache/save@v3
+#       with:
+#         path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+#         key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+#  build-master:
+#   runs-on: windows-2022
+#   steps:
+#     - name: Checkout Dynamo Repo master branch
+#       uses: actions/checkout@v3
+#       with:
+#         ref: master
+#         path: master_Dynamo
+#         repository: DynamoDS/Dynamo
+#     - name: Setup Nuget.exe to use on VM (master)
+#       uses: nuget/setup-nuget@v1
+#     - name: Nuget Restore in Dynamo solution (master)
+#       run: nuget restore $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+#     - name: Build Dynamo master branch with MSBuild
+#       run: |
+#         echo "***Continue with the build, Good luck developer!***"
+#         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
+#            .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+#     - name: Confirm Dynamo Build (master)
+#       run: |
+#         cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+#         echo "***Locating DynamoSandbox after master build!***"
+#         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
+#     - name: Cache Master Build
+#       uses: actions/cache/save@v3
+#       with:
+#         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+#         key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
  run-bin-diff:
-  needs: [build-current, build-master]
+  # needs: [build-current, build-master]
   runs-on: windows-2022
   steps:
     - name: Restore Current Build
@@ -68,19 +68,21 @@ jobs:
       with:
         fail-on-cache-miss: true
         path: ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
-        key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+        #key: cache-current-${{ github.run_id }}-${{ github.run_attempt }}
+        key: cache-current-5020929388-1
     - name: Restore Master Build
       uses: actions/cache/restore@v3
       with:
         fail-on-cache-miss: true
         path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
-        key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+        #key: cache-master-${{ github.run_id }}-${{ github.run_attempt }}
+        key: cache-master-5020929388-1
     - name: Run Binary Diff Job
       run: |
           echo "***Running the binary diff job between the current branch and the master branch!***"
-          pwd
-          ls -al
-          ls -al D:/a/Dynamo/Dynamo
+          cd
+          dir
+          dir D:/a/Dynamo/Dynamo
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
           .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug
     - name: Cleanup Caches


### PR DESCRIPTION
### Purpose

Add a binary diff workflow that will run on each push and PR, this will enable devs to check for updated files (Added, Deleted or Modified) in their PR vs files on the master branch.

Note: caches will be removed automatically after 7 days.

![Screenshot 2023-05-19 at 6 44 49 PM](https://github.com/DynamoDS/Dynamo/assets/32665108/fb1972d6-c334-4909-9fd5-07bce6fc48d8)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Add Bin Diff support on PRs


### Reviewers

@DynamoDS/dynamo 
