### PR TITLE
fix more memory leaks when starting and closing DynamoRevit

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -109,23 +109,19 @@ namespace Dynamo.DocumentationBrowser
             // Cleanup
             this.viewModel.LinkChanged -= NavigateToPage;
             this.documentationBrowser.NavigationStarting -= ShouldAllowNavigation;
+            this.documentationBrowser.DpiChanged -= DocumentationBrowser_DpiChanged;
+
+            if (this.documentationBrowser.CoreWebView2 != null)
+            {
+                this.documentationBrowser.CoreWebView2.WebMessageReceived -= CoreWebView2OnWebMessageReceived;
+            }
+
             // Note to test writers
             // Disposing the document browser will cause future tests
             // that uses the Browser component to crash
             if (!Models.DynamoModel.IsTestMode)
             {
                 this.documentationBrowser.Dispose();
-            }
-            this.documentationBrowser.DpiChanged -= DocumentationBrowser_DpiChanged;
-            try
-            {
-                if (this.documentationBrowser.CoreWebView2 != null)
-                    this.documentationBrowser.CoreWebView2.WebMessageReceived -= CoreWebView2OnWebMessageReceived;
-
-            }
-            catch (Exception)
-            {
-                return;
             }
         }
 

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -436,6 +436,8 @@ namespace Dynamo.DocumentationBrowser
             {
                 this.pmExtension.PackageLoader.PackgeLoaded -= OnPackageLoaded;
             }
+
+            PackageDocumentationManager.Instance.MessageLogged -= OnMessageLogged;
             PackageDocumentationManager.Instance.Dispose();
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -873,8 +873,8 @@ namespace Dynamo.Models
             if (!IsServiceMode)
             {
                 SearchModel = new NodeSearchModel(Logger);
-                SearchModel.ItemProduced +=
-                    node => ExecuteCommand(new CreateNodeCommand(node, 0, 0, true, true));
+                SearchModel.ItemProduced += SearchModel_ItemProduced;
+                    
             }
 
             NodeFactory = new NodeFactory();
@@ -1019,6 +1019,11 @@ namespace Dynamo.Models
             State = DynamoModelState.StartedUIless;
             // This event should only be raised at the end of this method.
             DynamoReady(new ReadyParams(this));
+        }
+
+        private void SearchModel_ItemProduced(NodeModel node)
+        {
+            ExecuteCommand(new CreateNodeCommand(node, 0, 0, true, true));
         }
 
         /// <summary>
@@ -1476,6 +1481,10 @@ namespace Dynamo.Models
                 FeatureFlags.MessageLogged -= LogMessageWrapper;
             }
             DynamoUtilities.DynamoFeatureFlagsManager.FlagsRetrieved -= CheckFeatureFlagTest;
+            if (!IsServiceMode)
+            {
+                SearchModel.ItemProduced -= SearchModel_ItemProduced;
+            }
         }
 
         private void InitializeCustomNodeManager()
