### PR TITLE
Dyn-5978 eliminate net6 warnings

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -344,6 +344,7 @@ namespace Dynamo.Configuration
         /// </summary>
         public int RenderPrecision { get; set; }
 
+        /// <summary>
         /// Indicates whether surface and solid edges will
         /// be rendered.
         /// </summary>

--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dynamo.Engine;
@@ -41,7 +41,6 @@ namespace Dynamo
 
             var topMost = new List<Tuple<int, NodeModel>>();
 
-            List<string> outNames;
             returns = new List<Tuple<string, string>>();
 
             // if we found output nodes, add select their inputs

--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -235,7 +235,7 @@ namespace Dynamo.Core
                             return ret;
                         }
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         return false;
                     }

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -642,12 +642,12 @@ namespace Dynamo.Engine
             priorNames = libraryServices.GetPriorNames();
         }
 
-        [Obsolete("This method is deprecated and will be removed in Dynamo 3.0")]
         /// <summary>
         /// Pre-compiles Design script code in code block node.
         /// </summary>
         /// <param name="parseParams">Container for compilation related parameters</param>
         /// <returns>true if code compilation succeeds, false otherwise</returns>
+        [Obsolete("This method is deprecated and will be removed in Dynamo 3.0")]
         public bool PreCompileCodeBlock(ref ParseParam parseParams)
         {
             return CompilerUtils.PreCompileCodeBlock(compilationCore, parseParams, priorNames);

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -635,7 +635,7 @@ namespace Dynamo.Engine
         /// <summary>
         /// Creates CompilationServices.
         /// </summary>
-        /// <param name="core">Copilation core</param>
+        /// <param name="libraryServices">Copilation core</param>
         public CompilationServices(LibraryServices libraryServices)
         {
             compilationCore = libraryServices.LibraryManagementCore;

--- a/src/DynamoCore/Extensions/StartupParams.cs
+++ b/src/DynamoCore/Extensions/StartupParams.cs
@@ -83,7 +83,6 @@ namespace Dynamo.Extensions
             this.dynamoVersion = dynamoVersion;
             this.preferences = preferences;
         }
-        [Obsolete("Use internal constructor")]
         /// <summary>
         /// Initializes a new instance of the <see cref="StartupParams"/> class.
         /// </summary>
@@ -94,6 +93,7 @@ namespace Dynamo.Extensions
         /// <param name="dynamoVersion"><see cref="Version"/> for DynamoModel</param>
         /// <param name="preferences"><see cref="IPreferences"/> for DynamoModel</param>
         /// <param name="linterManager"><see cref="LinterManager"/> for DynamoModel></param>
+        [Obsolete("Use internal constructor")]
         public StartupParams(IAuthProvider provider, IPathManager pathManager,
             ILibraryLoader libraryLoader, ICustomNodeManager customNodeManager,
             Version dynamoVersion, IPreferences preferences, LinterManager linterManager)

--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -293,6 +293,16 @@ namespace Dynamo.Graph.Connectors
         {
             var handler = Deleted;
             if (handler != null) handler();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();   
         }
     }
 }

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -1013,6 +1013,8 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         /// <param name="inportConnections">A list of connections that will be destroyed</param>
         /// <param name="outportConnections"></param>
+        /// <param name="inportPins"></param>
+        /// <param name="outportPins"></param>
         private void SaveAndDeleteConnectors(IDictionary inportConnections, IDictionary outportConnections, IDictionary inportPins, IDictionary outportPins)
         {
             //----------------------------Inputs---------------------------------
@@ -1070,6 +1072,8 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         /// <param name="inportConnections"></param>
         /// <param name="outportConnections"> List of the connections that were killed</param>
+        /// <param name="inportPins"></param>
+        /// <param name="outportPins"></param>
         /// <param name="context">context this operation is being performed in</param>
         private void LoadAndCreateConnectors(OrderedDictionary inportConnections, OrderedDictionary outportConnections,
             OrderedDictionary inportPins, OrderedDictionary outportPins, SaveContext context)

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -272,9 +272,9 @@ namespace Dynamo.Graph.Nodes
 
                 var inportConnections = new OrderedDictionary();
                 var outportConnections = new OrderedDictionary();
-                ///ConnectorPins corresponding to inports
+                // ConnectorPins corresponding to inports
                 var inportPins = new OrderedDictionary();
-                ///ConnectorPins corresponding to outports
+                // ConnectorPins corresponding to outports
                 var outportPins = new OrderedDictionary();
 
                 // disable node modification events while mutating the code
@@ -385,9 +385,9 @@ namespace Dynamo.Graph.Nodes
 
             var inportConnections = new OrderedDictionary();
             var outportConnections = new OrderedDictionary();
-            ///ConnectorPins corresponding to inports
+            // ConnectorPins corresponding to inports
             var inportPins = new OrderedDictionary();
-            ///ConnectorPins corresponding to outports
+            // ConnectorPins corresponding to outports
             var outportPins = new OrderedDictionary();
 
             //before the refactor here: https://github.com/DynamoDS/Dynamo/pull/7301
@@ -1217,9 +1217,9 @@ namespace Dynamo.Graph.Nodes
                 unusedConnections.RemoveAt(0);
             }
 
-            ///All connectorPins corresponding to INports
+            // All connectorPins corresponding to INports
             List<List<ConnectorPinModel>> inportPinsList = inportPins.Values.Cast<List<ConnectorPinModel>>().ToList();
-            ///All connectorPins corresponding to OUTports
+            // All connectorPins corresponding to OUTports
             List<List<ConnectorPinModel>> outportPinsList = outportPins.Values.Cast<List<ConnectorPinModel>>().ToList();
 
             AddConnectorPinsToConnectors(inportPinsList);

--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -66,10 +66,6 @@ namespace Dynamo.Graph.Nodes
         /// <param name="statements">A list of Statement objects whose defined 
         /// variables are to be retrieved. This list can be empty but it cannot 
         /// be null.</param>
-        /// <param name="onlyTopLevel">Set this parameter to false to retrieve 
-        /// all variables defined in nested Statement objects.</param>
-        /// <returns>Returns a list of lists of variables defined by the given 
-        /// set of Statement objects.</returns>
         internal static List<List<string>> GetStatementVariables(
             IEnumerable<Statement> statements)
         {

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -184,6 +184,11 @@ namespace Dynamo.Graph.Nodes
                 //check if the value is the same or if the value is a number check is it similar
                 ((this.Value == converted.Value) || valNumberComparison || this.Value.ToString() == converted.Value.ToString());
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
 }

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -81,6 +81,7 @@ namespace Dynamo.Graph.Nodes
                 else { type = value; }
             }
         }
+        /// <summary>
         /// The type of input this node is.
         /// </summary>
         public NodeInputTypes Type2 { get; set; }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -799,10 +799,10 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
-        [JsonConverter(typeof(DescriptionConverter))]
         /// <summary>
         ///     Description of this Node.
         /// </summary>
+        [JsonConverter(typeof(DescriptionConverter))]
         [JsonProperty(Order = 7)]
         public string Description
         {

--- a/src/DynamoCore/Graph/Nodes/NodeOutputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeOutputData.cs
@@ -109,6 +109,11 @@ namespace Dynamo.Graph.Nodes
                 //check if the value is the same or if the value is a number check is it similar
                 ((this.InitialValue == converted.InitialValue) || valNumberComparison || this.InitialValue.ToString() == converted.InitialValue.ToString());
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
 }

