### PR TITLE
2.19 fix visualization tests

### DIFF
--- a/src/VisualizationTests/CustomNodeTests.cs
+++ b/src/VisualizationTests/CustomNodeTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -36,7 +36,7 @@ namespace WpfVisualizationTests
         }
 
         [Test]
-        public async void InHomeWorkspace_CustomNodeInstance_HasGeometry()
+        public void InHomeWorkspace_CustomNodeInstance_HasGeometry()
         {
             Assert.AreEqual(3, BackgroundPreviewGeometry.Meshes().Count());
             Assert.AreEqual(3, BackgroundPreviewGeometry.Curves().Count());
@@ -141,7 +141,7 @@ namespace WpfVisualizationTests
         }
 
         [Test]
-        public async void InsideInstance_AllGeometryFromInstancesOfThisCustomNode_Alive()
+        public void InsideInstance_AllGeometryFromInstancesOfThisCustomNode_Alive()
         {
             Assert.AreEqual(2, BackgroundPreviewGeometry.Points().Count(p => p.IsAlive()));
             Assert.AreEqual(2, BackgroundPreviewGeometry.Curves().Count(p => p.IsAlive()));
@@ -149,7 +149,7 @@ namespace WpfVisualizationTests
         }
 
         [Test]
-        public async void InsideInstance_OtherGeometryFromOtherNodes_Dead()
+        public void InsideInstance_OtherGeometryFromOtherNodes_Dead()
         {
             Assert.AreEqual(1, BackgroundPreviewGeometry.Points().Count(p => p.IsDead()));
             Assert.AreEqual(1, BackgroundPreviewGeometry.Curves().Count(p => p.IsDead()));

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -109,12 +109,15 @@ namespace WpfVisualizationTests
             vmConfig.DynamoModel = Model;
 
             ViewModel = DynamoViewModel.Start(vmConfig);
+            // Disable edge rendering to ensure that curve counts are correct.
+            // because preferences settings is now a sinleton prefs changes can affect other tests.
+            ViewModel.RenderPackageFactoryViewModel.ShowEdges = false;
 
             //create the view
             View = new DynamoView(ViewModel);
             View.Show();
 
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            //SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
         }
 
         /// <summary>
@@ -140,7 +143,7 @@ namespace WpfVisualizationTests
             };
         }
 
-        private async void Model_EvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
+        private void Model_EvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
             DispatcherUtil.DoEvents();
         }
@@ -159,11 +162,12 @@ namespace WpfVisualizationTests
             ViewModel.OpenCommand.Execute(relativePath);
         }
 
-        // With version 2.5 NUnit will call base class TearDown methods after those in the derived classes
-        [TearDown]
-        private void CleanUp()
+        //because this overrides the base class it will be called first.
+        public override void TearDown()
         {
             Model.EvaluationCompleted -= Model_EvaluationCompleted;
+            base.TearDown();
+            DispatcherUtil.DoEvents();
         }
     }
 
@@ -1261,7 +1265,7 @@ namespace WpfVisualizationTests
             }
         }
 
-        private async void tagGeometryWhenClickingItem(int[] indexes, int expectedNumberOfLabels,
+        private void tagGeometryWhenClickingItem(int[] indexes, int expectedNumberOfLabels,
             string nodeName, Func<NodeView,NodeModel> getGeometryOwnerNode, bool expandPreviewBubble = false)
         {
             OpenVisualizationTest("MAGN_3815.dyn");
@@ -1295,7 +1299,7 @@ namespace WpfVisualizationTests
             {
                 treeViewItem.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
                 {
-                    RoutedEvent = Mouse.MouseDownEvent
+                    RoutedEvent = Mouse.MouseUpEvent
                 });
             });
 


### PR DESCRIPTION
### Purpose

attempt to fix visualization tests for 2.19
* flush the dispatcher after the views are closed so unloaded is called
* get rid of hacky async code
* reset some graphics prefs between tests

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

fix visualization tests

### Reviewers
