### PR TITLE
DYN-6037 lucene overloaded nodes

### DIFF
--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -92,7 +92,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// This represent the fields that will be indexed when initializing Lucene Search
         /// </summary>
-        public enum IndexFieldsEnum
+        public enum NodeFieldsEnum
         {
             /// <summary>
             /// Name - The name of the node
@@ -138,21 +138,21 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Nodes Fields to be indexed by Lucene Search
         /// </summary>
-        public static string[] NodeIndexFields = { nameof(IndexFieldsEnum.Name),
-                                                   nameof(IndexFieldsEnum.FullCategoryName),
-                                                   nameof(IndexFieldsEnum.Description),
-                                                   nameof(IndexFieldsEnum.SearchKeywords),
-                                                   nameof(IndexFieldsEnum.DocName),
-                                                   nameof(IndexFieldsEnum.Documentation),
-                                                   nameof(IndexFieldsEnum.Parameters)};
+        public static string[] NodeIndexFields = { nameof(NodeFieldsEnum.Name),
+                                                   nameof(NodeFieldsEnum.FullCategoryName),
+                                                   nameof(NodeFieldsEnum.Description),
+                                                   nameof(NodeFieldsEnum.SearchKeywords),
+                                                   nameof(NodeFieldsEnum.DocName),
+                                                   nameof(NodeFieldsEnum.Documentation),
+                                                   nameof(NodeFieldsEnum.Parameters)};
 
 
         /// <summary>
         /// Package Fields to be indexed by Lucene Search
         /// </summary>
-        public static string[] PackageIndexFields = { nameof(IndexFieldsEnum.Name),
-                                                      nameof(IndexFieldsEnum.Description),
-                                                      nameof(IndexFieldsEnum.SearchKeywords),
-                                                      nameof(IndexFieldsEnum.Hosts)};
+        public static string[] PackageIndexFields = { nameof(NodeFieldsEnum.Name),
+                                                      nameof(NodeFieldsEnum.Description),
+                                                      nameof(NodeFieldsEnum.SearchKeywords),
+                                                      nameof(NodeFieldsEnum.Hosts)};
     }
 }

--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -127,7 +127,12 @@ namespace Dynamo.Configuration
             /// <summary>
             /// Hosts - Package hosts
             /// </summary>
-            Hosts
+            Hosts,
+
+            /// <summary>
+            /// Parameters that are received (there are nodes with same name and category but different parameters)
+            /// </summary>
+            Parameters
         }
 
         /// <summary>
@@ -138,7 +143,8 @@ namespace Dynamo.Configuration
                                                    nameof(IndexFieldsEnum.Description),
                                                    nameof(IndexFieldsEnum.SearchKeywords),
                                                    nameof(IndexFieldsEnum.DocName),
-                                                   nameof(IndexFieldsEnum.Documentation)};
+                                                   nameof(IndexFieldsEnum.Documentation),
+                                                   nameof(IndexFieldsEnum.Parameters)};
 
 
         /// <summary>

--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -130,7 +130,7 @@ namespace Dynamo.Configuration
             Hosts,
 
             /// <summary>
-            /// Parameters that are received (there are nodes with same name and category but different parameters)
+            /// Node Input Parameters as string (there are nodes with same name and category but different parameters)
             /// </summary>
             Parameters
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3257,6 +3257,7 @@ namespace Dynamo.Models
             LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Name), node.Name);
             LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Description), node.Description);
             if (node.SearchKeywords.Count > 0) LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Parameters), node.Parameters?? string.Empty);
 
             LuceneSearchUtility.writer?.AddDocument(doc);
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3253,11 +3253,11 @@ namespace Dynamo.Models
             if (IsTestMode) return;
             if (LuceneSearchUtility.addedFields == null) return;
 
