### PR TITLE
DYN-5960 Net6 Linux Build Fix Trial

### DIFF
--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -417,6 +417,9 @@ namespace Dynamo.Tests
             Assert.AreEqual(pi, packageDependencies.First());
         }
 
+        /// <summary>
+        /// This test verifies the package dependency states after loading the package.
+        /// </summary>
         [Test]
         public void PackageDependencyStatechangeTestAfterLoadingPackage()
         {

--- a/test/DynamoCoreTests/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageDependencyTests.cs
@@ -95,41 +95,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void NodeModelPackageDependencyIsCollected()
-        {
-            // Load JSON file graph
-            string path = Path.Combine(TestDirectory, @"core\packageDependencyTests\OneDependentNode_NodeModel.dyn");
-
-            // Assert package dependency is not already serialized to .dyn
-            using (StreamReader file = new StreamReader(path))
-            {
-                var data = file.ReadToEnd();
-                var json = (JObject)JsonConvert.DeserializeObject(data);
-                Assert.IsNull(json[WorkspaceReadConverter.NodeLibraryDependenciesPropString]);
-            }
-
-            // Assert package dependency is collected
-            OpenModel(path);
-
-            var currentws = CurrentDynamoModel.CurrentWorkspace;
-            currentws.ForceComputeWorkspaceReferences = true;
-
-            var packageDependencies = currentws.NodeLibraryDependencies;
-            Assert.AreEqual(1, packageDependencies.Count);
-            var package = packageDependencies.First();
-            //TODO_NET6 following package cannot be loaded as depends on wpf.
-            Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), package);
-            Assert.AreEqual(1, package.Nodes.Count);
-
-            Assert.IsTrue(package.IsLoaded);
-            if (package is PackageDependencyInfo)
-            {
-                var packageDependencyState = ((PackageDependencyInfo)package).State;
-                Assert.AreEqual(PackageDependencyState.Loaded, packageDependencyState);
-            }
-        }
-
-        [Test]
         public void CustomNodePackageDependencyIsCollected()
         {
             // Add "Round Down To Precision" custom node from the "Custom Rounding" package to a new workspace
@@ -451,6 +416,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(1, packageDependencies.Count);
             Assert.AreEqual(pi, packageDependencies.First());
         }
+
         [Test]
         public void PackageDependencyStatechangeTestAfterLoadingPackage()
         {
@@ -464,7 +430,7 @@ namespace Dynamo.Tests
 
             // Assert the total number of package dependencies.
             var packageDependenciesList = currentws.NodeLibraryDependencies;
-            Assert.AreEqual(4, packageDependenciesList.Count);
+            Assert.AreEqual(3, packageDependenciesList.Count);
 
             // Check for Missing package state
             PackageDependencyInfo firstPackage = (PackageDependencyInfo) packageDependenciesList[0];
@@ -478,13 +444,6 @@ namespace Dynamo.Tests
             PackageDependencyInfo thirdPackage = (PackageDependencyInfo) packageDependenciesList[2];
             Assert.AreEqual(new PackageDependencyInfo("Clockwork for Dynamo 1.x", new Version("1.33.0")), thirdPackage);
             Assert.AreEqual(PackageDependencyState.Missing, thirdPackage.State);
-
-            //TODO_NET6 following package cannot be loaded as depends on wpf.
-
-            // Check for Loaded package state
-            PackageDependencyInfo lastPackage = (PackageDependencyInfo) packageDependenciesList.Last();
-            Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), lastPackage);
-            Assert.AreEqual(PackageDependencyState.Loaded, lastPackage.State);
 
             CurrentDynamoModel.ClearCurrentWorkspace();
 
@@ -501,7 +460,7 @@ namespace Dynamo.Tests
 
             // Assert the total number of package dependencies.
             packageDependenciesList = currentws.NodeLibraryDependencies;
-            Assert.AreEqual(4, packageDependenciesList.Count);
+            Assert.AreEqual(3, packageDependenciesList.Count);
 
             // Check for Missing package state
             firstPackage = (PackageDependencyInfo)packageDependenciesList[0];
