### PR TITLE
2.19.1 disable network traffic WIP

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -398,24 +398,20 @@ namespace Dynamo.Applications
             HostAnalyticsInfo info = new HostAnalyticsInfo(),
             bool isServiceMode = false)
         {
+
             var config = new DynamoModel.DefaultStartConfiguration
             {
                 GeometryFactoryPath = geometryFactoryPath,
                 ProcessMode = CLImode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous,
                 HostAnalyticsInfo = info,
                 CLIMode = CLImode,
-                AuthProvider = CLImode ? null : new Core.IDSDKManager(),
+                AuthProvider = CLImode || Dynamo.Logging.Analytics.DisableAnalytics ? null : new Core.IDSDKManager(),
                 UpdateManager = CLImode ? null : OSHelper.IsWindows() ? InitializeUpdateManager() : null,
                 StartInTestMode = CLImode,
                 PathResolver = CreatePathResolver(CLImode, preloaderLocation, userDataFolder, commonDataFolder),
                 IsServiceMode = isServiceMode,
                 Preferences = PreferenceSettings.Instance
             };
-            config.AuthProvider = CLImode ? null : new Core.IDSDKManager();
-            config.UpdateManager = CLImode ? null : InitializeUpdateManager();
-            config.StartInTestMode = CLImode;
-            config.PathResolver = CLImode ? new CLIPathResolver(preloaderLocation, userDataFolder, commonDataFolder) as IPathResolver : new SandboxPathResolver(preloaderLocation) as IPathResolver;
-
             var model = DynamoModel.Start(config);
             return model;
         }

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -405,6 +405,7 @@ namespace Dynamo.Applications
                 ProcessMode = CLImode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous,
                 HostAnalyticsInfo = info,
                 CLIMode = CLImode,
+                //TODO we currently use this like a no network comms flags - work on introducing a new flag or renaming this flag.
                 AuthProvider = CLImode || Dynamo.Logging.Analytics.DisableAnalytics ? null : new Core.IDSDKManager(),
                 UpdateManager = CLImode ? null : OSHelper.IsWindows() ? InitializeUpdateManager() : null,
                 StartInTestMode = CLImode,

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -411,6 +411,10 @@ namespace Dynamo.Applications
                 IsServiceMode = isServiceMode,
                 Preferences = PreferenceSettings.Instance
             };
+            config.AuthProvider = CLImode ? null : new Core.IDSDKManager();
+            config.UpdateManager = CLImode ? null : InitializeUpdateManager();
+            config.StartInTestMode = CLImode;
+            config.PathResolver = CLImode ? new CLIPathResolver(preloaderLocation, userDataFolder, commonDataFolder) as IPathResolver : new SandboxPathResolver(preloaderLocation) as IPathResolver;
 
             var model = DynamoModel.Start(config);
             return model;

--- a/src/DynamoCore/Logging/AnalyticsService.cs
+++ b/src/DynamoCore/Logging/AnalyticsService.cs
@@ -84,12 +84,6 @@ namespace Dynamo.Logging
 
         internal static bool IsADPAvailable()
         {
-            if (Analytics.DisableAnalytics ||
-                adpAnalyticsUI == null)
-            {
-                return false;
-            }
-
             return adpAnalyticsUI.IsProviderAvailable();
         }
 

