### PR TITLE
DYN-6259 Fix Handling preferences bearing in mind the hosts

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1056,7 +1056,7 @@ namespace Dynamo.Models
         internal PreferenceSettings CreatePreferences(IStartConfiguration config)
         {
             PreferenceSettings preferences = null;
-            if (!config.StartInTestMode)
+            if (config.Preferences != null)
             {
                 if (config.Preferences is PreferenceSettings settings)
                 {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -678,7 +678,7 @@ namespace Dynamo.Models
 
             OnRequestUpdateLoadBarStatus(new SplashScreenLoadEventArgs(Resources.SplashScreenInitPreferencesSettings, 30));
 
-            PreferenceSettings = CreatePreferences(config);
+            PreferenceSettings = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
             if (PreferenceSettings != null)
             {
                 PreferenceSettings.PropertyChanged += PreferenceSettings_PropertyChanged;
@@ -1046,29 +1046,6 @@ namespace Dynamo.Models
                     PathResolver = config.PathResolver
                 });
             }
-        }
-
-        /// <summary>
-        /// It returns a PreferenceSettings instance based on the mode in order to reuse it's Singleton instance or create a new one
-        /// </summary>
-        /// <param name="config"></param>
-        /// <returns></returns>
-        internal PreferenceSettings CreatePreferences(IStartConfiguration config)
-        {
-            PreferenceSettings preferences = null;
-            if (config.Preferences != null)
-            {
-                if (config.Preferences is PreferenceSettings settings)
-                {
-                    preferences = settings;
-                }
-            }
-            else
-            {
-                preferences = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
-            }
-
-            return preferences;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose
Fixing the bug https://jira.autodesk.com/browse/DYN-6259 handling the creation/assignation of the Preferences in the Dynamic Model ctor bearing in mind the PathManager info.
A host doesn't need to pass any Preferences instance because it will be created in the Dynamo side considering the PathManager has the proper paths to do it.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Reviewers
@QilongTang 
@reddyashish 