@@ -2886,7 +2895,7 @@ namespace Dynamo.Models
         {
             OnWorkspaceRemoveStarted(workspace);
             if (_workspaces.Remove(workspace))
-            {
+            {   
                 if (workspace is HomeWorkspaceModel)
                 {
                     workspace.Dispose();

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -24,7 +24,7 @@ namespace Dynamo.UI.Controls
     /// Notice this control shares a lot of logic with InCanvasSearchControl for now
     /// But they will diverge eventually because of UI improvements to auto complete.
     /// </summary>
-    public partial class NodeAutoCompleteSearchControl
+    public partial class NodeAutoCompleteSearchControl : IDisposable
     {
         ListBoxItem HighlightedItem;
 
@@ -45,7 +45,10 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated += CurrentApplicationDeactivated;
-                Application.Current.MainWindow.Closing += NodeAutoCompleteSearchControl_Unloaded;
+                if (Application.Current.MainWindow != null)
+                {
+                    Application.Current.MainWindow.Closing -= NodeAutoCompleteSearchControl_Unloaded;
+                }
             }
             HomeWorkspaceModel.WorkspaceClosed += this.CloseAutoCompletion;
         }
@@ -55,8 +58,12 @@ namespace Dynamo.UI.Controls
             if (Application.Current != null)
             {
                 Application.Current.Deactivated -= CurrentApplicationDeactivated;
-                Application.Current.MainWindow.Closing -= NodeAutoCompleteSearchControl_Unloaded;
+                if (Application.Current.MainWindow != null)
+                {
+                    Application.Current.MainWindow.Closing -= NodeAutoCompleteSearchControl_Unloaded;
+                }
             }
+            HomeWorkspaceModel.WorkspaceClosed -= this.CloseAutoCompletion;
         }
 
         private void CurrentApplicationDeactivated(object sender, EventArgs e)
@@ -387,6 +394,11 @@ namespace Dynamo.UI.Controls
                 Analytics.TrackEvent(Actions.Switch, Categories.Preferences, nameof(NodeAutocompleteSuggestion.ObjectType));
             }
             ViewModel.PopulateAutoCompleteCandidates();
+        }
+
+        public void Dispose()
+        {
+            NodeAutoCompleteSearchControl_Unloaded(this,null);
         }
     }
 }

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -47,7 +47,7 @@ namespace Dynamo.UI.Controls
                 Application.Current.Deactivated += CurrentApplicationDeactivated;
                 if (Application.Current.MainWindow != null)
                 {
-                    Application.Current.MainWindow.Closing -= NodeAutoCompleteSearchControl_Unloaded;
+                    Application.Current.MainWindow.Closing += NodeAutoCompleteSearchControl_Unloaded;
                 }
             }
             HomeWorkspaceModel.WorkspaceClosed += this.CloseAutoCompletion;

--- a/src/DynamoCoreWpf/Extensions/ViewExtensionCommandExecutive.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewExtensionCommandExecutive.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Dynamo.Extensions;
 using Dynamo.Logging;
 using Dynamo.Models;
@@ -7,14 +7,19 @@ using LogMessage = Dynamo.Logging.LogMessage;
 
 namespace Dynamo.Wpf.Extensions
 {
-    internal class ViewExtensionCommandExecutive : ICommandExecutive
+    internal class ViewExtensionCommandExecutive : ICommandExecutive,IDisposable
     {
         private readonly DynamoViewModel dynamoViewModel;
 
         public ViewExtensionCommandExecutive(DynamoViewModel model)
         {
             dynamoViewModel = model;
-            MessageLogged += (message) => { dynamoViewModel.Model.Logger.Log(message); };
+            MessageLogged += ViewExtensionCommandExecutive_MessageLogged;
+        }
+
+        private void ViewExtensionCommandExecutive_MessageLogged(ILogMessage message)
+        {
+            dynamoViewModel.Model.Logger.Log(message);
         }
 
         public void ExecuteCommand(DynamoModel.RecordableCommand command, string uniqueId, string extensionName)
@@ -41,6 +46,11 @@ namespace Dynamo.Wpf.Extensions
         {
             var handler = MessageLogged;
             if (handler != null) handler(obj);
+        }
+
+        public void Dispose()
+        {
+            MessageLogged -= ViewExtensionCommandExecutive_MessageLogged;
         }
     }
 }

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
@@ -120,7 +120,7 @@ namespace Dynamo.Wpf.Extensions
         /// <returns></returns>
         public void AddToExtensionsSideBar(IViewExtension viewExtension, ContentControl contentControl)
         {
-            bool added  = dynamoView.AddOrFocusExtensionControl(viewExtension, contentControl);
+            bool added = dynamoView.AddOrFocusExtensionControl(viewExtension, contentControl);
 
             if (added)
             {
@@ -223,7 +223,7 @@ namespace Dynamo.Wpf.Extensions
         {
             dynamoViewModel.OnViewExtensionOpenRequest(extensionName);
         }
-        
+
         /// <summary>
         /// Event raised when a component inside Dynamo raises a request to open a view extension.
         /// </summary>
@@ -245,6 +245,13 @@ namespace Dynamo.Wpf.Extensions
             // so that the ViewLoadedParams class itself doesn't appear as a subscriber to the event
             add => dynamoViewModel.ViewExtensionOpenWithParameterRequest += value;
             remove => dynamoViewModel.ViewExtensionOpenWithParameterRequest -= value;
+        }
+
+        public new void Dispose()
+        {
+            if (CommandExecutive is IDisposable disposable)
+            { disposable.Dispose(); }
+            base.Dispose();
         }
 
     }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -3421,6 +3421,10 @@ namespace Dynamo.ViewModels
 
 
             BackgroundPreviewViewModel.Dispose();
