### PR TITLE
mark 5 tests as no longer failing on net6

### DIFF
--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -309,21 +309,7 @@ namespace DynamoShapeManager
                 }
 
                 // Fallback mechanism, look inside libg folders if any of them contains ASM dlls.
-                foreach (var v in versions)
-                {
-                    var dirpath = GetLibGPreloaderLocation(v, rootFolder);
-                    if (string.IsNullOrEmpty(dirpath))
-                    {
-                        continue;
-                    }
-                    var dir = new DirectoryInfo(dirpath);
-                    var files = dir.GetFiles(ASMFileMask);
-                    if (!files.Any())
-                        continue;
-
-                    location = dir.FullName;
-                    return v;
-                }
+                if (SearchForASMInLibGFallback(versions, ref location, rootFolder, out var installedAsmVersion3)) return installedAsmVersion3;
             }
             catch (Exception)
             {
@@ -331,6 +317,33 @@ namespace DynamoShapeManager
             }
 
             return null;
+        }
+
+        internal static bool SearchForASMInLibGFallback(IEnumerable<Version> versions, ref string location, string rootFolder,
+            out Version installedAsmVersion3)
+        {
+            foreach (var v in versions)
+            {
+                var dirpath = GetLibGPreloaderLocation(v, rootFolder);
+                if (string.IsNullOrEmpty(dirpath))
+                {
+                    continue;
+                }
+
+                var dir = new DirectoryInfo(dirpath);
+                var files = dir.GetFiles(ASMFileMask);
+                if (!files.Any())
+                    continue;
+
+                location = dir.FullName;
+                {
+                    installedAsmVersion3 = v;
+                    return true;
+                }
+            }
+
+            installedAsmVersion3 = null;
+            return false;
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/AstBuildFailTest.cs
+++ b/test/DynamoCoreTests/AstBuildFailTest.cs
@@ -7,7 +7,7 @@ namespace Dynamo.Tests
     [TestFixture]
     internal class AstBuildFailTest : DynamoModelTestBase
     {
-        [Test,Category("FailureNET6")]//this currently fails because the node is in TestUINodes.dll.
+        [Test]
         public void TestAstBuildException()
         {
             // This dyn file contains a node which will throw an exception 

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -375,7 +375,7 @@ namespace Dynamo.Tests.Configuration
         }
 
         [Test]
-        [Category("UnitTests"), Category("FailureNET6")]
+        [Category("UnitTests")]
         public void TestImportCopySettings()
         {
             string settingDirectory = Path.Combine(TestDirectory, "settings");

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -394,7 +394,7 @@ namespace Dynamo.Tests.Configuration
             string firstPropertyWithSameValue = checkDifference.Properties.Except(checkDifference.DifferentPropertyValues).ToList().FirstOrDefault();
             string defSettNumberFormat = defaultSettings.NumberFormat;
             string newSettNumberFormat = newSettings.NumberFormat;
-            string failMessage = @$"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} |
+            string failMessage = $@"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} |
                                   DiffProps: {diffProps.ToString()} | 
                                   TotProps: {totProps.ToString()} | 
                                   Default Sett NumberFormat: {defSettNumberFormat} |

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -394,8 +394,19 @@ namespace Dynamo.Tests.Configuration
             string firstPropertyWithSameValue = checkDifference.Properties.Except(checkDifference.DifferentPropertyValues).ToList().FirstOrDefault();
             string defSettNumberFormat = defaultSettings.NumberFormat;
             string newSettNumberFormat = newSettings.NumberFormat;
-            string failMessage = $"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} | DiffProps: {diffProps.ToString()} | TotProps: {totProps.ToString()} | Default Sett NumberFormat: {defSettNumberFormat} | New Sett NumberFormat: {newSettNumberFormat} | First Property with the same value {firstPropertyWithSameValue}";
-
+            string failMessage = @$"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} |
+                                  DiffProps: {diffProps.ToString()} | 
+                                  TotProps: {totProps.ToString()} | 
+                                  Default Sett NumberFormat: {defSettNumberFormat} |
+                                  New Sett NumberFormat: {newSettNumberFormat} | 
+                                  First Property with the same value {firstPropertyWithSameValue} |
+                                  Property with the different value { checkDifference.DifferentPropertyValues.FirstOrDefault()} | ";
+            var p1 = Path.GetTempFileName();
+            newSettings.Save(p1);
+            Console.WriteLine(File.ReadAllText(p1));
+            var p2 = Path.GetTempFileName();
+            newSettings.Save(p2);
+            Console.WriteLine(File.ReadAllText(p2));
             // checking if the new Setting are completely different from the Default
             Assert.IsTrue(checkDifference.DifferentPropertyValues.Count == checkDifference.Properties.Count, failMessage);
 

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -402,9 +402,11 @@ namespace Dynamo.Tests.Configuration
                                   First Property with the same value {firstPropertyWithSameValue} |
                                   Property with the different value { checkDifference.DifferentPropertyValues.FirstOrDefault()} | ";
             var p1 = Path.GetTempFileName();
-            newSettings.Save(p1);
+            defaultSettings.Save(p1);
+            Console.WriteLine("def settings");
             Console.WriteLine(File.ReadAllText(p1));
             var p2 = Path.GetTempFileName();
+            Console.WriteLine("new settings");
             newSettings.Save(p2);
             Console.WriteLine(File.ReadAllText(p2));
             // checking if the new Setting are completely different from the Default

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -8,7 +8,6 @@ using System;
 using Dynamo.Interfaces;
 using System.Reflection;
 using Dynamo.Utilities;
-using Newtonsoft.Json;
 
 namespace Dynamo.Tests.Configuration
 {
@@ -32,7 +31,7 @@ namespace Dynamo.Tests.Configuration
 
         [Test]
         [Category("UnitTests")]
-        public void TestGetPythonTemplateFilePath ()
+        public void TestGetPythonTemplateFilePath()
         {
             string settingDirectory = Path.Combine(TestDirectory, "settings");
             string settingsFilePath = Path.Combine(settingDirectory, "DynamoSettings-PythonTemplate-initial.xml");
@@ -190,7 +189,7 @@ namespace Dynamo.Tests.Configuration
 
             var token = settings.CustomPackageFolders[1];
 
-            Assert.AreEqual(DynamoModel.BuiltInPackagesToken,token);
+            Assert.AreEqual(DynamoModel.BuiltInPackagesToken, token);
         }
 
         [Test]
@@ -236,12 +235,11 @@ namespace Dynamo.Tests.Configuration
         /// <summary>
         /// Struct to support the comparison between two PreferenceSettings instances
         /// </summary>
-        class PreferencesComparison
+        struct PreferencesComparison
         {
             public List<string> Properties { get; set; }
             public List<String> SamePropertyValues { get; set; }
             public List<String> DifferentPropertyValues { get; set; }
-            public Dictionary<string,string> DebugString { get; set; } = new Dictionary<string,string>();
         }
 
         /// <summary>
@@ -302,14 +300,10 @@ namespace Dynamo.Tests.Configuration
                         if (newList.Except(oldList).ToList().Count == 0)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<GroupStyleItem>))
@@ -318,14 +312,10 @@ namespace Dynamo.Tests.Configuration
                             ((List<GroupStyleItem>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<ViewExtensionSettings>))
@@ -334,14 +324,10 @@ namespace Dynamo.Tests.Configuration
                             ((List<ViewExtensionSettings>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<BackgroundPreviewActiveState>))
@@ -350,14 +336,10 @@ namespace Dynamo.Tests.Configuration
                             ((List<BackgroundPreviewActiveState>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<DynamoPlayerFolderGroup>))
@@ -366,14 +348,10 @@ namespace Dynamo.Tests.Configuration
                             ((List<DynamoPlayerFolderGroup>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else
@@ -381,14 +359,10 @@ namespace Dynamo.Tests.Configuration
                         if (newValue?.ToString() == oldValue?.ToString())
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
-                            result.DebugString.Add(destinationPi.Name,
-                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                 }
@@ -401,7 +375,7 @@ namespace Dynamo.Tests.Configuration
         }
 
         [Test]
-        [Category("UnitTests")]
+        [Category("UnitTests"), Category("FailureNET6")]
         public void TestImportCopySettings()
         {
             string settingDirectory = Path.Combine(TestDirectory, "settings");
@@ -417,26 +391,10 @@ namespace Dynamo.Tests.Configuration
             var checkDifference = comparePrefenceSettings(defaultSettings, newSettings);
             int diffProps = checkDifference.DifferentPropertyValues.Count;
             int totProps = checkDifference.Properties.Count;
-            var firstPropertyWithSameValue = checkDifference.Properties.Except(checkDifference.DifferentPropertyValues).ToList();
+            string firstPropertyWithSameValue = checkDifference.Properties.Except(checkDifference.DifferentPropertyValues).ToList().FirstOrDefault();
             string defSettNumberFormat = defaultSettings.NumberFormat;
             string newSettNumberFormat = newSettings.NumberFormat;
-            string failMessage = $@"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} |
-                                  DiffProps: {diffProps.ToString()} | 
-                                  TotProps: {totProps.ToString()} | 
-                                  Default Sett NumberFormat: {defSettNumberFormat} |
-                                  New Sett NumberFormat: {newSettNumberFormat} | 
-                                  First Property with the same value {String.Join(",",firstPropertyWithSameValue)} |
-                                  Properties with the different value { String.Join(",",checkDifference.DifferentPropertyValues)} | ";
-            var p1 = Path.GetTempFileName();
-            defaultSettings.Save(p1);
-            Console.WriteLine("def settings");
-            Console.WriteLine(File.ReadAllText(p1));
-            var p2 = Path.GetTempFileName();
-            Console.WriteLine("new settings");
-            newSettings.Save(p2);
-            Console.WriteLine(File.ReadAllText(p2));
-
-            Console.WriteLine(JsonConvert.SerializeObject(checkDifference.DebugString));
+            string failMessage = $"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} | DiffProps: {diffProps.ToString()} | TotProps: {totProps.ToString()} | Default Sett NumberFormat: {defSettNumberFormat} | New Sett NumberFormat: {newSettNumberFormat} | First Property with the same value {firstPropertyWithSameValue}";
 
             // checking if the new Setting are completely different from the Default
             Assert.IsTrue(checkDifference.DifferentPropertyValues.Count == checkDifference.Properties.Count, failMessage);

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -8,6 +8,7 @@ using System;
 using Dynamo.Interfaces;
 using System.Reflection;
 using Dynamo.Utilities;
+using Newtonsoft.Json;
 
 namespace Dynamo.Tests.Configuration
 {
@@ -235,11 +236,12 @@ namespace Dynamo.Tests.Configuration
         /// <summary>
         /// Struct to support the comparison between two PreferenceSettings instances
         /// </summary>
-        struct PreferencesComparison
+        class PreferencesComparison
         {
             public List<string> Properties { get; set; }
             public List<String> SamePropertyValues { get; set; }
             public List<String> DifferentPropertyValues { get; set; }
+            public Dictionary<string,string> DebugString { get; set; } = new Dictionary<string,string>();
         }
 
         /// <summary>
@@ -300,10 +302,14 @@ namespace Dynamo.Tests.Configuration
                         if (newList.Except(oldList).ToList().Count == 0)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<GroupStyleItem>))
@@ -312,10 +318,14 @@ namespace Dynamo.Tests.Configuration
                             ((List<GroupStyleItem>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<ViewExtensionSettings>))
@@ -324,10 +334,14 @@ namespace Dynamo.Tests.Configuration
                             ((List<ViewExtensionSettings>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<BackgroundPreviewActiveState>))
@@ -336,10 +350,14 @@ namespace Dynamo.Tests.Configuration
                             ((List<BackgroundPreviewActiveState>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else if (destinationPi.PropertyType == typeof(List<DynamoPlayerFolderGroup>))
@@ -348,10 +366,14 @@ namespace Dynamo.Tests.Configuration
                             ((List<DynamoPlayerFolderGroup>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                     else
@@ -359,10 +381,14 @@ namespace Dynamo.Tests.Configuration
                         if (newValue?.ToString() == oldValue?.ToString())
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"same {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                         else
                         {
                             propertiesWithDifferentValue.Add(destinationPi.Name);
+                            result.DebugString.Add(destinationPi.Name,
+                                $"diff {oldValue?.ToString()}, {newValue?.ToString()}");
                         }
                     }
                 }
@@ -391,7 +417,7 @@ namespace Dynamo.Tests.Configuration
             var checkDifference = comparePrefenceSettings(defaultSettings, newSettings);
             int diffProps = checkDifference.DifferentPropertyValues.Count;
             int totProps = checkDifference.Properties.Count;
-            string firstPropertyWithSameValue = checkDifference.Properties.Except(checkDifference.DifferentPropertyValues).ToList().FirstOrDefault();
+            var firstPropertyWithSameValue = checkDifference.Properties.Except(checkDifference.DifferentPropertyValues).ToList();
             string defSettNumberFormat = defaultSettings.NumberFormat;
             string newSettNumberFormat = newSettings.NumberFormat;
             string failMessage = $@"The file {newSettingslFilePath} exist: {newSettingsExist.ToString()} |
@@ -399,8 +425,8 @@ namespace Dynamo.Tests.Configuration
                                   TotProps: {totProps.ToString()} | 
                                   Default Sett NumberFormat: {defSettNumberFormat} |
                                   New Sett NumberFormat: {newSettNumberFormat} | 
-                                  First Property with the same value {firstPropertyWithSameValue} |
-                                  Property with the different value { checkDifference.DifferentPropertyValues.FirstOrDefault()} | ";
+                                  First Property with the same value {String.Join(",",firstPropertyWithSameValue)} |
+                                  Properties with the different value { String.Join(",",checkDifference.DifferentPropertyValues)} | ";
             var p1 = Path.GetTempFileName();
             defaultSettings.Save(p1);
             Console.WriteLine("def settings");
@@ -409,6 +435,9 @@ namespace Dynamo.Tests.Configuration
             Console.WriteLine("new settings");
             newSettings.Save(p2);
             Console.WriteLine(File.ReadAllText(p2));
+
+            Console.WriteLine(JsonConvert.SerializeObject(checkDifference.DebugString));
+
             // checking if the new Setting are completely different from the Default
             Assert.IsTrue(checkDifference.DifferentPropertyValues.Count == checkDifference.Properties.Count, failMessage);
 

--- a/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
+++ b/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
@@ -4,15 +4,19 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime;
 using NUnit.Framework;
+using System.Runtime.Versioning;
 
 namespace Dynamo.Tests.Loggings
 {
     public class DynamoAnalyticsDisableTest
     {
-        [Test,Category("FailureNET6")]//TODO this test requires finding ASM using the registry, will not run on linux.
+        [Test]
+        //[Platform("win")]//nunit attribute
+        //TODO this test requires finding ASM using the registry, will not run on linux.
         public void DisableAnalytics()
         {
             var versions = new List<Version>(){
@@ -28,8 +32,14 @@ namespace Dynamo.Tests.Loggings
             var locatedPath = string.Empty;
             var coreDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             Process dynamoCLI = null;
-
-            DynamoShapeManager.Utilities.GetInstalledAsmVersion2(versions, ref locatedPath, coreDirectory);
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                DynamoShapeManager.Utilities.SearchForASMInLibGFallback(versions, ref locatedPath, coreDirectory, out _);
+            }
+            else
+            {
+                DynamoShapeManager.Utilities.GetInstalledAsmVersion2(versions, ref locatedPath, coreDirectory);
+            }
             try
             {
                 Assert.DoesNotThrow(() =>

--- a/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
+++ b/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
@@ -15,8 +15,7 @@ namespace Dynamo.Tests.Loggings
     public class DynamoAnalyticsDisableTest
     {
         [Test]
-        //[Platform("win")]//nunit attribute
-        //TODO this test requires finding ASM using the registry, will not run on linux.
+        [Platform("win")]//nunit attribute for now only run on windows until we know it's useful on linux.
         public void DisableAnalytics()
         {
             var versions = new List<Version>(){
@@ -32,7 +31,10 @@ namespace Dynamo.Tests.Loggings
             var locatedPath = string.Empty;
             var coreDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             Process dynamoCLI = null;
-            if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            //TODO an approach we could take to get this running on linux.
+            //unclear if this needs to be compiled with an ifdef or runtime is ok.
+            //related to https://jira.autodesk.com/browse/DYN-5705
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 DynamoShapeManager.Utilities.SearchForASMInLibGFallback(versions, ref locatedPath, coreDirectory, out _);
             }

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -64,7 +64,7 @@ namespace Dynamo.Tests
             TestMigration("TestMigration_Core_Functions.dyn");
         }
 
-        [Test,Category("FailureNET6")]
+        [Test]
         public void TestMigration_Core_Input()
         {
             TestMigration("TestMigration_Core_Input.dyn");

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -94,7 +94,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(package.Nodes.Select(n => n.ToString("N")), nodes);
         }
 
-        [Test,Category("FailureNET6")]
+        [Test]
         public void NodeModelPackageDependencyIsCollected()
         {
             // Load JSON file graph
@@ -451,8 +451,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(pi, packageDependencies.First());
         }
-
-        [Test,Category("FailureNET6")]
+        [Test]
         public void PackageDependencyStatechangeTestAfterLoadingPackage()
         {
             // Before loading the clockworkpackage,veify the package dependency states. 

--- a/test/Libraries/GeometryColorTests/GeometryImportHelperTests.cs
+++ b/test/Libraries/GeometryColorTests/GeometryImportHelperTests.cs
@@ -31,7 +31,6 @@ namespace GeometryTests
         }
 
         [Test]
-        [Category("FailureNET6")]
         public void SATAndSABUnitImportNodeModelNodesWork_PartialApplication_Replication()
         {
             OpenModel(Path.Combine("core", "GeometryTestFiles", "sat_import_with_units.dyn"));


### PR DESCRIPTION
### Purpose

* mark 4 tests no longer failing
* mark 1 test as no longer failing, mark as platform win, and do small refactoring so it could potentially run on linux when we actually get the tests running there.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

mark net6 tests correctly.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
