### PR TITLE
DYN-5931 Lucene Search typo tolerance changes

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -1,9 +1,8 @@
-using Dynamo.Properties;
-using Dynamo.Utilities;
-using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dynamo.Properties;
+using Dynamo.Utilities;
 
 namespace Dynamo.Configuration
 {
@@ -50,53 +49,6 @@ namespace Dynamo.Configuration
         /// </summary>
         [Obsolete("This property is no longer used. Remove in Dynamo 3.0")]
         public static readonly double MaxWatchNodeHeight = 310.0;
-
-        /// <summary>
-        /// Specify the Lucene.Net compatibility version
-        /// </summary>
-        public static LuceneVersion LuceneNetVersion = LuceneVersion.LUCENE_48;
-
-
-        /// <summary>
-        /// This represent the fields that will be indexed when initializing Lucene Search
-        /// </summary>
-        public enum IndexFieldsEnum
-        {
-            /// <summary>
-            /// Name - The name of the node
-            /// </summary>
-            Name,
-            /// <summary>
-            /// FullCategoryName - The category of the node
-            /// </summary>
-            FullCategoryName,
-            /// <summary>
-            /// Description - The description of the node
-            /// </summary>
-            Description,
-            /// <summary>
-            /// SearchKeywords - Several keywords that will be used when searching any word (this values are coming from xml files like BuiltIn.xml, DesignScriptBuiltin.xml or ProtoGeometry.xml)
-            /// </summary>
-            SearchKeywords,
-            /// <summary>
-            /// DocName - Name of the Document
-            /// </summary>
-            DocName,
-            /// <summary>
-            /// Documentation - Documentation of the node
-            /// </summary>
-            Documentation
-        }
-
-        /// <summary>
-        /// Fields to be indexed by Lucene Search
-        /// </summary>
-        public static string[] IndexFields = { nameof(IndexFieldsEnum.Name),
-                                               nameof(IndexFieldsEnum.FullCategoryName),
-                                               nameof(IndexFieldsEnum.Description),
-                                               nameof(IndexFieldsEnum.SearchKeywords),
-                                               nameof(IndexFieldsEnum.DocName),
-                                               nameof(IndexFieldsEnum.Documentation)};
 
         #endregion
 

--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -24,15 +24,25 @@ namespace Dynamo.Configuration
         internal static float MinimumSimilarity = 0.5f;
 
         /// <summary>
+        /// Minimal length of the search term that the fuzzy search to take effect
+        /// </summary>
+        internal static int FuzzySearchMinimalTermLength = 4;
+
+        /// <summary>
         /// Minimal edits for typo check in FuzzyQuery
         /// </summary>
-        internal static int MinEdits = 1;
+        internal static int FuzzySearchMinEdits = 1;
+
+        /// <summary>
+        /// Minimal length of the search term that the fuzzy search max edits limit to take effect
+        /// </summary>
+        internal static int FuzzySearchMaxEditsThreshold = 6;
 
         /// <summary>
         /// Maximal edits for typo check in FuzzyQuery, value larger than 3 is not proper according to
         /// https://blog.mikemccandless.com/2011/03/lucenes-fuzzyquery-is-100-times-faster.html
         /// </summary>
-        internal static int MaxEdits = 2;
+        internal static int FuzzySearchMaxEdits = 2;
 
         /// <summary>
         /// Default max results count in Dynamo to display
@@ -43,6 +53,26 @@ namespace Dynamo.Configuration
         /// Search name matching weight
         /// </summary>
         internal static int SearchNameWeight = 10;
+
+        /// <summary>
+        /// Wildcards search name matching weight
+        /// </summary>
+        internal static int WildcardsSearchNameWeight = 7;
+
+        /// <summary>
+        /// Search non-name meta fields matching weight
+        /// </summary>
+        internal static int SearchMetaFieldsWeight = 6;
+
+        /// <summary>
+        /// Wildcards search non-name meta fields matching weight
+        /// </summary>
+        internal static int WildcardsSearchMetaFieldsWeight = 4;
+
+        /// <summary>
+        /// Fuzzy search matching weight
+        /// </summary>
+        internal static int FuzzySearchWeight = 2;
 
         /// <summary>
         /// This represent the fields that will be indexed when initializing Lucene Search

--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Minimal length of the search term that the fuzzy search max edits limit to take effect
         /// </summary>
-        internal static int FuzzySearchMaxEditsThreshold = 6;
+        internal static int FuzzySearchMaxEditsThreshold = 7;
 
         /// <summary>
         /// Maximal edits for typo check in FuzzyQuery, value larger than 3 is not proper according to

--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -1,0 +1,71 @@
+using Lucene.Net.QueryParsers.Classic;
+using Lucene.Net.Util;
+
+namespace Dynamo.Configuration
+{
+    /// <summary>
+    /// This class includes all settings of Lucene search
+    /// </summary>
+    internal class LuceneConfig
+    {
+        /// <summary>
+        /// Specify the Lucene.Net compatibility version
+        /// </summary>
+        public static LuceneVersion LuceneNetVersion = LuceneVersion.LUCENE_48;
+
+        /// <summary>
+        /// Default operator for Lucence query parser
+        /// </summary>
+        internal static Operator DefaultOperator = Operator.OR;
+
+        internal static float MinimumSimilarity = 0.5f;
+
+        internal static int DefaultResultsCount = 50;
+
+        /// <summary>
+        /// This represent the fields that will be indexed when initializing Lucene Search
+        /// </summary>
+        public enum IndexFieldsEnum
+        {
+            /// <summary>
+            /// Name - The name of the node
+            /// </summary>
+            Name,
+
+            /// <summary>
+            /// FullCategoryName - The category of the node
+            /// </summary>
+            FullCategoryName,
+
+            /// <summary>
+            /// Description - The description of the node
+            /// </summary>
+            Description,
+
+            /// <summary>
+            /// SearchKeywords - Several keywords that will be used when searching any word (this values are coming from xml files like BuiltIn.xml, DesignScriptBuiltin.xml or ProtoGeometry.xml)
+            /// </summary>
+            SearchKeywords,
+
+            /// <summary>
+            /// DocName - Name of the Document
+            /// </summary>
+            DocName,
+
+            /// <summary>
+            /// Documentation - Documentation of the node
+            /// </summary>
+            Documentation
+        }
+
+        /// <summary>
+        /// Fields to be indexed by Lucene Search
+        /// </summary>
+        public static string[] IndexFields = { nameof(IndexFieldsEnum.Name),
+                                               nameof(IndexFieldsEnum.FullCategoryName),
+                                               nameof(IndexFieldsEnum.Description),
+                                               nameof(IndexFieldsEnum.SearchKeywords),
+                                               nameof(IndexFieldsEnum.DocName),
+                                               nameof(IndexFieldsEnum.Documentation)};
+    }
+}

--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -18,9 +18,31 @@ namespace Dynamo.Configuration
         /// </summary>
         internal static Operator DefaultOperator = Operator.OR;
 
+        /// <summary>
+        /// MinimumSimilarity value
+        /// </summary>
         internal static float MinimumSimilarity = 0.5f;
 
+        /// <summary>
+        /// Minimal edits for typo check in FuzzyQuery
+        /// </summary>
+        internal static int MinEdits = 1;
+
+        /// <summary>
+        /// Maximal edits for typo check in FuzzyQuery, value larger than 3 is not proper according to
+        /// https://blog.mikemccandless.com/2011/03/lucenes-fuzzyquery-is-100-times-faster.html
+        /// </summary>
+        internal static int MaxEdits = 2;
+
+        /// <summary>
+        /// Default max results count in Dynamo to display
+        /// </summary>
         internal static int DefaultResultsCount = 50;
+
+        /// <summary>
+        /// Search name matching weight
+        /// </summary>
+        internal static int SearchNameWeight = 10;
 
         /// <summary>
         /// This represent the fields that will be indexed when initializing Lucene Search

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -520,7 +520,7 @@ namespace Dynamo.Core
                 xmlDoc.Save(savePath);
                 return true;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return false;
             }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -632,14 +632,14 @@ namespace Dynamo.Models
             indexDir = Lucene.Net.Store.FSDirectory.Open(indexPath);
 
             // Create an analyzer to process the text
