### PR TITLE
DYN-6058 - UI changed location for Package Download toast

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -815,11 +815,12 @@
                 </ListBox.ItemTemplate>
             </ListBox>
         </Border>
+        
         <!--  Download bar: A stacking list of (up to 3) most-recently downloaded packages. Appears when the user installs a package.  -->
         <ListBox
             Name="DownloadsListBox"
             Grid.Row="3"
-            Margin="0,5,0,10"
+            Margin="0,5,0,0"
             Background="Transparent"
             BorderThickness="0"
             IsHitTestVisible="True"
@@ -1012,7 +1013,7 @@
         <ListBox
             Name="InfectedListBox"
             Grid.Row="4"
-            Margin="0,5,0,10"
+            Margin="0,5,0,0"
             Background="Transparent"
             BorderThickness="0"
             IsHitTestVisible="True"


### PR DESCRIPTION
### Purpose

This is a small UI fix to the Search for packages window. When a package is downloaded, a (toast) notification is shown in the bottom row of the window. This row was observed to have started displaying a bit higher than it should. This PR addressed the issue.

[Jira task](https://jira.autodesk.com/browse/DYN-6058)

[Figma link](https://www.figma.com/file/7aqwAs1GzUEus5MZIJKBfY/Package-Manager%3A-Consuming?type=design&node-id=181-33280&mode=design)

#### UI Snapshot
![image](https://github.com/DynamoDS/Dynamo/assets/5354594/ea6e7b0f-e3ab-4b10-a657-c4939998b292)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- Removed margin bottom offsets to the last 2 grid rows as to lessen the amount of offset the Toast row is pushed up from the bottom of the window. The figma mock-up shows a thick gray bottom line which partly hides the gap - that line is not to be implemented, though, and was present in the figma document by mistake (checked with the team). 

### Reviewers

@avidit 

### FYIs

@reddyashish 
@Jingyi-Wen 
