### PR TITLE
FixingWarningMessage

### DIFF
--- a/doc/distrib/NodeHelpFiles/PythonNodeModels.PythonStringNode.dyn
+++ b/doc/distrib/NodeHelpFiles/PythonNodeModels.PythonStringNode.dyn
@@ -328,7 +328,7 @@
       ],
       "Replication": "Disabled",
       "Description": "Allows you to select a file on the system and returns its file path",
-      "HintPath": "C:\\Users\\roberto.tellez\\Downloads\\PythonScript.txt",
+      "HintPath": "PythonScript.txt",
       "InputValue": ".\\PythonScript.txt"
     },
     {


### PR DESCRIPTION
### Purpose

Changing the path of the PythonScript.txt so the warning message will be according to the user path.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Changing the path of the PythonScript.txt so the warning message will be according to the user path.


### Reviewers

@QilongTang 

### FYIs

