### PR TITLE
Fix for failing Docs browser wpf tests

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1511,12 +1511,12 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
-            /// <summary>
-            ///     Adds a node to this workspace.
-            /// </summary>
-            /// <param name="node">The node which is being added to the workspace.</param>
-            /// <param name="centered">Indicates if the node should be placed at the center of workspace.</param>
-            internal void AddAndRegisterNode(NodeModel node, bool centered = false)
+        /// <summary>
+        ///     Adds a node to this workspace.
+        /// </summary>
+        /// <param name="node">The node which is being added to the workspace.</param>
+        /// <param name="centered">Indicates if the node should be placed at the center of workspace.</param>
+        internal void AddAndRegisterNode(NodeModel node, bool centered = false)
         {
             if (nodes.Contains(node))
                 return;

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -36,7 +36,7 @@ namespace DynamoCoreWpfTests
 
         protected string TempFolder { get; private set; }
 
-        [OneTimeSetUp]
+        [SetUp]
         public virtual void Start()
         {
             var assemblyPath = Assembly.GetExecutingAssembly().Location;
@@ -105,7 +105,7 @@ namespace DynamoCoreWpfTests
             };
         }
 
-        [OneTimeTearDown]
+        [TearDown]
         public void Exit()
         {
             //Ensure that we leave the workspace marked as


### PR DESCRIPTION
### Purpose

The DynamoTestUIBase setup and teardown attributes were meant for per-test setup/teardown within the test fixture (I think), and these attributes are still being used by nunit3. I had mistakenly [changed](https://github.com/DynamoDS/Dynamo/pull/14230) them to a one-time setup and teardown for the whole test fixture itself, which is what caused the tests to regress. ~~At least this makes the docs browser tests pass again, hopefully, it should work for all other tests as well.~~

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
