### PR TITLE
fix:rename notifications mark as read function

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Notifications
             this.onNotificationPopupUpdated = onNotificationPopupUpdated;
         }
 
-        public void SetNoficationsAsRead(object[] ids)
+        public void SetNotificationsAsRead(object[] ids)
         {
             onMarkAllAsRead(ids);
         }


### PR DESCRIPTION
### Purpose

This PR renames the notifications markAsRead function we expose to NotificationsCenter  from "SetNoficationsAsRead" to "SetNotificationsAsRead".

### Ref
[DYN-5219](https://jira.autodesk.com/browse/DYN-5219) 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 


### FYIs
@QilongTang 
(FILL ME IN, Optional) Names of anyone else you wish to be notified of
