### PR TITLE
DYN-6057: Starting the Browser in an External Process Crashes

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -89,7 +89,7 @@ namespace Dynamo.DocumentationBrowser
                 // in either of these two cases, cancel the navigation 
                 // and redirect it to a new process that starts the default OS browser
                 e.Cancel = true;
-                Process.Start(new ProcessStartInfo(e.Uri));
+                Process.Start(new ProcessStartInfo(e.Uri) { UseShellExecute = true });
             }
         }
 

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Dynamo.Models;
 
 namespace Dynamo.ViewModels
@@ -29,7 +30,7 @@ namespace Dynamo.ViewModels
                 if (string.IsNullOrEmpty(xmlFilePath) == false)
                 {
                     if (System.IO.File.Exists(xmlFilePath))
-                        System.Diagnostics.Process.Start(xmlFilePath);
+                        System.Diagnostics.Process.Start(new ProcessStartInfo(xmlFilePath) { UseShellExecute = true });
                 }
             }
         }

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -427,7 +427,7 @@ namespace Dynamo.UI.Controls
 
         private void HandleExternalUrl(StartPageListItem item)
         {
-            System.Diagnostics.Process.Start(item.ContextData);
+            System.Diagnostics.Process.Start(new ProcessStartInfo(item.ContextData) { UseShellExecute = true });
         }
 
         #endregion
@@ -516,14 +516,15 @@ namespace Dynamo.UI.Controls
         private void ShowSamplesInFolder(object sender, MouseButtonEventArgs e)
         {
             var startPageViewModel = this.DataContext as StartPageViewModel;
-            Process.Start("explorer.exe", "/select," 
-                + startPageViewModel.SampleFolderPath);
+            Process.Start(new ProcessStartInfo("explorer.exe", "/select," 
+                + startPageViewModel.SampleFolderPath)
+                { UseShellExecute = true });
         }
 
         private void ShowBackupFilesInFolder(object sender, MouseButtonEventArgs e)
         {
             var startPageViewModel = this.DataContext as StartPageViewModel;
-            Process.Start("explorer.exe", dynamoViewModel.Model.PathManager.BackupDirectory);
+            Process.Start(new ProcessStartInfo("explorer.exe", dynamoViewModel.Model.PathManager.BackupDirectory) { UseShellExecute = true });
         }
 
         private void StartPage_OnDrop(object sender, DragEventArgs e)

--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Controls;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
 
@@ -22,7 +22,7 @@ namespace Dynamo.UI.Controls
 
         private void RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(e.Uri.AbsoluteUri));
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
             e.Handled = true;
         }
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/CustomRichTextBox.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/CustomRichTextBox.cs
@@ -124,7 +124,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                             Hyperlink link = new Hyperlink(run3);
                             link.IsEnabled = true;
                             link.NavigateUri = new Uri(linkURL);
-                            link.RequestNavigate += (sender, args) => Process.Start(args.Uri.ToString());
+                            link.RequestNavigate += (sender, args) => Process.Start(new ProcessStartInfo(args.Uri.ToString()) { UseShellExecute = true });
                             para.Inlines.Add(link);
                             bHyperlinkActive = false;
                         }

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -131,7 +131,7 @@ namespace Dynamo.Nodes.Prompts
                 return;
 
             // Catch for exception, for cases where the directory does not exist
-            try { Process.Start(@folderPath); }
+            try { Process.Start(new ProcessStartInfo(@folderPath) { UseShellExecute = true }); }
             catch { }
         }
 

--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -256,7 +256,7 @@ namespace Dynamo.Wpf.Utilities
 
                     var cerArgs = $"/UPITOKEN \"{upiConfigFilePath}\" /DMP \"{miniDumpFilePath}\" /APPXML \"{appConfig}\" {dynConfig} {extras} /USEEXCEPTIONTRACE";
                     
-                    Process.Start(new ProcessStartInfo(cerToolPath, cerArgs)).WaitForExit();
+                    Process.Start(new ProcessStartInfo(cerToolPath, cerArgs) { UseShellExecute = true }).WaitForExit();
                     return true;
                 }
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1045,7 +1045,7 @@ namespace Dynamo.ViewModels
             // launching the process using explorer.exe will format the URL incorrectly
             // and Github will not recognise the query parameters in the URL
             // so launch with default operating system web browser
-            Process.Start(new ProcessStartInfo(urlWithParameters));
+            Process.Start(new ProcessStartInfo(urlWithParameters) { UseShellExecute = true });
         }
 
         public static void ReportABug()
