### PR TITLE
Fix python editor crash inside custom node.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1519,22 +1519,26 @@ namespace Dynamo.ViewModels
                 if (DockedNodeWindows.Contains(id))
                 {
                     var tabItem = SideBarTabItems.OfType<TabItem>().SingleOrDefault(n => n.Uid.ToString() == id);
-                    NodeModel nodeModel = GetDockedWindowNodeModel(tabItem.Uid);
 
-                    if (nodeModel is PythonNode pythonNode)
+                    if (tabItem != null)
                     {
-                        var editor = (tabItem.Content as Grid).ChildOfType<TextEditor>();
-                        if (editor != null && editor.IsModified)
-                        {
-                            pythonNode.OnWarnUserScript();
-                            tabItem.Focus();
-                            return false;
-                        }
-                        pythonNode.Dispose();
-                    }
+                        NodeModel nodeModel = GetDockedWindowNodeModel(tabItem.Uid);
 
-                    SideBarTabItems.Remove(tabItem);
-                    DockedNodeWindows.Remove(id);
+                        if (nodeModel is PythonNode pythonNode)
+                        {
+                            var editor = (tabItem.Content as Grid).ChildOfType<TextEditor>();
+                            if (editor != null && editor.IsModified)
+                            {
+                                pythonNode.OnWarnUserScript();
+                                tabItem.Focus();
+                                return false;
+                            }
+                            pythonNode.Dispose();
+                        }
+
+                        SideBarTabItems.Remove(tabItem);
+                        DockedNodeWindows.Remove(id);
+                    }
                 }
             }
             return true;

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -637,7 +637,11 @@ namespace PythonNodeModelsWpf
                 {
                     var dynamoView = Owner as DynamoView;
                     TabItem tabItem = dynamoViewModel.SideBarTabItems.OfType<TabItem>().SingleOrDefault(n => n.Uid.ToString() == NodeModel.GUID.ToString());
-                    dynamoView.CloseRightSideBarTab(tabItem);
+                    if (tabItem != null)
+                    {
+                        dynamoView.CloseRightSideBarTab(tabItem);
+                        dynamoViewModel.DockedNodeWindows.Remove(tabItem.Uid);
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
### Purpose

For the crash reported here https://autodesk.slack.com/archives/C01C2AGPSG2/p1684856549984199 by Aaron, this should fix it.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes
Fix python editor crash inside custom node.

### Reviewers
@QilongTang @avidit 

