### PR TITLE
DYN-5835: Deliver the .net6 dynamocoreruntime builds

### DIFF
--- a/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
+++ b/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
@@ -18,6 +18,6 @@
     </metadata>
     <files>
         <!--we expect that the base path is bin\NET60_Windows\Release\-->
-        <file src="..\..\NET60_Windows\Release\**" target="lib\net6.0\windows\" />
+        <file src="NET60_Windows\Release\**" target="lib\net6.0\windows\" />
     </files>
 </package>

--- a/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
+++ b/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <id>DynamoVisualProgramming.Net6CoreRuntime</id>
+        <id>DynamoVisualProgramming.CoreRuntimeNet6</id>
         <version>$Version$</version>
         <authors>Autodesk</authors>
         <owners>Autodesk</owners>
@@ -17,7 +17,7 @@
         </dependencies>
     </metadata>
     <files>
-        <!--we expect that the base path is bin\NET60_Linux\Release\-->
+        <!--we expect that the base path is bin\NET60_Windows\Release\-->
         <file src="..\..\NET60_Windows\Release\**" target="lib\net6.0\windows\" />
     </files>
 </package>

--- a/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
+++ b/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
@@ -18,6 +18,6 @@
     </metadata>
     <files>
         <!--we expect that the base path is bin\NET60_Windows\Release\-->
-        <file src="NET60_Windows\Release\**" target="lib\net6.0\windows\" />
+        <file src="**" target="lib\net6.0\windows\" />
     </files>
 </package>

--- a/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
+++ b/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.CoreRuntimeNet6.nuspec
@@ -17,7 +17,6 @@
         </dependencies>
     </metadata>
     <files>
-        <!--we expect that the base path is bin\NET60_Windows\Release\-->
         <file src="**" target="lib\net6.0\windows\" />
     </files>
 </package>

--- a/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.Net6CoreRuntime.nuspec
+++ b/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.Net6CoreRuntime.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>DynamoVisualProgramming.Net6CoreRuntime</id>
+        <version>$Version$</version>
+        <authors>Autodesk</authors>
+        <owners>Autodesk</owners>
+        <license type="expression">Apache-2.0</license>
+        <projectUrl>https://github.com/DynamoDS/Dynamo</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Assemblies required to start a DynamoModel and execute DesignScript code bundled along with their dependencies.
+            Built targeting Windows Net6. </description>
+        <copyright>Copyright Autodesk 2023</copyright>
+ <dependencies>
+            <group targetFramework="net6.0">
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <!--we expect that the base path is bin\NET60_Linux\Release\-->
+        <file src="..\..\NET60_Windows\Release\**" target="lib\net6.0\windows\" />
+    </files>
+</package>

--- a/tools/NuGet/template-net60-core/DynamoVisualProgramming.ServiceCoreRuntime.nuspec
+++ b/tools/NuGet/template-net60-core/DynamoVisualProgramming.ServiceCoreRuntime.nuspec
@@ -17,8 +17,6 @@
         </dependencies>
     </metadata>
     <files>
-        <!--we expect that the base path is bin\NET60_Linux\Release\-->
-        <file src="..\..\NET60_Windows\Release\**" target="lib\net6.0\windows\" />
         <file src="**" target="lib\net6.0\linux\" />
     </files>
 </package>


### PR DESCRIPTION
### Purpose

This pull request does:
* add a new template for a net6 windows core package
* remove windows binaries from the existing service net6 runtime

I new job, `Dynamo>DynamoSelfServ>net60_windows_target-release` has been added for daily releases on `master-5`

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