@@ -1055,7 +1055,7 @@ namespace Dynamo.ViewModels
 
         internal static void DownloadDynamo()
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDownloadLink));
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDownloadLink) { UseShellExecute = true });
         }
 
         private void Disable3DPreview()
@@ -2921,7 +2921,7 @@ namespace Dynamo.ViewModels
 
         public void GoToWiki(object parameter)
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoWikiLink));
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoWikiLink) { UseShellExecute = true });
         }
 
         internal bool CanGoToWiki(object parameter)
@@ -2931,7 +2931,7 @@ namespace Dynamo.ViewModels
 
         public void GoToSourceCode(object parameter)
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubDynamoLink));
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubDynamoLink) { UseShellExecute = true });
         }
 
         internal bool CanGoToSourceCode(object parameter)
@@ -2941,7 +2941,7 @@ namespace Dynamo.ViewModels
 
         public void GoToDictionary(object parameter)
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDictionary));
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDictionary) { UseShellExecute = true });
         }
 
         internal bool CanGoToDictionary(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1053,7 +1053,7 @@ namespace Dynamo.ViewModels
         {
             if (Uri.IsWellFormedUriString(Model.BaseUrl, UriKind.Absolute))
             {
-                var sInfo = new ProcessStartInfo("explorer.exe", new Uri(Model.BaseUrl).AbsoluteUri);
+                var sInfo = new ProcessStartInfo("explorer.exe", new Uri(Model.BaseUrl).AbsoluteUri) { UseShellExecute = true };
                 Process.Start(sInfo);
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -118,7 +118,7 @@ namespace Dynamo.PackageManager.ViewModels
         {
             if (Uri.IsWellFormedUriString(url, UriKind.Absolute))
             {
-                var sInfo = new ProcessStartInfo("explorer.exe", new Uri(url).AbsoluteUri);
+                var sInfo = new ProcessStartInfo("explorer.exe", new Uri(url).AbsoluteUri) { UseShellExecute = true };
                 Process.Start(sInfo);
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -394,7 +394,7 @@ namespace Dynamo.ViewModels
             // Check for the existance of RootDirectory
             if (Directory.Exists(Model.RootDirectory))
             {
-                Process.Start(Model.RootDirectory);
+                Process.Start(new ProcessStartInfo(Model.RootDirectory) { UseShellExecute = true });
                 Analytics.TrackEvent(Actions.Open, Categories.PackageManagerOperations, $"{Model?.Name}");
             }
             else

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
@@ -44,7 +44,7 @@ namespace Dynamo.UI.Views
 
         private void OnClickLink(object sender, RoutedEventArgs e)
         {
-            Process.Start("http://dynamobim.org/");
+            Process.Start(new ProcessStartInfo("http://dynamobim.org/") { UseShellExecute = true });
         }
         
         private void CloseButton_OnClick(object sender, RoutedEventArgs e)
@@ -122,7 +122,7 @@ namespace Dynamo.UI.Views
                 Hyperlink link = inArgs.Source as Hyperlink;
                 if (link != null)
                 {
-                    Process.Start(link.NavigateUri.ToString());
+                    Process.Start(new ProcessStartInfo(link.NavigateUri.ToString()) { UseShellExecute = true });
                     inArgs.Handled = true;
                 }
             }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2159,7 +2159,7 @@ namespace Dynamo.Controls
         private static void OnShowInFolder(object sender, RoutedEventArgs e)
         {
             var folderPath = (string)((MenuItem)sender).Tag;
-            Process.Start("explorer.exe", "/select," + folderPath);
+            Process.Start(new ProcessStartInfo("explorer.exe", "/select," + folderPath) { UseShellExecute = true });
         }
 #endif
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -491,7 +492,7 @@ namespace Dynamo.Wpf.Views
 
                     File.Copy(dynViewModel.Model.PathManager.PreferenceFilePath, selectedPathFile);
                     string argument = "/select, \"" + selectedPathFile + "\"";
-                    System.Diagnostics.Process.Start("explorer.exe", argument);
+                    System.Diagnostics.Process.Start(new ProcessStartInfo("explorer.exe", argument) { UseShellExecute = true });
                     Analytics.TrackEvent(Actions.Export, Categories.Preferences);
                 }
                 catch (Exception ex)

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
@@ -122,7 +122,7 @@ namespace Dynamo.PackageManager.UI
         /// <param name="e"></param>
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
             e.Handled = true;
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Input;
@@ -129,7 +129,7 @@ namespace Dynamo.PackageManager
         /// <param name="e"></param>
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
             e.Handled = true;
         }
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -117,7 +117,7 @@ namespace DynamoSandbox
 
                         if (result == MessageBoxResult.Yes)
                         {
-                            Process.Start(sandboxWikiPage);
+                            Process.Start(new ProcessStartInfo(sandboxWikiPage) { UseShellExecute = true });
                         }
                     }
                 }

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -133,7 +133,7 @@ namespace DynamoSandbox
                     MessageBoxButton.OKCancel,
                     MessageBoxImage.Error))
             {
-                Process.Start("http://dynamobim.org/download/");
+                Process.Start(new ProcessStartInfo("http://dynamobim.org/download/") { UseShellExecute = true });
             }
         }
     }