@@ -518,11 +477,6 @@ namespace Dynamo.Tests
             thirdPackage = (PackageDependencyInfo)packageDependenciesList[2];
             Assert.AreEqual(new PackageDependencyInfo("Clockwork for Dynamo 1.x", new Version("1.33.0")), thirdPackage);
             Assert.AreEqual(PackageDependencyState.IncorrectVersion, thirdPackage.State);
-
-            // Check for Loaded package state
-            lastPackage = (PackageDependencyInfo)packageDependenciesList.Last();
-            Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), lastPackage);
-            Assert.AreEqual(PackageDependencyState.Loaded, lastPackage.State);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -42,7 +42,7 @@
 	  <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-      <PackageReference Include="Prism.Core" Version="8.1.97"/>
+      <PackageReference Include="Prism.Core" Version="8.1.97" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DocumentationBrowserViewExtension\DocumentationBrowserViewExtension.csproj">

--- a/test/DynamoCoreWpfTests/Engine/AstBuildFailTest.cs
+++ b/test/DynamoCoreWpfTests/Engine/AstBuildFailTest.cs
@@ -4,6 +4,9 @@ using NUnit.Framework;
 
 namespace Dynamo.Tests
 {
+    /// <summary>
+    /// This is a WPF test because NodeWithFailingASTOutput is a node that is defined in the TestUINodes assembly
+    /// </summary>
     [TestFixture]
     internal class AstBuildFailTest : DynamoModelTestBase
     {

--- a/test/DynamoCoreWpfTests/PackageManager/PackageDependencyTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageDependencyTests.cs
@@ -9,11 +9,17 @@ using Dynamo.Tests;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Dynamo.Models;
+using Dynamo.Interfaces;
+using Dynamo.Scheduler;
+using Dynamo.Configuration;
 
 namespace Dynamo.PackageManager.Wpf.Tests
 {
     internal class PackageDependencyTests : DynamoModelTestBase
     {
+        public string PackagesDirectory { get { return Path.Combine(TestDirectory, "pkgs"); } }
+
         [Test]
         public void CanDiscoverDependenciesForFunctionDefinitionOpenFromFile()
         {
@@ -62,7 +68,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
             var packageDependencies = currentws.NodeLibraryDependencies;
             Assert.AreEqual(1, packageDependencies.Count);
             var package = packageDependencies.First();
-            Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("1.0.0")), package);
+            Assert.AreEqual(new PackageDependencyInfo("Dynamo Samples", new Version("2.0.0")), package);
             Assert.AreEqual(1, package.Nodes.Count);
 
             Assert.IsTrue(package.IsLoaded);
@@ -71,6 +77,18 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 var packageDependencyState = ((PackageDependencyInfo)package).State;
                 Assert.AreEqual(PackageDependencyState.Loaded, packageDependencyState);
             }
+        }
+
+        protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPreferences settings)
+        {
+            return new DynamoModel.DefaultStartConfiguration()
+            {
+                PathResolver = pathResolver,
+                StartInTestMode = true,
+                GeometryFactoryPath = preloader.GeometryFactoryPath,
+                ProcessMode = TaskProcessMode.Synchronous,
+                Preferences = new PreferenceSettings() { CustomPackageFolders = new List<string>() { this.PackagesDirectory } }
+            };
         }
     }
 }

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerExtensionLoadingTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerExtensionLoadingTests.cs
@@ -11,11 +11,11 @@ using Dynamo.Models;
 using Dynamo.Scheduler;
 using NUnit.Framework;
 
-namespace DynamoCoreWpfTests
+namespace DynamoCoreWpfTests.PackageManager
 {
     class PackageManagerExtensionLoadingTests : DynamoTestUIBase
     {
-        private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "pkgs"); } }
+        private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(ExecutingDirectory), "pkgs"); } }
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -33,47 +33,47 @@ namespace DynamoCoreWpfTests
                 StartInTestMode = true,
                 GeometryFactoryPath = preloader.GeometryFactoryPath,
                 ProcessMode = TaskProcessMode.Synchronous,
