### PR TITLE
[DYN-5916] Move workspace reference extension code from code-behind to extension class

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -25,7 +25,7 @@ namespace Dynamo.WorkspaceDependency
     public partial class WorkspaceDependencyView : UserControl, IDisposable
     {
 
-        private WorkspaceModel currentWorkspace;
+        internal WorkspaceModel currentWorkspace;
 
         /// <summary>
         /// The hyper link where Dynamo user will be forwarded to for submitting comments.
@@ -33,18 +33,10 @@ namespace Dynamo.WorkspaceDependency
         private readonly string FeedbackLink = "https://forum.dynamobim.com/t/call-for-feedback-on-dynamo-graph-package-dependency-display/37229";
         private readonly string customNodeExtension = ".dyf";
 
-        private ViewLoadedParams loadedParams;
+        internal ViewLoadedParams loadedParams;
         private WorkspaceDependencyViewExtension dependencyViewExtension;
 
         private IPackageInstaller packageInstaller;
-
-        /// <summary>
-        /// Internal cache of the data displayed in data grid, useful in unit testing.
-        /// You are not expected to modify this but rather inspection.
-        /// </summary>
-        internal IEnumerable<PackageDependencyRow> dataRows;
-        internal IEnumerable<DependencyRow> localDefinitionDataRows;
-        internal IEnumerable<DependencyRow> externalFilesDataRows;
 
         private Boolean hasDependencyIssue = false;
 
@@ -100,7 +92,7 @@ namespace Dynamo.WorkspaceDependency
                 {
                     currentWorkspace.PropertyChanged -= OnWorkspacePropertyChanged;
                 }
-                DependencyRegen(obj as WorkspaceModel, true);
+                dependencyViewExtension.DependencyRegen(obj as WorkspaceModel, true);
                 // Update current workspace
                 currentWorkspace = obj as WorkspaceModel;
                 currentWorkspace.Saved += TriggerDependencyRegen;
@@ -117,124 +109,14 @@ namespace Dynamo.WorkspaceDependency
             PackageDependencyTable.ItemsSource = null;
             if (obj is WorkspaceModel)
             {
-                DependencyRegen(obj as WorkspaceModel);
+                dependencyViewExtension.DependencyRegen(obj as WorkspaceModel);
             }
         }
 
         private void OnWorkspacePropertyChanged(object sender, PropertyChangedEventArgs args)
         {
             if (args.PropertyName == nameof(currentWorkspace.NodeLibraryDependencies) || args.PropertyName == nameof(currentWorkspace.NodeLocalDefinitions) || args.PropertyName == nameof(currentWorkspace.ExternalFiles))
-                DependencyRegen(currentWorkspace);
-        }
-
-        /// <summary>
-        /// Regenerate dependency table
-        /// </summary>
-        /// <param name="ws">workspace model</param>
-        /// <param name="forceCompute">flag indicating if the workspace references should be computed</param>
-        internal void DependencyRegen(WorkspaceModel ws, bool forceCompute = false)
-        {
-            RestartBanner.Visibility = Visibility.Hidden;
-            ws.ForceComputeWorkspaceReferences = forceCompute;
-
-            var packageDependencies = ws.NodeLibraryDependencies?.Where(d => d is PackageDependencyInfo).ToList();
-            var localDefinitions = ws.NodeLocalDefinitions?.Where(d => d is DependencyInfo).ToList();
-            var externalFiles = ws.ExternalFiles?.Where(d => d is DependencyInfo).ToList();
-
-            foreach (DependencyInfo info in localDefinitions)
-            {
-                try
-                {
-                    if (info.ReferenceType == ReferenceType.DYFFile)
-                    {
-                        // Try to get the Custom node information if possible.
-                        string customNodeName = info.Name.Replace(customNodeExtension, "");
-                        dependencyViewExtension.DependencyView.CustomNodeManager.TryGetNodeInfo(customNodeName, out CustomNodeInfo customNodeInfo);
-
-                        if (customNodeInfo != null)
-                        {
-                            info.Path = customNodeInfo.Path;
-                        }
-                    }
-                    info.Size = PathHelper.GetFileSize(info.Path);
-                }
-                catch (Exception ex)
-                {
-                    dependencyViewExtension.OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
-                }
-
-                HasDependencyIssue = string.IsNullOrEmpty(info.Path);
-            }
-
-            foreach (DependencyInfo info in externalFiles)
-            {
-                HasDependencyIssue = string.IsNullOrEmpty(info.Path);
-            }
-
-            var pythonPackageDependencies = ws.OnRequestPackageDependencies();
-            if (pythonPackageDependencies != null)
-                packageDependencies.AddRange(pythonPackageDependencies);
-
-            if (packageDependencies.Any(d => d.State != PackageDependencyState.Loaded))
-            {
-                HasDependencyIssue = true;
-            }
-
-            if (packageDependencies.Any())
-            {
-                Boolean hasPackageMarkedForUninstall = false;
-                // If package is set to uninstall state, update the package info
-                foreach (var package in dependencyViewExtension.pmExtension.PackageLoader.LocalPackages.Where(x => 
-                x.LoadState.ScheduledState == PackageLoadState.ScheduledTypes.ScheduledForDeletion || x.LoadState.ScheduledState == PackageLoadState.ScheduledTypes.ScheduledForUnload))
-                {
-                    try
-                    {
-                        (packageDependencies.FirstOrDefault(x => x.Name == package.Name) as PackageDependencyInfo).State =
-                        PackageDependencyState.RequiresRestart;
-                        hasPackageMarkedForUninstall = true;
-                    }
-                    catch (Exception ex)
-                    {
-                        dependencyViewExtension.OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, $"failure to set package uninstall state |{ ex.ToString()}")));
-                    }
-                }
-
-                RestartBanner.Visibility = hasPackageMarkedForUninstall ? Visibility.Visible: Visibility.Hidden;
-            }
-
-            var pmExtension = dependencyViewExtension.pmExtension;
-            if (pmExtension != null)
-            {
-                foreach (PackageDependencyInfo packageDependencyInfo in packageDependencies)
-                {
-                    try
-                    {
-                        var targetInfo = pmExtension.PackageLoader.LocalPackages.Where(x => x.Name == packageDependencyInfo.Name).FirstOrDefault();
-                        if (targetInfo != null)
-                        {
-                            packageDependencyInfo.Path = targetInfo.RootDirectory;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        dependencyViewExtension.OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
-                    }
-                }
-            }
-
-            dataRows = packageDependencies.Select(d => new PackageDependencyRow(d as PackageDependencyInfo));
-            localDefinitionDataRows = localDefinitions.Select(d => new DependencyRow(d as DependencyInfo));
-            externalFilesDataRows = externalFiles.Select(d => new DependencyRow(d as DependencyInfo));
-
-            Packages.IsExpanded = dataRows.Count() > 0;
-            LocalDefinitions.IsExpanded = localDefinitionDataRows.Count() > 0;
-            ExternalFiles.IsExpanded = externalFilesDataRows.Count() > 0;
-
-            ws.ForceComputeWorkspaceReferences = false;
-
-            PackageDependencyTable.ItemsSource = dataRows;
-            LocalDefinitionsTable.ItemsSource = localDefinitionDataRows;
-            ExternalFilesTable.ItemsSource = externalFilesDataRows;
+                dependencyViewExtension.DependencyRegen(currentWorkspace);
         }
 
         /// <summary>
