### PR TITLE
Dyn 6207 - Fix the D4R samples path

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -244,7 +244,7 @@ namespace Dynamo.Applications
         public static DynamoModel MakeCLIModel(string asmPath, string userDataFolder, string commonDataFolder, HostAnalyticsInfo info = new HostAnalyticsInfo(), bool isServiceMode = false)
         {
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
-            PathManager.Instance.AssignIPathResolver(string.Empty, pathResolver);
+            PathManager.Instance.AssignHostPathAndIPathResolver(string.Empty, pathResolver);
 
             Thread.CurrentThread.CurrentUICulture = new CultureInfo(PreferenceSettings.Instance.Locale);
             Thread.CurrentThread.CurrentCulture = new CultureInfo(PreferenceSettings.Instance.Locale);
@@ -282,8 +282,8 @@ namespace Dynamo.Applications
         /// <returns></returns>
         public static DynamoModel MakeModel(bool CLImode, string asmPath = "", HostAnalyticsInfo info = new HostAnalyticsInfo())
         {
-            IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);            
-            PathManager.Instance.AssignIPathResolver(string.Empty,pathResolver);
+            IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
+            PathManager.Instance.AssignHostPathAndIPathResolver(string.Empty, pathResolver);
 
             Thread.CurrentThread.CurrentUICulture = new CultureInfo(PreferenceSettings.Instance.Locale);
             Thread.CurrentThread.CurrentCulture = new CultureInfo(PreferenceSettings.Instance.Locale);

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -366,7 +366,7 @@ namespace Dynamo.Core
         /// </summary>
         /// <param name="hostPath"></param>
         /// /// <param name="resolver"></param>
-        internal void AssignIPathResolver(string hostPath, IPathResolver resolver)
+        internal void AssignHostPathAndIPathResolver(string hostPath, IPathResolver resolver)
         {
             pathResolver = resolver;
             BuildHostDirectories(hostPath);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1032,7 +1032,7 @@ namespace Dynamo.Models
             {
                 if (!Core.PathManager.Instance.HasPathResolver)
                 {
-                    Core.PathManager.Instance.AssignIPathResolver(config.DynamoHostPath, config.PathResolver);
+                    Core.PathManager.Instance.AssignHostPathAndIPathResolver(config.DynamoHostPath, config.PathResolver);
                 }
                 return Core.PathManager.Instance;
             }


### PR DESCRIPTION
### Purpose

Fix the Bug https://jira.autodesk.com/browse/DYN-6207 Dissecting the PathManager's constructor to reuse its granular methods in the AssignHostPathAndIPathResolver method, on this way we can update the PathManager Singleton Instance according to the assigned PathResolver and DynamoHost.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@mjkkirschner 
@RobertGlobant20 