-                Preferences = new PreferenceSettings() { CustomPackageFolders = new List<string>() { this.PackagesDirectory } }
+                Preferences = new PreferenceSettings() { CustomPackageFolders = new List<string>() { PackagesDirectory } }
             };
         }
 
         [Test]
         public void PackageManagerLoadsAndAddsExtension()
         {
-         
-            Assert.That(this.Model.ExtensionManager.Extensions.Select(x => x.Name),
-                Is.EquivalentTo (new List<string> { "DynamoPackageManager", "testExtension" }));
+
+            Assert.That(Model.ExtensionManager.Extensions.Select(x => x.Name),
+                Is.EquivalentTo(new List<string> { "DynamoPackageManager", "testExtension" }));
         }
         [Test]
         public void PackageManagerLoadsExtensionAndItWorks()
         {
-         
-            dynamic sampleExtension = this.Model.ExtensionManager.Extensions.Where(x => x.Name == "testExtension").FirstOrDefault();
+
+            dynamic sampleExtension = Model.ExtensionManager.Extensions.Where(x => x.Name == "testExtension").FirstOrDefault();
             var node = new DoubleInput();
-            this.Model.CurrentWorkspace.AddAndRegisterNode(node);
+            Model.CurrentWorkspace.AddAndRegisterNode(node);
             //assert the extension was keeping track of the node events in the workspace.
             Assert.AreEqual(1, (sampleExtension.nodes as List<NodeModel>).Count());
         }
         [Test]
         public void PackageManagerLoadsAndAddsViewExtension()
         {
-            Assert.That(this.View.viewExtensionManager.ViewExtensions.OrderBy(x => x.Name).Select(x => x.Name),
+            Assert.That(View.viewExtensionManager.ViewExtensions.OrderBy(x => x.Name).Select(x => x.Name),
                 Is.EquivalentTo(
-                    (new List<string>
+                    new List<string>
                     {
-                        "Documentation Browser", 
+                        "Documentation Browser",
                         "DynamoManipulationExtension",
                         "Graph Node Manager",
                         "Graph Status",
-                        "LibraryUI - WebView2", 
-                        "Notifications", 
+                        "LibraryUI - WebView2",
+                        "Notifications",
                         "Package Details",
                         "PackageManagerViewExtension",
                         "Properties",
                         "Python Migration",
                         "Sample View Extension",
                         "Workspace References",
-                    })
+                    }
                 )
             );
         }
@@ -81,12 +81,12 @@ namespace DynamoCoreWpfTests
         [Test]
         public void PackageManagerLoadsViewExtensionAndItWorks()
         {
-            dynamic sampleExtension = this.View.viewExtensionManager.ViewExtensions.Where(x => x.Name == "Sample View Extension").FirstOrDefault();
+            dynamic sampleExtension = View.viewExtensionManager.ViewExtensions.Where(x => x.Name == "Sample View Extension").FirstOrDefault();
             var node = new DoubleInput();
-            this.Model.CurrentWorkspace.AddAndRegisterNode(node);
+            Model.CurrentWorkspace.AddAndRegisterNode(node);
 
             //assert a menu item was added with the correct header.
-            var mi = this.View.viewMenu.Items.Cast<MenuItem>().Where
+            var mi = View.viewMenu.Items.Cast<MenuItem>().Where
                 (x => (string)x.Header == "Show View Extension Sample Window").FirstOrDefault();
             Assert.IsNotNull(mi);
         }

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerUITests.cs
@@ -23,7 +23,7 @@ using Moq;
 using NUnit.Framework;
 using SystemTestServices;
 
-namespace DynamoCoreWpfTests
+namespace DynamoCoreWpfTests.PackageManager
 {
     [TestFixture]
     public class PackageManagerUITests : SystemTestBase
@@ -73,7 +73,7 @@ namespace DynamoCoreWpfTests
             var window = windows.FirstOrDefault(x => x is T);
             Assert.IsNotNull(window);
 
-            Assert.IsTrue(window.Owner == (Window)View);
+            Assert.IsTrue(window.Owner == View);
         }
 
         public void AssertWindowClosedWithDynamoView<T>()
@@ -84,7 +84,7 @@ namespace DynamoCoreWpfTests
             var window = windows.FirstOrDefault(x => x is T);
             Assert.IsNotNull(window);
 
-            Assert.IsTrue(window.Owner == (Window)View);
+            Assert.IsTrue(window.Owner == View);
         }
 
         public override void Setup()
