### PR TITLE
Reference Greg Version 2.5.0.5076 which has a dotnet 6 target

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
 [assembly: AssemblyProduct("Dynamo")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2023")]
+[assembly: AssemblyCopyright("Copyright Â© Autodesk, Inc 2023")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.19.0.5077")]
+[assembly: AssemblyVersion("2.19.0.4737")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.19.0.5077")]
+[assembly: AssemblyFileVersion("2.19.0.4737")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
 [assembly: AssemblyProduct("Dynamo")]
-[assembly: AssemblyCopyright("Copyright Â© Autodesk, Inc 2023")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2023")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.19.0.4737")]
+[assembly: AssemblyVersion("2.19.0.5077")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.19.0.4737")]
+[assembly: AssemblyFileVersion("2.19.0.5077")]

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="DynamoVisualProgramming.Analytics" Version="3.0.1.740" />
     <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.18.0.1400" GeneratePathProperty="true" />
     <PackageReference Include="DynamoVisualProgramming.LibG_228_0_0" Version="2.18.0.1400" GeneratePathProperty="true" />
-    <PackageReference Include="Greg" Version="2.4.0.4766" />
+    <PackageReference Include="Greg" Version="2.5.0.5076" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" CopyXML="true" />
 	  <PackageReference Include="RestSharp" Version="106.12.0" CopyXML="true" />
   </ItemGroup>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -104,7 +104,7 @@
   <ItemGroup>
   <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.18.0.1400" />
   <PackageReference Include="AvalonEdit" Version="4.3.1.9430" CopyXML="true" />
-  <PackageReference Include="Greg" Version="2.4.0.4766" />
+  <PackageReference Include="Greg" Version="2.5.0.5076" />
   <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	<PackageReference Include="RestSharp" Version="106.12.0" />

--- a/src/DynamoPackages/DynamoPackages.csproj
+++ b/src/DynamoPackages/DynamoPackages.csproj
@@ -32,7 +32,7 @@
     <Content Include="PackageManagerExtension_ExtensionDefinition.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Greg" Version="2.4.0.4766" />
+    <PackageReference Include="Greg" Version="2.5.0.5076" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>PackageDetailsViewExtension</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Greg" Version="2.4.0.4766" />
+	<PackageReference Include="Greg" Version="2.5.0.5076" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	<PackageReference Include="RestSharp" Version="106.12.0" />
     <Reference Include="Microsoft.Practices.Prism, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.18.0.1400" />
-    <PackageReference Include="Greg" Version="2.4.0.4766" />
+    <PackageReference Include="Greg" Version="2.5.0.5076" />
     <PackageReference Include="Magick.NET.Core" Version="7.0.1" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Greg" Version="2.4.0.4766">
+    <PackageReference Include="Greg" Version="2.5.0.5076">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -18,7 +18,7 @@
 	  <PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
       <PackageReference Include="Moq" Version="4.18.4" />
 	  <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
-	  <PackageReference Include="Greg" Version="2.4.0.4766">
+	  <PackageReference Include="Greg" Version="2.5.0.5076">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
+++ b/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>PackageManagerTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Greg" Version="2.4.0.4766">
+    <PackageReference Include="Greg" Version="2.5.0.5076">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Purpose

Upgrade Greg Client package to 2.5.0.5076 which now has a dotnet 6 target

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

Upgrade Greg Version to 2.5.0.5076

### Reviewers


### FYIs