@@ -242,7 +124,7 @@ namespace Dynamo.WorkspaceDependency
         /// </summary>
         internal void TriggerDependencyRegen()
         {
-            DependencyRegen(currentWorkspace);
+            dependencyViewExtension.DependencyRegen(currentWorkspace);
         }
 
         /// <summary>
@@ -250,7 +132,7 @@ namespace Dynamo.WorkspaceDependency
         /// </summary>
         internal void ForceTriggerDependencyRegen()
         {
-            DependencyRegen(currentWorkspace, true);
+            dependencyViewExtension.DependencyRegen(currentWorkspace, true);
         }
 
         /// <summary>
@@ -270,7 +152,6 @@ namespace Dynamo.WorkspaceDependency
             loadedParams = p;
             packageInstaller = p.PackageInstaller;
             dependencyViewExtension = viewExtension;
-            DependencyRegen(currentWorkspace);
             HomeWorkspaceModel.WorkspaceClosed += this.CloseExtensionTab;
         }
 
@@ -349,7 +230,7 @@ namespace Dynamo.WorkspaceDependency
                     info.Path = targetInfo.RootDirectory;
                     // Mark the current workspace dirty for save
                     currentWorkspace.HasUnsavedChanges = true;
-                    DependencyRegen(currentWorkspace);
+                    dependencyViewExtension.DependencyRegen(currentWorkspace);
                 }
             }
         }