+            foreach (var wsvm in workspaces)
+            {
+                wsvm.Dispose();
+            }
             MainGuideManager?.CloseRealTimeInfoWindow();
 
             model.ShutDown(shutdownParams.ShutdownHost);

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -403,6 +403,7 @@ namespace Dynamo.ViewModels
             {
                 cate.DisposeTree();
             }
+            Model.EntryAdded += AddEntry;
             Model.EntryUpdated -= UpdateEntry;
             Model.EntryRemoved -= RemoveEntry;
 
@@ -425,12 +426,7 @@ namespace Dynamo.ViewModels
             searchIconAlignment = System.Windows.HorizontalAlignment.Left;
 
             // When Library changes, sync up
-            Model.EntryAdded += entry =>
-            {
-                InsertEntry(MakeNodeSearchElementVM(entry), entry.Categories);
-                RaisePropertyChanged("BrowserRootCategories");
-            };
-             
+            Model.EntryAdded += AddEntry;
             Model.EntryUpdated += UpdateEntry;
             Model.EntryRemoved += RemoveEntry;
 
@@ -438,6 +434,12 @@ namespace Dynamo.ViewModels
 
             DefineFullCategoryNames(LibraryRootCategories, "");
             InsertClassesIntoTree(LibraryRootCategories);
+        }
+
+        private void AddEntry(NodeSearchElement entry)
+        {
+            InsertEntry(MakeNodeSearchElementVM(entry), entry.Categories);
+            RaisePropertyChanged("BrowserRootCategories");
         }
 
         private IEnumerable<RootNodeCategoryViewModel> CategorizeEntries(IEnumerable<NodeSearchElement> entries, bool expanded)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2892,7 +2892,13 @@ namespace Dynamo.Controls
             dynamoViewModel.SideBarTabItems.CollectionChanged -= this.OnCollectionChanged;
 
             if (fileTrustWarningPopup != null)
+            {
                 fileTrustWarningPopup.CleanPopup();
+            }
+            //TODO code smell.
+            var workspaceView = this.ChildOfType<WorkspaceView>();
+            workspaceView?.Dispose();
+            (workspaceView?.NodeAutoCompleteSearchBar?.Child as IDisposable)?.Dispose();
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Views
     /// <summary>
     /// Interaction logic for WorkspaceView.xaml
     /// </summary>
-    public partial class WorkspaceView
+    public partial class WorkspaceView: IDisposable
     {
         public enum CursorState
         {
@@ -1133,6 +1133,11 @@ namespace Dynamo.Views
                 GeoScalingPopup.PlacementTarget = geometryScalingButton;
             }
             GeoScalingPopup.IsOpen = true;
+        }
+
+        public void Dispose()
+        {
+            RemoveViewModelsubscriptions(ViewModel);
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -73,6 +73,10 @@ namespace Dynamo.UI.Views
             set
             {
                 dynamoView = value;
+                if(dynamoView == null)
+                {
+                    return;
+                }
                 viewModel = value.DataContext as DynamoViewModel;
                 // When view model is closed, we need to close the splash screen if it is displayed.
                 viewModel.RequestClose += SplashScreenRequestClose;
@@ -484,8 +488,14 @@ namespace Dynamo.UI.Views
             // RequestUpdateLoadBarStatus event needs to be unsubscribed when the splash screen window is closed, to avoid populating the info on splash screen.
             else
             {
-                this.Close();
-                viewModel?.Model.ShutDown(false);
+                Close();
+                if (viewModel != null)
+                {
+                    viewModel.RequestClose -= SplashScreenRequestClose;
+                }
+
+                DynamoView?.Close();
+                DynamoView = null;
             }
         }
 

--- a/src/DynamoManipulation/DynamoManipulationExtension.cs
+++ b/src/DynamoManipulation/DynamoManipulationExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -174,6 +174,13 @@ namespace Dynamo.Manipulation
                 BackgroundPreviewViewModel.CanNavigateBackgroundPropertyChanged -= Watch3DViewModelNavigateBackgroundPropertyChanged;
                 BackgroundPreviewViewModel.ViewMouseDown -= Watch3DViewModelOnViewMouseDown;
             }
