### PR TITLE
partially revert #13744 and add comments

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -260,6 +260,7 @@ namespace Dynamo.ViewModels
                     return ObjectToLabelString(obj);
                 case TypeCode.Double:
                     return ((double)obj).ToString(numberFormat, CultureInfo.InvariantCulture);
+                //!!!!carefully consider the consequences of this change before uncommenting.
                 //TODO: uncomment this once https://jira.autodesk.com/browse/DYN-5101 is complete
                 //return ((double)obj).ToString(ProtoCore.Mirror.MirrorData.PrecisionFormat, CultureInfo.InvariantCulture);
                 case TypeCode.Int32:
@@ -271,10 +272,6 @@ namespace Dynamo.ViewModels
                 case TypeCode.Object:
                     return ObjectToLabelString(obj);
                 default:
-                    if (double.TryParse(obj.ToString(), out double d))
-                    {
-                        return Convert.ToDouble(obj).ToString(ProtoCore.Mirror.MirrorData.PrecisionFormat, CultureInfo.InvariantCulture);
-                    }
                     return (string)obj;
             };
         }

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -224,11 +224,11 @@ namespace ProtoCore
                     {
                         return "null";
                     }
-                    else if (Data is bool)
+                    if (Data is bool)
                     {
                         return Data.ToString().ToLower();
                     }
-                    else if (Data is IFormattable)
+                    if (Data is IFormattable)
                     {
                         // Object.ToString() by default will use the current 
                         // culture to do formatting. For example, Double.ToString()
@@ -236,6 +236,7 @@ namespace ProtoCore
                         // We should always use invariant culture format for formattable 
                         // object.
 
+                        //!!!!carefully consider the consequences of this change before uncommenting.
                         //TODO: uncomment this once https://jira.autodesk.com/browse/DYN-5101 is complete
                         //if (Data is double)
                         //{
@@ -246,12 +247,8 @@ namespace ProtoCore
                         return (Data as IFormattable).ToString(null, CultureInfo.InvariantCulture);
                         //}
                     }
-                    else
+                    
                     {
-                        if (double.TryParse(Data.ToString(), out double d))
-                        {
-                            return Convert.ToDouble(Data).ToString(PrecisionFormat, CultureInfo.InvariantCulture);
-                        }
                         return Data.ToString();
                     }
                 }


### PR DESCRIPTION
### Purpose

As a first step toward addressing the bug report here:
https://github.com/DynamoDS/Dynamo/pull/14369

This PR just reverts the initial string preview transformations, we can merge there and then quickly cherry pick to 2.19. Even though I intend to send a proposal for an alternative string format improvement to master, I want to make sure these changes make it to master and 2.19.

strings now stay strings.

<img width="274" alt="Screenshot 2023-09-05 at 8 21 55 PM" src="https://github.com/DynamoDS/Dynamo/assets/508936/958b526b-1209-46c2-9076-c023d0e8432a">
<img width="367" alt="Screenshot 2023-09-05 at 8 22 17 PM" src="https://github.com/DynamoDS/Dynamo/assets/508936/20cdb7c6-2ba9-4766-9e84-b2d82c3d3281">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Fix bug with numeric display in preview bubbles.

### Reviewers