--- a/src/DynamoCore/Logging/AnalyticsService.cs
+++ b/src/DynamoCore/Logging/AnalyticsService.cs
@@ -84,6 +84,12 @@ namespace Dynamo.Logging
 
         internal static bool IsADPAvailable()
         {
+            if (Analytics.DisableAnalytics ||
+                adpAnalyticsUI == null)
+            {
+                return false;
+            }
+
             return adpAnalyticsUI.IsProviderAvailable();
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1111,6 +1111,9 @@ namespace Dynamo.Models
         {
             if (!DynamoModel.IsTestMode)
             {
+                if (DynamoModel.FeatureFlags == null)
+                    return;
+            
                 if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false))
                 {
                     this.Logger.Log("EasterEggIcon1 is true FROM MODEL");

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1109,28 +1109,26 @@ namespace Dynamo.Models
 
         private void CheckFeatureFlagTest()
         {
-            if (DynamoModel.IsTestMode)
-                return;
+            if (!DynamoModel.IsTestMode)
+            {
+                if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false))
+                {
+                    this.Logger.Log("EasterEggIcon1 is true FROM MODEL");
 
-            if (DynamoModel.FeatureFlags == null)
-                return;
+                }
+                else
+                {
+                    this.Logger.Log("EasterEggIcon1 is false FROM MODEL");
+                }
 
-            if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false))
-            {
-                this.Logger.Log("EasterEggIcon1 is true FROM MODEL");
-            }
-            else
-            {
-                this.Logger.Log("EasterEggIcon1 is false FROM MODEL");
-            }
-
-            if (DynamoModel.FeatureFlags.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is var s && s != "NA")
-            {
-                this.Logger.Log("EasterEggMessage1 is enabled FROM MODEL");
-            }
-            else
-            {
-                this.Logger.Log("EasterEggMessage1 is disabled FROM MODEL");
+                if (DynamoModel.FeatureFlags.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is var s && s != "NA")
+                {
+                    this.Logger.Log("EasterEggMessage1 is enabled FROM MODEL");
+                }
+                else
+                {
+                    this.Logger.Log("EasterEggMessage1 is disabled FROM MODEL");
+                }
             }
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -761,10 +761,6 @@ namespace Dynamo.Models
                     }
                     catch (Exception e) { Logger.LogError($"could not start feature flags manager {e}"); };
                 });
-
-                //TODO just a test of feature flag event, safe to remove at any time.
-                DynamoUtilities.DynamoFeatureFlagsManager.FlagsRetrieved += CheckFeatureFlagTest;
-
             }
 
             // TBD: Do we need settings migrator for service mode? If we config the docker correctly, this could be skipped I think
@@ -1105,34 +1101,6 @@ namespace Dynamo.Models
 
             // Otherwise make a default preference settings object.
             return new PreferenceSettings();
-        }
-
-        private void CheckFeatureFlagTest()
-        {
-            if (!DynamoModel.IsTestMode)
-            {
-                if (DynamoModel.FeatureFlags == null)
-                    return;
-            
-                if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false))
-                {
-                    this.Logger.Log("EasterEggIcon1 is true FROM MODEL");
-
-                }
-                else
-                {
-                    this.Logger.Log("EasterEggIcon1 is false FROM MODEL");
-                }
-
-                if (DynamoModel.FeatureFlags.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is var s && s != "NA")
-                {
-                    this.Logger.Log("EasterEggMessage1 is enabled FROM MODEL");
-                }
-                else
-                {
-                    this.Logger.Log("EasterEggMessage1 is disabled FROM MODEL");
-                }
-            }
         }
 
         private void SetDefaultPythonTemplate()
@@ -1478,7 +1446,6 @@ namespace Dynamo.Models
             {
                 FeatureFlags.MessageLogged -= LogMessageWrapper;
             }
-            DynamoUtilities.DynamoFeatureFlagsManager.FlagsRetrieved -= CheckFeatureFlagTest;
         }
 
         private void InitializeCustomNodeManager()

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1109,26 +1109,28 @@ namespace Dynamo.Models
 
         private void CheckFeatureFlagTest()
         {
-            if (!DynamoModel.IsTestMode)
+            if (DynamoModel.IsTestMode)
+                return;
+
+            if (DynamoModel.FeatureFlags == null)
+                return;
+
+            if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false))
             {
-                if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false))
-                {
-                    this.Logger.Log("EasterEggIcon1 is true FROM MODEL");
+                this.Logger.Log("EasterEggIcon1 is true FROM MODEL");
+            }
+            else
+            {
+                this.Logger.Log("EasterEggIcon1 is false FROM MODEL");
+            }
 