-            SearchModel.Analyzer = new StandardAnalyzer(Configurations.LuceneNetVersion);
+            SearchModel.Analyzer = new StandardAnalyzer(LuceneConfig.LuceneNetVersion);
 
             // When running parallel tests several are trying to write in the AppData folder then the job
             // is failing and in a wrong state so we prevent to initialize Lucene index writer during test mode.
             if (!IsTestMode)
             {
                 // Create an index writer
-                IndexWriterConfig indexConfig = new IndexWriterConfig(Configurations.LuceneNetVersion, SearchModel.Analyzer)
+                IndexWriterConfig indexConfig = new IndexWriterConfig(LuceneConfig.LuceneNetVersion, SearchModel.Analyzer)
                 {
                     OpenMode = OpenMode.CREATE
                 };
@@ -3274,12 +3274,12 @@ namespace Dynamo.Models
         {
             if (IsTestMode) return null;
 
-            var name = new TextField(nameof(Configurations.IndexFieldsEnum.Name), string.Empty, Field.Store.YES);
-            var fullCategory = new TextField(nameof(Configurations.IndexFieldsEnum.FullCategoryName), string.Empty, Field.Store.YES);
-            var description = new TextField(nameof(Configurations.IndexFieldsEnum.Description), string.Empty, Field.Store.YES);
-            var keywords = new TextField(nameof(Configurations.IndexFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
-            var docName = new StringField(nameof(Configurations.IndexFieldsEnum.DocName), string.Empty, Field.Store.YES);
-            var fullDoc = new TextField(nameof(Configurations.IndexFieldsEnum.Documentation), string.Empty, Field.Store.YES);
+            var name = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Name), string.Empty, Field.Store.YES);
+            var fullCategory = new TextField(nameof(LuceneConfig.IndexFieldsEnum.FullCategoryName), string.Empty, Field.Store.YES);
+            var description = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Description), string.Empty, Field.Store.YES);
+            var keywords = new TextField(nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
+            var docName = new StringField(nameof(LuceneConfig.IndexFieldsEnum.DocName), string.Empty, Field.Store.YES);
+            var fullDoc = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Documentation), string.Empty, Field.Store.YES);
 
             var d = new Document()
             {
@@ -3303,10 +3303,10 @@ namespace Dynamo.Models
             if (IsTestMode) return;
             if (addedFields == null) return;
 
-            SetDocumentFieldValue(doc, nameof(Configurations.IndexFieldsEnum.FullCategoryName), node.FullCategoryName);
-            SetDocumentFieldValue(doc, nameof(Configurations.IndexFieldsEnum.Name), node.Name);
-            SetDocumentFieldValue(doc, nameof(Configurations.IndexFieldsEnum.Description), node.Description);
-            if (node.SearchKeywords.Count > 0) SetDocumentFieldValue(doc, nameof(Configurations.IndexFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
+            SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.FullCategoryName), node.FullCategoryName);
+            SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Name), node.Name);
+            SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Description), node.Description);
+            if (node.SearchKeywords.Count > 0) SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
 
             writer?.AddDocument(doc);
         }