--- a/src/GraphMetadataViewExtension/GraphMetadataView.xaml.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
@@ -45,7 +45,7 @@ namespace Dynamo.GraphMetadata
             {
                 try
                 {
-                    Process.Start(new ProcessStartInfo(uri.ToString()));
+                    Process.Start(new ProcessStartInfo(uri.ToString()) { UseShellExecute = true });
                 }
                 catch
                 {

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -219,7 +219,7 @@ namespace Dynamo.Notifications
         // Handler for new Webview2 tab window request
         private void WebView_NewWindowRequested(object sender, Microsoft.Web.WebView2.Core.CoreWebView2NewWindowRequestedEventArgs e)
         {
-            Process.Start(e.Uri);
+            Process.Start(new ProcessStartInfo(e.Uri) { UseShellExecute = true });
             e.Handled = true;
         }
 

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System.Diagnostics;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
@@ -38,7 +39,7 @@ namespace Dynamo.PackageDetails
 
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            System.Diagnostics.Process.Start(e.Uri.ToString());
+            System.Diagnostics.Process.Start(new ProcessStartInfo(e.Uri.ToString()) { UseShellExecute = true });
             e.Handled = true;
         }
     }

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows;
@@ -66,7 +67,7 @@ namespace Dynamo.WorkspaceDependency
         {
             try
             {
-                System.Diagnostics.Process.Start(FeedbackLink);
+                System.Diagnostics.Process.Start(new ProcessStartInfo(FeedbackLink) { UseShellExecute = true });
             }
             catch (Exception ex)
             {

--- a/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
+++ b/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
@@ -35,7 +35,7 @@ namespace Dynamo.Tests.Loggings
                 Assert.DoesNotThrow(() =>
                 {
 
-                    dynamoCLI = Process.Start(Path.Combine(coreDirectory, "DynamoCLI.exe"), $"--GeometryPath \"{locatedPath}\" -k --DisableAnalytics -o \"{openPath}\" ");
+                    dynamoCLI = Process.Start(new ProcessStartInfo(Path.Combine(coreDirectory, "DynamoCLI.exe"), $"--GeometryPath \"{locatedPath}\" -k --DisableAnalytics -o \"{openPath}\" ") { UseShellExecute = true });
 
                     Thread.Sleep(5000);// Wait 5 seconds to open the dyn
                     Assert.IsFalse(dynamoCLI.HasExited);

--- a/test/System/IntegrationTests/DynamoApplicationTests.cs
+++ b/test/System/IntegrationTests/DynamoApplicationTests.cs
@@ -30,7 +30,7 @@ namespace IntegrationTests
                 {
                     // we use a new process to avoid checking against previously loaded
                     // asm modules in the nunit-agent process.
-                    dynamoSandbox = System.Diagnostics.Process.Start(Path.Combine(coreDirectory, "DynamoSandbox.exe"), $"-gp \"{locatedPath}\"");
+                    dynamoSandbox = System.Diagnostics.Process.Start(new ProcessStartInfo(Path.Combine(coreDirectory, "DynamoSandbox.exe"), $"-gp \"{locatedPath}\""){ UseShellExecute = true });
                     dynamoSandbox.WaitForInputIdle();
 
                     var firstASMmodulePath = string.Empty;


### PR DESCRIPTION
### Purpose

Use  `System.Diagnostics.Process.Start(new ProcessStartInfo(path, args) { UseShellExecute = true })` when starting a new process. This should work both for 4.8 (where  `UseShellExecute` defaults to true and `ProcessStartInfo` is optional) and net6 (where `UseShellExecute` defaults to false and `ProcessStartInfo` is required).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [X] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