@@ -368,19 +249,16 @@ namespace Dynamo.WorkspaceDependency
             PackageDependencyTable.ItemsSource = null;
             LocalDefinitionsTable.ItemsSource = null;
             ExternalFilesTable.ItemsSource = null;
-            dataRows = null;
-            localDefinitionDataRows = null;
-            externalFilesDataRows = null;
         }
 
         private void Refresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            DependencyRegen(currentWorkspace);
+            dependencyViewExtension.DependencyRegen(currentWorkspace);
         }
 
         private void ForceRefresh_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            DependencyRegen(currentWorkspace, true);
+            dependencyViewExtension.DependencyRegen(currentWorkspace, true);
         }
     }
 

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Core;
 using Dynamo.Extensions;
@@ -8,6 +10,7 @@ using Dynamo.Logging;
 using Dynamo.PackageManager;
 using Dynamo.WorkspaceDependency.Properties;
 using Dynamo.Wpf.Extensions;
+using DynamoUtilities;
 
 namespace Dynamo.WorkspaceDependency
 {
@@ -20,12 +23,21 @@ namespace Dynamo.WorkspaceDependency
     {
         internal MenuItem workspaceReferencesMenuItem;
         private readonly String extensionName = Properties.Resources.ExtensionName;
+        private readonly string customNodeExtension = ".dyf";
 
         internal WorkspaceDependencyView DependencyView
         {
             get;
             set;
         }
+
+        /// <summary>
+        /// Internal cache of the data displayed in data grid, useful in unit testing.
+        /// You are not expected to modify this but rather inspection.
+        /// </summary>
+        internal IEnumerable<PackageDependencyRow> dataRows;
+        internal IEnumerable<DependencyRow> localDefinitionDataRows;
+        internal IEnumerable<DependencyRow> externalFilesDataRows;
 
         internal PackageManagerExtension pmExtension;
 
@@ -57,6 +69,9 @@ namespace Dynamo.WorkspaceDependency
         public override void Dispose()
         {
             DependencyView.Dispose();
+            dataRows = null;
+            localDefinitionDataRows = null;
+            externalFilesDataRows = null;
         }
 
 
@@ -77,9 +92,32 @@ namespace Dynamo.WorkspaceDependency
             this.MessageLogged?.Invoke(msg);
         }
 
+        private Boolean hasDependencyIssue = false;
+        /// <summary>
+        /// Property to raise to author's attention, if the Dynamo active workspace has any missing dependencies.
+        /// This determines if the package dep viewer will be injected into right panel.
+        /// </summary>
+        private Boolean HasDependencyIssue
+        {
+            get { return hasDependencyIssue; }
+            set
+            {
+                hasDependencyIssue = value;
+                if (hasDependencyIssue)
+                {
+                    DependencyView.loadedParams.AddToExtensionsSideBar(this, DependencyView);
+                    if (workspaceReferencesMenuItem != null && !workspaceReferencesMenuItem.IsChecked)
+                    {
+                        workspaceReferencesMenuItem.IsChecked = true;
+                    }
+                }
+            }
+        }
+
         public override void Loaded(ViewLoadedParams viewLoadedParams)
         {
             DependencyView = new WorkspaceDependencyView(this, viewLoadedParams);
+            DependencyRegen(DependencyView.currentWorkspace);
             // when a package is loaded update the DependencyView 
             // as we may have installed a missing package.
 
@@ -88,7 +126,7 @@ namespace Dynamo.WorkspaceDependency
             {
                 pmExtension.PackageLoader.PackgeLoaded += (package) =>
                 {
-                    DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel, true);
+                    DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel, true);
                 };
             }
 
