### PR TITLE
hide new package manager for release

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -621,9 +621,9 @@
                         <MenuItem Header="{x:Static p:Resources.DynamoViewPackageMenuPublishWorkspace}"
                                   Command="{Binding Path=DataContext.PublishCurrentWorkspaceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                                   Name="publishCurrent" />
-                        <MenuItem Header="New Package Manager Placeholder"
+                        <!--<MenuItem Header="New Package Manager Placeholder"
                                   Command="{Binding Path=DataContext.ShowPackageManagerCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Name="showPM" />
+                                  Name="showPM" />-->
                     </MenuItem>
 
                     <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenu}"


### PR DESCRIPTION

### Purpose

Hide the upcoming Package Manager WIP from the menu items in Dynamo for the release of 2.19.

#### Screenshot
![image](https://github.com/DynamoDS/Dynamo/assets/5354594/c4bcabbe-5211-47de-9662-9ee17e827241)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

- hide the menu item for the new package manager for the 2.19 release

### Reviewers

@reddyashish 
@QilongTang 

### FYIs

@Amoursol 
