### PR TITLE
DYN-5975 Indexing Package Nodes.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1626,6 +1626,7 @@ namespace Dynamo.Models
             // is failing and in a wrong state so we prevent to initialize Lucene index writer during test mode.
             // Without the index files on disk, the dirReader cant be initialized correctly. So does the searcher.
             LuceneSearchUtility.CommitWriterChanges();
+            LuceneSearchUtility.DisposeWriter();
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1359,12 +1359,8 @@ namespace Dynamo.Models
                 PreferenceSettings.MessageLogged -= LogMessage;
             }
 
-            if (!IsTestMode)
-            {
-                //The writer have to be disposed at DynamoModel level due that we could index package-nodes as new packages are installed
-                LuceneSearchUtility.writer?.Dispose();
-                LuceneSearchUtility.writer = null;
-            }
+            //The writer have to be disposed at DynamoModel level due that we could index package-nodes as new packages are installed
+            LuceneSearchUtility.DisposeWriter();
 
             // Lucene disposals (just if LuceneNET was initialized)
             LuceneSearchUtility.indexDir?.Dispose();
@@ -1431,11 +1427,7 @@ namespace Dynamo.Models
                     AddNodeTypeToSearchIndex(searchElement, iDoc);
                 }
 
-                if (!IsTestMode)
-                {
-                    //Commit the packages node info indexed
-                    LuceneSearchUtility.writer?.Commit();
-                }
+                LuceneSearchUtility.CommitWriterChanges();
 
                 Action<CustomNodeInfo> infoUpdatedHandler = null;
                 infoUpdatedHandler = newInfo =>
@@ -1633,10 +1625,7 @@ namespace Dynamo.Models
             // When running parallel tests several are trying to write in the AppData folder then the job
             // is failing and in a wrong state so we prevent to initialize Lucene index writer during test mode.
             // Without the index files on disk, the dirReader cant be initialized correctly. So does the searcher.
-            if (!IsTestMode)
-            {
-                LuceneSearchUtility.writer?.Commit();
-            }
+            LuceneSearchUtility.CommitWriterChanges();
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1626,7 +1626,6 @@ namespace Dynamo.Models
             // is failing and in a wrong state so we prevent to initialize Lucene index writer during test mode.
             // Without the index files on disk, the dirReader cant be initialized correctly. So does the searcher.
             LuceneSearchUtility.CommitWriterChanges();
-            LuceneSearchUtility.DisposeWriter();
         }
 
         /// <summary>

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.QueryParsers.Classic;
 using Lucene.Net.Search;
+using Lucene.Net.Store;
 
 namespace Dynamo.Utilities
 {
@@ -58,7 +59,15 @@ namespace Dynamo.Utilities
                 {
                     OpenMode = OpenMode.CREATE
                 };
-                writer = new IndexWriter(indexDir, indexConfig);
+                try
+                {
+                    writer = new IndexWriter(indexDir, indexConfig);
+                }
+                catch(LockObtainFailedException ex)
+                {
+                    DisposeWriter();
+                    dynamoModel.Logger.LogError($"LuceneNET LockObtainFailedException {ex}");
+                }
             }
         }
 

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -248,7 +248,7 @@ namespace Dynamo.Utilities
         {
             if (!DynamoModel.IsTestMode)
             {
-                //Commit the packages node info indexed
+                //Commit the info indexed
                 writer?.Commit();
             }
         }

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -233,5 +233,24 @@ namespace Dynamo.Utilities
             }
             return booleanQuery.ToString();
         }
+
+        internal void DisposeWriter()
+        {
+            //We need to check if we are not running Dynamo tests because otherwise parallel test start to fail when trying to write in the same Lucene directory location
+            if (!DynamoModel.IsTestMode)
+            {
+                writer?.Dispose();
+                writer = null;
+            }
+        }
+
+        internal void CommitWriterChanges()
+        {
+            if (!DynamoModel.IsTestMode)
+            {
+                //Commit the packages node info indexed
+                writer?.Commit();
+            }
+        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -939,6 +939,10 @@ namespace Dynamo.ViewModels
         {
             if (useLucene)
             {
+                //The DirectoryReader and IndexSearcher have to be assigned after commiting indexing changes and before executing the Searcher.Search() method, otherwise new indexed info won't be reflected
+                LuceneSearchUtility.dirReader = LuceneSearchUtility.writer?.GetReader(applyAllDeletes: true);
+                LuceneSearchUtility.Searcher = new IndexSearcher(LuceneSearchUtility.dirReader);
+
                 string searchTerm = search.Trim();
                 var candidates = new List<NodeSearchElementViewModel>();
                 var parser = new MultiFieldQueryParser(LuceneConfig.LuceneNetVersion, LuceneConfig.NodeIndexFields, LuceneSearchUtility.Analyzer)

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -941,6 +941,8 @@ namespace Dynamo.ViewModels
             {
                 //The DirectoryReader and IndexSearcher have to be assigned after commiting indexing changes and before executing the Searcher.Search() method, otherwise new indexed info won't be reflected
                 LuceneSearchUtility.dirReader = LuceneSearchUtility.writer?.GetReader(applyAllDeletes: true);
+                if (LuceneSearchUtility.dirReader == null) return null;
+
                 LuceneSearchUtility.Searcher = new IndexSearcher(LuceneSearchUtility.dirReader);
 
                 string searchTerm = search.Trim();


### PR DESCRIPTION
### Purpose

Indexing installed package nodes using LuceneNET
This fix is adding the packages nodes already installed or if during Dynamo execution the user install more packages, the nodes will be also indexed so they can be shown as results in the InCanvasSearch functionality.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Indexing installed package nodes using LuceneNET


### Reviewers

@QilongTang @reddyashish 

### FYIs
