### PR TITLE
Fix Group Styles section

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -42,7 +42,7 @@
             <!--This Template will be used for the controls generated in the Styles list when a new Style is saved-->
             <DataTemplate x:Key="styleViewItemTemplate">
                  <Border Background="{StaticResource PreferencesWindowBackgroundColor}" Padding="0,0,0,10" Margin="0,0,0,5"
-                        BorderThickness="1" BorderBrush="#FF97A0A5" Width="210">
+                        BorderThickness="1" BorderBrush="#FF97A0A5" Width="205">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="auto" />


### PR DESCRIPTION
### Purpose

Fix in Group Styles section for showing styles added correctly
In a previous fix a vertical scrollbar was added generating that the GroupStyles items added are shown in only one column (previously two columns) so in this fix I'm reducing the width so two group styles are shown again in two columns.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fix in Group Styles section for showing styles added correctly


### Reviewers

@QilongTang 

### FYIs

@avidit 
