### PR TITLE
DYN-6010 Enable Node Help Docs Sharing Images

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -26,6 +26,8 @@ namespace Dynamo.DocumentationBrowser
 
         internal string WebBrowserUserDataFolder { get; set; }
         internal string FallbackDirectoryName { get; set; }
+        //This folder will be used to store all the images located in Degub/en-US/fallback_docs so we don't need to copy all the images per each language
+        internal const string FallbackImagesDirectoryName = "fallback_docs_images";
 
         //Path in which the virtual folder for loading images will be created
         internal string VirtualFolderPath { get; set; }
@@ -136,7 +138,11 @@ namespace Dynamo.DocumentationBrowser
             {
                 if (viewModel.Link != null && !string.IsNullOrEmpty(viewModel.CurrentPackageName))
                 {
-                    VirtualFolderPath = Path.GetDirectoryName(HttpUtility.UrlDecode(viewModel.Link.AbsolutePath));
+                    string absolutePath = Path.GetDirectoryName(HttpUtility.UrlDecode(viewModel.Link.AbsolutePath));
+                    //We move two levels up so it will be located in same level than the the fallback_docs_images directory
+                    string imagesLocation = Directory.GetParent(Directory.GetParent(absolutePath).FullName).FullName;
+                    //Adds the fallback_docs_images directory to the path
+                    VirtualFolderPath = Path.Combine(imagesLocation, FallbackImagesDirectoryName);
                 }
                 else
                     VirtualFolderPath = FallbackDirectoryName;

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -123,6 +123,9 @@
           <ExternSimplexNoise Include="$(SolutionDir)..\extern\SimplexNoise\*" />
           <SampleFiles Include="$(SolutionDir)..\doc\distrib\Samples\**\*.*" />
           <NodeHelpFiles Include="$(SolutionDir)..\doc\distrib\NodeHelpFiles\**\*.*" />
+          <NodeHelpJpgImageFiles Include="$(SolutionDir)..\doc\distrib\NodeHelpFiles\**\*.jpg" />
+		  <NodeHelpPngImageFiles Include="$(SolutionDir)..\doc\distrib\NodeHelpFiles\**\*.png" />
+		  <NodeHelpGifImageFiles Include="$(SolutionDir)..\doc\distrib\NodeHelpFiles\**\*.gif" />
           <OpenSourceLicenses Include="$(SolutionDir)..\doc\distrib\Open Source Licenses\**\*.*" />
           <LocalizedResources Include="$(SolutionDir)..\extern\Localized\**\*.*" />
       </ItemGroup>
@@ -132,6 +135,9 @@
     <Copy SourceFiles="$(SolutionDir)..\doc\distrib\InstrumentationConsent.rtf" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="$(SolutionDir)..\doc\distrib\ADPAnalyticsConsent.rtf" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(NodeHelpFiles)" DestinationFolder="$(OutputPath)\en-US\fallback_docs\" />
+    <Copy SourceFiles="@(NodeHelpJpgImageFiles)" DestinationFolder="$(OutputPath)\fallback_docs_images\" />
+	<Copy SourceFiles="@(NodeHelpPngImageFiles)" DestinationFolder="$(OutputPath)\fallback_docs_images\" />
+	<Copy SourceFiles="@(NodeHelpGifImageFiles)" DestinationFolder="$(OutputPath)\fallback_docs_images\" />
     <Copy SourceFiles="@(OpenSourceLicenses)" DestinationFolder="$(OutputPath)Open Source Licenses\" />
     <Copy SourceFiles="@(LibGInterface)" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(LibGProtoGeometryDLL)" DestinationFolder="$(OutputPath)" />


### PR DESCRIPTION

### Purpose

Creating a shared folder for images so we won't need to copy the images per each language.
With this fix now all the images will be copied to the Dynamo\bin\AnyCPU\Debug\fallback_docs_images folder (also in the Debug\en-US\fallback_docs  as currently is happening), so WebView2 will be creating the virtual folder in fallback_docs_images and will be reading the images from this folder, then there is no need that the localization team is copying the images in each folder language.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Creating a shared folder for images so we won't need to copy the images per each language.


### Reviewers

@QilongTang 

### FYIs