-                }
-                else
-                {
-                    this.Logger.Log("EasterEggIcon1 is false FROM MODEL");
-                }
-
-                if (DynamoModel.FeatureFlags.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is var s && s != "NA")
-                {
-                    this.Logger.Log("EasterEggMessage1 is enabled FROM MODEL");
-                }
-                else
-                {
-                    this.Logger.Log("EasterEggMessage1 is disabled FROM MODEL");
-                }
+            if (DynamoModel.FeatureFlags.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is var s && s != "NA")
+            {
+                this.Logger.Log("EasterEggMessage1 is enabled FROM MODEL");
+            }
+            else
+            {
+                this.Logger.Log("EasterEggMessage1 is disabled FROM MODEL");
             }
         }
 

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -230,7 +230,7 @@ namespace Dynamo.Scheduler
                 var previousMeshVertexCount = package.MeshVertexCount;
 
                 //Todo Plane tessellation needs to be handled here vs in LibG currently
-                bool instancingEnabled = DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("graphics-primitive-instancing", false) ?? false;
+                bool instancingEnabled = DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("graphics-primitive-instancing", false);
                 if (graphicItem is Plane plane)
                 {
                     CreatePlaneTessellation(package, plane);

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -230,7 +230,7 @@ namespace Dynamo.Scheduler
                 var previousMeshVertexCount = package.MeshVertexCount;
 
                 //Todo Plane tessellation needs to be handled here vs in LibG currently
-                bool instancingEnabled = DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("graphics-primitive-instancing", false);
+                bool instancingEnabled = DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("graphics-primitive-instancing", false) ?? false;
                 if (graphicItem is Plane plane)
                 {
                     CreatePlaneTessellation(package, plane);

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1114,7 +1114,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return DynamoModel.FeatureFlags.CheckFeatureFlag("NodeAutocompleteMachineLearningIsBeta", false);
+                return DynamoModel.FeatureFlags?.CheckFeatureFlag("NodeAutocompleteMachineLearningIsBeta", false) ?? false;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1853,7 +1853,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         //If we have any line geometry that was not associated with an instance,
                         //remove the previously added line data from the render package so the remaining lines can be added to the scene.
                         if (rp.LineVertexRangesAssociatedWithInstancing.Any() 
-                            && DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("graphics-primitive-instancing", false))
+                            && DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("graphics-primitive-instancing", false) == true)
                         {
                             //For each range of line vertices add the line data and instances to the scene
                             var j = 0;
@@ -1946,7 +1946,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     //If we have any mesh geometry that was not associated with an instance, remove the previously added
                     //mesh data from the render package so the remaining mesh can be added to the scene.
                     if (rp.MeshVertexRangesAssociatedWithInstancing.Any() 
-                        && DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("graphics-primitive-instancing", false))
+                        && DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("graphics-primitive-instancing", false) == true)
                     {
                         //For each range of mesh vertices add the mesh data and instances to the scene
                         var j = 0;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1853,7 +1853,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         //If we have any line geometry that was not associated with an instance,
                         //remove the previously added line data from the render package so the remaining lines can be added to the scene.
                         if (rp.LineVertexRangesAssociatedWithInstancing.Any() 
-                            && DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("graphics-primitive-instancing", false) == true)
+                            && DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("graphics-primitive-instancing", false))
                         {
                             //For each range of line vertices add the line data and instances to the scene
                             var j = 0;
@@ -1946,7 +1946,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     //If we have any mesh geometry that was not associated with an instance, remove the previously added
                     //mesh data from the render package so the remaining mesh can be added to the scene.
                     if (rp.MeshVertexRangesAssociatedWithInstancing.Any() 
-                        && DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("graphics-primitive-instancing", false) == true)
+                        && DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("graphics-primitive-instancing", false))
                     {
                         //For each range of mesh vertices add the mesh data and instances to the scene
                         var j = 0;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1346,27 +1346,30 @@ namespace Dynamo.Controls
         /// </summary>
         private void CheckTestFlags()
         {
-            if (!DynamoModel.IsTestMode)
-            {
-                //feature flag test.
-                if (DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("EasterEggIcon1", false) == true)
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true from view");
-                }
-                else
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is false from view");
-                }
+           if (DynamoModel.IsTestMode)
+                return;
 
-                if (DynamoModel.FeatureFlags?.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is string ffs && ffs != "NA")
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is enabled from view");
-                    MessageBoxService.Show(this, ffs, "EasterEggMessage1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
-                }
-                else
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is disabled from view");
-                }
+            if (DynamoModel.FeatureFlags == null)
+                return;
+
+            //feature flag test.
+            if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false) == true)
+            {
+                dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true from view");
+            }
+            else
+            {
+                dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is false from view");
+            }
+
+            if (DynamoModel.FeatureFlags?.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is string ffs && ffs != "NA")
+            {
+                dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is enabled from view");
+                MessageBoxService.Show(this, ffs, "EasterEggMessage1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+            }
+            else
+            {
+                dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is disabled from view");
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1346,30 +1346,27 @@ namespace Dynamo.Controls
         /// </summary>
         private void CheckTestFlags()
         {
-           if (DynamoModel.IsTestMode)
-                return;
+            if (!DynamoModel.IsTestMode)
+            {
+                //feature flag test.
+                if (DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("EasterEggIcon1", false) == true)
+                {
+                    dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true from view");
+                }
+                else
+                {
+                    dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is false from view");
+                }
 
-            if (DynamoModel.FeatureFlags == null)
-                return;
-
-            //feature flag test.
-            if (DynamoModel.FeatureFlags.CheckFeatureFlag<bool>("EasterEggIcon1", false) == true)
-            {
-                dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true from view");
-            }
-            else
-            {
-                dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is false from view");
-            }
-
-            if (DynamoModel.FeatureFlags?.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is string ffs && ffs != "NA")
-            {
-                dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is enabled from view");
-                MessageBoxService.Show(this, ffs, "EasterEggMessage1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
-            }
-            else
-            {
-                dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is disabled from view");
+                if (DynamoModel.FeatureFlags?.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is string ffs && ffs != "NA")
+                {
+                    dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is enabled from view");
+                    MessageBoxService.Show(this, ffs, "EasterEggMessage1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+                }
+                else
+                {
+                    dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is disabled from view");
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1307,19 +1307,6 @@ namespace Dynamo.Controls
                 this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(null); };
             }
             loaded = true;
-
-
-            //The following code illustrates use of FeatureFlagsManager.
-            //safe to remove.
-            if (DynamoModel.FeatureFlags != null)
-            {
-                CheckTestFlags();
-            }
-            //if feature flags is not yet initialized, subscribe to the event and wait.
-            else
-            {
-                DynamoUtilities.DynamoFeatureFlagsManager.FlagsRetrieved += CheckTestFlags;
-            }            
         }
 
         private void GuideFlowEvents_GuidedTourStart(GuidedTourStateEventArgs args)
@@ -1333,44 +1320,11 @@ namespace Dynamo.Controls
         /// <summary>
         /// Close Popup when the Dynamo window is not in the foreground.
         /// </summary>
-
         private void HidePopupWhenWindowDeactivated(object obj)
         {
             var workspace = this.ChildOfType<WorkspaceView>();
             if (workspace != null)
                 workspace.HideAllPopUp(obj);
-        }
-        /// <summary>
-        /// check some test flags from launch darkly.
-        /// code is safe to remove at any time.
-        /// </summary>
-        private void CheckTestFlags()
-        {
-            if (!DynamoModel.IsTestMode)
-            {
-                if (DynamoModel.FeatureFlags == null)
-                    return;
-                    
-                //feature flag test.
-                if (DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("EasterEggIcon1", false) == true)
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is true from view");
-                }
-                else
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggIcon1 is false from view");
-                }
-
-                if (DynamoModel.FeatureFlags?.CheckFeatureFlag<string>("EasterEggMessage1", "NA") is string ffs && ffs != "NA")
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is enabled from view");
-                    MessageBoxService.Show(this, ffs, "EasterEggMessage1", MessageBoxButton.OK, MessageBoxImage.Asterisk);
-                }
-                else
-                {
-                    dynamoViewModel.Model.Logger.Log("EasterEggMessage1 is disabled from view");
-                }
-            }
         }
 
         private void TrackStartupAnalytics()
@@ -1971,8 +1925,6 @@ namespace Dynamo.Controls
             this.dynamoViewModel.RequestReturnFocusToView -= OnRequestReturnFocusToView;
             this.dynamoViewModel.Model.WorkspaceSaving -= OnWorkspaceSaving;
             this.dynamoViewModel.Model.WorkspaceOpened -= OnWorkspaceOpened;
-            DynamoUtilities.DynamoFeatureFlagsManager.FlagsRetrieved -= CheckTestFlags;
-
             this.dynamoViewModel.RequestEnableShortcutBarItems -= DynamoViewModel_RequestEnableShortcutBarItems;
             this.dynamoViewModel.RequestExportWorkSpaceAsImage -= OnRequestExportWorkSpaceAsImage;
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1348,6 +1348,9 @@ namespace Dynamo.Controls
         {
             if (!DynamoModel.IsTestMode)
             {
+                if (DynamoModel.FeatureFlags == null)
+                    return;
+                    
                 //feature flag test.
                 if (DynamoModel.FeatureFlags?.CheckFeatureFlag<bool>("EasterEggIcon1", false) == true)
                 {

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -337,9 +337,15 @@ namespace Dynamo.PackageManager
         {
             // determine if any of the packages are targeting other hosts
             var containsPackagesThatTargetOtherHosts = false;
-
-            // Known hosts
-            var knownHosts = PackageManagerClient.GetKnownHosts();
+            //fallback list of hosts as of 9/8/23
+            IEnumerable<string> knownHosts =  new List<string> { "Revit", "Civil 3D", "Alias", "Advance Steel", "FormIt" };
+            //if analytics is disabled, treat this as network black out
+            //and don't ask dpm for known hosts.
+            if (!Dynamo.Logging.Analytics.DisableAnalytics)
+            {
+                // Known hosts
+                knownHosts = PackageManagerClient.GetKnownHosts();
+            }
 
             // Sandbox, special case: Warn if any package targets only one known host
             if (String.IsNullOrEmpty(Host))

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -341,6 +341,7 @@ namespace Dynamo.PackageManager
             IEnumerable<string> knownHosts =  new List<string> { "Revit", "Civil 3D", "Alias", "Advance Steel", "FormIt" };
             //if analytics is disabled, treat this as network black out
             //and don't ask dpm for known hosts.
+            //TODO we currently use this like a no network comms flags - work on introducing a new flag or renaming this flag.
             if (!Dynamo.Logging.Analytics.DisableAnalytics)
             {
                 // Known hosts

--- a/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
+++ b/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
@@ -143,7 +143,7 @@ namespace Dynamo.PackageManager.UI
         {
             // ALIAS does needs a total network traffic blackout.
             // Since there is no way to switch this on/off, we will just skip it for now.
-            /*
+            
             foreach (var pkg in packages)
             {
                 //check that the package does not target another host, if it does raise a warning.
@@ -160,7 +160,6 @@ namespace Dynamo.PackageManager.UI
                         Resources.TitlePackageTargetOtherHost));
                 }
             }
-            */
         }
 
         private void RequestLoadLayoutSpecs(IEnumerable<Package> packages)

--- a/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
+++ b/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
@@ -141,9 +141,6 @@ namespace Dynamo.PackageManager.UI
 
         private void RaisePackageHostNotifications(IEnumerable<Package> packages)
         {
-            // ALIAS does needs a total network traffic blackout.
-            // Since there is no way to switch this on/off, we will just skip it for now.
-            
             foreach (var pkg in packages)
             {
                 //check that the package does not target another host, if it does raise a warning.

--- a/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
+++ b/src/DynamoPackagesWPF/PackageManagerViewExtension.cs
@@ -141,6 +141,9 @@ namespace Dynamo.PackageManager.UI
 
         private void RaisePackageHostNotifications(IEnumerable<Package> packages)
         {
+            // ALIAS does needs a total network traffic blackout.
+            // Since there is no way to switch this on/off, we will just skip it for now.
+            /*
             foreach (var pkg in packages)
             {
                 //check that the package does not target another host, if it does raise a warning.
@@ -157,7 +160,7 @@ namespace Dynamo.PackageManager.UI
                         Resources.TitlePackageTargetOtherHost));
                 }
             }
-
+            */
         }
 
         private void RequestLoadLayoutSpecs(IEnumerable<Package> packages)

--- a/src/NodeServices/Analytics.cs
+++ b/src/NodeServices/Analytics.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Dynamo.Logging
 {
@@ -7,6 +7,7 @@ namespace Dynamo.Logging
     /// </summary>
     public static class Analytics
     {
+        //TODO we currently use this like a no network comms flags - work on introducing a new flag or renaming this flag.
         /// <summary>
         /// Disables all analytics collection for the lifetime of the process.
         /// To ensure that no analytics get through, please set set this flag to false before the DynamoModel is constructed.

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -92,10 +92,11 @@ namespace Dynamo.Notifications
                 VerticalOffset = notificationPopupVerticalOffset
             };
             logger = dynLogger;
-            
+
             // If user turns on the feature, they will need to restart Dynamo to see the count
             // This ensures no network traffic when Notification center feature is turned off
-            if (dynamoViewModel.PreferenceSettings.EnableNotificationCenter) 
+            //TODO we currently use DisableAnalytics like a no network comms flags - work on introducing a new flag or renaming this flag.
+            if (dynamoViewModel.PreferenceSettings.EnableNotificationCenter && !Dynamo.Logging.Analytics.DisableAnalytics ) 
             {               
                 InitializeBrowserAsync();
                 RequestNotifications();

--- a/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
@@ -239,8 +239,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(Path.Combine(BuiltinPackagesTestDir,"SignedPackage2","extra","layoutspecs.json"), packageManagerViewExtension.RequestedLayoutSpecPaths.FirstOrDefault());
         }
 
-        // Fails because we are now forcefully disabling host checking because of ALIAS issues. 
-        [Test, Category("Failure")]
+        [Test]
         public void PackageManagerViewExtesion_SendsNotificationForPackagesThatTargetDifferentHost_AtExtensionLoad()
         {
             var count = 0;
@@ -273,8 +272,7 @@ namespace DynamoCoreWpfTests
             }
         }
 
-        // Fails because we are now forcefully disabling host checking because of ALIAS issues.
-        [Test, Category("Failure")]
+        [Test]
         public void PackageManagerViewExtesion_SendsNotificationForPackagesThatTargetDifferentHost_AtLatePackageLoad()
         {
             var count = 0;

--- a/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerViewExtensionTests.cs
@@ -239,7 +239,8 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(Path.Combine(BuiltinPackagesTestDir,"SignedPackage2","extra","layoutspecs.json"), packageManagerViewExtension.RequestedLayoutSpecPaths.FirstOrDefault());
         }
 
-        [Test]
+        // Fails because we are now forcefully disabling host checking because of ALIAS issues. 
+        [Test, Category("Failure")]
         public void PackageManagerViewExtesion_SendsNotificationForPackagesThatTargetDifferentHost_AtExtensionLoad()
         {
             var count = 0;
@@ -271,7 +272,9 @@ namespace DynamoCoreWpfTests
                 count = count + 1;
             }
         }
-        [Test]
+
+        // Fails because we are now forcefully disabling host checking because of ALIAS issues.
+        [Test, Category("Failure")]
         public void PackageManagerViewExtesion_SendsNotificationForPackagesThatTargetDifferentHost_AtLatePackageLoad()
         {
             var count = 0;


### PR DESCRIPTION
This pulls in some changes from @pinzart90's changes for 2.17.4 and tries to adapt them to use the `DisableAnalytics` flag as a stand in `DisableNetworkActivity` flag until we have that.

Additionally, it disables the notification center requests if `DisableAnalytics` is true.

I believe it is safe to merge to master, unlike the original changes.