### PR TITLE
AGD-9999 : add id for graph json content

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -220,7 +220,7 @@ namespace Dynamo.Graph.Workspaces
         internal readonly LinterManager linterManager;
 
         private string fileName;
-        private string fileContentId;
+        private string fromJsonGraphId;
         private string name;
         private double height = 100;
         private double width = 100;
@@ -277,6 +277,11 @@ namespace Dynamo.Graph.Workspaces
         public void OnDummyNodesReloaded()
         {
             DummyNodesReloaded?.Invoke();
+        }
+
+        internal static string ComputeGraphIdFromJson(string fileContents)
+        {
+            return Hash.ToBase32String(Hash.GetHashFromString(fileContents));
         }
 
         /// <summary>
@@ -1139,15 +1144,17 @@ namespace Dynamo.Graph.Workspaces
         /// <summary>
         ///     A unique id representing a workspace that was created from an in-memory graph content.
         ///     This is usefull if you need to check if the current workspace was initially created from
-        ///     a specific graph content.
+        ///     a specific graph content. As oposed to graph uuid, FromJsonGraphId is not serialized and it
+        ///     only makes sense (and is computed) at runtime when we OpenFileFromJson. Because of that
+        ///     we eliminate the risk of having this value modified outside Dynamo environment.
         /// </summary>
         [JsonIgnore]
-        public string FileContentId
+        internal string FromJsonGraphId
         {
-            get { return fileContentId; }
+            get { return fromJsonGraphId; }
             set
             {
-                fileContentId = value;
+                fromJsonGraphId = value;
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -220,6 +220,7 @@ namespace Dynamo.Graph.Workspaces
         internal readonly LinterManager linterManager;
 
         private string fileName;
+        private string fileContentId;
         private string name;
         private double height = 100;
         private double width = 100;
@@ -1132,6 +1133,21 @@ namespace Dynamo.Graph.Workspaces
             {
                 fileName = value;
                 RaisePropertyChanged("FileName");
+            }
+        }
+
+        /// <summary>
+        ///     A unique id representing a workspace that was created from an in-memory graph content.
+        ///     This is usefull if you need to check if the current workspace was initially created from
+        ///     a specific graph content.
+        /// </summary>
+        [JsonIgnore]
+        public string FileContentId
+        {
+            get { return fileContentId; }
+            set
+            {
+                fileContentId = value;
             }
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2305,6 +2305,7 @@ namespace Dynamo.Models
                 this.LinterManager);
 
             workspace.FileName = string.IsNullOrEmpty(filePath) ? "" : filePath;
+            workspace.FileContentId = string.IsNullOrEmpty(filePath) ? fileContents.GetHashCode().ToString() : "";
             workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
 
             // NOTE: This is to handle the case of opening a JSON file that does not have a version string

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2305,7 +2305,7 @@ namespace Dynamo.Models
                 this.LinterManager);
 
             workspace.FileName = string.IsNullOrEmpty(filePath) ? "" : filePath;
-            workspace.FileContentId = string.IsNullOrEmpty(filePath) ? fileContents.GetHashCode().ToString() : "";
+            workspace.FromJsonGraphId = string.IsNullOrEmpty(filePath) ? WorkspaceModel.ComputeGraphIdFromJson(fileContents) : "";
             workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
 
             // NOTE: This is to handle the case of opening a JSON file that does not have a version string

--- a/test/DynamoCoreTests/Models/OpenFileFromJsonCommandTest.cs
+++ b/test/DynamoCoreTests/Models/OpenFileFromJsonCommandTest.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Xml;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Utilities;
 using NUnit.Framework;
@@ -20,7 +21,7 @@ namespace Dynamo.Tests.ModelsTest
             //Arrange
             string samplepath = Path.Combine(TestDirectory, @"core\callsite\RebindingSingleDimension.dyn");
             string fileContents = File.ReadAllText(samplepath);
-            string fileContentId = fileContents.GetHashCode().ToString();
+            string jsonGraphId = WorkspaceModel.ComputeGraphIdFromJson(fileContents);
             var openFromJsonCommand = new OpenFileFromJsonCommand(fileContents, true);
 
             //Act
@@ -36,7 +37,7 @@ namespace Dynamo.Tests.ModelsTest
 
 
             //Assert
-            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.FileContentId == fileContentId);
+            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.FromJsonGraphId == jsonGraphId);
             Assert.IsEmpty(CurrentDynamoModel.CurrentWorkspace.FileName);
             Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.HasUnsavedChanges);
             Assert.IsNotNull(deserializedCommand);

--- a/test/DynamoCoreTests/Models/OpenFileFromJsonCommandTest.cs
+++ b/test/DynamoCoreTests/Models/OpenFileFromJsonCommandTest.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Xml;
 using Dynamo.Models;
 using Dynamo.Utilities;
@@ -20,6 +20,7 @@ namespace Dynamo.Tests.ModelsTest
             //Arrange
             string samplepath = Path.Combine(TestDirectory, @"core\callsite\RebindingSingleDimension.dyn");
             string fileContents = File.ReadAllText(samplepath);
+            string fileContentId = fileContents.GetHashCode().ToString();
             var openFromJsonCommand = new OpenFileFromJsonCommand(fileContents, true);
 
             //Act
@@ -35,6 +36,7 @@ namespace Dynamo.Tests.ModelsTest
 
 
             //Assert
+            Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.FileContentId == fileContentId);
             Assert.IsEmpty(CurrentDynamoModel.CurrentWorkspace.FileName);
             Assert.IsTrue(CurrentDynamoModel.CurrentWorkspace.HasUnsavedChanges);
             Assert.IsNotNull(deserializedCommand);


### PR DESCRIPTION
### Purpose
Add an identifier in workspace when a graph is opened from json content.
Sometimes we want to check if the current workspace was initially created from a specific graph content.
We rely on this in GD where we work with in-memory graphs and we do not want to open the same graph multiple times.
This info was stored somewhere in there but it makes more sense to have it in the workspace.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 
