### PR TITLE
Border to PreferenceView

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -21,7 +21,10 @@
         mc:Ignorable="d" 
         Height="480" 
         Width="665"
-        ResizeMode="NoResize">
+        ResizeMode="NoResize"
+        BorderThickness="0"
+        AllowsTransparency="True"
+        Background="Transparent">
 
     <!--Using the Styles from the SharedResourcesDictionary located in DynamoCoreWpf/UI/Themes/DynamoModern.xaml-->
     <Window.Resources>
@@ -133,8 +136,13 @@
     </Window.Resources>
 
     <!--This is the main row of the Preference Window-->
-    <Grid x:Name="mainGrid"
-    	  Background="{StaticResource PreferencesWindowBackgroundColor}">
+    <Border x:Name="mainBorder"
+            BorderBrush="{StaticResource WorkspaceBackgroundHomeBrush}"
+            BorderThickness="2"
+            CornerRadius="4"
+            Background="{StaticResource PreferencesWindowBackgroundColor}">
+        <Grid x:Name="mainGrid"
+    	  Background="Transparent">
         <Grid.Resources>
             <sys:Double x:Key="ToggleButtonWidth">40</sys:Double>
             <sys:Double x:Key="ToggleButtonHeight">20</sys:Double>
@@ -1906,4 +1914,5 @@
             </Grid>
         </Grid>
     </Grid>
+    </Border>
 </Window>


### PR DESCRIPTION
### Purpose

A visual update to the Preferences View adding a white (`WorkspaceBackgroundHomeBrush`)  2px border. This should increase the visibility of the control and make it easier for users to make out the actual window when overlapping with other UI elements.

#### Screenshot of changes

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/c4085c70-ec23-4f5b-b38a-253d95ef74b8)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- added white border to preference view to increase visibility

### Reviewers

@Amoursol 
@reddyashish 
@QilongTang 

### FYIs


