### PR TITLE
fix legacy issue with watch3dnodes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -2840,11 +2840,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     effectsManager = null;
                    
                 }
-                SelectedMaterial = null;
-                WhiteMaterial = null;
-                FrozenMaterial = null;
-                IsolatedMaterial = null;
-
                 foreach (var sceneItem in SceneItems)
                 {
                     sceneItem.Dispose();

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -1450,6 +1450,35 @@ X: 0.5 Y: -0.5 Z: -0.5".Replace(" ",string.Empty),
                 System.String.Join(Environment.NewLine, edgeVerts.Select(x=>x.ToString())).Replace(" ",string.Empty));
         }
 
+        [Test]
+        public void Watch3dNodeDisposal_DoesNotBreakBackGroundPreview()
+        {
+           OpenVisualizationTest("FirstRunWatch3D.dyn");
+           RunCurrentModel();
+           DispatcherUtil.DoEvents();
+            //asset that background preview contains a mesh.
+            Assert.AreEqual(1, BackgroundPreviewGeometry.NumberOfVisibleMeshes());
+
+            //now delete watch3d and the cube constructor node
+            var delCommand = new DynamoModel.DeleteModelCommand("60a5fa8a-c0ef-41c8-b717-5465ef759f80");
+            var del2Command = new DynamoModel.DeleteModelCommand("fb256aa2-819a-4037-80fb-40dc2a70f2f0");
+            Model.ExecuteCommand(delCommand);
+            Model.ExecuteCommand(del2Command);
+            RunCurrentModel();
+            DispatcherUtil.DoEvents();
+            Assert.AreEqual(0, BackgroundPreviewGeometry.NumberOfVisibleMeshes());
+
+            //recreate the cube node
+            var undocommand = new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Undo);
+            Model.ExecuteCommand(undocommand);
+            RunCurrentModel();
+            DispatcherUtil.DoEvents();
+            Assert.AreEqual(1, BackgroundPreviewGeometry.NumberOfVisibleMeshes());
+            Assert.NotNull(HelixWatch3DViewModel.WhiteMaterial);
+            Assert.NotNull(HelixWatch3DViewModel.SelectedMaterial);
+            Assert.NotNull(HelixWatch3DViewModel.FrozenMaterial);
+            Assert.NotNull(HelixWatch3DViewModel.IsolatedMaterial);
+        }
 
     }
 


### PR DESCRIPTION
### Purpose

Disposal of HelixWatch3dViewModel set some static properties to null to attempt to address memory leaks (though it's not clear it was ever required), unfortunately, this also breaks rendering when deleting a watch3d node.

I am not sure if this change incurs a memory leak cost, so before merging I will profile it.
If it does cause memory leaks we will need to do something smarter like only set these properties null from the main background preview or stop using static materials - though that has its own memory cost.

TODO:
- [x] profile memory changes 


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fix an issue where deleting a watch3d node would break rendering of meshes in the main background preview.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