@@ -99,7 +137,7 @@ namespace Dynamo.WorkspaceDependency
                 if (workspaceReferencesMenuItem.IsChecked)
                 {
                     // Refresh dependency data
-                    DependencyView.DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel, true);
+                    DependencyRegen(viewLoadedParams.CurrentWorkspaceModel as WorkspaceModel, true);
                     viewLoadedParams.AddToExtensionsSideBar(this, DependencyView);
                     workspaceReferencesMenuItem.IsChecked = true;
                 }
@@ -110,6 +148,115 @@ namespace Dynamo.WorkspaceDependency
                 }
             };
             viewLoadedParams.AddExtensionMenuItem(workspaceReferencesMenuItem);
+        }
+
+                /// <summary>
+        /// Regenerate dependency table
+        /// </summary>
+        /// <param name="ws">workspace model</param>
+        /// <param name="forceCompute">flag indicating if the workspace references should be computed</param>
+        internal void DependencyRegen(WorkspaceModel ws, bool forceCompute = false)
+        {
+            DependencyView.RestartBanner.Visibility = Visibility.Hidden;
+            ws.ForceComputeWorkspaceReferences = forceCompute;
+
+            var packageDependencies = ws.NodeLibraryDependencies?.Where(d => d is PackageDependencyInfo).ToList();
+            var localDefinitions = ws.NodeLocalDefinitions?.Where(d => d is DependencyInfo).ToList();
+            var externalFiles = ws.ExternalFiles?.Where(d => d is DependencyInfo).ToList();
+
+            foreach (DependencyInfo info in localDefinitions)
+            {
+                try
+                {
+                    if (info.ReferenceType == ReferenceType.DYFFile)
+                    {
+                        // Try to get the Custom node information if possible.
+                        string customNodeName = info.Name.Replace(customNodeExtension, "");
+                        DependencyView.CustomNodeManager.TryGetNodeInfo(customNodeName, out CustomNodeInfo customNodeInfo);
+
+                        if (customNodeInfo != null)
+                        {
+                            info.Path = customNodeInfo.Path;
+                        }
+                    }
+                    info.Size = PathHelper.GetFileSize(info.Path);
+                }
+                catch (Exception ex)
+                {
+                    OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
+                }
+
+                HasDependencyIssue = string.IsNullOrEmpty(info.Path);
+            }
+
+            foreach (DependencyInfo info in externalFiles)
+            {
+                HasDependencyIssue = string.IsNullOrEmpty(info.Path);
+            }
+
+            var pythonPackageDependencies = ws.OnRequestPackageDependencies();
+            if (pythonPackageDependencies != null)
+                packageDependencies.AddRange(pythonPackageDependencies);
+
+            if (packageDependencies.Any(d => d.State != PackageDependencyState.Loaded))
+            {
+                HasDependencyIssue = true;
+            }
+
+            if (packageDependencies.Any())
+            {
+                Boolean hasPackageMarkedForUninstall = false;
+                // If package is set to uninstall state, update the package info
+                foreach (var package in pmExtension.PackageLoader.LocalPackages.Where(x => 
+                x.LoadState.ScheduledState == PackageLoadState.ScheduledTypes.ScheduledForDeletion || x.LoadState.ScheduledState == PackageLoadState.ScheduledTypes.ScheduledForUnload))
+                {
+                    try
+                    {
+                        (packageDependencies.FirstOrDefault(x => x.Name == package.Name) as PackageDependencyInfo).State =
+                        PackageDependencyState.RequiresRestart;
+                        hasPackageMarkedForUninstall = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, $"failure to set package uninstall state |{ ex.ToString()}")));
+                    }
+                }
+
+                DependencyView.RestartBanner.Visibility = hasPackageMarkedForUninstall ? Visibility.Visible: Visibility.Hidden;
+            }
+
+            if (pmExtension != null)
+            {
+                foreach (PackageDependencyInfo packageDependencyInfo in packageDependencies)
+                {
+                    try
+                    {
+                        var targetInfo = pmExtension.PackageLoader.LocalPackages.Where(x => x.Name == packageDependencyInfo.Name).FirstOrDefault();
+                        if (targetInfo != null)
+                        {
+                            packageDependencyInfo.Path = targetInfo.RootDirectory;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
+                    }
+                }
+            }
+
+            dataRows = packageDependencies.Select(d => new PackageDependencyRow(d as PackageDependencyInfo));
+            localDefinitionDataRows = localDefinitions.Select(d => new DependencyRow(d as DependencyInfo));
+            externalFilesDataRows = externalFiles.Select(d => new DependencyRow(d as DependencyInfo));
+
+            DependencyView.Packages.IsExpanded = dataRows.Count() > 0;
+            DependencyView.LocalDefinitions.IsExpanded = localDefinitionDataRows.Count() > 0;
+            DependencyView.ExternalFiles.IsExpanded = externalFilesDataRows.Count() > 0;
+
+            ws.ForceComputeWorkspaceReferences = false;
+
+            DependencyView.PackageDependencyTable.ItemsSource = dataRows;
+            DependencyView.LocalDefinitionsTable.ItemsSource = localDefinitionDataRows;
+            DependencyView.ExternalFilesTable.ItemsSource = externalFilesDataRows;
         }
 
         public override void Closed()

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -66,7 +66,7 @@ namespace DynamoCoreWpfTests
             viewExtension.Loaded(loadedParams);
 
             var CurrentWorkspace = ViewModel.Model.CurrentWorkspace;