@@ -3328,7 +3328,7 @@ namespace Dynamo.Models
             }
             if (isLast)
             {
-                List<string> diff = Configurations.IndexFields.Except(addedFields).ToList();
+                List<string> diff = LuceneConfig.IndexFields.Except(addedFields).ToList();
                 foreach (var d in diff)
                 {
                     SetDocumentFieldValue(doc, d, "");

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -993,7 +993,7 @@ namespace Dynamo.ViewModels
         private string CreateSearchQuery(string[] fields, string SearchTerm)
         {
             int fuzzyLogicMaxEdits = LuceneConfig.FuzzySearchMinEdits;
-            // Use a larger max edit value when search term is longer 
+            // Use a larger max edit value - more tolerant with typo when search term is longer than threshold
             if (SearchTerm.Length > LuceneConfig.FuzzySearchMaxEditsThreshold)
             {
                 fuzzyLogicMaxEdits = LuceneConfig.FuzzySearchMaxEdits;


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Per [DYN-5931](https://jira.autodesk.com/browse/DYN-5931), making changes to where all Lucene settings are and trying to modify our fuzzy search param. But from my own testing, it seems the FuzzyMinSim is always 2 (max edits) regardless of the float value. 

More to read at https://stackoverflow.com/questions/18317546/changing-similarity-in-lucene-fuzzyquery and https://blog.mikemccandless.com/2011/03/lucenes-fuzzyquery-is-100-times-faster.html

- When the search term length is less than 4, no typo is allowed
- When the search term length is between 5 to 7, typo with one edit is allowed
- When the search term length is larger than or equal to 8, typo with two edits are allowed

Example:
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/f6d90550-ac3d-438f-a681-c544780c36d0)
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/451ba688-2f2b-4b92-8056-9379ad8091fa)

If the max edits are larger than 2, in the following case, the max edits would be 3, then no results would be shown. This matches what the author blog post wrote but I failed to find a way to make the max edits value less than 2
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/a0ce2b0f-7397-4d1d-8d28-c1d0fb8c414d)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
