### PR TITLE
Point the BinDiff job to Release builds

### DIFF
--- a/.github/workflows/dynamoBinDiff.yml
+++ b/.github/workflows/dynamoBinDiff.yml
@@ -20,17 +20,17 @@ jobs:
       run: |
         echo "***Continue with the build, Good luck developer!***"
         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln /p:Configuration=Release
     - name: Confirm Dynamo Build (current)
       run: |
-        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug"
+        cd "$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Release"
         echo "***Locating DynamoSandbox after current build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
     - name: Cache Current Build
       uses: actions/cache/save@v3
       with:
         path: |
-           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+           ${{ github.workspace }}\Dynamo\bin\AnyCPU\Release
            ${{ github.workspace }}\Dynamo\.github\scripts
         key: ${{ github.run_id }}-${{ github.run_attempt }}-cache-current
  build-master:
@@ -50,16 +50,16 @@ jobs:
       run: |
         echo "***Continue with the build, Good luck developer!***"
         cd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\master_Dynamo\src\Dynamo.All.sln /p:Configuration=Release
     - name: Confirm Dynamo Build (master)
       run: |
-        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug"
+        cd "$Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Release"
         echo "***Locating DynamoSandbox after master build!***"
         test ".\DynamoSandbox.exe" && echo "DynamoSandbox exists!"
     - name: Cache Master Build
       uses: actions/cache/save@v3
       with:
-        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Release
         key: ${{ github.run_id }}-${{ github.run_attempt }}-cache-master
  run-bin-diff:
   needs: [build-current, build-master]
@@ -70,21 +70,21 @@ jobs:
       with:
         fail-on-cache-miss: true
         path: |
-          ${{ github.workspace }}\Dynamo\bin\AnyCPU\Debug
+          ${{ github.workspace }}\Dynamo\bin\AnyCPU\Release
           ${{ github.workspace }}\Dynamo\.github\scripts
         key: ${{ github.run_id }}-${{ github.run_attempt }}-cache-current
     - name: Restore Master Build
       uses: actions/cache/restore@v3
       with:
         fail-on-cache-miss: true
-        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Debug
+        path: ${{ github.workspace }}\master_Dynamo\bin\AnyCPU\Release
         key: ${{ github.run_id }}-${{ github.run_attempt }}-cache-master
     - name: Run Binary Diff Job
       id: Diff1
       run: |
           echo "***Running the binary diff job between the current branch and the master branch!***"
           cd "$Env:GITHUB_WORKSPACE\Dynamo\.github\scripts"
-          .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Debug,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Debug -src ${{ github.job }}
+          .\bin_diff.ps1 $Env:GITHUB_WORKSPACE\master_Dynamo\bin\AnyCPU\Release,$Env:GITHUB_WORKSPACE\Dynamo\bin\AnyCPU\Release -src ${{ github.job }}
           echo "Diff1=$(cat ./result.txt)" >> $Env:GITHUB_OUTPUT
   outputs:
     Diff1: ${{ steps.Diff1.outputs.Diff1 }}


### PR DESCRIPTION
### Purpose

Updating the bin diff jobs to point to release builds

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@mjkkirschner 