--- a/src/DynamoCore/Graph/Nodes/NodeOutputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeOutputData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.Serialization;
@@ -94,7 +94,7 @@ namespace Dynamo.Graph.Nodes
             {
                 valNumberComparison = Math.Abs(Convert.ToDouble(this.InitialValue, CultureInfo.InvariantCulture) - Convert.ToDouble(converted.InitialValue, CultureInfo.InvariantCulture)) < .000001;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //this just stays false.
                 valNumberComparison = false;

--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunction.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunction.cs
@@ -47,7 +47,7 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
         /// <summary>
         ///     Initializes a new instance of the <see cref="DSFunction"/> class.
         /// </summary>
-        /// <param name="description">Function descritor.</param>
+        /// <param name="functionDescription">Function descritor.</param>
         public DSFunction(FunctionDescriptor functionDescription) 
             : base(new ZeroTouchNodeController<FunctionDescriptor>(functionDescription)) 
         {

--- a/src/DynamoCore/Graph/Workspaces/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/CustomNodeWorkspaceModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -210,7 +210,7 @@ namespace Dynamo.Graph.Workspaces
         /// <summary>
         ///     A description of the workspace
         /// </summary>
-        public string Description
+        public new string Description
         {
             get { return description; }
             set

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -367,7 +367,7 @@ namespace Dynamo.Graph.Workspaces
         /// <param name="notes">Note collection of the workspace</param>
         /// <param name="annotations">Group collection of the workspace</param>
         /// <param name="presets">Preset collection of the workspace</param>
-        /// <param name="elementResolver">ElementResolver responsible for resolving 
+        /// <param name="resolver">ElementResolver responsible for resolving 
         /// a partial class name to its fully resolved name</param>
         /// <param name="info">Information for creating custom node workspace</param>
         /// <param name="verboseLogging">Indicates if detailed descriptions should be logged</param>
@@ -403,7 +403,7 @@ namespace Dynamo.Graph.Workspaces
         /// <param name="notes">Note collection of the workspace</param>
         /// <param name="annotations">Group collection of the workspace</param>
         /// <param name="presets">Preset collection of the workspace</param>
-        /// <param name="elementResolver">ElementResolver responsible for resolving 
+        /// <param name="resolver">ElementResolver responsible for resolving 
         /// a partial class name to its fully resolved name</param>
         /// <param name="info">Information for creating custom node workspace</param>
         /// <param name="verboseLogging">Indicates if detailed descriptions should be logged</param>

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -257,7 +257,7 @@ namespace Dynamo.Graph.Workspaces
         /// <param name="end"></param>
         private static void AddConnectorEdgesIncludingPinEdges(GraphLayout.Graph combinedGraph, ConnectorModel connector, Guid? start = null, Guid? end = null)
         {
-            ///Bail if there are no connectorPins
+            // Bail if there are no connectorPins
             if (connector.ConnectorPinModels.Count < 1)
             {
                 Guid startGuid = start == null ? connector.Start.Owner.GUID : (Guid)start;
@@ -268,8 +268,8 @@ namespace Dynamo.Graph.Workspaces
                 return;
             }
 
-            ///Add an edge between the left-most (start) node 
-            ///(its corresponding port) to which this connector connects, and the first connectorPin.
+            // Add an edge between the left-most (start) node 
+            // (its corresponding port) to which this connector connects, and the first connectorPin.
             combinedGraph.AddEdge(connector.Start.Owner.GUID, 
                 connector.ConnectorPinModels[0].GUID,
                 connector.Start.Center.X, 
@@ -277,8 +277,8 @@ namespace Dynamo.Graph.Workspaces
                 connector.ConnectorPinModels[0].CenterX, 
                 connector.ConnectorPinModels[0].CenterY);
 
-            ///Add an edge between all other connectorPins that follow, 
-            ///from left to right (except for last one)
+            // Add an edge between all other connectorPins that follow, 
+            // from left to right (except for last one)
             for (int i = 0; i < connector.ConnectorPinModels.Count; i++)
             {
                 if (i != connector.ConnectorPinModels.Count - 1)
@@ -292,8 +292,8 @@ namespace Dynamo.Graph.Workspaces
                 }
             }
 
-            ///Add an edge between the last connectorPin and the right-most (end) node
-            ///(its corresponding port) to which this connector connects.
+            // Add an edge between the last connectorPin and the right-most (end) node
+            // (its corresponding port) to which this connector connects.
             combinedGraph.AddEdge(connector.ConnectorPinModels[connector.ConnectorPinModels.Count - 1].GUID, 
                 connector.End.Owner.GUID,
                 connector.ConnectorPinModels[connector.ConnectorPinModels.Count - 1].CenterX, 

--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dynamo.Graph.Annotations;
@@ -20,6 +20,8 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         /// <param name="workspace">Workspace on which graph layout will be performed.</param>
         /// <param name="reuseUndoRedoGroup">If true, skip initializing new undo action group.</param>
+        /// <param name="isNodeAutoComplete"></param>
+        /// <param name="originalNodeGUID"></param>
         internal static List<GraphLayout.Graph> DoGraphAutoLayout(this WorkspaceModel workspace, bool reuseUndoRedoGroup = false, bool isNodeAutoComplete = false, Guid? originalNodeGUID = null)
         {
             if (workspace.Nodes.Count() < 2) return null;
@@ -251,6 +253,8 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         /// <param name="combinedGraph"></param>
         /// <param name="connector"></param>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
         private static void AddConnectorEdgesIncludingPinEdges(GraphLayout.Graph combinedGraph, ConnectorModel connector, Guid? start = null, Guid? end = null)
         {
             ///Bail if there are no connectorPins

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -340,6 +340,7 @@ namespace Dynamo.Graph.Workspaces
         /// <param name="inPorts">The deserialized input ports.</param>
         /// <param name="outPorts">The deserialized output ports.</param>
         /// <param name="resolver">The IdReferenceResolver used during deserialization.</param>
+        /// <param name="logger"></param>
         private static void RemapPorts(NodeModel node, PortModel[] inPorts, PortModel[] outPorts, IdReferenceResolver resolver, ILogger logger)
         {
             foreach (var p in node.InPorts)
@@ -1375,7 +1376,7 @@ namespace Dynamo.Graph.Workspaces
         /// Add a reference to a newly created object, referencing
         /// an old id.
         /// </summary>
-        /// <param name="oldid">The old id of the object.</param>
+        /// <param name="oldId">The old id of the object.</param>
         /// <param name="newObject">The new object which maps to the old id.</param>
         public void AddToReferenceMap(Guid oldId, object newObject)
         {

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -377,7 +377,7 @@ namespace Dynamo.Graph.Workspaces
             }
             else if (model is ConnectorPinModel connectorPin)
             {
-                ///The equivalent of 'deleting' a connectorPin
+                // The equivalent of 'deleting' a connectorPin
                 var matchingConnector = Connectors.FirstOrDefault(connector => connector.GUID == connectorPin.ConnectorId);
                 if (matchingConnector is null)
                 {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -157,6 +157,11 @@ namespace Dynamo.Graph.Workspaces
             //this.Height == other.Height &&
             //this.TextBlockHeight == other.TextBlockHeight;
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
     /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1575,6 +1575,7 @@ namespace Dynamo.Graph.Workspaces
         /// This method does not raise a NodesModified event. (LC notes this is clearly not true)
         /// </summary>
         /// <param name="model">The node which is being removed from the worksapce.</param>
+        /// <param name="dispose"></param>
         internal void RemoveAndDisposeNode(NodeModel model, bool dispose = true)
         {
             lock (nodes)

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2389,7 +2389,7 @@ namespace Dynamo.Graph.Workspaces
             //            ensure that any contained notes are contained properly
             LoadNotesFromAnnotations(workspaceViewInfo.Annotations);
 
-            ///This function loads ConnectorPins to the corresponding connector models.
+            // This function loads ConnectorPins to the corresponding connector models.
             LoadConnectorPins(workspaceViewInfo.ConnectorPins);
 
             // This function loads annotations from the Annotations array in the JSON format
@@ -2434,7 +2434,7 @@ namespace Dynamo.Graph.Workspaces
             //            ensure that any contained notes are contained properly
             LoadNotesFromAnnotations(workspaceViewInfo.Annotations, offsetX, offsetY);
 
-            ///This function loads ConnectorPins to the corresponding connector models.
+            // This function loads ConnectorPins to the corresponding connector models.
             LoadConnectorPins(workspaceViewInfo.ConnectorPins, offsetX, offsetY);
 
             // This function loads annotations from the Annotations array in the JSON format

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1510,7 +1510,7 @@ namespace Dynamo.Graph.Workspaces
             catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
-                throw (ex);
+                throw;
             }
         }
 

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -742,7 +742,7 @@ namespace Dynamo.Engine
                     }
                 }
             }
-            catch (Exception exception)
+            catch (Exception)
             {
                 return; // if the XML file is badly formatted, return like it doesn't exist
             }

--- a/src/DynamoCore/Linting/Rules/GraphRuleEvaluationResult.cs
+++ b/src/DynamoCore/Linting/Rules/GraphRuleEvaluationResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Dynamo.Linting.Interfaces;
 
@@ -46,6 +46,11 @@ namespace Dynamo.Linting.Rules
             if (obj is null) return false;
 
             return Equals(obj as GraphRuleEvaluationResult);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/src/DynamoCore/Linting/Rules/NodeRuleEvaluationResult.cs
+++ b/src/DynamoCore/Linting/Rules/NodeRuleEvaluationResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -49,6 +49,11 @@ namespace Dynamo.Linting.Rules
             if (obj is null) return false;
 
             return Equals(obj as NodeRuleEvaluationResult);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -1,4 +1,4 @@
-﻿using Dynamo.Configuration;
+using Dynamo.Configuration;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.NodeLoaders;
 using Dynamo.Graph.Workspaces;
@@ -612,6 +612,7 @@ namespace Dynamo.Migration
         /// function.</param>
         /// <param name="name">The name to display on the node.</param>
         /// <param name="signature">The signature of the function.</param>
+        /// <param name="inputcount"></param>
         /// <returns>Returns the XmlElement that represents a DSVarArgFunction node 
         /// with its basic function information with default attributes.</returns>
         public static XmlElement CreateVarArgFunctionNode(XmlDocument document, XmlElement oldNode,

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2072,7 +2072,7 @@ namespace Dynamo.Models
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);
-                throw e;
+                throw;
             }
         }
 
@@ -2104,7 +2104,7 @@ namespace Dynamo.Models
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);
-                throw e;
+                throw;
             }
         }
         

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2111,6 +2111,7 @@ namespace Dynamo.Models
         /// <summary>
         /// Opens a Dynamo workspace from a path to an Xml file on disk.
         /// </summary>
+        /// <param name="xmlDoc"></param>
         /// <param name="filePath">Path to file</param>
         /// <param name="forceManualExecutionMode">Set this to true to discard
         /// execution mode specified in the file and set manual mode</param>

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1165,7 +1165,7 @@ namespace Dynamo.Models
                 this.Outputs = outputs;
             }
 