@@ -318,7 +318,7 @@ namespace DynamoCoreWpfTests
             var pmVm = new PackageManagerClientViewModel(ViewModel, client);
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
-            dlgMock.Setup(m => m.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(), 
+            dlgMock.Setup(m => m.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.Is<MessageBoxButton>(x => x == MessageBoxButton.OKCancel || x == MessageBoxButton.OK), It.IsAny<MessageBoxImage>()))
                 .Returns(MessageBoxResult.OK);
             MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
@@ -705,7 +705,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual("1", messageBox.YesButton.Content);
             Assert.AreEqual("2", messageBox.NoButton.Content);
         }
-      
+
         [Test]
         [Description("DynamoMessageBox buttons set correct results")]
         public void DynamoMessageBoxButtonsSetCorrectly()
@@ -1052,11 +1052,11 @@ namespace DynamoCoreWpfTests
 
             var clientmock = new Mock<Dynamo.PackageManager.PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
             var pmVmMock = new Mock<PackageManagerClientViewModel>(ViewModel, clientmock.Object) { CallBase = true };
-       
+
 
             //when we attempt a download - it returns a valid download path, also record order
             pmVmMock.Setup(x => x.Download(It.IsAny<PackageDownloadHandle>())).
-                Returns<PackageDownloadHandle>(h => Task.Factory.StartNew(()=>
+                Returns<PackageDownloadHandle>(h => Task.Factory.StartNew(() =>
                 {
                     //our downloads should take different amounts of time.
                     var dlTime = 0;
@@ -1067,11 +1067,12 @@ namespace DynamoCoreWpfTests
                             break;
                         case "Dep123":
                             dlTime = 200;
-                       break;
+                            break;
                     }
-                    System.Threading.Thread.Sleep(dlTime); 
-                    operations.Add($"download operation:{h.Name}"); 
-                    return (h, h.Name); }));
+                    Thread.Sleep(dlTime);
+                    operations.Add($"download operation:{h.Name}");
+                    return (h, h.Name);
+                }));
 
             //these are our fake packages
 
@@ -1135,7 +1136,7 @@ namespace DynamoCoreWpfTests
             pmVmMock.Object.ExecutePackageDownload(id, pkgVer, "");
 
             //wait a bit.
-            System.Threading.Thread.Sleep(500);
+            Thread.Sleep(500);
 
             //assert that all downloads are complete before installs,
             // and install order is determined by topological order, not download completion order.
@@ -1271,9 +1272,9 @@ namespace DynamoCoreWpfTests
             Assert.DoesNotThrow(() =>
             {
                 pmVmMock.InstallPackage(new PackageDownloadHandle(), string.Empty, string.Empty);
-                pmVmMock.InstallPackage(new PackageDownloadHandle() {DownloadState=PackageDownloadHandle.State.Error }, "somepath","somepath");
+                pmVmMock.InstallPackage(new PackageDownloadHandle() { DownloadState = PackageDownloadHandle.State.Error }, "somepath", "somepath");
             });
-          
+
 
         }
 
@@ -1295,7 +1296,8 @@ namespace DynamoCoreWpfTests
             string expectedDownloadPath = "download/" + bltInPackage.Name + "/" + bltInPackage.VersionName;
             // Simulate the user downloading the same package from PM
             var mockGreg = new Mock<IGregClient>();
