### PR TITLE
Sign tool is now using CommandLine.dll

### DIFF
--- a/tools/NuGet/template-artifactory/DynamoVisualProgramming.SignDynamo.nuspec
+++ b/tools/NuGet/template-artifactory/DynamoVisualProgramming.SignDynamo.nuspec
@@ -19,7 +19,7 @@
         <!--These assemblies are referenced from the bin directory since they are not harvested for the installer-->
         <file src="..\..\..\src\Tools\SignDynamo\bin\Release\Dynamo.cer" target="lib\net48" />
         <file src="..\..\..\src\Tools\SignDynamo\bin\Release\DynamoCrypto.dll" target="lib\net48" />
-        <file src="..\..\..\src\Tools\SignDynamo\bin\Release\NDesk.Options.dll" target="lib\net48" />
+        <file src="..\..\..\src\Tools\SignDynamo\bin\Release\CommandLine.dll" target="lib\net48" />
         <file src="..\..\..\src\Tools\SignDynamo\bin\Release\SignDynamo.exe" target="lib\net48" />
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
     </files>


### PR DESCRIPTION
### Purpose
* Sign tool is now using CommandLine.dll

master-15 is currently failing because of this. I assume there is no need to keep the old file around is this case.

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [X] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
