### PR TITLE
DYN-6064/remove: deliberated scroll to bottom on library searching

### DIFF
--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -381,11 +381,6 @@
             return JSON.stringify(locationInfo);
         }
 
-        //scroll down until the bottom of the page so the AddOns always be visible
-        function scrollToBottom() {
-            document.getElementsByClassName("LibraryItemContainer")[0].scroll(0, document.body.scrollHeight)
-        }
-
         //This method will be executed when the WebBrowser change its size, so we can update the Popup vertical location that is over the library
         function bodyResizeEvent() {
              window.chrome.webview.postMessage(JSON.stringify({ "func": "ResizedEvent", "data": "" }));


### PR DESCRIPTION
### Purpose

This PR removes a function that force the scroll to bottom on library search results.
Ref.: [DYN-6064](https://jira.autodesk.com/browse/DYN-6064)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

I've removed **scrollToBottom()** function that forced the scroll to bottom on library search results.

### Reviewers


### FYIs