-            mockGreg.Setup(x => x.Execute(It.IsAny<PackageDownload>())).Callback((Request x) => {
+            mockGreg.Setup(x => x.Execute(It.IsAny<PackageDownload>())).Callback((Request x) =>
+            {
                 Assert.AreEqual(expectedDownloadPath, x.Path);
             });
 
@@ -1369,11 +1371,11 @@ namespace DynamoCoreWpfTests
             var pmVm = new PackageManagerClientViewModel(ViewModel, client);
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
-            dlgMock.Setup(m => m.Show(It.Is<string>(x => x.Contains("conflicts with a different version")), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<string[]>(),It.IsAny<MessageBoxImage>()))
+            dlgMock.Setup(m => m.Show(It.Is<string>(x => x.Contains("conflicts with a different version")), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<string[]>(), It.IsAny<MessageBoxImage>()))
                 .Returns(MessageBoxResult.Cancel);
-             dlgMock.Setup(m => m.Show(It.Is<string>(x => x.Contains("Are you sure you want to install")), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()))
-                .Returns(MessageBoxResult.OK);
-            
+            dlgMock.Setup(m => m.Show(It.Is<string>(x => x.Contains("Are you sure you want to install")), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()))
+               .Returns(MessageBoxResult.OK);
+
             MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
 
             //

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerUnitTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerUnitTests.cs
@@ -2,7 +2,7 @@
 using Dynamo.PackageManager;
 using NUnit.Framework;
 
-namespace DynamoCoreWpfTests
+namespace DynamoCoreWpfTests.PackageManager
 {
     [TestFixture]
     public class PackageManagerUnitTests : UnitTestBase

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerViewExtensionTests.cs
@@ -16,19 +16,19 @@ using Microsoft.CSharp;
 using Moq;
 using NUnit.Framework;
 
-namespace DynamoCoreWpfTests
+namespace DynamoCoreWpfTests.PackageManager
 {
     [TestFixture, Category("Failure")]
     class PackageManagerViewExtensionTests : DynamoTestUIBase
     {
-        private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "pkgs"); } }
-        internal string BuiltinPackagesTestDir { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "builtinpackages testdir", "Packages"); } }
+        private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(ExecutingDirectory), "pkgs"); } }
+        internal string BuiltinPackagesTestDir { get { return Path.Combine(GetTestDirectory(ExecutingDirectory), "builtinpackages testdir", "Packages"); } }
 
 
         #region extensionGeneration
         private string extensionPath;
         private string manifestPath;
-        private string extensionManifest = 
+        private string extensionManifest =
             @"<ViewExtensionDefinition>
           <AssemblyPath>..\bin\TestViewExtension.dll</AssemblyPath>
           <TypeName>TestViewExtension</TypeName>
@@ -86,7 +86,7 @@ namespace DynamoCoreWpfTests
                 ProcessMode = TaskProcessMode.Synchronous,
                 Preferences = new PreferenceSettings()
                 {
-                    CustomPackageFolders = new List<string>() { Path.Combine(this.PackagesDirectory, "subPackageDirectory") }
+                    CustomPackageFolders = new List<string>() { Path.Combine(PackagesDirectory, "subPackageDirectory") }
                 }
             };
         }
@@ -106,7 +106,7 @@ namespace DynamoCoreWpfTests
             };
             options.ReferencedAssemblies.Add("DynamoCore.dll");
             options.ReferencedAssemblies.Add("DynamoCoreWPF.dll");
-            string source = this.testViewExtensionSource;
+            string source = testViewExtensionSource;
 
             var results = provider.CompileAssemblyFromSource(options, new[] { source });
             if (results.Errors.Count > 0)
@@ -125,32 +125,32 @@ namespace DynamoCoreWpfTests
 
                 //move the new assembly into the package directory/bin folder.
                 extensionPath = Path.Combine(PackagesDirectory, "subPackageDirectory", "runtimeGeneratedExtension", "bin", "TestViewExtension.dll");
-                System.IO.File.Copy(results.CompiledAssembly.Location, extensionPath, true);
+                File.Copy(results.CompiledAssembly.Location, extensionPath, true);
 
                 //copy the manifest as well.
                 manifestPath = Path.Combine(PackagesDirectory, "subPackageDirectory", "runtimeGeneratedExtension",
                     "extra", "TestViewExtension_ViewExtensionDefinition.xml");
