### PR TITLE
DYN-5296 setting dynamic height for notification center popup

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -37,7 +37,10 @@ namespace Dynamo.Notifications
         {
             onMarkAllAsRead(ids);
         }
-
+        /// <summary>
+        /// This function will be triggered in NotificationCenter side passing the current height it has so we can update popup height in Dynamo
+        /// </summary>
+        /// <param name="height"></param>
         public void UpdateNotificationWindowSize(int height)
         {
             onNotificationPopupUpdated(height);

--- a/src/Notifications/View/NotificationUI.xaml.cs
+++ b/src/Notifications/View/NotificationUI.xaml.cs
@@ -50,5 +50,15 @@ namespace Dynamo.Notifications.View
                 positionMethod.Invoke(this, null);
             }
         }
+
+        internal void UpdatePopupSize()
+        {
+            BackgroundRectangle.Rect = new Rect(notificationsUIViewModel.PopupBordersOffSet,
+                                                notificationsUIViewModel.PopupBordersOffSet,
+                                                notificationsUIViewModel.PopupRectangleWidth,
+                                                notificationsUIViewModel.PopupRectangleHeight);
+
+            this.Height = notificationsUIViewModel.PopupRectangleHeight + notificationsUIViewModel.PopupBordersOffSet + 10;
+        }
     }
 }


### PR DESCRIPTION
### Purpose

https://github.com/DynamoDS/Dynamo/assets/111511512/9b0c5cae-63b3-489e-a081-6ddabc494dec


This PR is related to [DYN-5296](https://jira.autodesk.com/browse/DYN-5296)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

This PR implements a dynamic height resizing for notifications popup base on Notification Center height.


### Reviewers

@RobertGlobant20 

### FYIs

@RobertGlobant20 
@reddyashish 
