### PR TITLE
Cherry-Pick DYN-6053-Adjust-Lucene-Weights (#14223)

### DIFF
--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -49,25 +49,68 @@ namespace Dynamo.Configuration
         /// </summary>
         internal static int DefaultResultsCount = 50;
 
+
+        #region Field Weights
         /// <summary>
         /// Search name matching weight
         /// </summary>
         internal static int SearchNameWeight = 10;
 
         /// <summary>
+        /// Search Category matching weight
+        /// </summary>
+        internal static int SearchCategoryWeight = 9;
+
+        /// <summary>
+        /// Search Description matching weight
+        /// </summary>
+        internal static int SearchDescriptionWeight = 6;
+
+        /// <summary>
+        /// Search tags matching weight
+        /// </summary>
+        internal static int SearchTagsWeight = 6;
+
+        /// <summary>
+        /// other fields search matching weight
+        /// </summary>
+        internal static int SearchMetaFieldsWeight = 6;
+
+        #endregion
+
+
+        #region Wildcards Field Weights
+        /// <summary>
         /// Wildcards search name matching weight
         /// </summary>
         internal static int WildcardsSearchNameWeight = 7;
 
         /// <summary>
-        /// Search non-name meta fields matching weight
+        /// Wildcards search Category matching weight
         /// </summary>
-        internal static int SearchMetaFieldsWeight = 6;
+        internal static int WildcardsSearchCategoryWeight = 6;
 
         /// <summary>
-        /// Wildcards search non-name meta fields matching weight
+        /// Wildcards search Description matching weight
+        /// </summary>
+        internal static int WildcardsSearchDescriptionWeight = 4;
+
+        /// <summary>
+        /// Wildcards search tags matching weight
+        /// </summary>
+        internal static int WildcardsSearchTagsWeight = 4;
+
+        /// <summary>
+        /// other wildcards fields search matching weight
         /// </summary>
         internal static int WildcardsSearchMetaFieldsWeight = 4;
+
+        /// <summary>
+        /// Wildcards search name matching weight
+        /// </summary>
+        internal static int WildcardsSearchNameParsedWeight = 5;
+
+        #endregion
 
         /// <summary>
         /// Fuzzy search matching weight

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -218,32 +218,18 @@ namespace Dynamo.Utilities
                     booleanQuery.Add(fuzzyQuery, Occur.SHOULD);
                 }
 
-                var wildcardQuery = new WildcardQuery(new Term(f, searchTerm));
-                if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
-                {
-                    wildcardQuery.Boost = LuceneConfig.SearchNameWeight;
-                }
-                else
-                {
-                    wildcardQuery.Boost = LuceneConfig.SearchMetaFieldsWeight;
-                }
-                booleanQuery.Add(wildcardQuery, Occur.SHOULD);
+                var fieldQuery = CalculateFieldWeight(f, searchTerm);
+                var wildcardQuery = CalculateFieldWeight(f, searchTerm, true);
 
-                wildcardQuery = new WildcardQuery(new Term(f, "*" + searchTerm + "*"));
-                if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
-                {
-                    wildcardQuery.Boost = LuceneConfig.WildcardsSearchNameWeight;
-                }
-                else
-                {
-                    wildcardQuery.Boost = LuceneConfig.WildcardsSearchMetaFieldsWeight;
-                }
+                booleanQuery.Add(fieldQuery, Occur.SHOULD);
                 booleanQuery.Add(wildcardQuery, Occur.SHOULD);
 
                 if (searchTerm.Contains(' ') || searchTerm.Contains('.'))
                 {
                     foreach (string s in searchTerm.Split(' ', '.'))
                     {
+                        if (string.IsNullOrEmpty(s)) continue;
+
                         if (s.Length > LuceneConfig.FuzzySearchMinimalTermLength)
                         {
                             fuzzyQuery = new FuzzyQuery(new Term(f, s), LuceneConfig.FuzzySearchMinEdits);
@@ -253,7 +239,7 @@ namespace Dynamo.Utilities
 
                         if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
                         {
-                            wildcardQuery.Boost = 5;
+                            wildcardQuery.Boost = LuceneConfig.WildcardsSearchNameParsedWeight;
                         }
                         else
                         {
@@ -264,6 +250,39 @@ namespace Dynamo.Utilities
                 }
             }
             return booleanQuery.ToString();
+        }
+
+        private WildcardQuery CalculateFieldWeight(string fieldName, string searchTerm, bool isWildcard = false)
+        {
+            WildcardQuery query;
+
+            query = isWildcard == false ?
+                new WildcardQuery(new Term(fieldName, searchTerm)) : new WildcardQuery(new Term(fieldName, "*" + searchTerm + "*"));
+
+            switch (fieldName)
+            {
+                case nameof(LuceneConfig.NodeFieldsEnum.Name):
+                    query.Boost = isWildcard == false?
+                        LuceneConfig.SearchNameWeight :  LuceneConfig.WildcardsSearchNameWeight;
+                    break;
+                case nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName):
+                    query.Boost = isWildcard == false?
+                        LuceneConfig.SearchCategoryWeight : LuceneConfig.WildcardsSearchCategoryWeight;
+                    break;
+                case nameof(LuceneConfig.NodeFieldsEnum.Description):
+                    query.Boost = isWildcard == false ?
+                        LuceneConfig.SearchDescriptionWeight : LuceneConfig.WildcardsSearchDescriptionWeight;
+                    break;
+                case nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords):
+                    query.Boost = isWildcard == false ?
+                       LuceneConfig.SearchTagsWeight : LuceneConfig.WildcardsSearchTagsWeight;
+                    break;
+                default:
+                    query.Boost = isWildcard == false ?
+                       LuceneConfig.SearchMetaFieldsWeight : LuceneConfig.WildcardsSearchMetaFieldsWeight;
+                    break;
+            }
+            return query;
         }
 
         internal void DisposeWriter()


### PR DESCRIPTION
### Purpose

Cherry-Pick DYN-6053-Adjust-Lucene-Weights (#14223)
https://github.com/DynamoDS/Dynamo/pull/14223

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Cherry-Pick DYN-6053-Adjust-Lucene-Weights (#14223)

### Reviewers

@QilongTang 

### FYIs

