### PR TITLE
fix most memory leaks from opening and closing Dynamo Splash Screen

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -73,6 +73,10 @@ namespace Dynamo.UI.Views
             set
             {
                 dynamoView = value;
+                if(dynamoView == null)
+                {
+                    return;
+                }
                 viewModel = value.DataContext as DynamoViewModel;
                 // When view model is closed, we need to close the splash screen if it is displayed.
                 viewModel.RequestClose += SplashScreenRequestClose;
@@ -484,8 +488,12 @@ namespace Dynamo.UI.Views
             // RequestUpdateLoadBarStatus event needs to be unsubscribed when the splash screen window is closed, to avoid populating the info on splash screen.
             else
             {
-                this.Close();
-                viewModel?.Model.ShutDown(false);
+                Close();
+                viewModel.RequestClose -= SplashScreenRequestClose;
+                //viewModel?.Model.ShutDown(false);
+                //TODO ensure viewmodel is shutdown by view being disposed.
+                DynamoView.Close();
+                DynamoView = null;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -489,10 +489,12 @@ namespace Dynamo.UI.Views
             else
             {
                 Close();
-                viewModel.RequestClose -= SplashScreenRequestClose;
-                //viewModel?.Model.ShutDown(false);
-                //TODO ensure viewmodel is shutdown by view being disposed.
-                DynamoView.Close();
+                if (viewModel != null)
+                {
+                    viewModel.RequestClose -= SplashScreenRequestClose;
+                }
+
+                DynamoView?.Close();
                 DynamoView = null;
             }
         }

--- a/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
@@ -110,10 +110,12 @@ namespace Dynamo.GraphMetadata
 
         protected virtual void Dispose(bool disposing)
         {
-            viewModel.Dispose();
-
-            this.graphMetadataMenuItem.Checked -= MenuItemCheckHandler;
-            this.graphMetadataMenuItem.Unchecked -= MenuItemUnCheckedHandler;
+            viewModel?.Dispose();
+            if (graphMetadataMenuItem != null)
+            {
+                graphMetadataMenuItem.Checked -= MenuItemCheckHandler;
+                graphMetadataMenuItem.Unchecked -= MenuItemUnCheckedHandler;
+            }
         }
 
         public override void Dispose()

--- a/src/LintingViewExtension/LintingViewExtension.cs
+++ b/src/LintingViewExtension/LintingViewExtension.cs
@@ -71,10 +71,18 @@ namespace Dynamo.LintingViewExtension
 
         public override void Dispose()
         {
-            this.linterMenuItem.Checked -= MenuItemCheckHandler;
-            this.linterMenuItem.Unchecked -= MenuItemUnCheckedHandler;
-            if (linterManager != null) linterManager.PropertyChanged -= OnLinterManagerPropertyChange;
-            viewLoadedParamsReference.ViewExtensionOpenRequest -= OnViewExtensionOpenRequest;
+            if (linterMenuItem != null)
+            {
+                linterMenuItem.Checked -= MenuItemCheckHandler;
+                linterMenuItem.Unchecked -= MenuItemUnCheckedHandler;
+            }
+            if (linterManager != null){
+                linterManager.PropertyChanged -= OnLinterManagerPropertyChange;
+            }
+            if (viewLoadedParamsReference != null)
+            {
+                viewLoadedParamsReference.ViewExtensionOpenRequest -= OnViewExtensionOpenRequest;
+            }
         }
 
         public override void Closed()

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -27,7 +27,7 @@ namespace Dynamo.Notifications
             get { return notifications; }
             private set
             {
-                if(notifications != value)
+                if (notifications != value)
                     notifications = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Notifications)));
             }
@@ -62,8 +62,11 @@ namespace Dynamo.Notifications
             {
                 UnregisterEventHandlers();
                 //for some reason the menuItem was not being gc'd in tests without manually removing it
-                viewLoadedParams.dynamoMenu.Items.Remove(notificationsMenuItem.MenuItem);
-                BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
+                viewLoadedParams?.dynamoMenu.Items.Remove(notificationsMenuItem.MenuItem);
+                if (notificationsMenuItem != null)
+                {
+                    BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
+                }
                 notificationsMenuItem = null;
                 disposed = true;
             }