-            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.FullCategoryName), node.FullCategoryName);
-            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Name), node.Name);
-            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Description), node.Description);
-            if (node.SearchKeywords.Count > 0) LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
-            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Parameters), node.Parameters?? string.Empty);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), node.FullCategoryName);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), node.Name);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), node.Description);
+            if (node.SearchKeywords.Count > 0) LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Parameters), node.Parameters?? string.Empty);
 
             LuceneSearchUtility.writer?.AddDocument(doc);
         }

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -79,13 +79,13 @@ namespace Dynamo.Utilities
         {
             if (DynamoModel.IsTestMode) return null;
 
-            var name = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Name), string.Empty, Field.Store.YES);
-            var fullCategory = new TextField(nameof(LuceneConfig.IndexFieldsEnum.FullCategoryName), string.Empty, Field.Store.YES);
-            var description = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Description), string.Empty, Field.Store.YES);
-            var keywords = new TextField(nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
-            var docName = new StringField(nameof(LuceneConfig.IndexFieldsEnum.DocName), string.Empty, Field.Store.YES);
-            var fullDoc = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Documentation), string.Empty, Field.Store.YES);
-            var parameters = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Parameters), string.Empty, Field.Store.YES);
+            var name = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Name), string.Empty, Field.Store.YES);
+            var fullCategory = new TextField(nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), string.Empty, Field.Store.YES);
+            var description = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Description), string.Empty, Field.Store.YES);
+            var keywords = new TextField(nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
+            var docName = new StringField(nameof(LuceneConfig.NodeFieldsEnum.DocName), string.Empty, Field.Store.YES);
+            var fullDoc = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Documentation), string.Empty, Field.Store.YES);
+            var parameters = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Parameters), string.Empty, Field.Store.YES);
 
             var d = new Document()
             {
@@ -108,10 +108,10 @@ namespace Dynamo.Utilities
         {
             if (DynamoModel.IsTestMode) return null;
 
-            var name = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Name), string.Empty, Field.Store.YES);
-            var description = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Description), string.Empty, Field.Store.YES);
-            var keywords = new TextField(nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
-            var hosts = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Hosts), string.Empty, Field.Store.YES);
+            var name = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Name), string.Empty, Field.Store.YES);
+            var description = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Description), string.Empty, Field.Store.YES);
+            var keywords = new TextField(nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
+            var hosts = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Hosts), string.Empty, Field.Store.YES);
 
             var d = new Document()
             {
@@ -198,7 +198,7 @@ namespace Dynamo.Utilities
                 }
 
                 var wildcardQuery = new WildcardQuery(new Term(f, searchTerm));
-                if (f.Equals(nameof(LuceneConfig.IndexFieldsEnum.Name)))
+                if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
                 {
                     wildcardQuery.Boost = LuceneConfig.SearchNameWeight;
                 }
@@ -209,7 +209,7 @@ namespace Dynamo.Utilities
                 booleanQuery.Add(wildcardQuery, Occur.SHOULD);
 
                 wildcardQuery = new WildcardQuery(new Term(f, "*" + searchTerm + "*"));
-                if (f.Equals(nameof(LuceneConfig.IndexFieldsEnum.Name)))
+                if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
                 {
                     wildcardQuery.Boost = LuceneConfig.WildcardsSearchNameWeight;
                 }
@@ -230,7 +230,7 @@ namespace Dynamo.Utilities
                         }
                         wildcardQuery = new WildcardQuery(new Term(f, "*" + s + "*"));
 
-                        if (f.Equals(nameof(LuceneConfig.IndexFieldsEnum.Name)))
+                        if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
                         {
                             wildcardQuery.Boost = 5;
                         }

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -85,6 +85,7 @@ namespace Dynamo.Utilities
             var keywords = new TextField(nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
             var docName = new StringField(nameof(LuceneConfig.IndexFieldsEnum.DocName), string.Empty, Field.Store.YES);
             var fullDoc = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Documentation), string.Empty, Field.Store.YES);
+            var parameters = new TextField(nameof(LuceneConfig.IndexFieldsEnum.Parameters), string.Empty, Field.Store.YES);
 
             var d = new Document()
             {
@@ -93,7 +94,8 @@ namespace Dynamo.Utilities
                 description,
                 keywords,
                 fullDoc,
-                docName
+                docName,
+                parameters
             };
             return d;
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -455,17 +455,17 @@ namespace Dynamo.PackageManager
             if (DynamoModel.IsTestMode) return;
             if (LuceneSearchUtility.addedFields == null) return;
 
