### PR TITLE
DYN-6036: Set dropdown IsModified outside WPF

### DIFF
--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -106,6 +106,7 @@ namespace CoreNodeModels
                     selectedString = GetSelectedStringFromItem(Items.ElementAt(value));
                 }
 
+                OnNodeModified();
                 RaisePropertyChanged("SelectedIndex");
                 RaisePropertyChanged("SelectedString");
             }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
@@ -38,11 +38,6 @@ namespace CoreNodeModelsWpf.Nodes
             System.Windows.Controls.Grid.SetRow(combo, 0);
 
             combo.DropDownOpened += combo_DropDownOpened;
-            combo.SelectionChanged += delegate
-            {
-                if (combo.SelectedIndex != -1)
-                    model.OnNodeModified();
-            };
 
             combo.DataContext = model;
 

--- a/test/pkgs/Dynamo Samples/extra/CustomDropdownMenuNodeSample.dyn
+++ b/test/pkgs/Dynamo Samples/extra/CustomDropdownMenuNodeSample.dyn
@@ -27,14 +27,14 @@
       ],
       "SelectedIndex": 1,
       "SelectedString": "Two",
-      "NodeType": "ExtensionNode",
       "Id": "2c9b14f9f3b04c909cbbf4fc1bf58315",
+      "NodeType": "ExtensionNode",
       "Inputs": [],
       "Outputs": [
         {
           "Id": "c4f968efd3b34cd4ae68f7e1bb073213",
-          "Name": "Value",
-          "Description": "The selected Value",
+          "Name": "value",
+          "Description": "Selected value",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -43,9 +43,47 @@
       ],
       "Replication": "Disabled",
       "Description": "A dropdown menu with customizable values."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 27.5,
+      "WatchHeight": 38.0,
+      "Id": "de5ce4eaea724bae90ddfc6d58a1907c",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "ada3f228896d48f284e7716a8b5a55ed",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "62ae1a52b09549d79e3da29c7f996db7",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
     }
   ],
-  "Connectors": [],
+  "Connectors": [
+    {
+      "Start": "c4f968efd3b34cd4ae68f7e1bb073213",
+      "End": "ada3f228896d48f284e7716a8b5a55ed",
+      "Id": "a73ae984e456400ab8da9424caf37282",
+      "IsHidden": "False"
+    }
+  ],
   "Dependencies": [],
   "NodeLibraryDependencies": [],
   "Thumbnail": "",
@@ -71,12 +109,12 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.16.0.2215",
+      "Version": "2.18.0.2986",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
     "Camera": {
-      "Name": "Background Preview",
+      "Name": "_Background Preview",
       "EyeX": -17.0,
       "EyeY": 24.0,
       "EyeZ": 50.0,
@@ -90,19 +128,29 @@
     "ConnectorPins": [],
     "NodeViews": [
       {
-        "Name": "Custom Dropdown Menu",
-        "ShowGeometry": true,
         "Id": "2c9b14f9f3b04c909cbbf4fc1bf58315",
+        "Name": "Custom Dropdown Menu",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
+        "ShowGeometry": true,
         "X": 125.0,
         "Y": 159.0
+      },
+      {
+        "Id": "de5ce4eaea724bae90ddfc6d58a1907c",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 562.9073737487314,
+        "Y": 160.17383716945719
       }
     ],
     "Annotations": [],
-    "X": 0.0,
-    "Y": 0.0,
-    "Zoom": 1.0
+    "X": -75.195648451677073,
+    "Y": 46.328897894012982,
+    "Zoom": 0.8033215934625979
   }
 }


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[DYN-6036](https://jira.autodesk.com/browse/DYN-6036)

Moves dropdowns' OnNodeModified call outside WPF so that it is also run in ui-less mode.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fix a bug where dropdown nodes were not marked as modified when the node's value was changed programatically while running in ui-less mode.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
