### PR TITLE
DYN-5968 Make timestamp as part of Dynamo Preferences setting

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -58,6 +58,7 @@ namespace Dynamo.Configuration
         private bool isNotificationCenterEnabled;
         private bool isEnablePersistExtensionsEnabled;
         private bool isStaticSplashScreenEnabled;
+        private bool isTimeStampIncludedInExportFilePath;
         private bool isCreatedFromValidFile = true;
         private string backupLocation;
 
@@ -669,6 +670,21 @@ namespace Dynamo.Configuration
         }
 
         /// <summary>
+        /// This defines if the user export file path would include timestamp
+        /// </summary>
+        public bool IsTimeStampIncludedInExportFilePath
+        {
+            get
+            {
+                return isTimeStampIncludedInExportFilePath;
+            }
+            set
+            {
+                isTimeStampIncludedInExportFilePath = value;
+            }
+        }
+
+        /// <summary>
         /// Engine used by default for new Python script and string nodes. If not empty, this takes precedence over any system settings.
         /// </summary>
         public string DefaultPythonEngine
@@ -889,6 +905,7 @@ namespace Dynamo.Configuration
             HideAutocompleteMethodOptions = false;
             EnableNotificationCenter = true;
             isStaticSplashScreenEnabled = true;
+            isTimeStampIncludedInExportFilePath = true;
             DefaultPythonEngine = string.Empty;
             ViewExtensionSettings = new List<ViewExtensionSettings>();
             GroupStyleItemsList = new List<GroupStyleItem>();

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -115,6 +115,21 @@ namespace Dynamo.Configuration
         public bool IsAnalyticsReportingApproved { get; set; }
 
         /// <summary>
+        /// This defines if the user export file path would include timestamp
+        /// </summary>
+        public bool IsTimeStampIncludedInExportFilePath
+        {
+            get
+            {
+                return isTimeStampIncludedInExportFilePath;
+            }
+            set
+            {
+                isTimeStampIncludedInExportFilePath = value;
+            }
+        }
+
+        /// <summary>
         /// Indicates whether ADP analytics reporting is approved or not.
         /// Note that the getter will communicate to a analytics server which might be slow.
         /// This API should only be used in UI scenarios (not in performance sensitive areas)