-            viewExtension.DependencyView.DependencyRegen(CurrentWorkspace);
+            viewExtension.DependencyRegen(CurrentWorkspace);
             // Restart banner should not display by default
             Assert.AreEqual(Visibility.Hidden, viewExtension.DependencyView.RestartBanner.Visibility);
         }
@@ -92,12 +92,12 @@ namespace DynamoCoreWpfTests
             package.LoadState.SetScheduledForDeletion();
 
             // Once choosing to install the specified version, info.State should reflect RequireRestart
-            viewExtension.DependencyView.DependencyRegen(CurrentWorkspace);
+            viewExtension.DependencyRegen(CurrentWorkspace);
 
             // Restart banner should display immediately
             Assert.AreEqual(Visibility.Visible, viewExtension.DependencyView.RestartBanner.Visibility);
             Assert.AreEqual(1, viewExtension.DependencyView.PackageDependencyTable.Items.Count);
-            var newInfo = viewExtension.DependencyView.dataRows.FirstOrDefault().DependencyInfo;
+            var newInfo = viewExtension.dataRows.FirstOrDefault().DependencyInfo;
 
             // Local loaded version was 2.0.0, but now will be update to date with dyn
             Assert.AreEqual("2.0.1", newInfo.Version.ToString());
@@ -214,7 +214,7 @@ namespace DynamoCoreWpfTests
             // Closing the dyf will trigger DependencyRegen of HomeWorkspaceModel.
             // The HomeWorkspaceModel does not contain any dependency info since it's empty
             // but DependencyRegen() call on it should not crash
