### PR TITLE
DYN-6130 remove the toast notification (#14317)

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -120,7 +120,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             guideBackgroundElement.ClearCutOffSection();
             guideBackgroundElement.ClearHighlightSection();
             stopwatch = Stopwatch.StartNew();
-    }
+        }
 
         /// <summary>
         /// Creates the background for the GuidedTour
@@ -244,10 +244,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 {
                     Logging.Analytics.TrackEvent(Logging.Actions.Completed, Logging.Categories.GuidedTourOperations, guidName, currentGuide.CurrentStep.Sequence);
                 }
-                else 
+                else
                 {
                     Logging.Analytics.TrackEvent(Logging.Actions.End, Logging.Categories.GuidedTourOperations, guidName, currentGuide.CurrentStep.Sequence);
-                }                
+                }
                 Logging.Analytics.TrackTimedEvent(Logging.Categories.GuidedTourOperations, Logging.Actions.TimeElapsed.ToString(), stopwatch.Elapsed, guidName);
 
                 currentGuide.ClearGuide();
@@ -338,7 +338,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 totalTooltips = (from step in guide.GuideSteps
                                  where step.StepType == Step.StepTypes.TOOLTIP ||
                                        step.StepType == Step.StepTypes.SURVEY
-                                 select step).GroupBy(x=>x.Sequence).Count();
+                                 select step).GroupBy(x => x.Sequence).Count();
 
                 foreach (Step step in guide.GuideSteps)
                 {
@@ -464,7 +464,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
                         }
                     };
                     var popupWindow = newStep.stepUIPopup as PopupWindow;
-                    if(popupWindow != null && hostControlInfo.HtmlPage != null && !string.IsNullOrEmpty(hostControlInfo.HtmlPage.FileName))
+                    if (popupWindow != null && hostControlInfo.HtmlPage != null && !string.IsNullOrEmpty(hostControlInfo.HtmlPage.FileName))
                     {
                         popupWindow.WebBrowserUserDataFolder = userDataFolder != null ? userDataFolder.FullName : string.Empty;
                     }
@@ -525,11 +525,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
 
         private void Popup_StepClosed(string name, Step.StepTypes stepType)
-        {            
+        {
             GuideFlowEvents.OnGuidedTourFinish(currentGuide.Name);
 
             //The exit tour popup will be shown only when a popup (doesn't apply for survey) is closed or when the tour is closed. 
-            if(stepType != Step.StepTypes.SURVEY)
+            if (stepType != Step.StepTypes.SURVEY)
                 CreateRealTimeInfoWindow(Res.ExitTourWindowContent);
         }
 
@@ -546,10 +546,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
             UIElement hostUIElement = GuideUtilities.FindChild(mainRootElement, "statusBarPanel");
 
             // When popup already exist, replace it
-            if ( exitTourPopup != null && exitTourPopup.IsOpen)
-            {
-                exitTourPopup.IsOpen = false;
-            }
+            CloseRealTimeInfoWindow();
             // Otherwise creates the RealTimeInfoWindow popup and set up all the needed values
             // to show the popup over the Dynamo workspace
             exitTourPopup = new RealTimeInfoWindow()
@@ -564,6 +561,17 @@ namespace Dynamo.Wpf.UI.GuidedTour
             if (hostUIElement != null)
                 exitTourPopup.PlacementTarget = hostUIElement;
             exitTourPopup.IsOpen = true;
+        }
+
+        /// <summary>
+        /// Closes the exitTourPopup if exist and it's open
+        /// </summary>
+        internal void CloseRealTimeInfoWindow()
+        {
+            if (exitTourPopup != null && exitTourPopup.IsOpen)
+            {
+                exitTourPopup.IsOpen = false;
+            }
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -3421,6 +3421,7 @@ namespace Dynamo.ViewModels
 
 
             BackgroundPreviewViewModel.Dispose();
+            MainGuideManager?.CloseRealTimeInfoWindow();
 
             model.ShutDown(shutdownParams.ShutdownHost);
             if (shutdownParams.ShutdownHost)
@@ -3434,7 +3435,7 @@ namespace Dynamo.ViewModels
             BackgroundPreviewViewModel.PropertyChanged -= Watch3DViewModelPropertyChanged;
             WatchHandler.RequestSelectGeometry -= BackgroundPreviewViewModel.AddLabelForPath;
             model.ComputeModelDeserialized -= model_ComputeModelDeserialized;
-            model.RequestNotification -= model_RequestNotification;
+            model.RequestNotification -= model_RequestNotification;            
 
             return true;
         }


### PR DESCRIPTION
### Purpose

Making sure close the toast notification from the Preferences when Dynamo closes, bug https://jira.autodesk.com/browse/DYN-6130, cherry-picked from https://github.com/DynamoDS/Dynamo/pull/14317

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 


### Reviewers
@QilongTang 