@@ -666,21 +681,6 @@ namespace Dynamo.Configuration
             set
             {
                 isStaticSplashScreenEnabled = value;
-            }
-        }
-
-        /// <summary>
-        /// This defines if the user export file path would include timestamp
-        /// </summary>
-        public bool IsTimeStampIncludedInExportFilePath
-        {
-            get
-            {
-                return isTimeStampIncludedInExportFilePath;
-            }
-            set
-            {
-                isTimeStampIncludedInExportFilePath = value;
             }
         }
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7134,7 +7134,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include TImestamp in Export Path.
+        ///   Looks up a localized string similar to Include Timestamp in Export Path.
         /// </summary>
         public static string PreferencesViewSettingIncludeTimestampExportPath {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7008,6 +7008,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This setting controls if the export image path from workspace or background geometry would include timestamp..
+        /// </summary>
+        public static string PreferencesViewIncludeTimestampExportPathTooltip {
+            get {
+                return ResourceManager.GetString("PreferencesViewIncludeTimestampExportPathTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Language.
         /// </summary>
         public static string PreferencesViewLanguageLabel {
@@ -7121,6 +7130,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PreferencesViewSelectedPackagePathForDownload {
             get {
                 return ResourceManager.GetString("PreferencesViewSelectedPackagePathForDownload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include TImestamp in Export Path.
+        /// </summary>
+        public static string PreferencesViewSettingIncludeTimestampExportPath {
+            get {
+                return ResourceManager.GetString("PreferencesViewSettingIncludeTimestampExportPath", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3646,7 +3646,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>The workspace cannot be exported as an image because it contains nodes that are too far away from each other.</value>
   </data>
   <data name="PreferencesViewSettingIncludeTimestampExportPath" xml:space="preserve">
-    <value>Include TImestamp in Export Path</value>
+    <value>Include Timestamp in Export Path</value>
   </data>
   <data name="PreferencesViewIncludeTimestampExportPathTooltip" xml:space="preserve">
     <value>This setting controls if the export image path from workspace or background geometry would include timestamp.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3629,7 +3629,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   </data>
   <data name="PreferencesGrahicHelpersScaleTooltip" xml:space="preserve">
     <value>Select a scale for the background graphic helpers (grids, axes).</value>
-  </data>    
+  </data>
   <data name="LibraryLoadFailureMessageSuffix" xml:space="preserve">
     <value>See the console log for the details of the import failure.</value>
   </data>
@@ -3645,5 +3645,10 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="CantExportWorkspaceAsImageNotValidMessage" xml:space="preserve">
     <value>The workspace cannot be exported as an image because it contains nodes that are too far away from each other.</value>
   </data>
+  <data name="PreferencesViewSettingIncludeTimestampExportPath" xml:space="preserve">
+    <value>Include TImestamp in Export Path</value>
+  </data>
+  <data name="PreferencesViewIncludeTimestampExportPathTooltip" xml:space="preserve">
+    <value>This setting controls if the export image path from workspace or background geometry would include timestamp.</value>
+  </data>
 </root>
-

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3633,7 +3633,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>The workspace cannot be exported as an image because it contains nodes that are too far away from each other.</value>
   </data>
   <data name="PreferencesViewSettingIncludeTimestampExportPath" xml:space="preserve">
-    <value>Include TImestamp in Export Path</value>
+    <value>Include Timestamp in Export Path</value>
   </data>
   <data name="PreferencesViewIncludeTimestampExportPathTooltip" xml:space="preserve">
     <value>This setting controls if the export image path from workspace or background geometry would include timestamp.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3632,4 +3632,10 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="CantExportWorkspaceAsImageNotValidMessage" xml:space="preserve">
     <value>The workspace cannot be exported as an image because it contains nodes that are too far away from each other.</value>
   </data>
+  <data name="PreferencesViewSettingIncludeTimestampExportPath" xml:space="preserve">
+    <value>Include TImestamp in Export Path</value>
+  </data>
+  <data name="PreferencesViewIncludeTimestampExportPathTooltip" xml:space="preserve">
+    <value>This setting controls if the export image path from workspace or background geometry would include timestamp.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2786,7 +2786,7 @@ namespace Dynamo.ViewModels
             if (!string.IsNullOrEmpty(model.CurrentWorkspace.FileName))
             {
                 var fi = new FileInfo(model.CurrentWorkspace.FileName);
-                var snapshotName = PathHelper.GetScreenCaptureNameFromPath(fi.FullName);
+                var snapshotName = PathHelper.GetScreenCaptureNameFromPath(fi.FullName, preferencesViewModel.IsTimeStampIncludedInExportFilePath);
                 _fileDialog.InitialDirectory = fi.DirectoryName;
                 _fileDialog.FileName = snapshotName;
             }

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -368,6 +368,22 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Controls the IsChecked property in the selecting to include timestamp for export path section
+        /// </summary>
+        public bool IsTimeStampIncludedInExportFilePath
+        {
+            get
+            {
+                return preferenceSettings.IsTimeStampIncludedInExportFilePath;
+            }
+            set
+            {
+                preferenceSettings.IsTimeStampIncludedInExportFilePath = value;
+                RaisePropertyChanged(nameof(IsTimeStampIncludedInExportFilePath));
+            }
+        }
+
+        /// <summary>
         /// Controls the Enabled property in the Show Run Preview toogle button
         /// </summary>
         public bool RunPreviewEnabled

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -221,6 +221,7 @@
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
 
                                 <!--The first Grid Row will contain the Language label and combobox added in a StackPanel vertical-->
@@ -366,8 +367,43 @@
                                     </Grid>
                                 </Grid>
 
-                                <!--This Grid contains Expanders for Run, Default Geometry Scaling and Backup settings-->
+                                <!--This Grid contains controls for selecting to include timestamp for export path -->
                                 <Grid Grid.Row="4"
+                                  Margin="14,0,0,20">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <ToggleButton Width="{StaticResource ToggleButtonWidth}"
+                                                  Height="{StaticResource ToggleButtonHeight}"
+                                                  VerticalAlignment="Center"
+                                                  Margin="2,0,0,0"
+                                                  Grid.Column="0" 
+                                                  IsEnabled="True"
+                                                  IsChecked="{Binding Path=IsTimeStampIncludedInExportFilePath}"
+                                                  Style="{StaticResource EllipseToggleButton1}"/>
+                                        <Label Grid.Column="1"
+                                           Content="{x:Static p:Resources.PreferencesViewSettingIncludeTimestampExportPath}"
+                                           Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                        <Image Name="IncludeTimestampExportPathIcon"
+                                               Grid.Column="2"
+                                               Width="14"
+                                               Height="14"
+                                               Margin="10,0,0,0"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               Style="{StaticResource QuestionIcon}">
+                                            <Image.ToolTip>
+                                                    <ToolTip Content="{x:Static p:Resources.PreferencesViewIncludeTimestampExportPathTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                                            </Image.ToolTip>
+                                        </Image>
+                                    </Grid>
+                                </Grid>
+
+                                <!--This Grid contains Expanders for Run, Default Geometry Scaling and Backup settings-->
+                                <Grid Grid.Row="5"
                                   Margin="-3,0,1,20">
                                     <Grid HorizontalAlignment="Stretch">
                                         <Grid.RowDefinitions>

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -276,6 +276,19 @@ namespace DynamoUtilities
             return false;
         }
 
+        /// This is a utility method for generating a default name to the snapshot image. 
+        /// </summary>
+        /// <param name="filePath">File path</param>
+        /// <returns>Returns a default name(along with the timestamp) for the workspace image</returns>
+        [Obsolete("This function will be removed in future version of Dynamo - please use the version with more parameters")]
+        public static String GetScreenCaptureNameFromPath(String filePath)
+        {
+            FileInfo fileInfo = new FileInfo(filePath);
+            String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
+            String snapshotName = fileInfo.Name.Replace(fileInfo.Extension, "_") + timeStamp;
+            return snapshotName;
+        }
+
         /// <summary>
         /// This is a utility method for generating a default name to the snapshot image. 
         /// </summary>

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -280,13 +280,22 @@ namespace DynamoUtilities
         /// This is a utility method for generating a default name to the snapshot image. 
         /// </summary>
         /// <param name="filePath">File path</param>
+        /// <param name="isTimeStampIncluded">Is timestamp included in file path</param>
         /// <returns>Returns a default name(along with the timestamp) for the workspace image</returns>
-        public static String GetScreenCaptureNameFromPath(String filePath)
+        public static String GetScreenCaptureNameFromPath(String filePath, bool isTimeStampIncluded)
         {
             FileInfo fileInfo = new FileInfo(filePath);
-            String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
-            String snapshotName = fileInfo.Name.Replace(fileInfo.Extension, "_") + timeStamp;
-            return snapshotName;
+            if (isTimeStampIncluded)
+            {
+                String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
+                String snapshotName = fileInfo.Name.Replace(fileInfo.Extension, "_") + timeStamp;
+                return snapshotName;
+            }
+            else
+            {
+                return fileInfo.Name.Replace(fileInfo.Extension, string.Empty);
+            }
+
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -832,8 +832,10 @@ namespace Dynamo.Tests
         public void GenerateSnapshotNameTest()
         {
             var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
-            var snapshotName = PathHelper.GetScreenCaptureNameFromPath(examplePath);
+            var snapshotName = PathHelper.GetScreenCaptureNameFromPath(examplePath, true);
             Assert.AreEqual(snapshotName, "Add_" + string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now));
+            var snapshotNameWithoutTimestamp = PathHelper.GetScreenCaptureNameFromPath(examplePath, false);
+            Assert.AreEqual(snapshotNameWithoutTimestamp, "Add");
         }
     }
 }

--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -67,6 +67,7 @@
   <HideAutocompleteMethodOptions>true</HideAutocompleteMethodOptions>
   <EnableNotificationCenter>false</EnableNotificationCenter>
   <EnableStaticSplashScreen>false</EnableStaticSplashScreen>
+  <IsTimeStampIncludedInExportFilePath>false</IsTimeStampIncludedInExportFilePath>
   <EnablePersistExtensions>true</EnablePersistExtensions>
   <DefaultPythonEngine/>
   <SelectedPackagePathForInstall>C:\Users\user\AppData\Roaming\Dynamo\Dynamo Core\2.16</SelectedPackagePathForInstall>


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per Follow up of https://github.com/DynamoDS/Dynamo/pull/14068, make a preferences setting for Dynamo user if the export file should include time stamp or not.

By default, this setting is turned on and consistent with legacy versions of Dynamo.
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/a5cd34b1-7e95-42f9-ad40-bbedb15a3820)


Once turned off
The export behavior will be what @chuongmep desired

New setting added to preferences file:
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/1733620d-1d77-41c4-86b5-5bf426615e79)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Dynamo user can now choose if they prefer the export file path include time stamp or not.


### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