+
+            var settings = GetRunSettings(WorkspaceModel);
+            if (settings != null)
+            {
+                settings.PropertyChanged -= OnRunSettingsPropertyChanged;
+            }
+
         }
 
         private void Watch3DViewModelOnViewMouseDown(object o, MouseButtonEventArgs mouseButtonEventArgs)

--- a/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewExtension.cs
@@ -110,10 +110,12 @@ namespace Dynamo.GraphMetadata
 
         protected virtual void Dispose(bool disposing)
         {
-            viewModel.Dispose();
-
-            this.graphMetadataMenuItem.Checked -= MenuItemCheckHandler;
-            this.graphMetadataMenuItem.Unchecked -= MenuItemUnCheckedHandler;
+            viewModel?.Dispose();
+            if (graphMetadataMenuItem != null)
+            {
+                graphMetadataMenuItem.Checked -= MenuItemCheckHandler;
+                graphMetadataMenuItem.Unchecked -= MenuItemUnCheckedHandler;
+            }
         }
 
         public override void Dispose()

--- a/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows.Media.Imaging;
@@ -266,6 +266,7 @@ namespace Dynamo.GraphMetadata
         public void Dispose()
         {
             this.viewLoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
+            this.viewLoadedParams.CurrentWorkspaceCleared += OnCurrentWorkspaceChanged;
             if (linterManager != null)
             {
                 linterManager.PropertyChanged -= OnLinterManagerPropertyChange;

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -622,7 +622,6 @@ namespace Dynamo.LibraryViewExtensionWebView2
         protected void Dispose(bool disposing)
         {
             if (!disposing) return;
-
             if (observer != null) observer.Dispose();
             observer = null;
             if (this.dynamoWindow != null)
@@ -636,11 +635,15 @@ namespace Dynamo.LibraryViewExtensionWebView2
             }
             if (this.browser != null)
             {
+                browser.CoreWebView2.RemoveHostObjectFromScript("bridgeTwoWay");
                 browser.SizeChanged -= Browser_SizeChanged;
                 browser.Loaded -= Browser_Loaded;
                 browser.Dispose();
                 browser = null;
             }
+            twoWayScriptingObject.Dispose();
+            dynamoViewModel = null;
+            commandExecutive = null;
         }
 
         public static async Task<string> ExecuteScriptFunctionAsync(WebView2 webView2, string functionName, params object[] parameters)

--- a/src/LibraryViewExtensionWebView2/ScriptingObject.cs
+++ b/src/LibraryViewExtensionWebView2/ScriptingObject.cs
@@ -11,13 +11,18 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
     [ClassInterface(ClassInterfaceType.AutoDual)]
     [ComVisible(true)]
-    public class ScriptingObject
+    public class ScriptingObject: IDisposable
     {
         private LibraryViewController controller;
 
         public ScriptingObject(LibraryViewController controller)
         {
             this.controller = controller;
+        }
+
+        public void Dispose()
+        {
+            controller = null;
         }
 
         /// <summary>

--- a/src/LintingViewExtension/LintingViewExtension.cs
+++ b/src/LintingViewExtension/LintingViewExtension.cs
@@ -71,10 +71,18 @@ namespace Dynamo.LintingViewExtension
 
         public override void Dispose()
         {
-            this.linterMenuItem.Checked -= MenuItemCheckHandler;
-            this.linterMenuItem.Unchecked -= MenuItemUnCheckedHandler;
-            if (linterManager != null) linterManager.PropertyChanged -= OnLinterManagerPropertyChange;
-            viewLoadedParamsReference.ViewExtensionOpenRequest -= OnViewExtensionOpenRequest;
+            if (linterMenuItem != null)
+            {
+                linterMenuItem.Checked -= MenuItemCheckHandler;
+                linterMenuItem.Unchecked -= MenuItemUnCheckedHandler;
+            }
+            if (linterManager != null){
+                linterManager.PropertyChanged -= OnLinterManagerPropertyChange;
+            }
+            if (viewLoadedParamsReference != null)
+            {
+                viewLoadedParamsReference.ViewExtensionOpenRequest -= OnViewExtensionOpenRequest;
+            }
         }
 
         public override void Closed()

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -27,7 +27,7 @@ namespace Dynamo.Notifications
             get { return notifications; }
             private set
             {
-                if(notifications != value)
+                if (notifications != value)
                     notifications = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Notifications)));
             }