-            internal static CreateProxyNodeCommand DeserializeCore(XmlElement element)
+            internal static new CreateProxyNodeCommand DeserializeCore(XmlElement element)
             {
                 var baseCommand = CreateNodeCommand.DeserializeCore(element);
                 var helper = new XmlElementHelper(element);
@@ -1987,7 +1987,7 @@ namespace Dynamo.Models
             /// <summary>
             /// A collection of <see cref="Guid"/> which identify the model objects to update.
             /// </summary>
-            public IEnumerable<Guid> ModelGuids { get { return modelGuids; } }
+            public new IEnumerable<Guid> ModelGuids { get { return modelGuids; } }
 
             /// <summary>
             /// The name of the property to update.

--- a/src/DynamoCore/Search/NodeSearchModel.cs
+++ b/src/DynamoCore/Search/NodeSearchModel.cs
@@ -48,6 +48,7 @@ namespace Dynamo.Search
         ///     Dumps the contents of search into an Xml file.
         /// </summary>
         /// <param name="fileName"></param>
+        /// <param name="dynamoPath"></param>
         internal void DumpLibraryToXml(string fileName, string dynamoPath)
         {
             if (string.IsNullOrEmpty(fileName))

--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -297,6 +297,7 @@ namespace Dynamo.Search
         /// matches any element in the tagDictionary.
         /// </summary>
         /// <param name="subset">The subset that will be used to match elements in tagDictionary.</param>
+        /// <param name="searchDict"></param>
         /// <returns></returns>
         private static Dictionary<V, double> MatchWithSubset(Dictionary<V,double> searchDict, IEnumerable<SearchElements.NodeSearchElement> subset)
         {

--- a/src/DynamoCore/Search/SearchElements/SearchElementBase.cs
+++ b/src/DynamoCore/Search/SearchElements/SearchElementBase.cs
@@ -43,7 +43,7 @@ namespace Dynamo.Search.SearchElements
         /// Higher = closer to the top of search results </value>
         public abstract double Weight { get; set; }
 
-        public virtual void Execute()
+        public new virtual void Execute()
         {
             this.OnExecuted();
         }
@@ -53,8 +53,8 @@ namespace Dynamo.Search.SearchElements
         /// </summary>
         /// <param name="ele">search element</param>
         public delegate void SearchElementHandler(SearchElementBase ele);
-        internal event SearchElementHandler Executed;
-        protected void OnExecuted()
+        internal new event SearchElementHandler Executed;
+        protected new void OnExecuted()
         {
             if (Executed != null)
             {

--- a/src/DynamoCoreWpf/Extensions/ObservableCollectionExtension.cs
+++ b/src/DynamoCoreWpf/Extensions/ObservableCollectionExtension.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using Dynamo.Wpf.ViewModels;
 
 namespace Dynamo.Wpf.Extensions
@@ -12,6 +12,7 @@ namespace Dynamo.Wpf.Extensions
         /// A method to insert an element to collection by index. If index exceeds 
         /// count of elements element will be pushed to the tail of collection.
         /// </summary>
+        /// <param name="items"></param>
         /// <param name="index">Index to insert element to.</param>
         /// <param name="entry">Element to insert.</param>
         public static void TryInsert(this ObservableCollection<ISearchEntryViewModel> items, int index, ISearchEntryViewModel entry)

--- a/src/DynamoCoreWpf/Interfaces/IShellCom.cs
+++ b/src/DynamoCoreWpf/Interfaces/IShellCom.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -198,7 +198,7 @@ namespace Dynamo.Wpf.Interfaces
         // Defined on IModalWindow - repeated here due to requirements of COM interop layer
         // --------------------------------------------------------------------------------
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime ), PreserveSig]
-        int Show ( [In] IntPtr parent );
+        new int Show ( [In] IntPtr parent );
 
         // IFileDialog-Specific interface members
         // --------------------------------------------------------------------------------
@@ -283,78 +283,78 @@ namespace Dynamo.Wpf.Interfaces
         // Defined on IModalWindow - repeated here due to requirements of COM interop layer
         // --------------------------------------------------------------------------------
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime ), PreserveSig]
-        int Show ( [In] IntPtr parent );
+        new int Show ( [In] IntPtr parent );
 
         // Defined on IFileDialog - repeated here due to requirements of COM interop layer
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetFileTypes ( [In] uint cFileTypes, [In, MarshalAs(UnmanagedType.LPArray)] COMDLG_FILTERSPEC[] rgFilterSpec );
+        new void SetFileTypes ( [In] uint cFileTypes, [In, MarshalAs(UnmanagedType.LPArray)] COMDLG_FILTERSPEC[] rgFilterSpec );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetFileTypeIndex ( [In] uint iFileType );
+        new void SetFileTypeIndex ( [In] uint iFileType );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void GetFileTypeIndex ( out uint piFileType );
+        new void GetFileTypeIndex ( out uint piFileType );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void Advise ( [In, MarshalAs ( UnmanagedType.Interface )] IFileDialogEvents pfde, out uint pdwCookie );
+        new void Advise ( [In, MarshalAs ( UnmanagedType.Interface )] IFileDialogEvents pfde, out uint pdwCookie );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void Unadvise ( [In] uint dwCookie );
+        new void Unadvise ( [In] uint dwCookie );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetOptions ( [In] FOS fos );
+        new void SetOptions ( [In] FOS fos );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void GetOptions ( out FOS pfos );
+        new void GetOptions ( out FOS pfos );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetDefaultFolder ( [In, MarshalAs ( UnmanagedType.Interface )] IShellItem psi );
+        new void SetDefaultFolder ( [In, MarshalAs ( UnmanagedType.Interface )] IShellItem psi );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetFolder ( [In, MarshalAs ( UnmanagedType.Interface )] IShellItem psi );
+        new void SetFolder ( [In, MarshalAs ( UnmanagedType.Interface )] IShellItem psi );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void GetFolder ( [MarshalAs ( UnmanagedType.Interface )] out IShellItem ppsi );
+        new void GetFolder ( [MarshalAs ( UnmanagedType.Interface )] out IShellItem ppsi );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void GetCurrentSelection ( [MarshalAs ( UnmanagedType.Interface )] out IShellItem ppsi );
+        new void GetCurrentSelection ( [MarshalAs ( UnmanagedType.Interface )] out IShellItem ppsi );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetFileName ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszName );
+        new void SetFileName ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszName );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void GetFileName ( [MarshalAs ( UnmanagedType.LPWStr )] out string pszName );
+        new void GetFileName ( [MarshalAs ( UnmanagedType.LPWStr )] out string pszName );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetTitle ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszTitle );
+        new void SetTitle ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszTitle );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetOkButtonLabel ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszText );
+        new void SetOkButtonLabel ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszText );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetFileNameLabel ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszLabel );
+        new void SetFileNameLabel ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszLabel );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void GetResult ( [MarshalAs ( UnmanagedType.Interface )] out IShellItem ppsi );
+        new void GetResult ( [MarshalAs ( UnmanagedType.Interface )] out IShellItem ppsi );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void AddPlace ( [In, MarshalAs ( UnmanagedType.Interface )] IShellItem psi, FDAP fdap );
+        new void AddPlace ( [In, MarshalAs ( UnmanagedType.Interface )] IShellItem psi, FDAP fdap );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetDefaultExtension ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszDefaultExtension );
+        new void SetDefaultExtension ( [In, MarshalAs ( UnmanagedType.LPWStr )] string pszDefaultExtension );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void Close ( [MarshalAs ( UnmanagedType.Error )] int hr );
+        new void Close ( [MarshalAs ( UnmanagedType.Error )] int hr );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetClientGuid ( [In] ref Guid guid );
+        new void SetClientGuid ( [In] ref Guid guid );
 
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void ClearClientData ( );
+        new void ClearClientData ( );
 
         // Not supported:  IShellItemFilter is not defined, converting to IntPtr
         [MethodImpl ( MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime )]
-        void SetFilter ( [MarshalAs ( UnmanagedType.Interface )] IntPtr pFilter );
+        new void SetFilter ( [MarshalAs ( UnmanagedType.Interface )] IntPtr pFilter );
 
         // Defined by IFileOpenDialog
         // ---------------------------------------------------------------------------------

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizationLibrary.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizationLibrary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Dynamo.Controls;
@@ -103,7 +103,7 @@ namespace Dynamo.Wpf
         /// <summary>
         /// Used only for testing.
         /// </summary>