-                System.IO.File.WriteAllText(manifestPath, this.extensionManifest);
+                File.WriteAllText(manifestPath, extensionManifest);
             }
         }
 
         [Test]
         public void PackageManagerLoadsRuntimeGeneratedExtension()
         {
-            Assert.IsTrue(this.View.viewExtensionManager.ViewExtensions.Select(x => x.Name).Contains("Test View Extension"));
+            Assert.IsTrue(View.viewExtensionManager.ViewExtensions.Select(x => x.Name).Contains("Test View Extension"));
         }
 
         [Test]
         public void PackageManagerViewExtensionHasCorrectNumberOfRequestedExtensions()
         {
-            var pkgViewExtension = this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
+            var pkgViewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
             Assert.AreEqual(pkgViewExtension.RequestedExtensions.Count(), 1);
         }
 
         [Test]
         async public void LateLoadedViewExtensionsHaveMethodsCalled()
         {
-            var pkgviewExtension = this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
+            var pkgviewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
             var pkgDir = Path.Combine(PackagesDirectory, "SampleViewExtension");
 
             var viewExtensionLoadStart = false;
@@ -165,7 +165,7 @@ namespace DynamoCoreWpfTests
             {
                 viewExtensionLoadStart = true;
 
-                var mockExtension = new Moq.Mock<IViewExtension>();
+                var mockExtension = new Mock<IViewExtension>();
                 mockExtension.Setup(ext => ext.Startup(It.IsAny<ViewStartupParams>())).Callback(() =>
                 {
                     startCount = startCount + 1;
@@ -186,14 +186,14 @@ namespace DynamoCoreWpfTests
             };
 
             //must wait until the view is loaded to accurately test late loading of a viewExtension package.
-            this.View.Loaded += (sender, args) =>
+            View.Loaded += (sender, args) =>
             {
                 viewLoaded = true;
                 var loader = Model.GetPackageManagerExtension().PackageLoader;
                 var pkg = loader.ScanPackageDirectory(pkgDir);
-                loader.LoadPackages(new List<Package> {pkg});
+                loader.LoadPackages(new List<Package> { pkg });
                 Assert.AreEqual(0, loader.RequestedExtensions.Count());
-                Assert.AreEqual(2, this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
+                Assert.AreEqual(2, View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault().RequestedExtensions.Count());
                 Assert.IsTrue(viewExtensionLoadStart);
                 Assert.IsTrue(viewExtensionAdd);
                 Assert.IsTrue(viewExtensionLoaded);
@@ -201,7 +201,7 @@ namespace DynamoCoreWpfTests
                 Assert.AreEqual(0, startCount);
             };
 
-            ViewExtensionTests.RaiseLoadedEvent(this.View);
+            ViewExtensionTests.RaiseLoadedEvent(View);
             Assert.IsTrue(viewLoaded, "view was never loaded, invalid test");
 
         }
@@ -211,7 +211,7 @@ namespace DynamoCoreWpfTests
         {
             //this extension is compiled at testTime and injected into test package folder.
             //source is above.
-            dynamic testExtension = this.View.viewExtensionManager.ViewExtensions.Where(x => x.Name == "Test View Extension").FirstOrDefault();
+            dynamic testExtension = View.viewExtensionManager.ViewExtensions.Where(x => x.Name == "Test View Extension").FirstOrDefault();
             Assert.AreEqual(1, testExtension.startupCount);
             Assert.AreEqual(1, testExtension.loadedCount);
         }
@@ -220,7 +220,7 @@ namespace DynamoCoreWpfTests
         public void PackageManagerViewExtesion_TriesToLoadLayoutSpecForBuiltInPackages()
         {
             //check that the packageManagerViewExtension requested the test layout spec to be applied.
-            var packageManagerViewExtension = this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
+            var packageManagerViewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
             var packageManager = ViewModel.Model.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
             Assert.IsNotNull(packageManagerViewExtension);
             Assert.IsNotNull(packageManager);
@@ -231,12 +231,12 @@ namespace DynamoCoreWpfTests
             var builtInPackageLocation = Path.Combine(BuiltinPackagesTestDir, "SignedPackage2");
             var bltinPkg = packageManager.PackageLoader.ScanPackageDirectory(builtInPackageLocation);
             packageManager.PackageLoader.LoadPackages(new List<Package> { bltinPkg });
-            
+
 
             //trigger packmanViewExt to load layoutspecs. Usually this would just happen at startup, but we're loading the bltin package late.
             packageManagerViewExtension.Loaded(new ViewLoadedParams(View, ViewModel));
             Assert.AreEqual(1, packageManagerViewExtension.RequestedLayoutSpecPaths.Count());
-            Assert.AreEqual(Path.Combine(BuiltinPackagesTestDir,"SignedPackage2","extra","layoutspecs.json"), packageManagerViewExtension.RequestedLayoutSpecPaths.FirstOrDefault());
+            Assert.AreEqual(Path.Combine(BuiltinPackagesTestDir, "SignedPackage2", "extra", "layoutspecs.json"), packageManagerViewExtension.RequestedLayoutSpecPaths.FirstOrDefault());
         }
 
         [Test]
@@ -244,7 +244,7 @@ namespace DynamoCoreWpfTests
         {
             var count = 0;
             //check that the packageManagerViewExtension logged a notification for a package that targets revit.
-            var packageManagerViewExtension = this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
+            var packageManagerViewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
             var packageManager = ViewModel.Model.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
 
             Assert.IsNotNull(packageManagerViewExtension);
@@ -258,7 +258,7 @@ namespace DynamoCoreWpfTests
             (packageManagerViewExtension as INotificationSource).NotificationLogged += PackageManagerViewExtensionTests_NotificationLogged;
 
             //force Loaded, which should run the check.
-            packageManagerViewExtension.Loaded(new ViewLoadedParams(View,ViewModel));
+            packageManagerViewExtension.Loaded(new ViewLoadedParams(View, ViewModel));
 
             //check that notification is raised.
             Assert.AreEqual(1, count);
@@ -276,7 +276,7 @@ namespace DynamoCoreWpfTests
         {
             var count = 0;
             //check that the packageManagerViewExtension logged a notification for a package that targets revit.
-            var packageManagerViewExtension = this.View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
+            var packageManagerViewExtension = View.viewExtensionManager.ViewExtensions.OfType<PackageManagerViewExtension>().FirstOrDefault();
             var packageManager = ViewModel.Model.ExtensionManager.Extensions.OfType<PackageManagerExtension>().FirstOrDefault();
             (packageManagerViewExtension as INotificationSource).NotificationLogged += PackageManagerViewExtensionTests_NotificationLogged;
 
@@ -310,7 +310,7 @@ namespace DynamoCoreWpfTests
         public void RemoveExtension()
         {
             //TODO it would be good to cleanup the dll as well but we can't as it is currently loaded.
-            System.IO.File.Delete(manifestPath);
+            File.Delete(manifestPath);
         }
     }
 }

--- a/test/core/packageDependencyTests/PackageDependencyStates.dyn
+++ b/test/core/packageDependencyTests/PackageDependencyStates.dyn
@@ -89,46 +89,6 @@
       ],
       "Replication": "Auto",
       "Description": "Returns the colour black."
-    },
-    {
-      "ConcreteType": "SampleLibraryUI.Examples.ButtonCustomNodeModel, SampleLibraryUI",
-      "ButtonText": "Default Button Text",
-      "WindowText": "Default Window Text",
-      "NodeType": "ExtensionNode",
-      "Id": "73f814ac558b430fa1050fca82f00f2b",
-      "Inputs": [
-        {
-          "Id": "5bdb9084a83f4a68876e48a3c55f441d",
-          "Name": "inputString",
-          "Description": "a string value displayed on our button",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "8291c0770fcc4b3997c903327242eafc",
-          "Name": "button value",
-          "Description": "returns the string value displayed on our button",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "1b68990b945341539000cff4159e896c",
-          "Name": "window value",
-          "Description": "returns the string value displayed in our window when button is pressed",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "A sample UI node which displays custom UI."
     }
   ],
   "Connectors": [],
@@ -159,14 +119,6 @@
       "ReferenceType": "Package",
       "Nodes": [
         "adfa5ed1381e42929f53c086928cd07e"
-      ]
-    },
-    {
-      "Name": "Dynamo Samples",
-      "Version": "2.0.0",
-      "ReferenceType": "Package",
-      "Nodes": [
-        "73f814ac558b430fa1050fca82f00f2b"
       ]
     }
   ],
@@ -222,16 +174,6 @@
         "Excluded": false,
         "X": 451.0,
         "Y": 402.0
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "Button Custom Node Model",
-        "Id": "73f814ac558b430fa1050fca82f00f2b",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 384.0,
-        "Y": 210.0
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

The job which build net60_linux_target-release of DynamoCore has been broken and blocking DynamoCore linux build. Giving the test an update in order to fix regressions on a DynamoCore built only environment.

It's worth noting that the Dynamo Sample package is depending on DynamoCoreWpf so without that, it will not be loaded correctly, thus any nodes depending on that package should not be part of DynamoCoreWpfTests.

- [x] Moved `NodeWithFailingASTOutput` test to be DynamoCoreWpf test
- [x] Moved `NodeModelPackageDependencyIsCollected` test to be DynamoCoreWpf test
- [x] Moved some PackageManager tests to be under the PackageManager subfolder 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

N/A


### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
