### PR TITLE
Autocrash

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -760,6 +760,11 @@ namespace Dynamo.ViewModels
             else if (PortViewModel.PortModel.PortType == PortType.Output)
             {
                 portType = PortViewModel.PortModel.GetOutPortType();
+                //if the custom node output name contains spaces, try using the first word.
+                if (PortViewModel.PortModel.Owner is Graph.Nodes.CustomNodes.Function && portType.Contains(" "))
+                {
+                    portType = portType.Split(new string[]{" "},StringSplitOptions.None).FirstOrDefault();
+                }
             }
 
             //List of input types that are skipped temporarily, and will display list of default suggestions instead.
@@ -784,7 +789,6 @@ namespace Dynamo.ViewModels
             var ast = parseResult?.CodeBlockNode.Children().FirstOrDefault() as IdentifierNode;
             //if parsing the type failed, revert to original string.
             portType = ast != null ? ast.datatype.Name : portType;
-
             //check if the input port return type is in the skipped input types list
             if (skippedInputTypes.Any(s => s == portType))
             {
@@ -824,7 +828,8 @@ namespace Dynamo.ViewModels
                 {
                     foreach (var inputParameter in ztSearchElement.Descriptor.Parameters.Select((value, index) => new { value, index }))
                     {
-                        if (inputParameter.value.Type.ToString() == portType || DerivesFrom(inputParameter.value.Type.ToString(), portType, core))
+                        var ZTparamName = inputParameter.value.Type.Name ?? inputParameter.value.Type.ToString();
+                        if (ZTparamName == portType || DerivesFrom(ZTparamName, portType, core))
                         {
                             ztSearchElement.AutoCompletionNodeElementInfo.PortToConnect = ztSearchElement.Descriptor.Type == FunctionType.InstanceMethod ? inputParameter.index + 1 : inputParameter.index;
                             elements.Add(ztSearchElement);

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -141,9 +141,9 @@ namespace DynamoCoreWpfTests
             // Set the suggestion to ObjectType
             searchViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = NodeAutocompleteSuggestion.ObjectType;
 
-            // The initial list will fill the FilteredResults with a few options - all basic input types
+            // Results will be nodes that take color or color[] etc as params.
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(7, searchViewModel.FilteredResults.Count());
+            Assert.AreEqual(10, searchViewModel.FilteredResults.Count());
         }
 
         [Test]
@@ -282,7 +282,7 @@ namespace DynamoCoreWpfTests
             var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
             searchViewModel.PortViewModel = outPorts[0];
             var suggestions = searchViewModel.GetMatchingSearchElements();
-            Assert.AreEqual(29, suggestions.Count());
+            Assert.AreEqual(44, suggestions.Count());
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -163,7 +163,7 @@ namespace DynamoCoreWpfTests
             // Set the suggestion to ObjectType
             searchViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = NodeAutocompleteSuggestion.ObjectType;
 
-            // Results will be nodes that take worksheet.
+            // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
             Assert.AreEqual(44, searchViewModel.FilteredResults.Count());
         }

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dynamo;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
@@ -144,6 +145,27 @@ namespace DynamoCoreWpfTests
             // Results will be nodes that take color or color[] etc as params.
             searchViewModel.PopulateAutoCompleteCandidates();
             Assert.AreEqual(10, searchViewModel.FilteredResults.Count());
+        }
+
+        [Test]
+        public void NodeSuggestions_CanAutoCompleteOnCustomNodesOutPort_WithSpaceInPortName()
+        {
+            var outputNode = new Dynamo.Graph.Nodes.CustomNodes.Output();
+            outputNode.Symbol = "Line Nonsense";
+            var cnm = new Dynamo.Graph.Nodes.CustomNodes.Function(
+                new CustomNodeDefinition(Guid.NewGuid(), "mock", new List<NodeModel>() { outputNode })
+                , "mock", "mock", "mock");
+            var cnvm = new NodeViewModel(ViewModel.CurrentSpaceViewModel, cnm);
+
+            var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
+            searchViewModel.PortViewModel = cnvm.OutPorts.First();
+
+            // Set the suggestion to ObjectType
+            searchViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = NodeAutocompleteSuggestion.ObjectType;
+
+            // Results will be nodes that take worksheet.
+            searchViewModel.PopulateAutoCompleteCandidates();
+            Assert.AreEqual(44, searchViewModel.FilteredResults.Count());
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

I could not reproduce the crash seen in https://github.com/DynamoDS/Dynamo/issues/14192 in master (2.19).

I did notice however that checking customNode outputs frequently throws thousands of exceptions and also fails to find results even when the type name is a valid type!

I've made two changes I think will improve the situation a small bit.
1. When we encounter a space in a custom node output port name, we just use the first word, it at least has a non zero chance of being a type name.
2. when we look for matching types we use the `Type.Name` instead of `Type.ToString()` `ToString` will also include rank, like `var[]..[]` - this is not a valid class name that can be found and so we never make any matches with types that include rank. After this PR we'll better match different ranks of type, and also derived types.

Note how more valid results are returned in the tests I have updated. Also less exceptions are thrown, so the results are computed a bit faster.



### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Return more results for object based node autocomplete when using custom node output ports.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
