### PR TITLE
Documentation browser error message fix

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -172,14 +172,27 @@ namespace Dynamo.DocumentationBrowser
                 {
                     sb.AppendLine("<br>");
                     sb.AppendLine($"<strong>{"Message"}</strong>");
-                    sb.AppendLine($"<p>{GetNthRowFromStringSplit(e.NodeInfos.ElementAt(i).Message, 0)}</p>");
 
-                    var help = e.NodeInfos.ElementAt(i).Message.Split(new string[] {". "}, StringSplitOptions.None);
-                    var html = help[1].Split(new string[] {"href="}, StringSplitOptions.None)[1];
-                    var helpHtml =
-                        DocumentationBrowserUtils.GetContentFromEmbeddedResource($"{RESOURCE_PREFIX + html}");
+                    var message = e.NodeInfos.ElementAt(i).Message;
 
-                    sb.AppendLine(helpHtml);
+                    if (message.Contains("href="))
+                    {
+                        sb.AppendLine($"<p>{GetNthRowFromStringSplit(e.NodeInfos.ElementAt(i).Message, 0)}</p>");
+
+                        var help = e.NodeInfos.ElementAt(i).Message.Split(new string[] {". "}, StringSplitOptions.None);
+                        var html = help[1].Split(new string[] {"href="}, StringSplitOptions.None)[1];
+                        var helpHtml =
+                            DocumentationBrowserUtils.GetContentFromEmbeddedResource($"{RESOURCE_PREFIX + html}");
+
+                        sb.AppendLine(helpHtml);
+                    }
+                    else
+                    {
+                        foreach(var line in message.Split(new string[] { "\r\n" }, StringSplitOptions.None))
+                        {
+                            sb.AppendLine($"<p>{line}</p>");
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
### Purpose

This PR fixes an issue with the Documentation Browser specifically when displaying a Warning without an "href" tag. Previously, when creating the Warning `message` part of the help body, we would assume that an "href" tag is present in the second line of the info message. This is not always the case, and as a result any warning message of more than 1 line would be clipped to display only the first line. 

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/3d84ddde-45c7-438b-8bba-811ffe7e18dc)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- a small fix around a limitation in how warnings were read
- now captures the case where a warning does not have an href tag to it
- will now display the full multiline text of a warning that does not have an href tag

### Reviewers

@Amoursol 

### FYIs

@reddyashish 