-            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Name), package.Name);
-            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Description), package.Description);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), package.Name);
+            LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), package.Description);
 
             if (package.Keywords.Count() > 0)
             {
-                LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.SearchKeywords), package.Keywords);
+                LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), package.Keywords);
             }
 
             if (package.Hosts != null && string.IsNullOrEmpty(package.Hosts.ToString()))
             {
-                LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.IndexFieldsEnum.Hosts), package.Hosts.ToString(), true, true);
+                LuceneSearchUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Hosts), package.Hosts.ToString(), true, true);
             }
 
             LuceneSearchUtility.writer?.AddDocument(doc);
@@ -1132,7 +1132,7 @@ namespace Dynamo.PackageManager
                     Document resultDoc = LuceneSearchUtility.Searcher.Doc(topDocs.ScoreDocs[i].Doc);
 
                     // Get the view model of the package element and add it to the results.
-                    string name = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.Name));
+                    string name = resultDoc.Get(nameof(LuceneConfig.NodeFieldsEnum.Name));
 
                     var foundPackage = GetViewModelForPackageSearchElement(name);
                     if (foundPackage != null)

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -962,10 +962,10 @@ namespace Dynamo.ViewModels
                     // read back a Lucene doc from results
                     Document resultDoc = LuceneSearchUtility.Searcher.Doc(topDocs.ScoreDocs[i].Doc);
 
-                    string name = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.Name));
-                    string docName = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.DocName));
-                    string cat = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.FullCategoryName));
-                    string parameters = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.Parameters));
+                    string name = resultDoc.Get(nameof(LuceneConfig.NodeFieldsEnum.Name));
+                    string docName = resultDoc.Get(nameof(LuceneConfig.NodeFieldsEnum.DocName));
+                    string cat = resultDoc.Get(nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName));
+                    string parameters = resultDoc.Get(nameof(LuceneConfig.NodeFieldsEnum.Parameters));
 
                     if (!string.IsNullOrEmpty(docName))
                     {

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -1000,8 +1000,11 @@ namespace Dynamo.ViewModels
             var result = Model.SearchEntries.Where(e => {
                 if (e.Name.Equals(nodeName) && e.FullCategoryName.Equals(nodeCategory))
                 {
+                    //When the node info was indexed if Parameters was null we added an empty space (null cannot be indexed)
+                    //Then in this case when searching if e.Parameters is null we need to check against empty space
                     if (e.Parameters == null)
                         return string.IsNullOrEmpty(parameters);
+                    //Parameters contain a value so we need to compare against the value indexed
                     else
                         return e.Parameters.Equals(parameters);
                 }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -965,6 +965,7 @@ namespace Dynamo.ViewModels
                     string name = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.Name));
                     string docName = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.DocName));
                     string cat = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.FullCategoryName));
+                    string parameters = resultDoc.Get(nameof(LuceneConfig.IndexFieldsEnum.Parameters));
 
                     if (!string.IsNullOrEmpty(docName))
                     {
@@ -972,7 +973,7 @@ namespace Dynamo.ViewModels
                     }
                     else
                     {
-                        var foundNode = FindViewModelForNodeNameAndCategory(name, cat);
+                        var foundNode = FindViewModelForNodeNameAndCategory(name, cat, parameters);
                         if (foundNode != null)
                         {
                             candidates.Add(foundNode);
@@ -992,13 +993,17 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="nodeName">Name of the node</param>
         /// <param name="nodeCategory">Full Category of the node</param>
+        /// <param name="parameters">Node input parameters</param>
         /// <returns></returns>
-        private NodeSearchElementViewModel FindViewModelForNodeNameAndCategory(string nodeName, string nodeCategory)
+        private NodeSearchElementViewModel FindViewModelForNodeNameAndCategory(string nodeName, string nodeCategory, string parameters)
         {
             var result = Model.SearchEntries.Where(e => {
                 if (e.Name.Equals(nodeName) && e.FullCategoryName.Equals(nodeCategory))
                 {
-                    return true;
+                    if (e.Parameters == null)
+                        return string.IsNullOrEmpty(parameters);
+                    else
+                        return e.Parameters.Equals(parameters);
                 }
                 return false;
             });


### PR DESCRIPTION
### Purpose
Fixing Lucene search result for overloaded nodes.
Some nodes were missing for the search due that were overloaded so the same node was added several times in the search results without considering the parameters.
The fix was indexing also the parameters so when executing the search we need to also match the parameters.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fixing Lucene search result for overloaded nodes.


### Reviewers

@QilongTang @reddyashish 

### FYIs

