### PR TITLE
Dynamo Add Comment action fix

### DIFF
--- a/.github/workflows/move_issue.yaml
+++ b/.github/workflows/move_issue.yaml
@@ -23,10 +23,11 @@ jobs:
       #Adds a comment to the issue before moving it
       - name: Add comment
         if: (github.event.label.name == matrix.label)
-        uses: ben-z/actions-comment-on-issue@1.0.2
+        uses: peter-evans/create-or-update-comment@v3
         with:
-          message: ${{ env.bot_comment }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{github.event.issue.number}}
+          body: ${{ env.bot_comment }}
+          token: ${{ secrets.DYNAMOBOTTOKEN }}
 
       #Move the issue depending on its labels
       - name: (Label ${{ matrix.label }}) Move to ${{ matrix.repoName }}


### PR DESCRIPTION
### Purpose
Github Action failing (due to a external bug)
The ben-z/actions-comment-on-issue action (created by a third party ) is failing in Dynamo and also in a external repo then I updated the action to use peter-evans/create-or-update-comment@v3 so the action can add comments successfully.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Github Action failing (due to a external bug)


### Reviewers

@QilongTang 

### FYIs

