### PR TITLE
DYN-5821-AddToWorkspace-DocumentationBrowser

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2269,10 +2269,13 @@ namespace Dynamo.Models
 
             CurrentWorkspace.UpdateWithExtraWorkspaceViewInfo(viewInfo, offsetX, offsetY);
 
-            List<NoteModel> insertedNotes = GetInsertedNotes(viewInfo.Annotations);
+            if(viewInfo != null)
+            {
+                List<NoteModel> insertedNotes = GetInsertedNotes(viewInfo.Annotations);
+                DynamoSelection.Instance.Selection.AddRange(insertedNotes);
+            }           
 
-            DynamoSelection.Instance.Selection.AddRange(nodes);
-            DynamoSelection.Instance.Selection.AddRange(insertedNotes);
+            DynamoSelection.Instance.Selection.AddRange(nodes); 
             
             currentWorkspace.HasUnsavedChanges = true;
         }
@@ -3735,6 +3738,8 @@ namespace Dynamo.Models
 
         private bool NotesAlreadyLoaded(IEnumerable<ExtraAnnotationViewInfo> notes)
         {
+            if (notes == null) return false;
+
             foreach (var note in notes)
             {
                 if (currentWorkspace.Notes.Any(n => n.GUID.ToString() == note.Id))
@@ -3743,7 +3748,7 @@ namespace Dynamo.Models
                     return true;
                 }
             }
-            // If no nodes exist with the same GUID, then we are good to go
+            // If no notes exist with the same GUID, then we are good to go
             return false;
         }
         #endregion


### PR DESCRIPTION
### Purpose
Preventing crash when inserting xml dyn graph files into workspace.
I've added some validations so when we are trying to insert a xml dyn file graph without notes, inserting doesn't crash (otherwise the graph is not added).


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Preventing crash when inserting xml dyn graph files into workspace.


### Reviewers

@QilongTang @reddyashish 

### FYIs


