### PR TITLE
bugfix[DYN-6170]clicking-on-library-category-does-not-navigate-to-respective-category

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -362,7 +362,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
         {
             if (e.Key == Key.Delete)
             {
-                _ = ExecuteScriptFunctionAsync(browser, "dispatchEvent");
+                _ = ExecuteScriptFunctionAsync(browser, "eventDispatcher");
             }
         }
 

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -391,7 +391,7 @@
              window.chrome.webview.postMessage(JSON.stringify({ "func": "ResizedEvent", "data": "" }));
         }
 
-        function dispatchEvent() {
+        function eventDispatcher() {
 
             const kbEvent = new KeyboardEvent('keydown', {
                 bubbles: true,


### PR DESCRIPTION

![Untitled-min](https://github.com/DynamoDS/Dynamo/assets/111511512/f6776ae1-24ee-4df3-a7f4-d89c5c949a26)


### Purpose

This PR fix the navigation to a clicked category within library search results list.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

This PR renames the function that dispatch forward delete event `dispatchEvent` to `eventDispatcher` avoiding side effects that prevent navigation to the clicked library category.


### Reviewers

@QilongTang 

### FYIs

@avidit 
