### PR TITLE
Adding the Unit Test TestToastNotificationClosingBehavior

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -573,5 +573,16 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 exitTourPopup.IsOpen = false;
             }
         }
+
+        /// <summary>
+        /// Returns if the ExitTourPopup (Toast Notification) is open or not.
+        /// </summary>
+        internal bool ExitTourPopupIsVisible
+        {
+            get
+            {
+                return exitTourPopup != null && exitTourPopup.IsOpen;
+            }
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -254,7 +254,8 @@
                                                 </Image>
                                             </Label>
                                         </WrapPanel>
-                                        <ComboBox Grid.Row="1" 
+                                        <ComboBox Grid.Row="1"
+                                              Name="LanguageCmb"    
                                               Width="213"
                                               HorizontalAlignment="Left"
                                               ItemsSource="{Binding Path=LanguagesList}"

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -106,7 +106,7 @@ namespace DynamoCoreWpfTests
         }
 
         [TearDown]
-        public virtual void Exit()
+        public void Exit()
         {
             //Ensure that we leave the workspace marked as
             //not having changes.

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -106,7 +106,7 @@ namespace DynamoCoreWpfTests
         }
 
         [TearDown]
-        public void Exit()
+        public virtual void Exit()
         {
             //Ensure that we leave the workspace marked as
             //not having changes.

--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -133,7 +133,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
             string selectedLanguage = (string)((ComboBox)preferencesWindow.FindName("LanguageCmb")).SelectedItem;
 
-            ViewModel.PreferencesViewModel.SelectedLanguage = selectedLanguage == "English" ? "Español" : "English";
+            ViewModel.PreferencesViewModel.SelectedLanguage = selectedLanguage == "English" ? "EspaÃ±ol" : "English";
 
             ViewModel.HomeSpace.HasUnsavedChanges = false;
             if (View.IsLoaded)
@@ -150,10 +150,5 @@ namespace DynamoCoreWpfTests
             bool isToastNotificationVisible = (bool)(ViewModel.MainGuideManager?.ExitTourPopupIsVisible);
             Assert.IsFalse(isToastNotificationVisible);
         }
-
-        /// <summary>
-        /// Overrides the Exit base class method to custom handling
-        /// </summary>
-
     }
 }

--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
@@ -132,8 +133,9 @@ namespace DynamoCoreWpfTests
             preferencesWindow.Show();
             DispatcherUtil.DoEvents();
             string selectedLanguage = (string)((ComboBox)preferencesWindow.FindName("LanguageCmb")).SelectedItem;
-
-            ViewModel.PreferencesViewModel.SelectedLanguage = selectedLanguage == "English" ? "EspaÃ±ol" : "English";
+            var english = Configurations.SupportedLocaleDic.FirstOrDefault(x => x.Value == "en-US").Key;
+            var spanish = Configurations.SupportedLocaleDic.FirstOrDefault(x => x.Value == "es-ES").Key;
+            ViewModel.PreferencesViewModel.SelectedLanguage = selectedLanguage == english ? spanish : english;
 
             ViewModel.HomeSpace.HasUnsavedChanges = false;
             if (View.IsLoaded)

--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -133,27 +133,9 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
             string selectedLanguage = (string)((ComboBox)preferencesWindow.FindName("LanguageCmb")).SelectedItem;
 
-            bool? xisToastNotificationVisible = ViewModel.MainGuideManager?.ExitTourPopupIsVisible;
             ViewModel.PreferencesViewModel.SelectedLanguage = selectedLanguage == "English" ? "Español" : "English";
 
-            DispatcherUtil.DoEvents();
-            Exit_FirstPart();
-
-            bool isToastNotificationVisible = (bool)(ViewModel.MainGuideManager?.ExitTourPopupIsVisible);
-            Assert.IsFalse(isToastNotificationVisible);
-
-            Exit_SecondPart();
-        }
-
-        /// <summary>
-        /// First part of the Exit in order to catch the viewModel info
-        /// </summary>
-        public void Exit_FirstPart()
-        {
-            //Ensure that we leave the workspace marked as
-            //not having changes.
             ViewModel.HomeSpace.HasUnsavedChanges = false;
-
             if (View.IsLoaded)
                 View.Close();
 
@@ -164,38 +146,14 @@ namespace DynamoCoreWpfTests
 
                 ViewModel.PerformShutdownSequence(shutdownParams);
             }
-        }
 
-        /// <summary>
-        /// Second part of the Exit in order to catch the viewModel info
-        /// </summary>
-        public void Exit_SecondPart()
-        {
-            if (ViewModel != null)
-            {
-                ViewModel = null;
-            }
-
-            View = null;
-            Model = null;
-            preloader = null;
-
-            try
-            {
-                var directory = new DirectoryInfo(TempFolder);
-                directory.Delete(true);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.StackTrace);
-            }
+            bool isToastNotificationVisible = (bool)(ViewModel.MainGuideManager?.ExitTourPopupIsVisible);
+            Assert.IsFalse(isToastNotificationVisible);
         }
 
         /// <summary>
         /// Overrides the Exit base class method to custom handling
         /// </summary>
-        public override void Exit()
-        {
-        }
+
     }
 }


### PR DESCRIPTION
### Purpose
Adding the Unit test for the PR https://github.com/DynamoDS/Dynamo/pull/14317

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Reviewers
@mjkkirschner 

### FYIs
@QilongTang 
