### PR TITLE
Adding a Unit Test to the PathManager

### DIFF
--- a/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PreferencesViewModelTests.cs
@@ -1,7 +1,10 @@
 using System.IO;
 using System.Linq;
+using Dynamo.Core;
+using Dynamo.Interfaces;
 using Dynamo.Tests;
 using NUnit.Framework;
+using TestServices;
 
 namespace DynamoCoreWpfTests
 {
@@ -89,7 +92,7 @@ namespace DynamoCoreWpfTests
         }
         [Test]
         public void PackagePathsForInstall_FiltersSomeFilePaths()
-        { 
+        {
             //add a new path to the package paths
             ViewModel.Model.PreferenceSettings.CustomPackageFolders.Add(@"C:\DoesNotExist\DoesNotExist.DLL");
             //set to null, so getter regenerates list
@@ -135,6 +138,29 @@ namespace DynamoCoreWpfTests
 
             Assert.AreEqual(ViewModel.PreferencesViewModel.GetTransformedHostUnits(Dynamo.Configuration.Configurations.Units.Miles),
                 Dynamo.Configuration.Configurations.Units.Miles);
+        }
+
+        [Test]
+        public void PathManagerWithDifferentHostTest()
+        {
+            PathManager singletonPathManager = PathManager.Instance;
+            TestPathResolverParams revitResolverParams = new TestPathResolverParams()
+            {
+                UserDataRootFolder = "C:\\Users\\user\\AppData\\Roaming\\Dynamo\\Dynamo Revit",
+                CommonDataRootFolder = "C:\\ProgramData\\Autodesk\\RVT 2024\\Dynamo"
+            };
+
+            IPathResolver revitPathResolver = new TestPathResolver(revitResolverParams);
+            string dynamoRevitHostPath = "C:\\Program Files\\Autodesk\\Revit 2024\\AddIns\\DynamoForRevit\\Revit)";
+            singletonPathManager.AssignHostPathAndIPathResolver(dynamoRevitHostPath, revitPathResolver);
+
+            string dynamoRevitUserDataDirectory = "C:\\Users\\user\\AppData\\Roaming\\Dynamo\\Dynamo Revit\\3.0";
+            string dynamoRevitCommonDataDirectory = "C:\\ProgramData\\Autodesk\\RVT 2024\\Dynamo\\3.0";
+            string dynamoRevitSamplesPath = "C:\\ProgramData\\Autodesk\\RVT 2024\\Dynamo\\samples\\en-US";
+
+            Assert.AreEqual(Path.GetFullPath(singletonPathManager.UserDataDirectory), Path.GetFullPath(dynamoRevitUserDataDirectory));
+            Assert.AreEqual(Path.GetFullPath(singletonPathManager.CommonDataDirectory), Path.GetFullPath(dynamoRevitCommonDataDirectory));
+            Assert.AreEqual(Path.GetFullPath(singletonPathManager.SamplesDirectory), Path.GetFullPath(dynamoRevitSamplesPath));
         }
     }
 }


### PR DESCRIPTION

### Purpose

Adding an Unit test for the PathManager and how its properties are updated when it deals with a different Host as part of the bug https://jira.autodesk.com/browse/DYN-6207

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Reviewers
@mjkkirschner

### FYIs
@QilongTang 