-        /// <param name="nodeModel"></param>
+        /// <param name="nodeModelType"></param>
         /// <returns></returns>
         internal bool ContainsCustomizationForNodeModel(Type nodeModelType)
         {

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -632,6 +632,9 @@ namespace Dynamo.Wpf.Rendering
         /// Add a label position to the render package.
         /// </summary>
         /// <param name="label">Text to be displayed in the label</param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
         public void AddLabel(string label, double x, double y, double z)
         {
             LabelPlaces.Add(new Tuple<string, Vector3>(label, Vector3ForYUp(x, y, z)));
@@ -911,6 +914,7 @@ namespace Dynamo.Wpf.Rendering
         /// <param name="m42"></param>
         /// <param name="m43"></param>
         /// <param name="m44"></param>
+        /// <param name="id"></param>
         public void AddInstanceMatrix(float m11, float m12, float m13, float m14,
             float m21, float m22, float m23, float m24,
             float m31, float m32, float m33, float m34,
@@ -946,6 +950,7 @@ namespace Dynamo.Wpf.Rendering
         /// the second row to the Y axis of the CS, the third row to the Z axis of the CS, and the last row to the CS origin, where W = 1. 
         /// </summary>
         /// <param name="matrix"></param>
+        /// <param name="id"></param>
         public void AddInstanceMatrix(float[] matrix, Guid id)
         {
             if (!ContainsTessellationId(id))

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -845,8 +845,8 @@ namespace Dynamo.Wpf.Rendering
         /// <summary>
         /// Set an instance reference for a specific range of mesh vertices
         /// </summary>
-        /// <param name="startIndex">The index associated with the first vertex in MeshVertices we want to associate with the instance matrices
-        /// <param name="endIndex">The index associated with the last vertex in MeshVertices we want to associate with the instance matrices
+        /// <param name="startIndex">The index associated with the first vertex in MeshVertices we want to associate with the instance matrices></param>
+        /// <param name="endIndex">The index associated with the last vertex in MeshVertices we want to associate with the instance matrices></param>
         /// <param name="id">A unique id associated with this tessellation geometry for instancing</param>
         public void AddInstanceGuidForMeshVertexRange(int startIndex, int endIndex, Guid id)
         {
@@ -871,8 +871,8 @@ namespace Dynamo.Wpf.Rendering
         /// <summary>
         /// Set an instance reference for a specific range of line vertices
         /// </summary>
-        /// <param name="startIndex">The index associated with the first vertex in LineVertices we want to associate with the instance matrices
-        /// <param name="endIndex">The index associated with the last vertex in LineVertices we want to associate with the instance matrices
+        /// <param name="startIndex">The index associated with the first vertex in LineVertices we want to associate with the instance matrices></param>
+        /// <param name="endIndex">The index associated with the last vertex in LineVertices we want to associate with the instance matrices></param>
         /// <param name="id">A unique id associated with this tessellation geometry for instancing</param>
         public void AddInstanceGuidForLineVertexRange(int startIndex, int endIndex, Guid id)
         {

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -3259,6 +3259,7 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
     /// Converter is used in WatchTree.xaml
     /// It converts the value of the padding required by each list level label to the required thickness (padding from the left)
     /// It then supplies the required thickness to the margin property for each label
@@ -3537,7 +3538,7 @@ namespace Dynamo.Controls
     }
 
     /// <summary>
-    /// Converts an ICollection<AnnotationViewModel> to a string
+    /// Converts an ICollection&lt;AnnotationViewModel&gt; to a string
     /// that displays how many AnnotationViewModels there is in the
     /// Collection.
     /// </summary>

--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -276,7 +276,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This event method will be executed when the user press the Back button in the tooltip/popup
         /// </summary>
-        /// <param name="args">This parameter will contain the "sequence" of the current Step so we can get the previous Step from the list</param>
         private void GuideFlowEvents_GuidedTourPrevStep()
         {
             PreviousStep(CurrentStep.Sequence);
@@ -285,7 +284,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// This event method will be executed then the user press the Next button in the tooltip/popup
         /// </summary>
-        /// <param name="args">This parameter will contain the "sequence" of the current Step so we can get the next Step from the list</param>
         private void GuideFlowEvents_GuidedTourNextStep()
         {
             NextStep(CurrentStep.Sequence);

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -386,7 +386,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// This method will return a new HostControlInfo object populated with the information passed as parameter
         /// Basically this method store the information coming from Step and search the UIElement in the main WPF VisualTree
         /// </summary>
-        /// <param name="jsonStepInfo">Step that contains all the info deserialized from the Json file</param>
+        /// <param name="jsonHostControlInfo">Step that contains all the info deserialized from the Json file</param>
         /// <returns></returns>
         private HostControlInfo CreateHostControl(HostControlInfo jsonHostControlInfo)
         {

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -380,6 +380,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         /// <param name="sender">PackageManagerSearchViewModel</param>
         /// <param name="e">PropertyChanged</param>
+        /// <param name="uiAutomationData"></param>
         private static void PackageManagerViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e, StepUIAutomation uiAutomationData)
         {
             PackageManagerSearchViewModel packageManagerViewModel = sender as PackageManagerSearchViewModel;

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -644,6 +644,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
         /// <summary>
         /// This function will highlight a Window element (the element can be located in DynamoView or another Window or can be a MenuItem
+        /// </summary>
         /// <param name="bVisible">Indicates if the highlight should be applied or removed</param>
         internal void HighlightWindowElement(bool bVisible)
         {

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -634,7 +634,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <summary>
         /// Calculate the Popup.PlacementTarget dynamically if is the case and highlight the sub MenuItem if the information was provided
         /// </summary>
-        /// <param name="bVisible">When the Step is shown this variable will be false when is hidden(due to passing to the next Step) it will be false</param>
         internal void CalculateTargetHost()
         {
             if (HostPopupInfo.DynamicHostWindow == true)

--- a/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Step.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -499,6 +499,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         /// <param name="uiAutomationData">UIAutomation info read from a json file</param>
         /// <param name="enableUIAutomation">Enable/Disable the automation action for a specific UIElement</param>
+        /// <param name="currentFlow"></param>
         private void ExecuteUIAutomationStep(StepUIAutomation uiAutomationData, bool enableUIAutomation, Guide.GuideFlow currentFlow)
         {
             var popupBorderName = "SubmenuBorder";

--- a/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Media;
 using Dynamo.Wpf.ViewModels.GuidedTour;
 using Dynamo.Wpf.Views.GuidedTour;
@@ -26,6 +26,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <param name="width">Tooltip width</param>
         /// <param name="height">Tooltip height</param>
         /// <param name="direction">The pointer direction of the tooltip</param>
+        /// <param name="verticalTooltipOffset"></param>
         public Tooltip(HostControlInfo host, double width, double height, PointerDirection direction, double verticalTooltipOffset)
             :base(host, width, height)
         {

--- a/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Tooltip.cs
@@ -15,7 +15,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         double PointerDownWidth = 20;
         double PointerDownHeight = 10;
         double PointerTooltipOverlap = 5;
-        double PointerVerticalOffset;
+        new double PointerVerticalOffset;
         double PointerHorizontalOffset;
         enum SHADOW_DIRECTION { LEFT = 180, RIGHT = 0, BOTTOM = 270, TOP = 90};
 

--- a/src/DynamoCoreWpf/Utilities/MouseClickManager.cs
+++ b/src/DynamoCoreWpf/Utilities/MouseClickManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -41,7 +41,7 @@ namespace Dynamo.Utilities
         /// <summary>
         /// Initializes a new instance of the <see cref="MouseClickManager"/> class.
         /// </summary>
-        /// <param name="control">The control.</param>
+        /// <param name="doubleClickTimeout">The control.</param>
         public MouseClickManager(int doubleClickTimeout)
         {
             this.Clicked = false;

--- a/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
@@ -611,7 +611,7 @@ namespace Dynamo.Utilities
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/ResourceUtilities.cs
@@ -349,6 +349,7 @@ namespace Dynamo.Utilities
         /// the culture name before the file extension. Example: NoContent.html => NoContent.de-DE.html
         /// </summary>
         /// <param name="name">Resource name</param>
+        /// <param name="culture"></param>
         /// <returns>Resource name with the culture name appended before the extension</returns>
         internal static string GetResourceNameWithCultureName(string name, CultureInfo culture)
         {
@@ -382,6 +383,7 @@ namespace Dynamo.Utilities
         /// with the UI culture is found, it returns the provided main/invariant assembly.
         /// </summary>
         /// <param name="assembly">The main assembly</param>
+        /// <param name="name"></param>
         /// <returns>The resource assembly</returns>
         private static Assembly GetResourceAssembly(Assembly assembly, string name)
         {

--- a/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -101,7 +101,8 @@ namespace Dynamo.Utilities
 
         /// <summary>
         /// Calls Dispatcher event after some delay.
-        /// </summary>        
+        /// </summary>
+        /// <param name="ds"></param>
         /// <param name="delay">delay in milliseconds</param>
         /// <param name="callback">action to be called</param>
         public static async void DelayInvoke(this Dispatcher ds, int delay, Action callback)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -579,14 +579,14 @@ namespace Dynamo.ViewModels
         {
             bool isCollectionofFiveorMore = false;
 
-            ///if model is null or enginecontroller is disposed, return
+            //if model is null or enginecontroller is disposed, return
             if (model is null ||
                 model.Start is null ||
                 model.Start.Owner is null||
                 workspaceViewModel.DynamoViewModel.EngineController.IsDisposed == true)
             { return; }
 
-            ///if it is possible to get the last value of the model.Start.Owner
+            //if it is possible to get the last value of the model.Start.Owner
             try
             {
                 var portValue = model.Start.Owner.GetValue(model.Start.Index, workspaceViewModel.DynamoViewModel.EngineController);
@@ -604,7 +604,7 @@ namespace Dynamo.ViewModels
                 {
                     if (isCollection && portValue.GetElements().Count() > 5)
                     {
-                        ///only sets 'is a collection' to true if the collection meets a size of 5
+                        // only sets 'is a collection' to true if the collection meets a size of 5
                         isCollectionofFiveorMore = true;
                         for (int i = 0; i < 5; i++)
                         {
@@ -1553,7 +1553,7 @@ namespace Dynamo.ViewModels
                 dotTop = CurvePoint3.Y - EndDotSize / 2;
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
-                ///Add chain of points including start/end
+                // Add chain of points including start/end
                 Point[] points = new Point[ConnectorPinViewCollection.Count];
                 int count = 0;
                 foreach (var wirePin in ConnectorPinViewCollection)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -904,7 +904,10 @@ namespace Dynamo.ViewModels
         /// Helper function ssed for placing (re-placing) connector
         /// pins when a WatchNode is placed in the center of a connector.
         /// </summary>
+        /// <param name="connectors"></param>
+        /// <param name="connectorWireIndex"></param>
         /// <param name="point"></param>
+        /// <param name="createdModels"></param>
         public void PinConnectorPlacementFromWatchNode(ConnectorModel[] connectors, int connectorWireIndex, Point point, List<ModelBase> createdModels)
         {
             var selectedConnector = connectors[connectorWireIndex];
@@ -1429,7 +1432,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Recalculate the connector's points given the end point
         /// </summary>
-        /// <param name="p2">The position of the end point</param>
+        /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
             var p2 = new Point();

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -371,11 +371,11 @@ namespace Dynamo.ViewModels
             }
         }
 
-        [Obsolete("This was moved to PreferencesViewModel.cs")]
         /// <summary>
         /// Indicates whether to make T-Spline nodes (under ProtoGeometry.dll) discoverable
         /// in the node search library.
         /// </summary>
+        [Obsolete("This was moved to PreferencesViewModel.cs")]
         public bool EnableTSpline
         {
             get
@@ -630,10 +630,10 @@ namespace Dynamo.ViewModels
             }
         }
 
-        [Obsolete ("This was moved to PreferencesViewModel.cs")]
         /// <summary>
         /// Engine used by default for new Python script and string nodes. If not empty, this takes precedence over any system settings.
         /// </summary>
+        [Obsolete ("This was moved to PreferencesViewModel.cs")]
         public string DefaultPythonEngine
         {
             get { return model.PreferenceSettings.DefaultPythonEngine; }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1677,7 +1677,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    throw (e);
+                    throw;
                 }
                 return;
             }
@@ -1761,7 +1761,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    throw (e);
+                    throw;
                 }
                 return;
             }
@@ -1843,7 +1843,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    throw (e);
+                    throw;
                 }
                 return;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1887,7 +1887,7 @@ namespace Dynamo.ViewModels
                 Model.CurrentWorkspace.UpdateWithExtraWorkspaceViewInfo(viewInfo);
                 Model.OnWorkspaceOpening(viewInfo);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 this.ShowStartPage = false; // Hide start page if there's one.
                 return;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1564,7 +1564,7 @@ namespace Dynamo.ViewModels
         /// Attempts to open a file using the Json content passed to OpenFromJsonCommand, but wraps
         /// the call with a check to make sure no unsaved changes to the HomeWorkspace are lost.
         /// </summary>
-        /// <param name="openFromJsonCommand"> <see cref="DynamoModel.OpenFileFromJsonCommand"/> </param>
+        /// <param name="openCommand"> <see cref="DynamoModel.OpenFileFromJsonCommand"/> </param>
         private void OpenFromJsonIfSaved(object openCommand)
         {
             filePath = string.Empty;
@@ -2714,6 +2714,7 @@ namespace Dynamo.ViewModels
         /// Requests a message box asking the user to save the workspace and allows saving.
         /// </summary>
         /// <param name="workspace">The workspace for which to show the dialog</param>
+        /// <param name="allowCancel"></param>
         /// <returns>False if the user cancels, otherwise true</returns>
         public bool AskUserToSaveWorkspaceOrCancel(WorkspaceModel workspace, bool allowCancel = true)
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1626,12 +1626,12 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// Open a definition or workspace.
-        /// </summary>
-        /// <param name="parameters"></param>
         /// For most cases, parameters variable refers to the Json content file to open
         /// However, when this command is used in OpenFileDialog, the variable is
-        /// a Tuple<string, bool> instead. The boolean flag is used to override the
+        /// a Tuple{string,bool} instead. The boolean flag is used to override the
         /// RunSetting of the workspace.
+        /// </summary>
+        /// <param name="parameters"></param>
         private void OpenFromJson(object parameters)
         {
             // try catch for exceptions thrown while opening files, say from a future version, 
@@ -1686,12 +1686,12 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// Open a definition or workspace.
-        /// </summary>
-        /// <param name="parameters"></param>
         /// For most cases, parameters variable refers to the file path to open
         /// However, when this command is used in OpenFileDialog, the variable is
-        /// a Tuple<string, bool> instead. The boolean flag is used to override the
+        /// a Tuple{string, bool} instead. The boolean flag is used to override the
         /// RunSetting of the workspace.
+        /// </summary>
+        /// <param name="parameters"></param>
         private void Open(object parameters)
         {
             // try catch for exceptions thrown while opening files, say from a future version, 
@@ -1770,12 +1770,12 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// Insert a definition or a custom node.
-        /// </summary>
-        /// <param name="parameters"></param>
         /// For most cases, parameters variable refers to the file path to open
         /// However, when this command is used in InsertFileDialog, the variable is
-        /// a Tuple<string, bool> instead. The boolean flag is used to override the
+        /// a Tuple&lt;string, bool&gt; instead. The boolean flag is used to override the
         /// RunSetting of the workspace.
+        /// </summary>
+        /// <param name="parameters"></param>
         private void Insert(object parameters)
         {
             // try catch for exceptions thrown while opening files, say from a future version, 

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -449,6 +449,7 @@ namespace Dynamo.Wpf.ViewModels.Core
         /// A sequence of methods to zoom around a selection of nodes 
         /// </summary>
         /// <param name="selectedNodes"></param>
+        /// <param name="currentNotificationType"></param>
         private void FitSelection(IEnumerable<NodeModel> selectedNodes, FooterNotificationItem.FooterNotificationType currentNotificationType)
         {
             Guid nodeToSelect = Guid.Empty;

--- a/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/InPortViewModel.cs
@@ -40,12 +40,12 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns whether this port has a default value that can be used.
         /// </summary>
-        public bool DefaultValueEnabled => port.DefaultValue != null;
+        public new bool DefaultValueEnabled => port.DefaultValue != null;
 
         /// <summary>
         /// Returns whether the port is using its default value, or whether this been disabled
         /// </summary>
-        public bool UsingDefaultValue
+        public new bool UsingDefaultValue
         {
             get => port.UsingDefaultValue;
             set
@@ -57,7 +57,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If should display Use Levels popup menu. 
         /// </summary>
-        public bool ShowUseLevelMenu
+        public new bool ShowUseLevelMenu
         {
             get => showUseLevelMenu;
             set
@@ -82,7 +82,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If UseLevel is enabled on this port.
         /// </summary>
-        public bool UseLevels => port.UseLevels;
+        public new bool UseLevels => port.UseLevels;
 
         /// <summary>
         /// Determines whether or not the UseLevelsSpinner is visible on the port.
@@ -108,12 +108,12 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If should keep list structure on this port.
         /// </summary>
-        public bool ShouldKeepListStructure => port.KeepListStructure;
+        public new bool ShouldKeepListStructure => port.KeepListStructure;
 
         /// <summary>
         /// Levle of list.
         /// </summary>
-        public int Level
+        public new int Level
         {
             get => port.Level;
             set
@@ -125,7 +125,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// The visibility of Use Levels menu.
         /// </summary>
-        public Visibility UseLevelVisibility
+        public new Visibility UseLevelVisibility
         {
             get
             {
@@ -249,7 +249,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// UseLevels command
         /// </summary>
-        public DelegateCommand UseLevelsCommand
+        public new DelegateCommand UseLevelsCommand
         {
             get { return useLevelsCommand ?? (useLevelsCommand = new DelegateCommand(UseLevel, p => true)); }
         }
@@ -267,7 +267,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// ShouldKeepListStructure command
         /// </summary>
-        public DelegateCommand KeepListStructureCommand
+        public new DelegateCommand KeepListStructureCommand
         {
             get
             {
@@ -296,7 +296,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Handles the Mouse left button click on the node levels context menu button.
         /// </summary>
-        public DelegateCommand MouseLeftButtonDownOnLevelCommand
+        public new DelegateCommand MouseLeftButtonDownOnLevelCommand
         {
             get
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1295,7 +1295,6 @@ namespace Dynamo.ViewModels
         /// Sets the color of the warning bar, which informs the user that the node is in
         /// either an error or a warning state.
         /// </summary>
-        /// <param name="style"></param>
         /// <returns></returns>
         internal SolidColorBrush GetWarningColor()
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -43,7 +43,7 @@ namespace Dynamo.ViewModels
         /// Sets the condensed styling on Code Block output ports.
         /// This is used to style the output ports on Code Blocks to be smaller.
         /// </summary>
-        public bool IsPortCondensed => this.PortModel.Owner is CodeBlockNodeModel;
+        public new bool IsPortCondensed => this.PortModel.Owner is CodeBlockNodeModel;
 
         /// <summary>
         /// If should display Use Levels popup menu. 

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -966,7 +966,7 @@ namespace Dynamo.ViewModels
             }
 
             /// <summary>
-            /// Handles the drag & drop for Notes over Nodes
+            /// Handles the drag &amp; drop for Notes over Nodes
             /// </summary>
             /// <param name="mouseCursor">The current location of the mouse cursor</param>
             /// <returns></returns>

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -654,7 +654,7 @@ namespace Dynamo.ViewModels
             catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
-                throw (ex);
+                throw;
             }
         }
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -35,7 +35,7 @@ namespace Dynamo.ViewModels
         private Dispatcher Dispatcher { get; set; }
 
         /// <summary>
-        /// The size of the Watch Icon (x & y dimensions).
+        /// The size of the Watch Icon (x &amp; y dimensions).
         /// </summary>
         public double MarkerSize { get; set; } = 30;
         public double AnchorSize { get; set; } = 15;

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Threading;
@@ -338,6 +338,10 @@ namespace Dynamo.ViewModels
         /// <param name="startNode"></param>
         /// <param name="endNode"></param>
         /// <param name="watchNodeModel"></param>
+        /// <param name="connector"></param>
+        /// <param name="connectorPinLocations"></param>
+        /// <param name="allCreatedModels"></param>
+        /// <param name="allDeletedModels"></param>
         private void WireNewNode(
             DynamoModel dynamoModel, 
             NodeModel startNode,

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -472,7 +472,6 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// This constructor will update the TopBottom and BottomRight positions of the warnings since the beginning.
         /// </summary>
-        /// <param name="dynamoViewModel"></param>
         /// <param name="nodeViewModel">This parameter will be used to get the TopBottom and BottomRight positions of the NodeModel</param>
         public InfoBubbleViewModel(NodeViewModel nodeViewModel)
         {
@@ -760,7 +759,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="infoBubbleDataPackets"></param>
         /// <param name="style">The style of messages to be returned</param>
-        /// <param name="secondStyle">A second (optional) style.</param>
         /// <returns></returns>
         private List<InfoBubbleDataPacket> GetMessagesOfStyle(ObservableCollection<InfoBubbleDataPacket> infoBubbleDataPackets, Style style)
         {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoRenderCoreDataStore.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DynamoRenderCoreDataStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
@@ -91,8 +91,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         /// <summary>
         /// Generates an int that packs all enum flags into a single int.
-        /// Can be decoded using binary &
-        /// ie - Flags & 1 = IsFrozen
+        /// Can be decoded using binary &amp;
+        /// ie - Flags &amp; 1 = IsFrozen
         ///  - if flags == 000000 - all flags are off
         ///  - if flags == 000001 - frozen is enabled
         ///  - if flags == 100001 - frozen and flatshade are enabled.

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -2978,7 +2978,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// This extension method is to correct for the Helix toolkit's GeometryModel3D.Bounds
         /// property which does not update correctly as new geometry is added to the GeometryModel3D.
         /// </summary>
-        /// <param name="pointGeom">A <see cref="GeometryModel3D"/> object.</param>
+        /// <param name="geom">A <see cref="GeometryModel3D"/> object.</param>
+        /// <param name="defaultBoundsSize"></param>
         /// <returns>A <see cref="BoundingBox"/> object encapsulating the geometry.</returns>
         internal static BoundingBox Bounds(this GeometryModel3D geom, float defaultBoundsSize = 5.0f)
         {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -131,7 +131,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             return false;
         }
 
-
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
     /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1614,8 +1614,7 @@ namespace Dynamo.Controls
         /// Presents the function name dialogue. Returns true if the user enters
         /// a function name and category.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="category"></param>
+        /// <param name="e"></param>
         /// <returns></returns>
         internal void ShowNewFunctionDialog(FunctionNamePromptEventArgs e)
         {

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -58,7 +58,7 @@ namespace Dynamo.Wpf.Views
         /// <summary>
         /// Constructor of Preferences View
         /// </summary>
-        /// <param name="dynamoViewModel"> Dynamo ViewModel</param>
+        /// <param name="dynamoView"> Dynamo ViewModel</param>
         public PreferencesView(DynamoView dynamoView)
         {
             dynViewModel = dynamoView.DataContext as DynamoViewModel;            

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -438,6 +438,7 @@ namespace Dynamo.UI.Controls
         /// It's used to apply Collapsed and Expanded events for TreeViewItems.
         /// </summary>
         /// <param name="sender">TreeView</param>
+        /// <param name="e"></param>
         private void WatchContainer_StatusChanged(object sender, EventArgs e)
         {
             var generator = sender as ItemContainerGenerator;

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Autodesk.DesignScript.Geometry;
 using Dynamo.Graph.Nodes;
@@ -83,7 +83,7 @@ namespace Dynamo.Manipulation
                 if (null == curve)
                     return;
             }
-            catch (Exception ex) 
+            catch (Exception) 
             { 
                 return; 
             }

--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -470,7 +470,7 @@ namespace Dynamo.PackageManager
                         return true;
                     }
                 }
-                catch (Exception _)
+                catch (Exception)
                 {
                     if (messages != null)
                     {

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -574,9 +574,9 @@ namespace Dynamo.PackageManager
                     
                 }
             }
-            catch (UnauthorizedAccessException ex) { }
-            catch (IOException ex) { }
-            catch (ArgumentException ex) { }
+            catch (UnauthorizedAccessException) { }
+            catch (IOException) { }
+            catch (ArgumentException) { }
         }
 
         public Package ScanPackageDirectory(string directory)

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -131,7 +131,7 @@ namespace Dynamo.Utilities
                             }
                         }
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         KillProcess();
                         return GetCantCommunicateErrorMessage();

--- a/src/DynamoUtilities/Option.cs
+++ b/src/DynamoUtilities/Option.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Dynamo.Utilities
@@ -402,6 +402,16 @@ namespace Dynamo.Utilities
             public bool Equals(_None<T> other)
             {
                 return this == other;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as _None<T>);
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
             }
         }
     }

--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -1634,6 +1634,11 @@ namespace ProtoCore.AssociativeGraph
 
             return false;
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
 
@@ -1725,6 +1730,11 @@ namespace ProtoCore.AssociativeGraph
                 }
             }
             return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/src/Engine/ProtoCore/CodeFile.cs
+++ b/src/Engine/ProtoCore/CodeFile.cs
@@ -22,5 +22,14 @@ namespace ProtoCore.CodeModel
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/src/Engine/ProtoCore/CodePoint.cs
+++ b/src/Engine/ProtoCore/CodePoint.cs
@@ -1,4 +1,4 @@
-﻿namespace ProtoCore.CodeModel
+namespace ProtoCore.CodeModel
 {
     public struct CodePoint
     {
@@ -23,6 +23,11 @@
         {
             return !(lhs == rhs);
         }
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
     }
 
     public struct CodeRange
@@ -44,6 +49,11 @@
         public static bool operator !=(CodeRange lhs, CodeRange rhs)
         {
             return !(lhs == rhs);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
         }
     }
 }

--- a/src/Engine/ProtoCore/DSASM/DSString.cs
+++ b/src/Engine/ProtoCore/DSASM/DSString.cs
@@ -1,4 +1,4 @@
-﻿using ProtoCore.Properties;
+using ProtoCore.Properties;
 using ProtoCore.Runtime;
 
 namespace ProtoCore.DSASM
@@ -93,6 +93,11 @@ namespace ProtoCore.DSASM
                 return true;
 
             return Value.Equals(otherString.Value);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/src/Engine/ProtoCore/DSDefinitions.cs
+++ b/src/Engine/ProtoCore/DSDefinitions.cs
@@ -1,4 +1,4 @@
-﻿namespace ProtoCore.DSDefinitions
+namespace ProtoCore.DSDefinitions
 {
     public struct Keyword
     {
@@ -42,7 +42,9 @@
         public const string Associative = "Associative";
         public const string Imperative = "Imperative";
         public const string Dispose = "_Dispose";
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         public const string GetType = "GetType";
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         public const string Invalid = "__invalid";
         public const string PointerReserved = "pointer_reserved";
         public static string[] KeywordList = {Native, Class, Constructor, Def, External, Extend, Heap,

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -55,7 +55,6 @@ namespace ProtoFFI
                 {
                     mtype = new CLRModuleType(type);
                     //Now check that a type with same name is not imported.
-                    Type otherType;
                     if (mTypeNames.TryGetValue(mtype.FullName, out CLRModuleType otherMType))
                     {
                         if (otherMType.CLRType.IsEquivalentTo(type))

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
@@ -1381,7 +1381,7 @@ namespace ProtoFFI
     /// </summary>
     public class ReferenceEqualityComparer: IEqualityComparer<object>
     {
-        public bool Equals(object x, object y)
+        bool IEqualityComparer<object>.Equals(object x, object y)
         {
             return object.ReferenceEquals(x, y);
         }

--- a/src/Engine/ProtoCore/ProcedureTable.cs
+++ b/src/Engine/ProtoCore/ProcedureTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ProtoCore.AssociativeGraph;
@@ -239,6 +239,11 @@ namespace ProtoCore.DSASM
                    ClassID == rhs.ClassID && 
                    LocalCount == rhs.LocalCount && 
                    Name.Equals(rhs.Name);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -319,6 +319,11 @@ namespace ProtoCore
 
                 return StackUtils.CompareStackValues(this.svData, data.svData, this.runtimeCore, data.runtimeCore);
             }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
         }
     }
 }

--- a/src/Engine/ProtoCore/SymbolTable.cs
+++ b/src/Engine/ProtoCore/SymbolTable.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ProtoCore.DSASM
@@ -83,6 +83,11 @@ namespace ProtoCore.DSASM
                    functionIndex == rhs.functionIndex && 
                    classScope == rhs.classScope && 
                    codeBlockId == rhs.codeBlockId;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 

--- a/src/Engine/ProtoCore/Utils/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CompilerUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
@@ -222,7 +222,7 @@ namespace ProtoCore.Utils
 
                 if (!(ex is ProtoCore.BuildHaltException))
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/src/GraphNodeManagerViewExtension/GraphNodeManagerViewModel.cs
+++ b/src/GraphNodeManagerViewExtension/GraphNodeManagerViewModel.cs
@@ -483,11 +483,11 @@ namespace Dynamo.GraphNodeManager
                         NodesCollection.View.Refresh();
                 });
             }
-            catch (InvalidOperationException invalidOperationException)
+            catch (InvalidOperationException)
             {
                 return;
             }
-            catch (Exception exception)
+            catch (Exception)
             {
                 return;
             }

--- a/src/GraphNodeManagerViewExtension/Utilities/Utilities.cs
+++ b/src/GraphNodeManagerViewExtension/Utilities/Utilities.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Linq;
@@ -21,8 +21,6 @@ namespace Dynamo.GraphNodeManager.Utilities
 
             using (SaveFileDialog saveFileDialog = new SaveFileDialog())
             {
-                Stream myStream;
-                
                 saveFileDialog.Filter = "csv files (*.csv)|*.csv|All files (*.*)|*.*";
                 saveFileDialog.FilterIndex = 2;
                 saveFileDialog.Title = "Save CSV file";
@@ -53,8 +51,6 @@ namespace Dynamo.GraphNodeManager.Utilities
 
             using (SaveFileDialog saveFileDialog = new SaveFileDialog())
             {
-                Stream myStream;
-                
                 saveFileDialog.Filter = "json files (*.json)|*.json|All files (*.*)|*.*";
                 saveFileDialog.FilterIndex = 2;
                 saveFileDialog.Title = "Save JSON file";

--- a/src/Libraries/Analysis/SurfaceData.cs
+++ b/src/Libraries/Analysis/SurfaceData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -110,18 +110,18 @@ namespace Analysis
             return new SurfaceData(surface, uvs, values);
         }
 
-        /// <summary>
-        /// This method constructs a surface through the UV locations,
-        /// converting UVs to Points in the 0,0->1,1 domain. This surface is used
-        /// to calculate gradient values at positions on a grid specified by width
-        /// and height. The Z coordinate of the created points is set to the normalized value 
-        /// associated with that UV locaton. Points are then found on the surface from UVs,
-        /// in a grid of the width and height provided. The Z component of the 
-        /// points is then stored in the map.
-        /// </summary>
-        /// <param name="width">The width of the value map.</param>
-        /// <param name="height"></param>
-        /// <returns></returns>
+        ///// <summary>
+        ///// This method constructs a surface through the UV locations,
+        ///// converting UVs to Points in the 0,0->1,1 domain. This surface is used
+        ///// to calculate gradient values at positions on a grid specified by width
+        ///// and height. The Z coordinate of the created points is set to the normalized value 
+        ///// associated with that UV locaton. Points are then found on the surface from UVs,
+        ///// in a grid of the width and height provided. The Z component of the 
+        ///// points is then stored in the map.
+        ///// </summary>
+        ///// <param name="width">The width of the value map.</param>
+        ///// <param name="height"></param>
+        ///// <returns></returns>
         //public double[][] GetValueMap(int width, int height)
         //{
         //    const int MinPointCount = 3;

--- a/src/Libraries/CoreNodeModels/IModelSelectionHelper.cs
+++ b/src/Libraries/CoreNodeModels/IModelSelectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Dynamo.Logging;
 
 namespace CoreNodeModels
@@ -23,11 +23,9 @@ namespace CoreNodeModels
         /// <summary>
         /// Request a selection filtered by a type.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="selectionMessage"></param>
         /// <param name="selectionType"></param>
         /// <param name="objectType"></param>
-        /// <param name="logger"></param>
         /// <returns></returns>
         IEnumerable<T> RequestSelectionOfType(
             string selectionMessage, SelectionType selectionType,

--- a/src/Libraries/CoreNodeModels/Logic/AndOr.cs
+++ b/src/Libraries/CoreNodeModels/Logic/AndOr.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.DesignScript.Runtime;
 using CoreNodeModels.Properties;
@@ -20,6 +20,7 @@ namespace CoreNodeModels.Logic
         /// <summary>
         /// Private constructor used for serialization.
         /// </summary>
+        /// <param name="op"></param>
         /// <param name="inPorts">A collection of <see cref="PortModel"/> objects.</param>
         /// <param name="outPorts">A collection of <see cref="PortModel"/> objects.</param>
         protected BinaryLogic(Operator op, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -79,7 +79,7 @@ namespace CoreNodeModels
         }
 
         [JsonProperty("NodeType")]
-        public string NodeType
+        public new string NodeType
         {
             get
             {

--- a/src/Libraries/CoreNodeModels/Watch.cs
+++ b/src/Libraries/CoreNodeModels/Watch.cs
@@ -42,12 +42,16 @@ namespace CoreNodeModels
 
         /// <summary>
         ///     Watch node's Width
+        /// </summary>
         public double WatchWidth { get; set; }
         /// <summary>
         ///     Watch node's Height
+        /// </summary>
         public double WatchHeight { get; set; }
 
-        //Stores the custom sizes for each watch node.
+        /// <summary>
+        /// Stores the custom sizes for each watch node.
+        /// </summary>
         public static Dictionary<Guid, Tuple<double,double>> NodeSizes = new Dictionary<Guid, Tuple<double, double>>();
 
         public void SetWatchSize(double w, double h)

--- a/src/Libraries/CoreNodeModelsWpf/Charts/BasicLineChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/BasicLineChartNodeModel.cs
@@ -83,10 +83,10 @@ namespace CoreNodeModelsWpf.Charts
             ArgumentLacing = LacingStrategy.Disabled;
         }
 
-        [JsonConstructor]
         /// <summary>
         /// Instantiate a new NodeModel instance.
         /// </summary>
+        [JsonConstructor]
         public BasicLineChartNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             PortConnected += BasicLineChartNodeModel_PortConnected;

--- a/src/Libraries/CoreNodeModelsWpf/Charts/HeatSeriesNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/HeatSeriesNodeModel.cs
@@ -92,10 +92,10 @@ namespace CoreNodeModelsWpf.Charts
             ArgumentLacing = LacingStrategy.Disabled;
         }
 
-        [JsonConstructor]
         /// <summary>
         /// Instantiate a new NodeModel instance.
         /// </summary>
+        [JsonConstructor]
         public HeatSeriesNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             PortConnected += HeatSeriesNodeModel_PortConnected;

--- a/src/Libraries/CoreNodeModelsWpf/Charts/PieChartNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/PieChartNodeModel.cs
@@ -85,10 +85,10 @@ namespace CoreNodeModelsWpf.Charts
         }
 
 
-        [JsonConstructor]
         /// <summary>
         /// Instantiate a new NodeModel instance.
         /// </summary>
+        [JsonConstructor]
         public PieChartNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             PortConnected += PieChartNodeModel_PortConnected;

--- a/src/Libraries/CoreNodeModelsWpf/Charts/ScatterPlotNodeModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Charts/ScatterPlotNodeModel.cs
@@ -91,10 +91,10 @@ namespace CoreNodeModelsWpf.Charts
             ArgumentLacing = LacingStrategy.Disabled;
         }
 
-        [JsonConstructor]
         /// <summary>
         /// Instantiate a new NodeModel instance.
         /// </summary>
+        [JsonConstructor]
         public ScatterPlotNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             PortConnected += ScatterPlotNodeModel_PortConnected;

--- a/src/Libraries/CoreNodeModelsWpf/ConverterViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/ConverterViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using CoreNodeModels;
 using Dynamo.Controls;
 using Dynamo.Core;
@@ -121,8 +121,7 @@ namespace CoreNodeModelsWpf
         /// Called when Toggle button is clicked.
         /// Switches the combo box values
         /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+        /// <param name="obj">The sender.</param>
         private void OnToggleButtonClick(object obj)
         {
             var undoRecorder = nodeViewModel.WorkspaceViewModel.Model.UndoRecorder;

--- a/src/Libraries/CoreNodeModelsWpf/Properties/CoreNodeModelWpfResources.Designer.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Properties/CoreNodeModelWpfResources.Designer.cs
@@ -377,8 +377,6 @@ namespace Dynamo.Wpf.Properties {
 
         /// <summary>
         ///   Looks up a localized string similar to A list of string labels for each group of points to be plotted.
-        ///
-        ///List&lt;string&gt.;
         /// </summary>
         public static string ChartsScatterPlotLabelsDataPortToolTip
         {

--- a/src/Libraries/CoreNodes/FileSystem.cs
+++ b/src/Libraries/CoreNodes/FileSystem.cs
@@ -122,7 +122,7 @@ namespace DSCore.IO
             }
             catch (System.Exception ex)
             {
-                throw ex;
+                throw;
             }
             return true;
             

--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -311,7 +311,7 @@ for modname,mod in sys.modules.copy().items():
                             }
                             else
                             {
-                                throw e;
+                                throw;
                             }
                         }
                         finally

--- a/src/Libraries/DynamoUnits/Quantity.cs
+++ b/src/Libraries/DynamoUnits/Quantity.cs
@@ -60,7 +60,7 @@ namespace DynamoUnits
             {
                 return new Quantity(Utilities.ForgeUnitsEngine.getQuantity(typeId));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //The exact match for the Forge TypeID failed.  Test for a fallback.  This can be either earlier or later version number.
                 if (Utilities.TryParseTypeId(typeId, out string typeName, out Version version))

--- a/src/Libraries/DynamoUnits/Symbol.cs
+++ b/src/Libraries/DynamoUnits/Symbol.cs
@@ -58,7 +58,7 @@ namespace DynamoUnits
             {
                 return new Symbol(Utilities.ForgeUnitsEngine.getSymbol(typeId));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //The exact match for the Forge TypeID failed.  Test for a fallback.  This can be either earlier or later version number.
                 if (Utilities.TryParseTypeId(typeId, out string typeName, out Version version))

--- a/src/Libraries/DynamoUnits/Unit.cs
+++ b/src/Libraries/DynamoUnits/Unit.cs
@@ -68,7 +68,7 @@ namespace DynamoUnits
             {
                 return new Unit(Utilities.ForgeUnitsEngine.getUnit(typeId));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //The exact match for the Forge TypeID failed.  Test for a fallback.  This can be either earlier or later version number.
                 if (Utilities.TryParseTypeId(typeId, out string typeName, out Version version))

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -1833,7 +1833,7 @@ namespace DynamoUnits
         /// <summary>
         /// Convert from decimal feet to feet and fractional inches
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="decimalFeet"></param>
         /// <returns></returns>
         public static string ToFeetAndFractionalInches(double decimalFeet)
         {

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Autodesk.DesignScript.Interfaces
@@ -329,6 +329,9 @@ namespace Autodesk.DesignScript.Interfaces
         /// Add a label position to the render package.
         /// </summary>
         /// <param name="label">Text to be displayed in the label</param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
         void AddLabel(string label, double x, double y, double z);
 
         /// <summary>
@@ -417,6 +420,7 @@ namespace Autodesk.DesignScript.Interfaces
         /// <param name="m42"></param>
         /// <param name="m43"></param>
         /// <param name="m44"></param>
+        /// <param name="id"></param>
         void AddInstanceMatrix(float m11, float m12, float m13, float m14,
            float m21, float m22, float m23, float m24,
            float m31, float m32, float m33, float m34,
@@ -434,6 +438,7 @@ namespace Autodesk.DesignScript.Interfaces
         /// the second row to the Y axis of the CS, the third row to the Z axis of the CS, and the last row to the CS origin, where W = 1. 
         /// </summary>
         /// <param name="matrix"></param>
+        /// <param name="id"></param>
         void AddInstanceMatrix(float[] matrix, Guid id);
     }
 

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -382,16 +382,16 @@ namespace Autodesk.DesignScript.Interfaces
         /// <summary>
         /// Set an instance reference for a specific range of mesh vertices
         /// </summary>
-        /// <param name="startIndex">The index associated with the first vertex in MeshVertices we want to associate with the instance matrices
-        /// <param name="endIndex">The index associated with the last vertex in MeshVertices we want to associate with the instance matrices
+        /// <param name="startIndex">The index associated with the first vertex in MeshVertices we want to associate with the instance matrices></param>
+        /// <param name="endIndex">The index associated with the last vertex in MeshVertices we want to associate with the instance matrices></param>
         /// <param name="id">A unique id associated with this tessellation geometry for instancing</param>
         void AddInstanceGuidForMeshVertexRange(int startIndex, int endIndex, Guid id);
 
         /// <summary>
         /// Set an instance reference for a specific range of line vertices
         /// </summary>
-        /// <param name="startIndex">The index associated with the first vertex in LineVertices we want to associate with the instance matrices
-        /// <param name="endIndex">The index associated with the last vertex in LineVertices we want to associate with the instance matrices
+        /// <param name="startIndex">The index associated with the first vertex in LineVertices we want to associate with the instance matrices></param>
+        /// <param name="endIndex">The index associated with the last vertex in LineVertices we want to associate with the instance matrices></param>
         /// <param name="id">A unique id associated with this tessellation geometry for instancing</param>
         void AddInstanceGuidForLineVertexRange(int startIndex, int endIndex, Guid id);
 

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -44,17 +44,17 @@ namespace Dynamo.PythonServices.EventHandlers
 
 namespace Dynamo.PythonServices
 {
-    [SupressImportIntoVM]
     /// <summary>
     /// Enum of possible python evaluation states.
     /// </summary>
+    [SupressImportIntoVM]
     public enum EvaluationState { Success, Failed }
 
-    [SupressImportIntoVM]
-    [IsVisibleInDynamoLibrary(false)]
     /// <summary>
     /// This abstract class is intended to act as a base class for different python engines
     /// </summary>
+    [SupressImportIntoVM]
+    [IsVisibleInDynamoLibrary(false)]
     public abstract class PythonEngine
     {
         /// <summary>

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -705,7 +705,7 @@ namespace Dynamo.PythonServices
                     var type = Type.GetType(typeName);
                     ImportedTypes.Add(name, type);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     LogError(String.Format("Failed to load module: {0}, with statement: {1}", memberName, statement));
                     // Log(e.ToString());

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -84,13 +84,11 @@ namespace Dynamo.PythonServices
         /// <summary>
         /// Add an event handler before the Python evaluation begins
         /// </summary>
-        /// <param name="callback"></param>
         public abstract event EvaluationStartedEventHandler EvaluationStarted;
 
         /// <summary>
         /// Add an event handler after the Python evaluation has finished
         /// </summary>
-        /// <param name="callback"></param>
         public abstract event EvaluationFinishedEventHandler EvaluationFinished;
 
         /// <summary>
@@ -1021,7 +1019,6 @@ namespace Dynamo.PythonServices
         /// the given regex
         /// </summary>
         /// <param name="code">The code to search</param>
-        /// <param name="valueRegex">Your regex to match the type</param>
         /// <returns>A dictionary of name to assignment line pairs</returns>
         internal Dictionary<string, Tuple<string, int, Type>> FindAllVariables(string code)
         {

--- a/src/Tools/DynamoFeatureFlags/Program.cs
+++ b/src/Tools/DynamoFeatureFlags/Program.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -48,7 +48,7 @@ namespace DynamoFeatureFlags
                     SendAllFlags();
 
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // Exit process
                 }

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -575,6 +575,11 @@ namespace Dynamo.Tests
                     other.UsingDefaultValue == this.UsingDefaultValue &&
                     other.Description == this.Description;
             }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
         }
     }
 #endregion

--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -9,7 +9,7 @@ namespace Dynamo.Tests
     internal class UnitsOfMeasureTests : UnitTestBase
     {
         [SetUp]
-        public void Setup()
+        public override void Setup()
         {
             Display.PrecisionFormat = "f4";
         }
@@ -759,7 +759,7 @@ namespace Dynamo.Tests
     internal class ForgeUnitsTests : UnitTestBase
     {
         [SetUp]
-        public void Setup()
+        public override void Setup()
         {
 
         }

--- a/test/Engine/FFITarget/DummyGeometry.cs
+++ b/test/Engine/FFITarget/DummyGeometry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.DesignScript.Runtime;
@@ -83,6 +83,11 @@ namespace FFITarget
         public void Dispose()
         {
             //Don't do anything
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 

--- a/test/Engine/FFITarget/InheritenceTests.cs
+++ b/test/Engine/FFITarget/InheritenceTests.cs
@@ -1,4 +1,4 @@
-﻿namespace FFITarget
+namespace FFITarget
 {
     public abstract class BaseTest
     {
@@ -55,13 +55,13 @@
 
     public class HidesMethodFromClassA: ClassA
     {
-        public int Bar()
+        public new int Bar()
         {
             
             return 3; 
         }
 
-        public static int Baz()
+        public static new int Baz()
         {
             return 23;
         }

--- a/test/Engine/ProtoTestFx/DebugTestFx.cs
+++ b/test/Engine/ProtoTestFx/DebugTestFx.cs
@@ -231,7 +231,7 @@ namespace ProtoTestFx
                         }
                         else
                         {
-                            throw ex;
+                            throw;
                         }
                     }
 


### PR DESCRIPTION

### Purpose

Go through the warnings generated by .NET 6 migration and resolve them

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes




### Reviewers



### FYIs


