### PR TITLE
Add samples and test package nuspecs for publishing to artifactory

### DIFF
--- a/tools/NuGet/template-artifactory/DynamoVisualProgramming.DynamoSamples.nuspec
+++ b/tools/NuGet/template-artifactory/DynamoVisualProgramming.DynamoSamples.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>DynamoVisualProgramming.DynamoSamples</id>
+        <version>$Version$</version>
+        <authors>Autodesk</authors>
+        <owners>Autodesk</owners>
+        <license type="expression">Apache-2.0</license>
+        <projectUrl>https://github.com/DynamoDS/Dynamo</projectUrl>
+        <icon>content\images\logo.png</icon>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>This package bundles all localized Sample files from the Dynamo bin Release folder.</description>
+        <copyright>Copyright Autodesk 2020</copyright>
+    </metadata>
+    <files>
+        <file src="..\..\..\bin\AnyCPU\Release\samples\**" target="Samples" />
+        <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
+    </files>
+</package>

--- a/tools/NuGet/template-artifactory/DynamoVisualProgramming.DynamoSamples.nuspec
+++ b/tools/NuGet/template-artifactory/DynamoVisualProgramming.DynamoSamples.nuspec
@@ -13,6 +13,7 @@
         <copyright>Copyright Autodesk 2020</copyright>
     </metadata>
     <files>
+        <!--These files are referenced from the bin directory since they are not harvested for the installer-->
         <file src="..\..\..\bin\AnyCPU\Release\samples\**" target="Samples" />
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
     </files>

--- a/tools/NuGet/template-artifactory/DynamoVisualProgramming.Tests.nuspec
+++ b/tools/NuGet/template-artifactory/DynamoVisualProgramming.Tests.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>DynamoVisualProgramming.Tests</id>
+        <version>$Version$</version>
+        <authors>Autodesk</authors>
+        <owners>Autodesk</owners>
+        <license type="expression">Apache-2.0</license>
+        <projectUrl>https://github.com/DynamoDS/Dynamo</projectUrl>
+        <icon>content\images\logo.png</icon>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Unit and system test infrastructure for Dynamo. It contains the following files:
+        1) DynamoCoreTests.dll
+        2) SystemTestServices.dll
+        3) TestServices.dll</description>
+        <summary>This package contains all that is required to get up and running creating tests for Dynamo libraries.</summary>
+        <copyright>Copyright Autodesk 2020</copyright>
+        <dependencies>
+            <group targetFramework=".NETFramework4.8">
+                <dependency id="DynamoVisualProgramming.Core" version="$Version$"/>
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <!--These assemblies are referenced from the bin directory since they are not harvested for the installer-->
+        <file src="..\..\..\bin\AnyCPU\Release\DynamoCoreTests.dll" target="lib\net48" />
+        <file src="..\..\..\bin\AnyCPU\Release\SystemTestServices.dll" target="lib\net48" />
+        <file src="..\..\..\bin\AnyCPU\Release\TestServices.dll" target="lib\net48" />
+        <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
+    </files>
+</package>

--- a/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.TestsNet6.nuspec
+++ b/tools/NuGet/template-net60-core-runtime/DynamoVisualProgramming.TestsNet6.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>DynamoVisualProgramming.TestsNet6</id>
+        <version>$Version$</version>
+        <authors>Autodesk</authors>
+        <owners>Autodesk</owners>
+        <license type="expression">Apache-2.0</license>
+        <projectUrl>https://github.com/DynamoDS/Dynamo</projectUrl>
+        <icon>content\images\logo.png</icon>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Unit and system test infrastructure for Dynamo. It contains the following files:
+        1) DynamoCoreTests.dll
+        2) SystemTestServices.dll
+        3) TestServices.dll</description>
+        <summary>This package contains all that is required to get up and running creating tests for Dynamo libraries.</summary>
+        <copyright>Copyright Autodesk 2020</copyright>
+        <dependencies>
+            <group targetFramework="net6.0">
+                <dependency id="DynamoVisualProgramming.CoreRuntimeNet6" version="$Version$"/>
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <!--These assemblies are referenced from the bin directory since they are not harvested for the installer-->
+        <file src="..\..\..\bin\AnyCPU\Release\DynamoCoreTests.dll" target="lib\net6.0\windows\" />
+        <file src="..\..\..\bin\AnyCPU\Release\SystemTestServices.dll" target="lib\net6.0\windows\" />
+        <file src="..\..\..\bin\AnyCPU\Release\TestServices.dll" target="lib\net6.0\windows\" />
+        <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
+    </files>
+</package>


### PR DESCRIPTION
### Purpose

Add DynamoVisualProgramming.DynamoSamples and DynamoVisualProgramming.Tests package nuspecs for publishing to artifactory.

For the time being these have been added for builds targeting only net48. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
