### PR TITLE
DYN-6173 add new close flag to splashscreen

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -275,34 +275,52 @@ namespace Dynamo.Controls
 
         private void DynamoViewModel_RequestEnableShortcutBarItems(bool enable)
         {
-            saveThisButton.IsEnabled = enable;
-            saveButton.IsEnabled = enable;
-            exportMenu.IsEnabled = enable;
-            
-            shortcutBar.IsNewButtonEnabled = enable;
-            shortcutBar.IsOpenButtonEnabled = enable;
-            shortcutBar.IsSaveButtonEnabled = enable;
-            shortcutBar.IsLoginMenuEnabled = enable;
-            shortcutBar.IsExportMenuEnabled  = enable;
-            shortcutBar.IsNotificationCenterEnabled = enable;
-
-            if(dynamoViewModel.ShowStartPage)
+            if (!(saveThisButton is null))
             {
-                shortcutBar.IsNewButtonEnabled = true;
-                shortcutBar.IsOpenButtonEnabled = true;
-                shortcutBar.IsLoginMenuEnabled = true;
-                shortcutBar.IsNotificationCenterEnabled = true;
+                saveThisButton.IsEnabled = enable;
+                saveButton.IsEnabled = enable;
+            }
+            if (!(exportMenu is null))
+            {
+                exportMenu.IsEnabled = enable;
+            }
+           
+            if (!(shortcutBar is null))
+            {
+                shortcutBar.IsNewButtonEnabled = enable;
+                shortcutBar.IsOpenButtonEnabled = enable;
+                shortcutBar.IsSaveButtonEnabled = enable;
+                shortcutBar.IsLoginMenuEnabled = enable;
+                shortcutBar.IsExportMenuEnabled = enable;
+                shortcutBar.IsNotificationCenterEnabled = enable;
+
+                if (dynamoViewModel.ShowStartPage)
+                {
+                    shortcutBar.IsNewButtonEnabled = true;
+                    shortcutBar.IsOpenButtonEnabled = true;
+                    shortcutBar.IsLoginMenuEnabled = true;
+                    shortcutBar.IsNotificationCenterEnabled = true;
+                }
             }
         }
 
         private void OnWorkspaceOpened(WorkspaceModel workspace)
         {
-            saveThisButton.IsEnabled = true;
-            saveButton.IsEnabled = true;
-            exportMenu.IsEnabled = true;
+            if (!(saveThisButton is null))
+            {
+                saveThisButton.IsEnabled = true;
+                saveButton.IsEnabled = true;
+            }
 
-            ShortcutBar.IsSaveButtonEnabled = true;
-            shortcutBar.IsExportMenuEnabled = true;
+            if (!(exportMenu is null))
+            {
+                exportMenu.IsEnabled = true;
+            }
+            if (!(shortcutBar is null))
+            {
+                ShortcutBar.IsSaveButtonEnabled = true;
+                shortcutBar.IsExportMenuEnabled = true;
+            }
 
             if (!(workspace is HomeWorkspaceModel hws))
             return;

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -164,9 +164,9 @@ namespace Dynamo.UI.Views
         /// </summary>
         private void SplashScreenRequestClose(object sender, EventArgs e)
         {
-            //TODO this does not seem to be called in Revit or Sandbox context.
-            //investigate if that is appropriate. It only gets called when
-            //ShutdownParams.CloseDynamoView is true... which is never??
+            //This is only called when shutdownparams.closeDynamoView = true
+            //which is during tests or an exist command
+            //which is used rarely, during but we it is used when the Revit document is lost and Dynamo is open.
             CloseWindow();
             viewModel.RequestClose -= SplashScreenRequestClose;
         }

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -157,7 +157,7 @@ namespace Dynamo.UI.Views
                 webView.Focus();
                 System.Windows.Forms.SendKeys.SendWait("{TAB}");
             }
-            OnRequestDynamicSplashScreen();           
+            OnRequestDynamicSplashScreen();
         }
         /// <summary>
         /// Request to close SplashScreen.
@@ -219,11 +219,14 @@ namespace Dynamo.UI.Views
         private void LaunchDynamo(bool isCheckboxChecked)
         {
             CloseWasExplicit = false;
-            viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
+            if (viewModel != null)
+            {
+                viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
+            }
             StaticSplashScreenReady -= OnStaticScreenReady;
             Close();
-            dynamoView.Show();
-            dynamoView.Activate();
+            dynamoView?.Show();
+            dynamoView?.Activate();
         }
 
         /// <summary>