-            Assert.DoesNotThrow(()=> viewExtension.DependencyView.DependencyRegen(homeWorkspaceModel));
+            Assert.DoesNotThrow(()=> viewExtension.DependencyRegen(homeWorkspaceModel));
         }
 
         [Test]
@@ -291,7 +291,7 @@ namespace DynamoCoreWpfTests
             Open(examplePath);
             Assert.AreEqual(1, ViewModel.SideBarTabItems.Count);
 
-            foreach (PackageDependencyRow packageDependencyRow in WorkspaceReferencesExtension.DependencyView.dataRows)
+            foreach (PackageDependencyRow packageDependencyRow in WorkspaceReferencesExtension.dataRows)
             {
                 var dependencyInfo = packageDependencyRow.DependencyInfo;
                 Assert.Contains(dependencyInfo.Name, dependenciesList);
@@ -314,8 +314,8 @@ namespace DynamoCoreWpfTests
             examplePath = Path.Combine(@"core\LocalDefinitionsTest.dyn");
             Open(examplePath);
            
-            Assert.AreEqual(1, WorkspaceReferencesExtension.DependencyView.localDefinitionDataRows.Count());
-            DependencyRow localDefinitionRow = WorkspaceReferencesExtension.DependencyView.localDefinitionDataRows.FirstOrDefault();
+            Assert.AreEqual(1, WorkspaceReferencesExtension.localDefinitionDataRows.Count());
+            DependencyRow localDefinitionRow = WorkspaceReferencesExtension.localDefinitionDataRows.FirstOrDefault();
             var dependencyInfo = localDefinitionRow.DependencyInfo;
             Assert.Contains(dependencyInfo.Name, dependenciesList);
         }
@@ -329,10 +329,10 @@ namespace DynamoCoreWpfTests
             var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
             Open(examplePath);
 
-            WorkspaceReferencesExtension.DependencyView.DependencyRegen(Model.CurrentWorkspace, true);
+            WorkspaceReferencesExtension.DependencyRegen(Model.CurrentWorkspace, true);
 
-            Assert.AreEqual(2, WorkspaceReferencesExtension.DependencyView.externalFilesDataRows.Count());
-            foreach (DependencyRow localDefinitionRow in WorkspaceReferencesExtension.DependencyView.externalFilesDataRows)
+            Assert.AreEqual(2, WorkspaceReferencesExtension.externalFilesDataRows.Count());
+            foreach (DependencyRow localDefinitionRow in WorkspaceReferencesExtension.externalFilesDataRows)
             {
                 var dependencyInfo = localDefinitionRow.DependencyInfo;
                 Assert.Contains(dependencyInfo.Name, dependenciesList);
@@ -346,11 +346,11 @@ namespace DynamoCoreWpfTests
             var examplePath = Path.Combine(@"core\ExternalReferencesTest.dyn");
             Open(examplePath);
             (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = false;
-            WorkspaceReferencesExtension.DependencyView.DependencyRegen(Model.CurrentWorkspace, true);
+            WorkspaceReferencesExtension.DependencyRegen(Model.CurrentWorkspace, true);
             var results = Model.CurrentWorkspace.ExternalFiles;
             Assert.AreEqual(0, results.Count());
             (Model.CurrentWorkspace as HomeWorkspaceModel).RunSettings.RunEnabled = true;
-            WorkspaceReferencesExtension.DependencyView.DependencyRegen(Model.CurrentWorkspace, true);
+            WorkspaceReferencesExtension.DependencyRegen(Model.CurrentWorkspace, true);
             results = Model.CurrentWorkspace.ExternalFiles;
             Assert.AreEqual(2, results.Count());
         }


### PR DESCRIPTION
### Purpose

Moving the code for better accessibility.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@DynamoDS/dynamo 