@@ -62,8 +62,11 @@ namespace Dynamo.Notifications
             {
                 UnregisterEventHandlers();
                 //for some reason the menuItem was not being gc'd in tests without manually removing it
-                viewLoadedParams.dynamoMenu.Items.Remove(notificationsMenuItem.MenuItem);
-                BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
+                viewLoadedParams?.dynamoMenu.Items.Remove(notificationsMenuItem.MenuItem);
+                if (notificationsMenuItem != null)
+                {
+                    BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
+                }
                 notificationsMenuItem = null;
                 disposed = true;
             }
@@ -71,8 +74,14 @@ namespace Dynamo.Notifications
 
         private void UnregisterEventHandlers()
         {
-            viewLoadedParams.NotificationRecieved -= notificationHandler;
-            Notifications.CollectionChanged -= notificationsMenuItem.NotificationsChangeHandler;
+            if (viewLoadedParams != null)
+            {
+                viewLoadedParams.NotificationRecieved -= notificationHandler;
+            }
+            if (notificationsMenuItem != null)
+            {
+                Notifications.CollectionChanged -= notificationsMenuItem.NotificationsChangeHandler;
+            }
         }
 
         public void Loaded(ViewLoadedParams viewStartupParams)
@@ -83,7 +92,7 @@ namespace Dynamo.Notifications
             logger = viewModel.Model.Logger;
 
             Notifications = new ObservableCollection<Logging.NotificationMessage>();
-            
+
             notificationHandler = (notificationMessage) =>
             {
                 Notifications.Add(notificationMessage);
@@ -117,12 +126,12 @@ namespace Dynamo.Notifications
 
         public void Shutdown()
         {
-           // Do nothing for now
+            // Do nothing for now
         }
 
         public void Startup(ViewStartupParams viewStartupParams)
         {
-           // Do nothing for now
+            // Do nothing for now
         }
     }
 }

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
@@ -143,7 +143,10 @@ namespace Dynamo.PackageDetails
         public override void Dispose()
         {
             PackageDetailsViewModel?.Dispose();
-            ViewLoadedParamsReference.ViewExtensionOpenRequestWithParameter -= OnViewExtensionOpenWithParameterRequest;
+            if (ViewLoadedParamsReference != null)
+            {
+                ViewLoadedParamsReference.ViewExtensionOpenRequestWithParameter -= OnViewExtensionOpenWithParameterRequest;
+            }
         }
 
         public override void Closed()

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -199,10 +199,17 @@ namespace Dynamo.PythonMigration
 
         private void UnsubscribeEvents()
         {
-            LoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
-            DynamoViewModel.CurrentSpaceViewModel.Model.NodeAdded -= OnNodeAdded;
-            DynamoViewModel.Model.Logger.NotificationLogged -= OnNotificationLogged;
-            CurrentWorkspace.RequestPackageDependencies -= PythonDependencies.AddPythonPackageDependency;
+            if (LoadedParams != null)
+            {
+                LoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
+                DynamoViewModel.CurrentSpaceViewModel.Model.NodeAdded -= OnNodeAdded;
+                DynamoViewModel.Model.Logger.NotificationLogged -= OnNotificationLogged;
+            }
+            
+            if (CurrentWorkspace  != null)
+            {
+                CurrentWorkspace.RequestPackageDependencies -= PythonDependencies.AddPythonPackageDependency;
+            }
             UnSubscribeWorkspaceEvents();
         }
         #endregion

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -68,7 +68,7 @@ namespace Dynamo.WorkspaceDependency
         /// </summary>
         public override void Dispose()
         {
-            DependencyView.Dispose();
+            DependencyView?.Dispose();
             dataRows = null;
             localDefinitionDataRows = null;
             externalFilesDataRows = null;


### PR DESCRIPTION
### Purpose

This PR fixes more memory leaks when starting and closing DynamoRevit and creating a single new workspace each time.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

fix additional memory leaks.



### Reviewers
