### PR TITLE
Revert changes to PackageName property

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -244,7 +244,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns the Package name of the node, if it comes from a package
         /// </summary>
-        [JsonProperty(Order = 9)]
+        [JsonIgnore]
         public string PackageName
         {
             get

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -444,7 +444,7 @@ namespace DynamoCoreWpfTests
             var workSpaceJobject = JObject.Parse(ViewModel.CurrentSpaceViewModel.ToJson());
             JObject nodeViewModelJobject = JObject.Parse(workSpaceJobject["NodeViews"][0].ToString());
 
-            Assert.AreEqual(9, nodeViewModelJobject.Properties().Count(), "The number of Serialized properties is not the expected");
+            Assert.AreEqual(8, nodeViewModelJobject.Properties().Count(), "The number of Serialized properties is not the expected");
 
             bool explicitOrder =
                 nodeViewModelJobject.Properties().ElementAt(0).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Id)) &&
@@ -454,8 +454,7 @@ namespace DynamoCoreWpfTests
                 nodeViewModelJobject.Properties().ElementAt(4).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.IsFrozenExplicitly)) &&
                 nodeViewModelJobject.Properties().ElementAt(5).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.IsVisible)) &&
                 nodeViewModelJobject.Properties().ElementAt(6).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.X)) &&
-                nodeViewModelJobject.Properties().ElementAt(7).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Y)) &&
-                nodeViewModelJobject.Properties().ElementAt(8).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.PackageName));
+                nodeViewModelJobject.Properties().ElementAt(7).Name == GetJsonPropertydName<NodeViewModel>(nameof(NodeViewModel.Y));
 
             Assert.IsTrue(explicitOrder, "The order of the properties is not the expected");
         }

--- a/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
+++ b/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
@@ -88,8 +88,7 @@
         "Excluded": false,
         "ShowGeometry": true,
         "X": 179.8,
-        "Y": 160.39999999999992,
-        "PackageName": ""
+        "Y": 160.39999999999992
       },
       {
         "Id": "6cbd0760736f4235a03b38fb359e9957",
@@ -99,8 +98,7 @@
         "Excluded": false,
         "ShowGeometry": true,
         "X": 76.8,
-        "Y": 162.4,
-        "PackageName": ""
+        "Y": 162.4
       }
     ],
     "Annotations": [],

--- a/test/core/serialization/serializationNodeViewModel.dyn
+++ b/test/core/serialization/serializationNodeViewModel.dyn
@@ -85,7 +85,6 @@
     "ConnectorPins": [],
     "NodeViews": [
       {
-        "PackageName": "",
         "Id": "62536c5a788843c285bd2ffdce10290f",
         "Name": "Code Block",
         "IsSetAsInput": false,
@@ -96,7 +95,6 @@
         "Y": 358.0
       },
       {
-        "PackageName": "",
         "Id": "993ed0e4eeb3492f8e301c3a9edf64f9",
         "Name": "Code Block",
         "IsSetAsInput": false,


### PR DESCRIPTION
### Purpose

Revert changes in https://github.com/DynamoDS/Dynamo/pull/14178 causing new property in the Node VM to be serialized. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- incorrectly serialized a new property causing unnecessary bloating of node information
- now ignores the property
- all tests passing

### Reviewers

@mjkkirschner 
@reddyashish 

### FYIs