@@ -468,7 +471,7 @@ namespace Dynamo.UI.Views
         /// <summary>
         /// If the user wants to close the window, we shutdown the application and don't launch Dynamo
         /// </summary>
-        private void CloseWindow()
+        internal void CloseWindow()
         {
             CloseWasExplicit = true;
             if (Application.Current != null)
@@ -479,10 +482,10 @@ namespace Dynamo.UI.Views
             // If Dynamo is launched from an integrator host, user should be able to close the splash screen window.
             // Additionally, we will have to shutdown the ViewModel which will close all the services and dispose the events.
             // RequestUpdateLoadBarStatus event needs to be unsubscribed when the splash screen window is closed, to avoid populating the info on splash screen.
-            else if (this is SplashScreen)
+            else
             {
                 this.Close();
-                viewModel.Model.ShutDown(false);
+                viewModel?.Model.ShutDown(false);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -26,6 +26,12 @@ namespace Dynamo.UI.Views
         private static readonly string jsEmbeddedFile = "Dynamo.Wpf.Packages.SplashScreen.build.index.bundle.js";
         private static readonly string backgroundImage = "Dynamo.Wpf.Views.SplashScreen.WebApp.splashScreenBackground.png";
         private static readonly string imageFileExtension = "png";
+        /// <summary>
+        /// True if the reason the splash screen was closed was because the user explicitly closed it,
+        /// as opposed to the splash screen closing because dynamo was launched.
+        /// This is useful for knowing if Dynamo is already started or not.
+        /// </summary>
+        public bool CloseWasExplicit { get; private set; }
 
         // Timer used for Splash Screen loading
         internal Stopwatch loadingTimer;
@@ -158,6 +164,9 @@ namespace Dynamo.UI.Views
         /// </summary>
         private void SplashScreenRequestClose(object sender, EventArgs e)
         {
+            //TODO this does not seem to be called in Revit or Sandbox context.
+            //investigate if that is appropriate. It only gets called when
+            //ShutdownParams.CloseDynamoView is true... which is never??
             CloseWindow();
             viewModel.RequestClose -= SplashScreenRequestClose;
         }
@@ -209,6 +218,7 @@ namespace Dynamo.UI.Views
         /// <param name="isCheckboxChecked"></param>
         private void LaunchDynamo(bool isCheckboxChecked)
         {
+            CloseWasExplicit = false;
             viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
             StaticSplashScreenReady -= OnStaticScreenReady;
             Close();
@@ -460,6 +470,7 @@ namespace Dynamo.UI.Views
         /// </summary>
         private void CloseWindow()
         {
+            CloseWasExplicit = true;
             if (Application.Current != null)
             {
                 Application.Current.Shutdown();

--- a/test/DynamoCoreWpfTests/SplashScreenTests.cs
+++ b/test/DynamoCoreWpfTests/SplashScreenTests.cs
@@ -1,0 +1,33 @@
+
+
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    internal class SplashScreenTests
+    {
+        [Test]
+        public void SplashScreen_CloseExplicitPropIsCorrect1()
+        {
+            var ss = new Dynamo.UI.Views.SplashScreen();
+            ss.RequestLaunchDynamo(true);
+            Assert.IsFalse(ss.CloseWasExplicit);
+        }
+        [Test]
+        public void SplashScreen_CloseExplicitPropIsCorrect2()
+        {
+            var ss = new Dynamo.UI.Views.SplashScreen();
+            Assert.IsFalse(ss.CloseWasExplicit);
+        }
+        [Test]
+        public async void SplashScreen_CloseExplicitPropIsCorrect3()
+        {
+            var ss = new Dynamo.UI.Views.SplashScreen();
+            ss.CloseWindow();
+            Assert.IsTrue(ss.CloseWasExplicit);
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Purpose

Adds a flag to the splashscreen so clients can tell why the splash screen was closed:
1. because dynamo was launched from the splash screen.
2. because the splash screen was closed.

- [x] add a test 

After this is merged, we'll publish a new nuget and consume it in this PR:
https://github.com/DynamoDS/DynamoRevit/pull/2955

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

NA

### Reviewers

