### PR TITLE
Remove duplicate visualization tests and fixes DYN-5962

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -368,25 +368,32 @@ namespace Dynamo.UI.Controls
             files.Clear();
             foreach (var filePath in filePaths)
             {
-                var extension = Path.GetExtension(filePath).ToUpper();
-                // If not extension specified and code reach here, this means this is still a valid file 
-                // only without file type. Otherwise, simply take extension substring skipping the 'dot'.
-                var subScript = extension.IndexOf(".") == 0 ? extension.Substring(1) : "";
-                var caption = Path.GetFileNameWithoutExtension(filePath);
-
-                files.Add(new StartPageListItem(caption)
+                try
                 {
-                    ContextData = filePath,
-                    ToolTip = filePath,
-                    SubScript = subScript,
-                    ClickAction = StartPageListItem.Action.FilePath
-                });
+                    var extension = Path.GetExtension(filePath).ToUpper();
+                    // If not extension specified and code reach here, this means this is still a valid file 
+                    // only without file type. Otherwise, simply take extension substring skipping the 'dot'.
+                    var subScript = extension.IndexOf(".") == 0 ? extension.Substring(1) : "";
+                    var caption = Path.GetFileNameWithoutExtension(filePath);
+
+                    files.Add(new StartPageListItem(caption)
+                    {
+                        ContextData = filePath,
+                        ToolTip = filePath,
+                        SubScript = subScript,
+                        ClickAction = StartPageListItem.Action.FilePath
+                    });
+                }
+                catch (ArgumentException ex)
+                {
+                    DynamoViewModel.Model.Logger.Log("File path is not valid: " + ex.StackTrace);
+                }
             }
         }
 
         private void HandleRegularCommand(StartPageListItem item)
         {
-            var dvm = this.DynamoViewModel;
+            var dvm = this.DynamoViewModel; 
 
             switch (item.ContextData)
             {

--- a/src/VisualizationTests/HelixImageComparisonTests.cs
+++ b/src/VisualizationTests/HelixImageComparisonTests.cs
@@ -26,8 +26,7 @@ namespace WpfVisualizationTests
         {
             get
             {
-                return (Watch3DView)View.background_grid.Children().
-                    FirstOrDefault(c => c is Watch3DView);
+                return (Watch3DView)View.background_grid.Children().FirstOrDefault(c => c is Watch3DView);
             }
         }
 

--- a/src/VisualizationTests/HelixImageComparisonTests.cs
+++ b/src/VisualizationTests/HelixImageComparisonTests.cs
@@ -10,18 +10,27 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Media.Imaging;
-using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Controls;
 using Dynamo.Selection;
+using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
 using HelixToolkit.Wpf.SharpDX;
 using NUnit.Framework;
 
 namespace WpfVisualizationTests
 {
-
     [TestFixture]
-    public class HelixImageComparisonTests : HelixWatch3DViewModelTests
+    public class HelixImageComparisonTests : VisualizationTest
     {
+        protected Watch3DView BackgroundPreview
+        {
+            get
+            {
+                return (Watch3DView)View.background_grid.Children().
+                    FirstOrDefault(c => c is Watch3DView);
+            }
+        }
+
         #region utilities
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Remove duplicate WPFVisualizationTests

Also fixes [DYN-5962](https://jira.autodesk.com/browse/DYN-5962)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes
Remove duplicate visualization tests

### Reviewers
@mjkkirschner 