@@ -71,8 +74,14 @@ namespace Dynamo.Notifications
 
         private void UnregisterEventHandlers()
         {
-            viewLoadedParams.NotificationRecieved -= notificationHandler;
-            Notifications.CollectionChanged -= notificationsMenuItem.NotificationsChangeHandler;
+            if (viewLoadedParams != null)
+            {
+                viewLoadedParams.NotificationRecieved -= notificationHandler;
+            }
+            if (notificationsMenuItem != null)
+            {
+                Notifications.CollectionChanged -= notificationsMenuItem.NotificationsChangeHandler;
+            }
         }
 
         public void Loaded(ViewLoadedParams viewStartupParams)
@@ -83,7 +92,7 @@ namespace Dynamo.Notifications
             logger = viewModel.Model.Logger;
 
             Notifications = new ObservableCollection<Logging.NotificationMessage>();
-            
+
             notificationHandler = (notificationMessage) =>
             {
                 Notifications.Add(notificationMessage);
@@ -117,12 +126,12 @@ namespace Dynamo.Notifications
 
         public void Shutdown()
         {
-           // Do nothing for now
+            // Do nothing for now
         }
 
         public void Startup(ViewStartupParams viewStartupParams)
         {
-           // Do nothing for now
+            // Do nothing for now
         }
     }
 }

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
@@ -61,7 +61,10 @@ namespace Dynamo.PackageDetails
         public override void Dispose()
         {
             PackageDetailsViewModel?.Dispose();
-            ViewLoadedParamsReference.ViewExtensionOpenRequestWithParameter -= OnViewExtensionOpenWithParameterRequest;
+            if (ViewLoadedParamsReference != null)
+            {
+                ViewLoadedParamsReference.ViewExtensionOpenRequestWithParameter -= OnViewExtensionOpenWithParameterRequest;
+            }
         }
 
         public override void Closed()

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -199,10 +199,17 @@ namespace Dynamo.PythonMigration
 
         private void UnsubscribeEvents()
         {
-            LoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
-            DynamoViewModel.CurrentSpaceViewModel.Model.NodeAdded -= OnNodeAdded;
-            DynamoViewModel.Model.Logger.NotificationLogged -= OnNotificationLogged;
-            CurrentWorkspace.RequestPackageDependencies -= PythonDependencies.AddPythonPackageDependency;
+            if (LoadedParams != null)
+            {
+                LoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
+                DynamoViewModel.CurrentSpaceViewModel.Model.NodeAdded -= OnNodeAdded;
+                DynamoViewModel.Model.Logger.NotificationLogged -= OnNotificationLogged;
+            }
+            
+            if (CurrentWorkspace  != null)
+            {
+                CurrentWorkspace.RequestPackageDependencies -= PythonDependencies.AddPythonPackageDependency;
+            }
             UnSubscribeWorkspaceEvents();
         }
         #endregion

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -68,7 +68,7 @@ namespace Dynamo.WorkspaceDependency
         /// </summary>
         public override void Dispose()
         {
-            DependencyView.Dispose();
+            DependencyView?.Dispose();
             dataRows = null;
             localDefinitionDataRows = null;
             externalFilesDataRows = null;

--- a/test/DynamoCoreWpfTests/SplashScreenTests.cs
+++ b/test/DynamoCoreWpfTests/SplashScreenTests.cs
@@ -21,7 +21,7 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(ss.CloseWasExplicit);
         }
         [Test]
-        public async void SplashScreen_CloseExplicitPropIsCorrect3()
+        public void SplashScreen_CloseExplicitPropIsCorrect3()
         {
             var ss = new Dynamo.UI.Views.SplashScreen();
             ss.CloseWindow();


### PR DESCRIPTION
### Purpose

Before this PR each time you opened Dynamo and closed the splash screen, > 10 megs would leak as well as an entire DynamoView and everything else in the tree.

This PR leaves only 1 extra DynamoView, I need to investigate the TODO before this is merged.

Will continue looking at more complex workflows when I have bandwidth.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fixes some memory leaks from repeatedly opening and closing Dynamo's splash screen

### Reviewers

