### PR TITLE
DYN-6263 Revert avalonedit version

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -119,17 +119,26 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-ICSharpCode.AvalonEdit v.6.3.0.90:
-http://www.avalonedit.net/
-https://licenses.nuget.org/MIT
+ICSharpCode.AvalonEdit v.4.3.1.9430:
+http://avalonedit.net
+https://opensource.org/licenses/lgpl-2.1.php
 
-MIT License
+Portions related to the Avalon Edit v.4.3.1.9429 are © 2014 AlphaSierraPapa for the SharpDevelop Team. All rights reserved. Avalon Edit is licensed under the GNU Lesser General Public License v.3.0, which can be found at http://opensource.org/licenses/lgpl-3.0.html. A text copy of this license is included on the media provided by Autodesk or with the download of this Autodesk software. You may obtain a copy of the source code for Avalon Edit v.4.3.1.9429 from www.autodesk.com/lgplsource or by sending a written request to:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Autodesk, Inc.
+Attention: General Counsel
+Legal Department
+111 McInnis Parkway
+San Rafael, CA 9490
 
-The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+Your written request must:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+1. Contain a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or the envelope you have chosen) weighing 5 ounces from San Rafael, California USA to your indicated address; and
+2. Identify:
+• this Autodesk software name and release number;
+• that you are requesting the source code for Avalon Edit v.4.3.1.9429; and
+• the above URL (www.autodesk.com/lgplsource)
+so that Autodesk may properly respond to your request. The offer to receive this Avalon Edit source code via the above URL (www.autodesk.com/lgplsource) or by written request to Autodesk is valid for a period of three (3) years from the date you purchased your license to this Autodesk software. You may modify, debug and relink Avalon Edit to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.3.0.
 
 Google OpenSans:
 OpenSans font from Google

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -1,71 +1,74 @@
-{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff4\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe2052\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
+{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff4\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f4\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Helvetica;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}
-{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f40\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604030504040204}Verdana;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}
-{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f64\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f65\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f67\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f68\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f69\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f70\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
-{\f71\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f72\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f84\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}{\f85\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}
-{\f87\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f88\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f89\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}{\f90\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}
-{\f91\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f92\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
-{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
-{\f444\fbidi \fswiss\fcharset238\fprq2 Verdana CE;}{\f445\fbidi \fswiss\fcharset204\fprq2 Verdana Cyr;}{\f447\fbidi \fswiss\fcharset161\fprq2 Verdana Greek;}{\f448\fbidi \fswiss\fcharset162\fprq2 Verdana Tur;}
-{\f451\fbidi \fswiss\fcharset186\fprq2 Verdana Baltic;}{\f452\fbidi \fswiss\fcharset163\fprq2 Verdana (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}
-{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}{\fhimajor\f31533\fbidi \fswiss\fcharset177\fprq2 Calibri Light (Hebrew);}{\fhimajor\f31534\fbidi \fswiss\fcharset178\fprq2 Calibri Light (Arabic);}
-{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Calibri Light (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}
-{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
-{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
-{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\caccentone\ctint255\cshade191\red47\green84\blue150;
-\caccentone\ctint255\cshade127\red31\green55\blue99;\chyperlink\ctint255\cshade255\red5\green99\blue193;\red96\green94\blue92;\red225\green223\blue221;\cfollowedhyperlink\ctint255\cshade255\red149\green79\blue114;\red165\green165\blue165;
-\red109\green210\blue255;\red70\green70\blue70;\red74\green74\blue74;\red5\green99\blue193;\red36\green41\blue47;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa160\sl259\slmult1
-\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \snext0 \sqformat \spriority0 Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink15 \sqformat heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 
-\ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\s3\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel2\rin0\lin0\itap0 \rtlch\fcs1 
-\af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink17 \sqformat heading 3;}{\s4\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel3\rin0\lin0\itap0 
-\rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink18 \sqformat heading 4;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 
-Default Paragraph Font;}{\*\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv 
-\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe2052\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp2052 
-\snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af0\afs32 \ltrch\fcs0 \fs32\cf19\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \af0\afs26 \ltrch\fcs0 
+{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f40\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604030504040204}Verdana;}{\f43\fbidi \fmodern\fcharset0\fprq1{\*\panose 020b0609020204030204}Consolas;}
+{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f45\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\f46\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f48\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f49\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f50\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\f51\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f52\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f53\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f65\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}
+{\f66\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}{\f68\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f69\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f70\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}
+{\f71\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}{\f72\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f73\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f85\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}
+{\f86\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}{\f88\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f89\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f90\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}
+{\f91\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}{\f92\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f93\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f385\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
+{\f386\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f388\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f389\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f392\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
+{\f393\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f445\fbidi \fswiss\fcharset238\fprq2 Verdana CE;}{\f446\fbidi \fswiss\fcharset204\fprq2 Verdana Cyr;}{\f448\fbidi \fswiss\fcharset161\fprq2 Verdana Greek;}
+{\f449\fbidi \fswiss\fcharset162\fprq2 Verdana Tur;}{\f452\fbidi \fswiss\fcharset186\fprq2 Verdana Baltic;}{\f453\fbidi \fswiss\fcharset163\fprq2 Verdana (Vietnamese);}{\f475\fbidi \fmodern\fcharset238\fprq1 Consolas CE;}
+{\f476\fbidi \fmodern\fcharset204\fprq1 Consolas Cyr;}{\f478\fbidi \fmodern\fcharset161\fprq1 Consolas Greek;}{\f479\fbidi \fmodern\fcharset162\fprq1 Consolas Tur;}{\f482\fbidi \fmodern\fcharset186\fprq1 Consolas Baltic;}
+{\f483\fbidi \fmodern\fcharset163\fprq1 Consolas (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}
+{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}
+{\fhimajor\f31533\fbidi \fswiss\fcharset177\fprq2 Calibri Light (Hebrew);}{\fhimajor\f31534\fbidi \fswiss\fcharset178\fprq2 Calibri Light (Arabic);}{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}
+{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Calibri Light (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}
+{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}
+{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
+{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;
+\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;
+\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\caccentone\ctint255\cshade191\red47\green84\blue150;\caccentone\ctint255\cshade127\red31\green55\blue99;\chyperlink\ctint255\cshade255\red5\green99\blue193;\red96\green94\blue92;
+\red225\green223\blue221;\cfollowedhyperlink\ctint255\cshade255\red149\green79\blue114;\red165\green165\blue165;\red109\green210\blue255;\red173\green186\blue199;\red70\green70\blue70;\red74\green74\blue74;\red5\green99\blue193;\red36\green41\blue47;}
+{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
+\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \snext0 \sqformat \spriority0 Normal;}{
+\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink15 \sqformat 
+heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 
+\sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\s3\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel2\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink17 \sqformat heading 3;}{\s4\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel3\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 
+\ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink18 \sqformat heading 4;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
+\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl259\slmult1
+\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
+Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af0\afs32 \ltrch\fcs0 \fs32\cf19\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \af0\afs26 \ltrch\fcs0 
 \fs26\cf19\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \ssemihidden \spriority9 Heading 2 Char;}{\*\cs17 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \fs24\cf20\loch\f31502\hich\af31502\dbch\af31501 
 \sbasedon10 \slink3 \ssemihidden \spriority9 Heading 3 Char;}{\*\cs18 \additive \rtlch\fcs1 \ai\af0\afs24 \ltrch\fcs0 \i\fs24\cf19\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink4 \ssemihidden \spriority9 Heading 4 Char;}{\*\cs19 \additive 
 \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf21 \sbasedon10 \sunhideused \styrsid14298549 Hyperlink;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf22\chshdng0\chcfpat0\chcbpat23 \sbasedon10 \ssemihidden \sunhideused \styrsid14298549 Unresolved Mention;}{\*
 \cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf24 \sbasedon10 \ssemihidden \sunhideused \styrsid4611777 FollowedHyperlink;}{\s22\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 
 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f0\hich\af0\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext22 \ssemihidden \sunhideused \styrsid9731339 Normal (Web);}{\*\cs23 \additive \rtlch\fcs1 \ai\af0 
-\ltrch\fcs0 \i \sbasedon10 \ssemihidden \sunhideused \styrsid9731339 HTML Variable;}}{\*\listtable{\list\listtemplateid-1{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fs20\fbias0 \fi-360\li720\jclisttab\tx720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01o;}{\levelnumbers;}\f2\fs20\fbias0 
-\fi-360\li1440\jclisttab\tx1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li2160
-\jclisttab\tx2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li2880\jclisttab\tx2880\lin2880 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li3600\jclisttab\tx3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li4320\jclisttab\tx4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li5040\jclisttab\tx5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li5760\jclisttab\tx5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li6480\jclisttab\tx6480\lin6480 }{\listname ;}\listid404035829}}{\*\listoverridetable{\listoverride\listid404035829\listoverridecount0\ls1}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0
-\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid1784394\rsid3092893\rsid3225273\rsid3346706\rsid3998130\rsid4484117
-\rsid4611777\rsid9377761\rsid9460105\rsid9635992\rsid9658238\rsid9731339\rsid10299691\rsid11167982\rsid12335516\rsid12653622\rsid14298549\rsid14628192\rsid14700233\rsid15019625\rsid15220234\rsid16659309}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
-\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Aaron Tang}{\creatim\yr2023\mo5\dy24\hr14\min10}{\revtim\yr2023\mo8\dy1\hr12\min1}{\version17}{\edmins32}{\nofpages25}{\nofwords12354}{\nofchars70423}
-{\nofcharsws82612}{\vern75}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\ltrch\fcs0 \i \sbasedon10 \ssemihidden \sunhideused \styrsid9731339 HTML Variable;}{\*\cs24 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \sbasedon10 \spriority0 \styrsid15533882 x;}}{\*\listtable{\list\listtemplateid-1{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}\f3\fs20\fbias0 \fi-360\li720\jclisttab\tx720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace0\levelindent0{\leveltext\'01o;}{\levelnumbers;}\f2\fs20\fbias0 \fi-360\li1440\jclisttab\tx1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
+{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li2160\jclisttab\tx2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li2880\jclisttab\tx2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}
+\f10\fs20\fbias0 \fi-360\li3600\jclisttab\tx3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li4320
+\jclisttab\tx4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li5040\jclisttab\tx5040\lin5040 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li5760\jclisttab\tx5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\'01\u-3929 ?;}{\levelnumbers;}\f10\fs20\fbias0 \fi-360\li6480\jclisttab\tx6480\lin6480 }{\listname ;}\listid404035829}}{\*\listoverridetable
+{\listoverride\listid404035829\listoverridecount0\ls1}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp4\itap0
+\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid1784394\rsid3092893\rsid3225273\rsid3346706\rsid3368283\rsid3998130\rsid4484117\rsid4611777\rsid9377761\rsid9380195\rsid9460105\rsid9635992\rsid9658238
+\rsid9731339\rsid10299691\rsid11167982\rsid12335516\rsid12653622\rsid14298549\rsid14628192\rsid14700233\rsid15019625\rsid15220234\rsid15533882\rsid16659309}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
+\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Aparajit Pratap}{\creatim\yr2023\mo5\dy24\hr14\min10}{\revtim\yr2023\mo9\dy21\hr12\min52}{\version20}{\edmins36}{\nofpages25}{\nofwords12446}{\nofchars70945}{\nofcharsws83225}{\vern77}}
+{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\hyphhotz425\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120
 \dghorigin1701\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot1784394 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
 \pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
@@ -95,57 +98,57 @@ om%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0
 003100370039003400370035003200300031003200300035003100310025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068004d003400530045004300520058
 006c004900330059003300620068005700640030006e00370061005600460045005300380070005900660045003300740066006400690049006600620053007300640049006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006b
-005b000070000000723600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache\hich\af4\dbch\af31505\loch\f4 .org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+005b00007000000072360048}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apach\hich\af4\dbch\af31505\loch\f4 e.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-\hich\af4\dbch\af31505\loch\f4 the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+\hich\af4\dbch\af31505\loch\f4  the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af40\afs20 \ltrch\fcs0 \b\f40\fs20\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Privacy
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 To learn more about Autodesk\hich\f4 \rquote \loch\f4 
 s online and offline privacy practices, please see the }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-statemen\hich\af4\dbch\af31505\loch\f4 t"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
+HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-stateme\hich\af4\dbch\af31505\loch\f4 nt"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bae00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f007400
-69006300650073002d00740072006100640065006d00610072006b0073002f0070007200690076006100630079002d00730074006100740065006d0065006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300590073002000000000006d00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+69006300650073002d00740072006100640065006d00610072006b0073002f0070007200690076006100630079002d00730074006100740065006d0065006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300590073002000000000006d0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Privacy Statement}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 .}{\rtlch\fcs1 \af40\afs16 \ltrch\fcs0 \f40\fs16\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Trademarks
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The trademarks on the }{\field{\*\fldinst {\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autode\hich\af4\dbch\af31505\loch\f4 sk.com/company/legal-notices-trademarks/intellectual-property/trademarks"}{
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.aut\hich\af4\dbch\af31505\loch\f4 odesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"}{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f0069006e00740065006c006c00650063007400750061006c002d00700072006f00700065007200740079002f00740072006100640065006d00610072006b0073000000795881f43b1d7f48af2c825dc485276300000000a5ab0003007300
-6f007500000000016500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Tradem\hich\af4\dbch\af31505\loch\f4 arks page}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
- are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.  
+6f00750000000001650000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Trademarks page}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.  
+
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 All other brand names, product names or trademarks belong to their respective holders.
-\par }\pard \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud and Desktop Co
-\hich\af4\dbch\af31505\loch\f4 mponents}{\rtlch\fcs1 \ab\af40\afs22 \ltrch\fcs0 \b\f40\fs22\lang2057\langfe2052\langnp2057\insrsid9658238 
+\par }\pard \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Au
+\hich\af4\dbch\af31505\loch\f4 todesk Cloud and Desktop Components}{\rtlch\fcs1 \ab\af40\afs22 \ltrch\fcs0 \b\f40\fs22\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 This Product or Service may incorporate or use background Autodesk online and desktop technology components.\~ For information about these components, see}{\rtlch\fcs1 \af40\afs22 \ltrch\fcs0 \f40\fs22\lang2057\langfe2052\langnp2057\insrsid9658238 
-\hich\af40\dbch\af31505\loch\f40  }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-\hich\af4\dbch\af31505\loch\f4 components"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
+\hich\af40\dbch\af31505\loch\f40  }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademar
+\hich\af4\dbch\af31505\loch\f4 ks/autodesk-cloud-platform-components"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd2000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f006100750074006f006400650073006b002d0063006c006f00750064002d0070006c006100740066006f0072006d002d0063006f006d0070006f006e0065006e00740073000000795881f43b1d7f48af2c825dc485276300000000a5ab00
-0300461a34ff6d01340000004e00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+0300461a34ff6d01340000004e0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af0\dbch\af31505\loch\f0  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-and }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.c\hich\af4\dbch\af31505\loch\f4 
-om/company/legal-notices-trademarks/autodesk-desktop-platform-components"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
+and }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERL\hich\af4\dbch\af31505\loch\f4 
+INK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd6000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f006100750074006f006400650073006b002d006400650073006b0074006f0070002d0070006c006100740066006f0072006d002d0063006f006d0070006f006e0065006e00740073000000795881f43b1d7f48af2c825dc4852763000000
-00a5ab00030073096f004f005d0000017b00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk De\hich\af4\dbch\af31505\loch\f4 sktop Platform Components}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 .
+00a5ab00030073096f004f005d0000017b0028}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Desktop Platform Components}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 .
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sb168\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 LIBG, ProtoGeometry v.2.7.0, Analytics.NET, ADP, GRegRevitAuth, AGET, IDSDK, and IDSDK Wrapper}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
  are closed source files licensed by Autodesk under the license that can be found here }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba8000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
-610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006f806ff00000710000507300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoD\hich\af4\dbch\af31505\loch\f4 S/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 
+610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006f806ff0000071000050730031}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Third-Party Trademarks, Software Credits and Attributions
@@ -156,7 +159,7 @@ HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rt
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2013 Peter Boyer }{\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af0\dbch\af31505\loch\f0 HYPERLINK "mailto:peter.boyer@autodesk.com" }{
 \rtlch\fcs1 \af0 \ltrch\fcs0 \f0\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b580000006d00610069006c0074006f003a00700065007400650072002e0062006f0079006500720040006100750074006f006400650073006b002e0063006f006d000000795881f43b1d7f48af2c825dc48527630000
-0000a5ab000300730061000000460000007000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 peter.boyer@autodesk.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+0000a5ab00030073006100000046000000700000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 peter.boyer@autodesk.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, 
 \hich\af4\dbch\af31505\loch\f4 m\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -196,12 +199,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 003100370039003400370035003200300034003100390032003000300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068007600520034006d005900670056
 0068004d005000700051006800340075004c0043004a00330050005900390059007700720038006d004d0030007600710058004600390038006100630038006d005000580041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030075
-000010e436ad00f8006c45}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+000010e436ad00f8006c4500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJamesNK%2FNewtonsoft.Json%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autode\hich\af4\dbch\af31505\loch\f4 
-sk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520429148%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=OuX0yvu%2F0kVS7X5KARjQ3p9Ycg8qvk67fFAaKNEWxbM
-\hich\af4\dbch\af31505\loch\f4 %\hich\af4\dbch\af31505\loch\f4 3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJamesNK%2FNewtonsoft.Json%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autod\hich\af4\dbch\af31505\loch\f4 
+esk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520429148%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=OuX0yvu%2F0kVS7X5KARjQ3p9Ycg8qvk67fFAaKNEWxb
+\hich\af4\dbch\af31505\loch\f4 M\hich\af4\dbch\af31505\loch\f4 %3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b88030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046004a0061006d00650073004e004b002500320046004e006500770074006f006e0073006f00660074002e004a0073006f006e0025
 003200460062006c006f0062002500320046006d00610073007400650072002500320046004c004900430045004e00530045002e006d006400260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f00
@@ -209,25 +212,27 @@ sk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0
 00650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003200390031003400380025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00
 73006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a0058005600430049
 0036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004f0075005800300079007600750025003200460030006b00560053003700580035004b00410052006a0051003300700039005900630067003800710076006b003600370066004600410061004b004e0045005700
-780062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030064002c002e00790000005c16}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
+780062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030064002c002e00790000005c1665}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007 James Newton-King
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associate\hich\af4\dbch\af31505\loch\f4 
-d documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom th
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4  Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
+\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 rge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY\hich\af4\dbch\af31505\loch\f4 
- KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
-\hich\af4\dbch\af31505\loch\f4 R\hich\af4\dbch\af31505\loch\f4  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N
+\hich\af4\dbch\af31505\loch\f4 
+O EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 \par 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 RestSharp v.106.12.0.0:
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C6376179475204789
-\hich\af4\dbch\af31505\loch\f4 4\hich\af4\dbch\af31505\loch\f4 7%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=foUoDUPyy8Or0rkNJtlLjI9XfJO7gemOLFnuKIkflHU%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C
+\hich\af4\dbch\af31505\loch\f4 0%7C0%7C637617947520478947%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=foUoDUPyy8Or0rkNJtlLjI9XfJO7gemOLFnuKIkflHU%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d0068007400740070002500330041002500320046002500320046007700770077002e006100700061006300680065002e006f00720067002500320046006c006900630065006e007300650073002500320046004c004900430045004e00530045002d0032002e00300026
@@ -236,41 +241,40 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 003100370039003400370035003200300034003700380039003400370025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066006f0055006f0044005500500079
 00790038004f007200300072006b004e004a0074006c004c006a0049003900580066004a004f003700670065006d004f004c0046006e0075004b0049006b0066006c00480055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030e49
-6354000048740000006d3d}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+6354000048740000006d3d00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2021 Alexe Zimarev
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Licensed under \hich\af4\dbch\af31505\loch\f4 the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {
+\par \hich\af4\dbch\af31505\loch\f4 Licensed under\hich\af4\dbch\af31505\loch\f4  the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang2057\langfe2052\langnp2057\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003126e000000220074000000c712}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003126e000000220074000000c7123f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHO\hich\af4\dbch\af31505\loch\f4 
-UT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITH\hich\af4\dbch\af31505\loch\f4 
+OUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang2057\langfe2052\kerning1\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 System.Collections.Immutable v.1.4.0:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2017 .NET Foundation and Contributor
-\hich\af4\dbch\af31505\loch\f4 s
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang2057\langfe2052\langnp2057\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2017 .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights 
-\hich\af4\dbch\af31505\loch\f4 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without res\hich\af4\dbch\af31505\loch\f4 
+triction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice \hich\af4\dbch\af31505\loch\f4 shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The \hich\af4\dbch\af31505\loch\f4 above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE A\hich\af4\dbch\af31505\loch\f4 
-ND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DE
-\hich\af4\dbch\af31505\loch\f4 A\hich\af4\dbch\af31505\loch\f4 LINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF M\hich\af4\dbch\af31505\loch\f4 
+ERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN C
+\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 NNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe2052\langnp2057\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1031\langfe2052\kerning1\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Fontawesome v.4.7.0.37774:
 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FFontAwesome.WPF%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67\hich\af4\dbch\af31505\loch\f4 
-bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520190208%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=X8xzrd%2Fj2Js0LaFtQIoDfDv5iv%2FWDi31xCr9xQYz%2B80%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FFontAwesome.WPF%2F&data=04%7C01%7CJames.Conner%40au\hich\af4\dbch\af31505\loch\f4 
+todesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520190208%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=X8xzrd%2Fj2Js0LaFtQIoDfDv5iv%2FWDi31xCr9x
+\hich\af4\dbch\af31505\loch\f4 Q\hich\af4\dbch\af31505\loch\f4 Yz%2B80%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b64030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046007700770077002e006e0075006700650074002e006f00720067002500320046007000610063006b00610067006500730025003200460046006f006e00740041007700650073006f006d0065002e
 00570050004600250032004600260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d0025003700430064006100650063006400360035003700380031003900
@@ -278,12 +282,12 @@ bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520190208%7CUnknown%7CTWFpbGZs
 0025003700430036003300370036003100370039003400370035003200300031003900300032003000380025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d00
 4400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0058
 00380078007a00720064002500320046006a0032004a00730030004c00610046007400510049006f0044006600440076003500690076002500320046005700440069003300310078004300720039007800510059007a00250032004200380030002500330044002600720065007300650072007600650064003d0030000000
-795881f43b1d7f48af2c825dc485276300000000a5ab000300724931003200680000005100}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https:\hich\af4\dbch\af31505\loch\f4 
-//www.nuget.org/packages/FontAwesome.WPF/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
+795881f43b1d7f48af2c825dc485276300000000a5ab00030072493100320068000000510000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+https://www.nuget.org/packages/FontAwesome.WPF/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcharri%2FFont-Awesome-WPF%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d9\hich\af4\dbch\af31505\loch\f4 
-46251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=sKAHUntVBjSIV8O68z3a0dCJ%2BlRxwngZUFlVrQNRkW8%3D&reserved=0" }{\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcharri%2FFont-Awesome-WPF%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65\hich\af4\dbch\af31505\loch\f4 
+781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=sKAHUntVBjSIV8O68z3a0dCJ%2BlRxwngZUFlVrQNRkW8%3D&reserved=0" 
+}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d0025003200460063006800610072007200690025003200460046006f006e0074002d0041007700650073006f006d0065002d0057005000460025
 003200460062006c006f0062002500320046006d00610073007400650072002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f00640065007300
@@ -291,21 +295,20 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003000300031003600340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300
 64003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e
 00300025003300440025003700430031003000300030002600730064006100740061003d0073004b004100480055006e007400560042006a0053004900560038004f00360038007a00330061003000640043004a002500320042006c005200780077006e0067005a00550046006c005600720051004e0052006b0057003800
-2500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000352001d009822f7000000003700}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 https://github.co\hich\af4\dbch\af31505\loch\f4 m/charri/Font-Awesome-WPF/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
+2500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000352001d009822f7000000003700a4}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2014-2016 charri
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to dea\hich\af4\dbch\af31505\loch\f4 
-l in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to t
-\hich\af4\dbch\af31505\loch\f4 h\hich\af4\dbch\af31505\loch\f4 e following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \hich\af4\dbch\af31505\loch\f4 
+"Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to 
+\hich\af4\dbch\af31505\loch\f4 d\hich\af4\dbch\af31505\loch\f4 o so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT L\hich\af4\dbch\af31505\loch\f4 
-IMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, \hich\af4\dbch\af31505\loch\f4 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Cyotek.Drawing.BitmapFont v.1.3.4:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLI\hich\af4\dbch\af31505\loch\f4 
@@ -319,12 +322,12 @@ NK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com
 004300300025003700430036003300370036003100370039003400370035003200300031003600300033003400330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a004100
 77004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061
 003d006b00760064004f002500320046005000500067007a0033005000750041005300470036007a00760039003300440077004e004a003400670050006b004c00360054003600690073006c005700420077006f004900390058006b002500330044002600720065007300650072007600650064003d0030000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab00030053002000000000000000c41f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}\sectd \ltrsect
+3b1d7f48af2c825dc485276300000000a5ab00030053002000000000000000c41f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.o\hich\af4\dbch\af31505\loch\f4 
-utlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont%2Fblob%2Fmaster%2FLICENSE.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520170297%7CUnk
-\hich\af4\dbch\af31505\loch\f4 n\hich\af4\dbch\af31505\loch\f4 own%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=WjEf%2FyE1koklbovxfFzHrScckILOiAOQlGkhPLaZ%2FL8%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont%2Fblob%2Fmaster%2FLICENSE.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cd\hich\af4\dbch\af31505\loch\f4 
+aecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520170297%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=WjEf%2FyE1koklbovxfFzHrScckILOiAOQlGkhPLaZ%2FL8%3D&rese
+\hich\af4\dbch\af31505\loch\f4 r\hich\af4\dbch\af31505\loch\f4 ved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600630079006f00740065006b00250032004600430079006f00740065006b002e00440072006100770069006e0067002e00420069
 0074006d006100700046006f006e00740025003200460062006c006f0062002500320046006d00610073007400650072002500320046004c004900430045004e00530045002e00740078007400260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e00
@@ -332,26 +335,26 @@ utlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont%2F
 003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300031003700300032003900370025003700430055006e006b006e006f0077006e00
 2500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061
 005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0057006a00450066002500320046007900450031006b006f006b006c0062006f0076007800660046007a00480072005300630063006b0049004c004f0069004100
-4f0051006c0047006b00680050004c0061005a002500320046004c0038002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300730000000000000000006900}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+4f0051006c0047006b00680050004c0061005a002500320046004c0038002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030073000000000000000000690070}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2012-2021 Cyotek Ltd.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, includ
-\hich\af4\dbch\af31505\loch\f4 
-ing without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software a\hich\af4\dbch\af31505\loch\f4 
+nd associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit person
+\hich\af4\dbch\af31505\loch\f4 s\hich\af4\dbch\af31505\loch\f4  to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright \hich\af4\dbch\af31505\loch\f4 notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \hich\af4\dbch\af31505\loch\f4 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH T
-\hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 E SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WAR\hich\af4\dbch\af31505\loch\f4 
+RANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABI
+\hich\af4\dbch\af31505\loch\f4 L\hich\af4\dbch\af31505\loch\f4 ITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Helix Toolkit v.2.11.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd6578\hich\af4\dbch\af31505\loch\f4 
-1944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=dfWqblB8VdDL63AyawNfgrFG2TD08PCrheqsu%2B7K0Us%3D&reserved=0" }{
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A\hich\af4\dbch\af31505\loch\f4 
+%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJB
+\hich\af4\dbch\af31505\loch\f4 T\hich\af4\dbch\af31505\loch\f4 iI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=dfWqblB8VdDL63AyawNfgrFG2TD08PCrheqsu%2B7K0Us%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b56030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600680065006c00690078002d0074006f006f006c006b0069007400250032004600680065006c00690078002d0074006f006f006c
 006b0069007400260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d0025003700430064006100650063006400360035003700380031003900340034006200
@@ -359,13 +362,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d00440041006900
 4c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0064006600570071
 0062006c00420038005600640044004c003600330041007900610077004e0066006700720046004700320054004400300038005000430072006800650071007300750025003200420037004b003000550073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003000000330000f22e0000646400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/heli\hich\af4\dbch\af31505\loch\f4 x-toolkit/helix-toolkit}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit%2Fblob%2Fdevelop%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67
+276300000000a5ab0003000000330000f22e00006464002e}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit%2Fblob
 \hich\af4\dbch\af31505\loch\f4 
-bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=qUPlp6EXAxHOk9eACY7DopacUlVCn355KLenUznV%2Ft0%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+%2Fdevelop%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7
+\hich\af4\dbch\af31505\loch\f4 C\hich\af4\dbch\af31505\loch\f4 1000&sdata=qUPlp6EXAxHOk9eACY7DopacUlVCn355KLenUznV%2Ft0%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8c030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600680065006c00690078002d0074006f006f006c006b0069007400250032004600680065006c00690078002d0074006f006f006c
 006b006900740025003200460062006c006f00620025003200460064006500760065006c006f0070002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e006500720025003400300061007500
@@ -373,26 +375,26 @@ bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZs
 0061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e006f0077006e0025003700430054005700460070006200
 47005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056
 004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d007100550050006c0070003600450058004100780048004f006b0039006500410043005900370044006f0070006100630055006c00560043006e003300350035004b004c0065006e0055007a006e005600
-250032004600740030002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005365d4000000000000005000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/helix\hich\af4\dbch\af31505\loch\f4 -toolkit/helix-toolkit/blob/develop/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+250032004600740030002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005365d400000000000000500074}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2019 Helix Toolkit contributors
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Softw\hich\af4\dbch\af31505\loch\f4 
-are"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of\hich\af4\dbch\af31505\loch\f4 
+ charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense
+,\hich\af4\dbch\af31505\loch\f4  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of th\hich\af4\dbch\af31505\loch\f4 e Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUD\hich\af4\dbch\af31505\loch\f4 
-ING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
-\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 R OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGH
+\hich\af4\dbch\af31505\loch\f4 T HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 SharpDX v.4.2.0:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsharpdx%2FSharpDX%2Fblob%2Fmaster\hich\af4\dbch\af31505\loch\f4 
-%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdat
-\hich\af4\dbch\af31505\loch\f4 a\hich\af4\dbch\af31505\loch\f4 =VOYhb2IAZGG0jx%2FwQxJ2Q9HXN2t6XKVVP6AiBEdD%2F3E%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://n\hich\af4\dbch\af31505\loch\f4 
+am11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsharpdx%2FSharpDX%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520488895
+\hich\af4\dbch\af31505\loch\f4 %\hich\af4\dbch\af31505\loch\f4 7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=VOYhb2IAZGG0jx%2FwQxJ2Q9HXN2t6XKVVP6AiBEdD%2F3E%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046007300680061007200700064007800250032004600530068006100720070004400580025003200460062006c006f006200250032
 0046006d00610073007400650072002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d00250037004300
@@ -400,45 +402,63 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003800380038003900350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a00
 6f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031
 003000300030002600730064006100740061003d0056004f005900680062003200490041005a004700470030006a0078002500320046007700510078004a00320051003900480058004e0032007400360058004b00560056005000360041006900420045006400440025003200460033004500250033004400260072006500
-7300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002d00000000240000ff003200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+7300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002d00000000240000ff00320007}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/sharpdx/SharpDX/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010-2014 SharpDX - \hich\af4\dbch\af31505\loch\f4 Alexandre Mutel
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 rge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associate\hich\af4\dbch\af31505\loch\f4 
+d documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom th
+\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4  Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N
-\hich\af4\dbch\af31505\loch\f4 
-O EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY\hich\af4\dbch\af31505\loch\f4 
+ KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
+\hich\af4\dbch\af31505\loch\f4 R\hich\af4\dbch\af31505\loch\f4  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14628192 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid14628192\charrsid14628192 \hich\af4\dbch\af31505\loch\f4 
-ICSharpCode.AvalonEdit v.6.3.0.90:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14628192 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid14628192\charrsid14628192 \hich\af4\dbch\af31505\loch\f4 http://www.avalonedit.net/
-\par \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT
-\par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid14628192\charrsid14628192 
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14628192\charrsid14628192 \hich\af4\dbch\af31505\loch\f4 MIT License
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14628192 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid14628192\charrsid14628192 \hich\af4\dbch\af31505\loch\f4 ICSharpCode.AvalonEdit v.
+}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3368283 \hich\af4\dbch\af31505\loch\f4 4.3.1.9430}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid14628192\charrsid14628192 \hich\af4\dbch\af31505\loch\f4 :
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14628192 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid14628192\charrsid14628192 \hich\af4\dbch\af31505\loch\f4 http://\hich\af4\dbch\af31505\loch\f4 
+avalonedit.net/
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882 \hich\af4\dbch\af31505\loch\f4 HYPERLINK \hich\af4\dbch\af31505\loch\f4 "}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882\charrsid15533882 
+\hich\af4\dbch\af31505\loch\f4 https:/}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 /}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882\charrsid15533882 
+\hich\af4\dbch\af31505\loch\f4 opensource.org/\hich\af4\dbch\af31505\loch\f4 license}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 s}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 /lgpl-2.1.php}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882 \hich\af4\dbch\af31505\loch\f4 "}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\cs19\fs22\ul\cf21\insrsid15533882\charrsid8663381 \hich\af4\dbch\af31505\loch\f4 https://\hich\af4\dbch\af31505\loch\f4 opensource.org/\hich\af4\dbch\af31505\loch\f4 licenses\hich\af4\dbch\af31505\loch\f4 /lgpl-2.1.php}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid14628192 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid15533882\charrsid15533882 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Portions related to the Avalon Edit v.4.3.1.9429 are \'a9\loch\f4 
+ 2014 AlphaSierraPapa for the SharpDevelop Team. All rights reserved. Avalon Edit is licensed under the GNU Lesser General Public \hich\af4\dbch\af31505\loch\f4 Licens}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 
+\hich\af4\dbch\af31505\loch\f4 e}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4  v.3.0, which can be found at http://opensource.org/licenses/lgpl\hich\af4\dbch\af31505\loch\f4 
+-3.0.html. A text copy of this license is included on the media provided by Autodesk or with the download of this Autodesk software. You may obtain a copy of the source code for Avalon Edit v.4.3.1.9429 from www.autodesk.com/lgplsource or by sending a wri
+\hich\af4\dbch\af31505\loch\f4 t\hich\af4\dbch\af31505\loch\f4 ten request to:}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14628192\charrsid15533882 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15533882 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
+\par \hich\af4\dbch\af31505\loch\f4 Attention: General Counsel
+\par \hich\af4\dbch\af31505\loch\f4 Legal Department
+\par \hich\af4\dbch\af31505\loch\f4 111 McInnis Parkway
+\par \hich\af4\dbch\af31505\loch\f4 San Rafael, CA 9490}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 rge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice (including the next para\hich\af4\dbch\af31505\loch\f4 graph) shall be included in all copies or substantial portions of the Software.
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PU\hich\af4\dbch\af31505\loch\f4 
-RPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR O
-\hich\af4\dbch\af31505\loch\f4 T\hich\af4\dbch\af31505\loch\f4 HER DEALINGS IN THE SOFTWARE}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238\charrsid14628192 
-\par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid14628192 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 Your written request must:
+\par }{\rtlch\fcs1 \af4\afs18 \ltrch\fcs0 \cs24\f43\fs18\cf27\insrsid15533882\charrsid15533882 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 \hich\af4\dbch\af31505\loch\f4 
+1. Contain a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or \hich\af4\dbch\af31505\loch\f4 
+the envelope you have chosen) weighing 5 ounces from San Rafael, California USA to your indicated address; and
+\par \hich\af4\dbch\af31505\loch\f4 2. Identify:
+\par \bullet \hich\af4\dbch\af31505\loch\f4  this Autodesk software name and release number;
+\par \bullet \hich\af4\dbch\af31505\loch\f4  that you are requesting the source code for Avalon Edit v.4.3.1.9429; and
+\par \bullet \hich\af4\dbch\af31505\loch\f4  the above URL (www.autodesk.com/lgplsource)
+\par \hich\af4\dbch\af31505\loch\f4 so that Autodesk may properly respond to your request. The offer to receive this Avalon Edit source code via the above URL (www.autode\hich\af4\dbch\af31505\loch\f4 
+sk.com/lgplsource) or by written request to Autodesk is valid for a period of three (3) years from the date you purchased your license to this Autodesk software. You may modify, debug and relink Avalon Edit to this Autodesk software as provided under the 
+\hich\af4\dbch\af31505\loch\f4 t\hich\af4\dbch\af31505\loch\f4 erms of the GNU Lesser General Public License v.3.0.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15533882\charrsid15533882 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14628192 {\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid15533882 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Google OpenSans:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 OpenSans font from Google
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.google.com%2Ffonts%2Fspecimen%2FOpen%2BSans&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b\hich\af4\dbch\af31505\loch\f4 
-855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520439110%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=uwmtTlbBUjq%2B1z%2FvJsb9jSJ7i6M8hIMll1qnznB0mDw%3D&reserved=0" }{
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.google.com%2Ffonts%2Fspecimen%2FOpen%2BSans&data=04%7C01%7
+\hich\af4\dbch\af31505\loch\f4 
+CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520439110%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=uwmtTlbBUjq%2B1z%2FvJsb
+\hich\af4\dbch\af31505\loch\f4 9\hich\af4\dbch\af31505\loch\f4 jSJ7i6M8hIMll1qnznB0mDw%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b62030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d0068007400740070002500330041002500320046002500320046007700770077002e0067006f006f0067006c0065002e0063006f006d0025003200460066006f006e0074007300250032004600730070006500630069006d0065006e002500320046004f00700065006e
 00250032004200530061006e007300260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d002500370043006400610065006300640036003500370038003100
@@ -446,12 +466,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 00300025003700430036003300370036003100370039003400370035003200300034003300390031003100300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a0041007700
 4d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d
 00750077006d00740054006c006200420055006a00710025003200420031007a0025003200460076004a007300620039006a0053004a003700690036004d003800680049004d006c006c00310071006e007a006e00420030006d00440077002500330044002600720065007300650072007600650064003d00300000007958
-81f43b1d7f48af2c825dc485276300000000a5ab000300730061006e002b6500007300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.google.com\hich\af4\dbch\af31505\loch\f4 
-/fonts/specimen/Open+Sans}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+81f43b1d7f48af2c825dc485276300000000a5ab000300730061006e002b650000730048}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.google.com/fonts/specimen/Open+Sans}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0.html&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d
-\hich\af4\dbch\af31505\loch\f4 2ddc1d%7C0%7C0%7C637617947520449066%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=u4S07VDF20%2BhKswWuPxfNxdMvEV6u6kUxVXid57TMkQ%3D&reserved=0" }{\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0.html&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b\hich\af4\dbch\af31505\loch\f4 
+855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520449066%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=u4S07VDF20%2BhKswWuPxfNxdMvEV6u6kUxVXid57TMkQ%3D&reserved=0" }{
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b58030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d0068007400740070002500330041002500320046002500320046007700770077002e006100700061006300680065002e006f00720067002500320046006c006900630065006e007300650073002500320046004c004900430045004e00530045002d0032002e0030002e
 00680074006d006c00260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d002500370043006400610065006300640036003500370038003100390034003400
@@ -459,17 +479,18 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 00430036003300370036003100370039003400370035003200300034003400390030003600360025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d0044004100
 69004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d007500340053
 00300037005600440046003200300025003200420068004b0073007700570075005000780066004e00780064004d007600450056003600750036006b005500780056005800690064003500370054004d006b0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825d
-c485276300000000a5ab000300468069007f006c0000000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  [yyyy] Stev\hich\af4\dbch\af31505\loch\f4 e Matteson
+c485276300000000a5ab000300468069007f006c000000000020}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj 
+{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  [yyyy] Steve Matteson
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
+\ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 YPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300740069007f01c10000003a00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300740069007f01c10000003a00e8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf26\insrsid9658238 \hich\af0\dbch\af31505\loch\f0  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
-\hich\af4\dbch\af31505\loch\f4 i\hich\af4\dbch\af31505\loch\f4 ng permissions and limitations under the License.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf26\insrsid9658238 
+Unless required by applicable law or a\hich\af4\dbch\af31505\loch\f4 
+greed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+\hich\af4\dbch\af31505\loch\f4 t\hich\af4\dbch\af31505\loch\f4 he License.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 DocumentFormat.OpenXml v.2.12.3:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
@@ -527,12 +548,12 @@ een PSF and Licensee.  This License Agreement does not grant permission to use P
 3700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003300300030003200360025003700430055006e006b006e006f
 0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b00
 3100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0069006d00520043005200350077006e007a004f00520069004f00250032004200480063006f00410073003400710059002500320046005500730067
-003200460033002500320042007600700051007300710075004700340070004c005000620063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030d50000095e417f40200277200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+003200460033002500320042007600700051007300710075004700340070004c005000620063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030d50000095e417f4020027720000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopensource.org%2Flicenses%2Fapache2.0.php&data=04%7C01%7CJames.Conner%4\hich\af4\dbch\af31505\loch\f4 
-0autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520339551%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=GqzN3ywkegHn8Xwxmkje5HuJNO7iecwBGZU3LO
-\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4 NIus%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopensource.org%2Flicenses%2Fapache2.0.php&data=04%7C01%7CJames.Conner%\hich\af4\dbch\af31505\loch\f4 
+40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520339551%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=GqzN3ywkegHn8Xwxmkje5HuJNO7iecwBGZU3L
+\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 oNIus%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d0068007400740070002500330041002500320046002500320046006f00700065006e0073006f0075007200630065002e006f00720067002500320046006c006900630065006e0073006500730025003200460061007000610063006800650032002e0030002e00700068
 007000260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d002500370043006400610065006300640036003500370038003100390034003400620038003500
@@ -540,65 +561,67 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopen
 00370036003100370039003400370035003200300033003300390035003500310025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c004300
 4a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d00470071007a004e00330079
 0077006b006500670048006e0038005800770078006d006b006a0065003500480075004a004e004f0037006900650063007700420047005a00550033004c004f006f004e004900750073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab
-000300380074000000b0003c004d00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http:\hich\af4\dbch\af31505\loch\f4 //opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+000300380074000000b0003c004d0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2018 Iron Python Community
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPE\hich\af4\dbch\af31505\loch\f4 RLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
+\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at\hich\af4\dbch\af31505\loch\f4  }{\field{\*\fldinst {
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000344010069007100610064006100}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  Unless required by applicable law or agre\hich\af4\dbch\af31505\loch\f4 
-ed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 License.
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003440100690071006100640061002d}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  Unless required by applicable law or\hich\af4\dbch\af31505\loch\f4 
+ agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations unde
+\hich\af4\dbch\af31505\loch\f4 r\hich\af4\dbch\af31505\loch\f4  the License.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Python.Runtime.NETStandard v.3.7.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2006-2021 the contributors of the Python.NET project
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Softwar\hich\af4\dbch\af31505\loch\f4 
-e"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, s
-\hich\af4\dbch\af31505\loch\f4 u\hich\af4\dbch\af31505\loch\f4 bject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "So\hich\af4\dbch\af31505\loch\f4 
+ftware"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do 
+\hich\af4\dbch\af31505\loch\f4 s\hich\af4\dbch\af31505\loch\f4 o, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDIN\hich\af4\dbch\af31505\loch\f4 
-G BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR 
-\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 THERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INC\hich\af4\dbch\af31505\loch\f4 
+LUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
+\hich\af4\dbch\af31505\loch\f4 T\hich\af4\dbch\af31505\loch\f4  OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Python.Included v.3.7.3.4
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 PSF LICENSE AGREEMENT FOR PYTHON 3.10.4
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"),\hich\af4\dbch\af31505\loch\f4 
- and the Individual or Organization ("Licensee") accessing and otherwise using Python 3.7.3.4 software in source or binary form and its associated documentation.
+\par \hich\af4\dbch\af31505\loch\f4 1. This LICENSE AGREEMENT is between the Python Software Foundation ("P\hich\af4\dbch\af31505\loch\f4 
+SF"), and the Individual or Organization ("Licensee") accessing and otherwise using Python 3.7.3.4 software in source or binary form and its associated documentation.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee \hich\af4\dbch\af31505\loch\f4 
-a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python 3.7.3.4 alone or in any derivative version, provided, however, that PSF's License
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 \hich\f4 Agreement and PSF's notice of copyright, i.e., "Copyright \'a9\loch\f4 
+\par \hich\af4\dbch\af31505\loch\f4 2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Lice\hich\af4\dbch\af31505\loch\f4 
+nsee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python 3.7.3.4 alone or in any derivative version, provided, however, that PSF's Li
+\hich\af4\dbch\af31505\loch\f4 c\hich\af4\dbch\af31505\loch\f4 \hich\f4 ense Agreement and PSF's notice of copyright, i.e., "Copyright \'a9\loch\f4 
  2001-2022 Python Software Foundation; All Rights Reserved" are retained in Python 3.7.3.4 alone or in any derivative version prepared by Licensee.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 3. In the event Licensee prepares a derivative w\hich\af4\dbch\af31505\loch\f4 
-ork that is based on or incorporates Python 3.7.3.4 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python 3.
-\hich\af4\dbch\af31505\loch\f4 7\hich\af4\dbch\af31505\loch\f4 .3.4.
+\par \hich\af4\dbch\af31505\loch\f4 3. In the event Licensee prepares a derivat\hich\af4\dbch\af31505\loch\f4 
+ive work that is based on or incorporates Python 3.7.3.4 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Pyth
+\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4 n 3.7.3.4.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 4. PSF is making Python 3.7.3.4 available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid15220234 
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 3.7.3.4 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY 
+\hich\af4\dbch\af31505\loch\f4 OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 3.7.3.4 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 5. PSF SHALL NOT BE LIABLE TO LICEN\hich\af4\dbch\af31505\loch\f4 
-SEE OR ANY OTHER USERS OF PYTHON 3.7.3.4 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.3.4, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+\par \hich\af4\dbch\af31505\loch\f4 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.7.3.4 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS \hich\af4\dbch\af31505\loch\f4 
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.3.4, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 6. Thi\hich\af4\dbch\af31505\loch\f4 s License Agreement will automatically terminate upon a material breach of its terms and conditions.
+\par \hich\af4\dbch\af31505\loch\f4 6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee. This Li\hich\af4\dbch\af31505\loch\f4 
-cense Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
+\par \hich\af4\dbch\af31505\loch\f4 7. N\hich\af4\dbch\af31505\loch\f4 
+othing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee. This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to end
+\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4 rse or promote products or services of Licensee, or any third party.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 8. By copying, installing or otherwise using Python 3.7.3.4, Licensee agrees to \hich\af4\dbch\af31505\loch\f4 be bound by the terms and conditions of this License Agreement.
+\par \hich\af4\dbch\af31505\loch\f4 8. By copying, installing or otherwise using Python 3.7.3.4, Licensee agrees to be bound by the terms and conditions of this License Agreement.
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 IPython (autoreload.py) v.7.24.1:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fipython%2Fipython%2Fblob%2Fmaster%2FIPython%2Fextensions%2Fautorelo\hich\af4\dbch\af31505\loch\f4 
-ad.py&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520359465%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=7At
-\hich\af4\dbch\af31505\loch\f4 W\hich\af4\dbch\af31505\loch\f4 EHhH3h2E0eDlvyhqM0OyREJugNDsYai4S5egwXc%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLI\hich\af4\dbch\af31505\loch\f4 
+NK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fipython%2Fipython%2Fblob%2Fmaster%2FIPython%2Fextensions%2Fautoreload.py&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e
+\hich\af4\dbch\af31505\loch\f4 5\hich\af4\dbch\af31505\loch\f4 
+c9252d2ddc1d%7C0%7C0%7C637617947520359465%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=7AtWEHhH3h2E0eDlvyhqM0OyREJugNDsYai4S5egwXc%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba8030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600690070007900740068006f006e00250032004600690070007900740068006f006e0025003200460062006c006f006200250032
 0046006d0061007300740065007200250032004600490050007900740068006f006e0025003200460065007800740065006e00730069006f006e0073002500320046006100750074006f00720065006c006f00610064002e0070007900260064006100740061003d0030003400250037004300300031002500370043004a00
@@ -606,12 +629,13 @@ ad.py&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251
 00360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003500390034003600350025003700
 430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a00420054
 0069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d003700410074005700450048006800480033006800320045003000650044006c0076007900680071004d0030004f007900
-520045004a00750067004e0044007300590061006900340053003500650067007700580063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00035444650000200000009a004400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/IPython/extensions/autoreload.py}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fipython\hich\af4\dbch\af31505\loch\f4 
-%2Fipython%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520359465%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwi
-\hich\af4\dbch\af31505\loch\f4 L\hich\af4\dbch\af31505\loch\f4 CJXVCI6Mn0%3D%7C1000&sdata=Pilk0qSjYqpb4gwsh9CFaG42mk5wngBXOSykgiBj1EQ%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+520045004a00750067004e0044007300590061006900340053003500650067007700580063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00035444650000200000009a00440030}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ip\hich\af4\dbch\af31505\loch\f4 ython/blob/master/IPython/extensions/autoreload.py}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fipython%2Fipython%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d\hich\af4\dbch\af31505\loch\f4 
+946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520359465%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=Pilk0qSjYqpb4gwsh9CFaG42mk5wngBXOSykgiBj1EQ%3D&reserved=0" }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600690070007900740068006f006e00250032004600690070007900740068006f006e0025003200460062006c006f006200250032
 0046006d00610073007400650072002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d00250037004300
@@ -619,29 +643,29 @@ ad.py&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251
 006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003500390034003600350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a00
 6f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031
 003000300030002600730064006100740061003d00500069006c006b003000710053006a0059007100700062003400670077007300680039004300460061004700340032006d006b00350077006e006700420058004f00530079006b006700690042006a003100450051002500330044002600720065007300650072007600
-650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000312430038002200630000005200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/ipython/ipython/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031243003800220063000000520031}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython
+\hich\af4\dbch\af31505\loch\f4 /ipython/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 BSD 3-Clause License
 \par \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2008-Present, IPython Development Team
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2001-2007, Fernando Perez <fe\hich\af4\dbch\af31505\loch\f4 rnando.perez@colorado.edu>
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2001-2007, Fernando Perez <fernando.perez@colorado.edu>
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
 \par \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without modification, are permitted\hich\af4\dbch\af31505\loch\f4  provided that the following conditions are met:
+\par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the followin\hich\af4\dbch\af31505\loch\f4 g conditions are met:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-\par \hich\af4\dbch\af31505\loch\f4 * Redistributions in binary form must reproduce the above copyright notice, thi\hich\af4\dbch\af31505\loch\f4 
-s list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-\par \hich\af4\dbch\af31505\loch\f4 * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived fr\hich\af4\dbch\af31505\loch\f4 om this software without specific prior written permission.
+\par \hich\af4\dbch\af31505\loch\f4 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and th\hich\af4\dbch\af31505\loch\f4 
+e following disclaimer in the documentation and/or other materials provided with the distribution.
+\par \hich\af4\dbch\af31505\loch\f4 * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without sp\hich\af4\dbch\af31505\loch\f4 ecific prior written permission.
 
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FIT
+\par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPO
 \hich\af4\dbch\af31505\loch\f4 
-NESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOO
-\hich\af4\dbch\af31505\loch\f4 D\hich\af4\dbch\af31505\loch\f4 
-S OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, E
-\hich\af4\dbch\af31505\loch\f4 V\hich\af4\dbch\af31505\loch\f4 EN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+SE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE
+,\hich\af4\dbch\af31505\loch\f4 
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
+\hich\af4\dbch\af31505\loch\f4 B\hich\af4\dbch\af31505\loch\f4 ILITY OF SUCH DAMAGE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Nunit v.2.6.3
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
@@ -654,49 +678,49 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003200390031003400380025003700430055006e006b006e006f0077
 006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100
 680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004200550066004e006b002500320046006c0077002500320042006300490066003600390077003200250032004600550066003000520071002500320046
-00690044006400780074006c006d00340055004f0072006b006c005700750031006a00420063006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000004e0020002c009a017200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+00690044006400780074006c006d00340055004f0072006b006c005700750031006a00420063006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000004e0020002c009a01720000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2002-2013 Charlie Poole\line \hich\f4 Copyright \'a9\loch\f4  2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov
-\line \hich\f4 Copyright \'a9\hich\af4\dbch\af31505\loch\f4  2000-2002 Philip A. Craig
+\line Copyright \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  2000-2002 Philip A. Craig
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
-\par \hich\af4\dbch\af31505\loch\f4 Permission is granted to anyone to use this software \hich\af4\dbch\af31505\loch\f4 for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is granted to anyone to use this software\hich\af4\dbch\af31505\loch\f4  for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
 
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If y\hich\af4\dbch\af31505\loch\f4 \hich\f4 
-ou use this software in a product, an acknowledgment (see the following) in the product documentation is required. Portions Copyright \'a9\loch\f4  2002-2009 Charlie Poole or Copyright\~\hich\f4 \'a9\loch\f4 
- 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov or Copyright\~\hich\f4 \'a9\loch\f4  20\hich\af4\dbch\af31505\loch\f4 00-2002 Philip A. Craig\~
+\par \hich\af4\dbch\af31505\loch\f4 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If \hich\af4\dbch\af31505\loch\f4 \hich\f4 
+you use this software in a product, an acknowledgment (see the following) in the product documentation is required. Portions Copyright \'a9\loch\f4  2002-2009 Charlie Poole or Copyright\~\hich\f4 \'a9\loch\f4 
+ 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov or Copyright\~\hich\f4 \'a9\loch\f4  \hich\af4\dbch\af31505\loch\f4 2\hich\af4\dbch\af31505\loch\f4 000-2002 Philip A. Craig\~
 \par \hich\af4\dbch\af31505\loch\f4 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.\~
 \par \hich\af4\dbch\af31505\loch\f4 3. This notice may not be removed or altered from any source distribution.
 \par }\pard \ltrpar\ql \li720\ri0\widctlpar\wrapdefault\faauto\rin0\lin720\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
 \par }\pard\plain \ltrpar\s4\ql \li0\ri0\widctlpar\wrapdefault\faauto\outlinelevel3\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License Note
 \par }\pard\plain \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 This license is bas\hich\af4\dbch\af31505\loch\f4 ed on\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 This license is ba\hich\af4\dbch\af31505\loch\f4 sed on\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "http://www.opensource.org/licenses/zlib-license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f007a006c00690062002d006c00
-6900630065006e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006400769871016e00f8007200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+6900630065006e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006400769871016e00f800720001}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 the open source zlib/libpng license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 YPERLINK https://opensource.org/licenses/zlib-license.html }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK http\hich\af4\dbch\af31505\loch\f4 s://opensource.org/licenses/zlib-license.html }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f007a006c00690062002d006c00690063006500
-6e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ea6c00450000002c0000006d00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-https://opensource.org/licenses/zlib-license.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ). The idea was to\hich\af4\dbch\af31505\loch\f4 
- keep the license as simple as possible to encourage use of NUnit in free and commercial applications and libraries, but to keep the source code together and to give credit to the NUnit contributors for their efforts. While this license allows shipping NU
-\hich\af4\dbch\af31505\loch\f4 n\hich\af4\dbch\af31505\loch\f4 it in source and binary form, if shipping a NUnit variant is the sole purpose of your product, please\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
+6e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ea6c00450000002c0000006d0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+https://opensource.org/licenses/zlib-license.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ). The idea was to keep the lic\hich\af4\dbch\af31505\loch\f4 
+ense as simple as possible to encourage use of NUnit in free and commercial applications and libraries, but to keep the source code together and to give credit to the NUnit contributors for their efforts. While this license allows shipping NUnit in source
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 and binary form, if shipping a NUnit variant is the sole purpose of your product, please\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c0000006d00610069006c0074006f003a00630070006f006f006c006500400070006f006f006c00650063006f006e00730075006c00740069006e0067002e0063006f006d000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003126300650000006c0000006e12}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 let us know}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+276300000000a5ab0003126300650000006c0000006e1200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 let us know}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c0000006d00610069006c0074006f003a00630070006f006f006c006500400070006f006f006c00650063006f006e00730075006c00740069006e0067002e0063006f006d000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003006e00040000006e0000706800}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 cpoole@pooleconsulting.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+276300000000a5ab0003006e00040000006e000070680000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 cpoole@pooleconsulting.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  ).
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang3082\langfe2052\kerning1\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Moq v.4.18.4:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.
 \hich\af4\dbch\af31505\loch\f4 
-.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmoq%2Fmoq4%2Fblob%2Fmaster%2FLicense.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520409253%7CUnknown%7CTWFp
-\hich\af4\dbch\af31505\loch\f4 b\hich\af4\dbch\af31505\loch\f4 GZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=H%2FwNgy%2FpMYIgd%2FFlP1IU1dbvTUCauizIJKCAU6ISQZI%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmoq%2Fmoq4%2Fblob%2Fmaster%2FLicense.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520409253%7CUnknown%7CTWFpb
+\hich\af4\dbch\af31505\loch\f4 G\hich\af4\dbch\af31505\loch\f4 Zsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=H%2FwNgy%2FpMYIgd%2FFlP1IU1dbvTUCauizIJKCAU6ISQZI%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b74030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046006d006f0071002500320046006d006f007100340025003200460062006c006f0062002500320046006d00610073007400650072
@@ -705,19 +729,18 @@ https://opensource.org/licenses/zlib-license.html}}}\sectd \ltrsect\linex0\sectd
 002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003000390032003500330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d00
 4300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030
 002600730064006100740061003d00480025003200460077004e006700790025003200460070004d00590049006700640025003200460046006c00500031004900550031006400620076005400550043006100750069007a0049004a004b0043004100550036004900530051005a0049002500330044002600720065007300
-650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300540000009700008b73485012}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300540000009700008b7348501200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/moq/moq4/blob/master/License.txt/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 BSD 3-Clause License
-\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors. All rights reserved.
+\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007, Clarius Cons\hich\af4\dbch\af31505\loch\f4 ulting, Manas Technology Solutions, InSTEDD, and Contributors. All rights reserved.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without
-\par \hich\af4\dbch\af31505\loch\f4 modification, are permitted provided that the following conditions are m\hich\af4\dbch\af31505\loch\f4 et:
+\par \hich\af4\dbch\af31505\loch\f4 modification, are permitted provided that the following conditions are met:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-\par \hich\af4\dbch\af31505\loch\f4 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following discla\hich\af4\dbch\af31505\loch\f4 
-imer in the documentation and/or other materials provided with the distribution.
-\par \hich\af4\dbch\af31505\loch\f4 * Neither the names of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior wri\hich\af4\dbch\af31505\loch\f4 tten permission.
-
+\par \hich\af4\dbch\af31505\loch\f4 * Redistributions of source\hich\af4\dbch\af31505\loch\f4  code must retain the above copyright notice, this list of conditions and the following disclaimer.
+\par \hich\af4\dbch\af31505\loch\f4 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or\hich\af4\dbch\af31505\loch\f4 
+ other materials provided with the distribution.
+\par \hich\af4\dbch\af31505\loch\f4 * Neither the names of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SH
@@ -739,11 +762,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 0039003400370035003200300033003600390034003200300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a00
 6f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066007900760051003800610078006400300037
 003200370041005200630073006300720032003300320069007100650057003100730047004b00360046005400710025003200460050003700730031005a0074004300360073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003cd73
-4700007117000000596100}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+470000711700000059610000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http\hich\af4\dbch\af31505\loch\f4 
-s%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520369420%7CUnknown%7CTWFpbGZsb3
-\hich\af4\dbch\af31505\loch\f4 d\hich\af4\dbch\af31505\loch\f4 8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=NZT9tNyZbyPw1WOLz%2BE6ShwxQDWHBJ9uLSyHhKPHWHk%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a
+\hich\af4\dbch\af31505\loch\f4 8\hich\af4\dbch\af31505\loch\f4 
+e5c9252d2ddc1d%7C0%7C0%7C637617947520369420%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=NZT9tNyZbyPw1WOLz%2BE6ShwxQDWHBJ9uLSyHhKPHWHk%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba2030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046007700770077002e0067006e0075002e006f007200670025003200460073006f0066007400770061007200650025003200460067006500740074006500780074002500320046006d0061006e0075
@@ -752,21 +776,21 @@ s%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%
 003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003600390034003200300025003700430055006e006b006e00
 6f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b
 003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e005a005400390074004e0079005a006200790050007700310057004f004c007a00250032004200450036005300680077007800510044005700
-480042004a00390075004c0053007900480068004b0050004800570048006b002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031265000000fa00000000006fff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  1998, 2013 Free\hich\af4\dbch\af31505\loch\f4  Software Foundation, Inc.  
+480042004a00390075004c0053007900480068004b0050004800570048006b002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031265000000fa00000000006fff00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software\hich\af4\dbch\af31505\loch\f4 /gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  1998, 2013 Free Software Foundation, Inc.  
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 This Autodesk software contains libiconv v. 1.14.0.1.  libiconv is licensed under the GNU Lesser General Public License v.2.1, which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
+\fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLIN\hich\af4\dbch\af31505\loch\f4 K http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e0067006e0075002e006f00720067002f006c006900630065006e007300650073002f006f006c0064006c006900630065006e007300650073002f006c00
-670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c00000000003300615c6500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-. A text copy of this license is included on the media or with the download of this Au\hich\af4\dbch\af31505\loch\f4 todesk software.  You may obtain a copy of the source code for libiconv from }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c00000000003300615c650000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 . A text copy o\hich\af4\dbch\af31505\loch\f4 
+f this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libiconv from }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+\hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab000300492f0000020035006e007400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.c\hich\af4\dbch\af31505\loch\f4 om/lgplsource}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
+c485276300000000a5ab000300492f0000020035006e00740000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
 \par \hich\af4\dbch\af31505\loch\f4 Attention:  General Counsel
@@ -775,26 +799,27 @@ c485276300000000a5ab000300492f0000020035006e007400}}}{\fldrslt {\rtlch\fcs1 \af4
 \par \hich\af4\dbch\af31505\loch\f4 San Rafael, CA 94903
 \par \hich\af4\dbch\af31505\loch\f4 Your written request must:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Contain a self-addressed CD/DVD mailer (or envelope sufficiently large t\hich\af4\dbch\af31505\loch\f4 
-o hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or the envelope you have chosen) weighing  5 ounces from San Rafael,    California USA to your indicated address; and Id
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 ntify:
+\par \hich\af4\dbch\af31505\loch\f4 Contai\hich\af4\dbch\af31505\loch\f4 
+n a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or the envelope you have chosen) weighing  5 ounces fr
+\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4 m San Rafael,    California USA to your indicated address; and Identify:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 This Autodesk software name and release number; That you are requesting  the source code for libiconvv .1.14.0.1; and The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030069000000f00036ff63003a00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+c485276300000000a5ab00030069000000f00036ff63003a00da}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ) so that Autodesk may properly respond to your request.  The offer to receive this libiconv source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab0003006f0000000000640065000015}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this \hich\af4\dbch\af31505\loch\f4 
-Autodesk software.  You may modify, debug and relink libiconv to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.2.1.
+c485276300000000a5ab0003006f00000000006400650000158a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.  You may modify, debug and relink libiconv to this A\hich\af4\dbch\af31505\loch\f4 
+utodesk software as provided under the terms of the GNU Lesser General Public License v.2.1.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 GNU gettext (libintl) v.0.19.8.3:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com
-\hich\af4\dbch\af31505\loch\f4 
-/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luM
-\hich\af4\dbch\af31505\loch\f4 z\hich\af4\dbch\af31505\loch\f4 IiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=Nf21XpKiL0wk%2Fv5o95n6NHU9yBTsVWmKLfq1AJGQ1bM%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2F&data=04%7C01%7C\hich\af4\dbch\af31505\loch\f4 
+James.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=Nf21XpKiL0wk%2Fv5o95n6NH
+\hich\af4\dbch\af31505\loch\f4 U\hich\af4\dbch\af31505\loch\f4 9yBTsVWmKLfq1AJGQ1bM%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b48030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046007700770077002e0067006e0075002e006f007200670025003200460073006f00660074007700610072006500250032004600670065007400740065007800740025003200460026006400610074
 0061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d00250037004300640061006500630064003600350037003800310039003400340062003800350035006500370038003000
@@ -802,12 +827,12 @@ Autodesk software.  You may modify, debug and relink libiconv to this Autodesk s
 003400370035003200300032003000300031003600340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f00
 6900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e00660032003100580070004b0069004c00300077
 006b00250032004600760035006f00390035006e0036004e004800550039007900420054007300560057006d004b004c0066007100310041004a0047005100310062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000301330b90
-00d02c582c4e00424c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00d02c582c4e00424c2d}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGN
-\hich\af4\dbch\af31505\loch\f4 
-U-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D
-\hich\af4\dbch\af31505\loch\f4 %\hich\af4\dbch\af31505\loch\f4 7C1000&sdata=fm4crd4P%2By6SL%2F0glLKwxCwV9NjLZs7f2LAoNHfi2QE%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdae\hich\af4\dbch\af31505\loch\f4 
+cd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=fm4crd4P%2By6SL%2F0glLKwxCwV9NjLZs7f2LAoNHfi2QE%3D&reserv
+\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 d=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba6030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046007700770077002e0067006e0075002e006f007200670025003200460073006f0066007400770061007200650025003200460067006500740074006500780074002500320046006d0061006e0075
 0061006c00250032004600680074006d006c005f006e006f006400650025003200460047004e0055002d004c00470050004c002e00680074006d006c0025003200330047004e0055002d004c00470050004c00260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e00
@@ -815,19 +840,20 @@ U-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd6578194
 003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e00
 6f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b
 003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066006d003400630072006400340050002500320042007900360053004c00250032004600300067006c004c004b00770078004300770056003900
-4e006a004c005a0073003700660032004c0041006f004e004800660069003200510045002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030242000000fa000000fb004300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+4e006a004c005a0073003700660032004c0041006f004e004800660069003200510045002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030242000000fa000000fb00430060}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4 \hich\f4  Copyright \'a9\loch\f4  1991, 1999 Free Software Foundation, Inc.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 This Autodesk software c\hich\af4\dbch\af31505\loch\f4 ontains libintl v.0.19.8.3.  libintl is licensed under the GNU Lesser General Public License v.2.1 , which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
+\par \hich\af4\dbch\af31505\loch\f4 This Autodesk software contains libintl v.0.19.8.3.  libintl is licensed under the GNU Lesser\hich\af4\dbch\af31505\loch\f4  General Public License v.2.1 , which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e0067006e0075002e006f00720067002f006c006900630065006e007300650073002f006f006c0064006c006900630065006e007300650073002f006c00
-670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300640000000072ff00ff004300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 . }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libintl v.0.19.8.3  from }{\field{\*\fldinst {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300640000000072ff00ff00430048}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://w
+\hich\af4\dbch\af31505\loch\f4 ww.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 . }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libintl v.0.19.8.3  from }
+{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab0003006d0000002000070000017700}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+c485276300000000a5ab0003006d000000200007000001770000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
@@ -845,26 +871,26 @@ c485276300000000a5ab0003006d0000002000070000017700}}}{\fldrslt {\rtlch\fcs1 \af4
 \par \hich\af4\dbch\af31505\loch\f4 c.\hich\af4\dbch\af31505\loch\f4  The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK www.autodesk.com/lgplsource }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006c
-00d4000000ff0000004100}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00d4000000ff000000410063}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 )
-\par \hich\af4\dbch\af31505\loch\f4 so that Autodesk may properly respond to your request.  The offer \hich\af4\dbch\af31505\loch\f4 to receive this libintl source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\par \hich\af4\dbch\af31505\loch\f4 so that Autodesk may properly respond to your request.  The offer\hich\af4\dbch\af31505\loch\f4  to receive this libintl source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK www.autodesk.com/lgplsource }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030073
-0000000000000000002000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ) or by written request to A\hich\af4\dbch\af31505\loch\f4 utodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.
-\par \hich\af4\dbch\af31505\loch\f4 You may modify, debug and relink libintl to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.\hich\af4\dbch\af31505\loch\f4 2.1.
+000000000000000000200061}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ) or by written request to \hich\af4\dbch\af31505\loch\f4 Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.
+\par \hich\af4\dbch\af31505\loch\f4 You may modify, debug and relink libintl to this Autodesk software as provided under the terms of the GNU Lesser General Public License v\hich\af4\dbch\af31505\loch\f4 .2.1.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 DynamoServices:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  Autodesk, Inc.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licen\hich\af4\dbch\af31505\loch\f4 ses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
+\ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/lice\hich\af4\dbch\af31505\loch\f4 nses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300430000000072000000007200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030043000000007200000000720035}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-Unless required by applicable law or agreed to in writing, software distrib\hich\af4\dbch\af31505\loch\f4 
-uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf25\insrsid9658238\charrsid3092893 
+Unless required by applicable law or agreed to in writing, software dist\hich\af4\dbch\af31505\loch\f4 
+ributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238\charrsid3092893 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang3082\langfe2052\kerning1\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Ncalc v.1.3.8.0:}{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 
@@ -878,27 +904,26 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fncal
 37006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003000390032003500330025003700430055
 006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a00420054006900
 4900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004d0058004a004e00610052003600390045004300670050004a0044004a005900500053006e0079004c00710047007800390041
-004700530077007a0025003200460051005a0052003500350046006e00440050007600350055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c141a000017f4021a0c009f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+004700530077007a0025003200460051005a0052003500350046006e00440050007600350055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c141a000017f4021a0c009f48}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang3082\langfe2052\langnp3082\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  2011 Sebastien Ros
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 rge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software an\hich\af4\dbch\af31505\loch\f4 
+d associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N
-\hich\af4\dbch\af31505\loch\f4 
-O EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARR\hich\af4\dbch\af31505\loch\f4 
+ANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABIL
+\hich\af4\dbch\af31505\loch\f4 I\hich\af4\dbch\af31505\loch\f4 TY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 MIConvexHull.NET v.1.0.17.411
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdesignengrlab.github.io%2FMIConvexHull%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2
-\hich\af4\dbch\af31505\loch\f4 ddc1d%7C0%7C0%7C637617947520389325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=NY1pGp4Rus1IhXoLEAgeQgcF3gsQK5hhpdBY1KGxtSY%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdesignengrlab.github.io%2FMIConvexHull%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C6376179475203
+\hich\af4\dbch\af31505\loch\f4 8\hich\af4\dbch\af31505\loch\f4 9325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=NY1pGp4Rus1IhXoLEAgeQgcF3gsQK5hhpdBY1KGxtSY%3D&reserved=0" }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b50030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d0068007400740070007300250033004100250032004600250032004600640065007300690067006e0065006e00670072006c00610062002e006700690074006800750062002e0069006f002500320046004d00490043006f006e00760065007800480075006c006c0025
 0032004600260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d00250037004300640061006500630064003600350037003800310039003400340062003800
@@ -906,12 +931,11 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdes
 003300370036003100370039003400370035003200300033003800390033003200350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c00
 43004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e0059003100700047
 007000340052007500730031004900680058006f004c004500410067006500510067006300460033006700730051004b00350068006800700064004200590031004b00470078007400530059002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000
-a5ab0003007314650000003a0000009000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+a5ab0003007314650000003a000000900000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection\hich\af4\dbch\af31505\loch\f4 
-.outlook.com/?url=http%3A%2F%2Fmiconvexhull.codeplex.com%2Flicense&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520389325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLC
-\hich\af4\dbch\af31505\loch\f4 J\hich\af4\dbch\af31505\loch\f4 QIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=hNSoZ7QXpdD4Fhf0DlaIzm2xF9XGsksCYNlWnpXQ%2BiM%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 
-{\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%\hich\af4\dbch\af31505\loch\f4 
+2Fmiconvexhull.codeplex.com%2Flicense&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520389325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWw
+\hich\af4\dbch\af31505\loch\f4 i\hich\af4\dbch\af31505\loch\f4 LCJXVCI6Mn0%3D%7C1000&sdata=hNSoZ7QXpdD4Fhf0DlaIzm2xF9XGsksCYNlWnpXQ%2BiM%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b46030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d0068007400740070002500330041002500320046002500320046006d00690063006f006e00760065007800680075006c006c002e0063006f006400650070006c00650078002e0063006f006d002500320046006c006900630065006e0073006500260064006100740061
 003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d002500370043006400610065006300640036003500370038003100390034003400620038003500350065003700380030003800
@@ -919,27 +943,26 @@ a5ab0003007314650000003a0000009000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fc
 00370035003200300033003800390033003200350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900
 560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068004e0053006f005a0037005100580070006400440034
 00460068006600300044006c00610049007a006d0032007800460039005800470073006b007300430059004e006c0057006e0070005800510025003200420069004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003007200000003
-00ea0000005200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00ea000000520050}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010 David Sehnal, Matthew Campbell
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a \hich\af4\dbch\af31505\loch\f4 
-copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Softwar
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 , and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and a\hich\af4\dbch\af31505\loch\f4 
+ssociated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 whom the Software is furnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVID\hich\af4\dbch\af31505\loch\f4 
-ED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANT\hich\af4\dbch\af31505\loch\f4 
+Y OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY
+,\hich\af4\dbch\af31505\loch\f4  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 StarMath v.2.0.1}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
 \b\fs22\cf25\kerning1\insrsid16659309 \hich\af4\dbch\af31505\loch\f4 7}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 :
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outloo
-\hich\af4\dbch\af31505\loch\f4 
-k.com/?url=https%3A%2F%2Fgithub.com%2FDesignEngrLab%2FStarMath%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 yJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=QlLJQ5zjjCkV03%2BrjgrcdUTiz9O6pTyzKdtSv5xpHsg%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FDesignEngrLab%2FStarMath%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7
+\hich\af4\dbch\af31505\loch\f4 C\hich\af4\dbch\af31505\loch\f4 0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=QlLJQ5zjjCkV03%2BrjgrcdUTiz9O6pTyzKdtSv5xpHsg%3D&reserved=0" 
+}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b80030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600440065007300690067006e0045006e00670072004c006100620025003200460053007400610072004d00610074006800250032
 00460062006c006f0062002500320046006d00610073007400650072002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b00
@@ -947,31 +970,32 @@ k.com/?url=https%3A%2F%2Fgithub.com%2FDesignEngrLab%2FStarMath%2Fblob%2Fmaster%2
 0032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003800380038003900350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a007300620033006400
 3800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e0030
 0025003300440025003700430031003000300030002600730064006100740061003d0051006c004c004a00510035007a006a006a0043006b0056003000330025003200420072006a0067007200630064005500540069007a0039004f0036007000540079007a004b0064007400530076003500780070004800730067002500
-330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005000a68e0000313d00006f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005000a68e0000313d00006f0091}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2015 DesignEngrLab
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "\hich\af4\dbch\af31505\loch\f4 
-Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to d
-\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4  so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, includ
+\hich\af4\dbch\af31505\loch\f4 
+ing without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright \hich\af4\dbch\af31505\loch\f4 notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", W\hich\af4\dbch\af31505\loch\f4 
-ITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR O
-\hich\af4\dbch\af31505\loch\f4 T\hich\af4\dbch\af31505\loch\f4 HER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \hich\af4\dbch\af31505\loch\f4 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH T
+\hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 E SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 DiffPlex v.1.6.3:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  2020 mmanela
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the\hich\af4\dbch\af31505\loch\f4  "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the Licens\hich\af4\dbch\af31505\loch\f4 e at
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e0a619800f7aa0064004d00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY K\hich\af4\dbch\af31505\loch\f4 
-IND, either express or implied. See the License for the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e0a619800f7aa0064004d0070}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Unless required by applicable la
+\hich\af4\dbch\af31505\loch\f4 
+w or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations 
+\hich\af4\dbch\af31505\loch\f4 u\hich\af4\dbch\af31505\loch\f4 nder the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 DiffPlex.wpf v.1.1.1:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  2020 mmanela
@@ -979,16 +1003,16 @@ IND, either express or implied. See the License for the specific language govern
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this f\hich\af4\dbch\af31505\loch\f4 ile except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005a2c6f0069006a00367f6f4c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 h\hich\af4\dbch\af31505\loch\f4 
-ttp://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See \hich\af4\dbch\af31505\loch\f4 
-the License for the specific language governing permissions and limitations under the License.
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005a2c6f0069006a00367f6f4cb0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See\hich\af4\dbch\af31505\loch\f4 
+ the License for the specific language governing permissions and limitations under the License.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1031\langfe2052\kerning1\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 FontAwesome v.4.0.7:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FFontAwesome.WPF%2F&data=04%7C01%7CJ\hich\af4\dbch\af31505\loch\f4 
-ames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520190208%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=X8xzrd%2Fj2Js0LaFtQIoDfDv
-\hich\af4\dbch\af31505\loch\f4 5\hich\af4\dbch\af31505\loch\f4 iv%2FWDi31xCr9xQYz%2B80%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FFontAwesome.WPF%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947
+\hich\af4\dbch\af31505\loch\f4 5\hich\af4\dbch\af31505\loch\f4 20190208%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=X8xzrd%2Fj2Js0LaFtQIoDfDv5iv%2FWDi31xCr9xQYz%2B80%3D&reserved=0" }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b64030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046007700770077002e006e0075006700650074002e006f00720067002500320046007000610063006b00610067006500730025003200460046006f006e00740041007700650073006f006d0065002e
 00570050004600250032004600260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d0025003700430064006100650063006400360035003700380031003900
@@ -996,11 +1020,11 @@ ames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433
 0025003700430036003300370036003100370039003400370035003200300031003900300032003000380025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d00
 4400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0058
 00380078007a00720064002500320046006a0032004a00730030004c00610046007400510049006f0044006600440076003500690076002500320046005700440069003300310078004300720039007800510059007a00250032004200380030002500330044002600720065007300650072007600650064003d0030000000
-795881f43b1d7f48af2c825dc485276300000000a5ab000300750030463e4d2f0000007200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+795881f43b1d7f48af2c825dc485276300000000a5ab000300750030463e4d2f000000720000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 https://www.nuget.org/packages/FontAwesome.WPF/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.protection.outlook.com/\hich\af4\dbch\af31505\loch\f4 
-?url=https%3A%2F%2Fgithub.com%2Fcharri%2FFont-Awesome-WPF%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7CTWFpbGZsb3d8eyJWI
-\hich\af4\dbch\af31505\loch\f4 j\hich\af4\dbch\af31505\loch\f4 oiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=sKAHUntVBjSIV8O68z3a0dCJ%2BlRxwngZUFlVrQNRkW8%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.prote\hich\af4\dbch\af31505\loch\f4 
+ction.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcharri%2FFont-Awesome-WPF%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7
+\hich\af4\dbch\af31505\loch\f4 C\hich\af4\dbch\af31505\loch\f4 TWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=sKAHUntVBjSIV8O68z3a0dCJ%2BlRxwngZUFlVrQNRkW8%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d0025003200460063006800610072007200690025003200460046006f006e0074002d0041007700650073006f006d0065002d0057005000460025
@@ -1009,42 +1033,41 @@ https://www.nuget.org/packages/FontAwesome.WPF/}}}\sectd \ltrsect\linex0\sectdef
 00390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003000300031003600340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300
 64003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e
 00300025003300440025003700430031003000300030002600730064006100740061003d0073004b004100480055006e007400560042006a0053004900560038004f00360038007a00330061003000640043004a002500320042006c005200780077006e0067005a00550046006c005600720051004e0052006b0057003800
-2500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003a64594600b1000000f17300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
+2500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003a64594600b1000000f173003a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/charri/Font-Awesome-WPF/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs17 \ltrch\fcs0 \fs17\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2014-2016 charri
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby \hich\af4\dbch\af31505\loch\f4 
-granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distri
-\hich\af4\dbch\af31505\loch\f4 b\hich\af4\dbch\af31505\loch\f4 ute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Pe\hich\af4\dbch\af31505\loch\f4 
+rmission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, mer
+\hich\af4\dbch\af31505\loch\f4 g\hich\af4\dbch\af31505\loch\f4 e, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantia\hich\af4\dbch\af31505\loch\f4 l portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all c\hich\af4\dbch\af31505\loch\f4 opies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUT
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
 \hich\af4\dbch\af31505\loch\f4 
-HORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 AngleSharp v.0.14.0: \hich\af4\dbch\af31505\loch\f4 
-Copyright (c) 2013 - 2019 AngleSharp
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 An\hich\af4\dbch\af31505\loch\f4 
+gleSharp v.0.14.0: Copyright (c) 2013 - 2019 AngleSharp
 \par \hich\af4\dbch\af31505\loch\f4 \hich\f4 AngleSharp.CSS v.0.14.2: Copyright \'a9\loch\f4  2013-2020 AngleSharp
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 rge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentat\hich\af4\dbch\af31505\loch\f4 
+ion files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software i
+\hich\af4\dbch\af31505\loch\f4 s\hich\af4\dbch\af31505\loch\f4  furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N
-\hich\af4\dbch\af31505\loch\f4 
-O EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRE\hich\af4\dbch\af31505\loch\f4 
+SS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTI
+\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 N OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HTMLSanitizer v.5.0.355:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7
-\hich\af4\dbch\af31505\loch\f4 C0%7C637617947520220149%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=t7WD0mko%2B%2FF%2FdpKKLHyM93UCXrX%2BXwo3yUYVGPZQcGs%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520220149%
+\hich\af4\dbch\af31505\loch\f4 7\hich\af4\dbch\af31505\loch\f4 CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=t7WD0mko%2B%2FF%2FdpKKLHyM93UCXrX%2BXwo3yUYVGPZQcGs%3D&reserved=0" }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046006d00670061006e0073007300250032004600480074006d006c00530061006e006900740069007a006500720026006400610074
 0061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d00250037004300640061006500630064003600350037003800310039003400340062003800350035006500370038003000
@@ -1052,12 +1075,13 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 003400370035003200300032003200300031003400390025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f00
 6900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d00740037005700440030006d006b006f002500320042
 002500320046004600250032004600640070004b004b004c00480079004d003900330055004300580072005800250032004200580077006f0033007900550059005600470050005a0051006300470073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab0003003b1707467feb610001577200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+00000000a5ab0003003b1707467feb6100015772005c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://nam11.safelinks.prot\hich\af4\dbch\af31505\loch\f4 
-ection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520220149%7CUnknown%
-\hich\af4\dbch\af31505\loch\f4 7\hich\af4\dbch\af31505\loch\f4 CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=phLGnloT%2FCglabebh%2FsUSc6iiDyt6D3vSMPPKA%2FgOJQ%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%
+\hich\af4\dbch\af31505\loch\f4 7\hich\af4\dbch\af31505\loch\f4 
+C0%7C0%7C637617947520220149%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=phLGnloT%2FCglabebh%2FsUSc6iiDyt6D3vSMPPKA%2FgOJQ%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046006d00670061006e0073007300250032004600480074006d006c00530061006e006900740069007a006500720025003200460062
 006c006f0062002500320046006d00610073007400650072002500320046004c004900430045004e00530045002e006d006400260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f00640065007300
@@ -1065,26 +1089,26 @@ ection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer%2Fblob
 00390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003200300031003400390025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300
 64003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e
 00300025003300440025003700430031003000300030002600730064006100740061003d00700068004c0047006e006c006f005400250032004600430067006c00610062006500620068002500320046007300550053006300360069006900440079007400360044003300760053004d00500050004b004100250032004600
-67004f004a0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030039006552fb2d00ff01805c00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+67004f004a0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030039006552fb2d00ff01805c0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer/blob/master/\hich\af4\dbch\af31505\loch\f4 LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2013-2016 Michael Ganss and HtmlSanitizer contributors
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the So\hich\af4\dbch\af31505\loch\f4 
-ftware without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the followin
-\hich\af4\dbch\af31505\loch\f4 g\hich\af4\dbch\af31505\loch\f4  conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to \hich\af4\dbch\af31505\loch\f4 
+deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject t
+\hich\af4\dbch\af31505\loch\f4 o\hich\af4\dbch\af31505\loch\f4  the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO T\hich\af4\dbch\af31505\loch\f4 
-HE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FR
-\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 M, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NO\hich\af4\dbch\af31505\loch\f4 
+T LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWI
+\hich\af4\dbch\af31505\loch\f4 S\hich\af4\dbch\af31505\loch\f4 E, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1031\langfe2052\kerning1\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Markdig v.0.22.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Flunet-io%2Fmarkdig&data=04%7C01%7CJames.Conner%40autodes\hich\af4\dbch\af31505\loch\f4 
-k.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520379375%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=IkaWjqj6UwIqoUB8EQOeZKYMz4qbWg8kbbCcZ0Qa%2Fhg%
-\hich\af4\dbch\af31505\loch\f4 3\hich\af4\dbch\af31505\loch\f4 D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Flunet-io%2Fmarkdig&data=04%7C01%7CJames.Co\hich\af4\dbch\af31505\loch\f4 
+nner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520379375%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=IkaWjqj6UwIqoUB8EQOeZKYMz4qbWg8k
+\hich\af4\dbch\af31505\loch\f4 b\hich\af4\dbch\af31505\loch\f4 bCcZ0Qa%2Fhg%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046006c0075006e00650074002d0069006f002500320046006d00610072006b00640069006700260064006100740061003d00300034
 00250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d002500370043006400610065006300640036003500370038003100390034003400620038003500350065003700380030003800640039003400
@@ -1092,12 +1116,12 @@ k.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%
 00300033003700390033003700350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c00
 75004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0049006b00610057006a0071006a00360055007700490071006f00550042
 003800450051004f0065005a004b0059004d007a003400710062005700670038006b0062006200430063005a00300051006100250032004600680067002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300620052006e727800000046
-00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com\hich\af4\dbch\af31505\loch\f4 /lunet-io/markdig}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj 
-{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
+0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 htt\hich\af4\dbch\af31505\loch\f4 ps://github.com/lunet-io/markdig}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Flunet-io%2Fmarkdig%2Fblob%2Fmaster%2Flicense.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433
-\hich\af4\dbch\af31505\loch\f4 a8e5c9252d2ddc1d%7C0%7C0%7C637617947520379375%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=eIL37c9G%2B11uq1htX8ARhSCvefpQIOMXjVAqMh1aceU%3D&reserved=0" }{
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Flunet-io%2Fmarkdig%2Fblob%2Fmaster%2Flicense.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C6\hich\af4\dbch\af31505\loch\f4 
+7bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520379375%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=eIL37c9G%2B11uq1htX8ARhSCvefpQIOMXjVAqMh1aceU%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d002500320046006c0075006e00650074002d0069006f002500320046006d00610072006b0064006900670025003200460062006c006f00620025
 00320046006d00610073007400650072002500320046006c006900630065006e00730065002e00740078007400260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e006300
@@ -1105,24 +1129,24 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003700390033003700350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300640038006500
 79004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e003000250033
 00440025003700430031003000300030002600730064006100740061003d00650049004c0033003700630039004700250032004200310031007500710031006800740058003800410052006800530043007600650066007000510049004f004d0058006a005600410071004d00680031006100630065005500250033004400
-2600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300440000003af76e0064006500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig/blob/maste\hich\af4\dbch\af31505\loch\f4 r/license.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+2600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300440000003af76e0064006500cd}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/mar\hich\af4\dbch\af31505\loch\f4 kdig/blob/master/license.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang1031\langfe2052\langnp1031\insrsid9658238 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2018-2019, Alexandre Mutel
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+\par \hich\af4\dbch\af31505\loch\f4 1. Redistribution\hich\af4\dbch\af31505\loch\f4 s of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaim\hich\af4\dbch\af31505\loch\f4 
-er in the documentation and/or other materials provided with the distribution.
+\par \hich\af4\dbch\af31505\loch\f4 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documen\hich\af4\dbch\af31505\loch\f4 
+tation and/or other materials provided with the distribution.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED  WARRANTIES OF ME\hich\af4\dbch\af31505\loch\f4 
-RCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUR
-\hich\af4\dbch\af31505\loch\f4 E\hich\af4\dbch\af31505\loch\f4 
-MENT OF SUBSTITUTE GOODS OR  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF TH
-\hich\af4\dbch\af31505\loch\f4 E\hich\af4\dbch\af31505\loch\f4  USE  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+\par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND\hich\af4\dbch\af31505\loch\f4 
+ FITNESS FOR A PARTICULAR PURPOSE ARE  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITU
+\hich\af4\dbch\af31505\loch\f4 T\hich\af4\dbch\af31505\loch\f4 
+E GOODS OR  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  OF THIS SO
+\hich\af4\dbch\af31505\loch\f4 F\hich\af4\dbch\af31505\loch\f4 TWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1036\langfe2052\kerning1\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
 ILMerge v.3.0.41:
@@ -1136,13 +1160,13 @@ tlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2FILMerge&data=04%7C01%7CJames.
 35003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033
 003400390035003000340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d00
 7a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0064003800520054004c004400760046006d006e0041005800300077007a006c0044
-004d0053006f006b00300043004500450062006a00730048007a00700050004d0039006d003800650034006b0058006c00610041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003cd6f006398490000ff05007919}}}{\fldrslt {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+004d0053006f006b00300043004500450062006a00730048007a00700050004d0039006d003800650034006b0058006c00610041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003cd6f006398490000ff05007919cd}}}{\fldrslt 
+{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2FILMerge%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7\hich\af4\dbch\af31505\loch\f4 
-CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520349504%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=73ySd49h5gcqiGS1xohabFn
-\hich\af4\dbch\af31505\loch\f4 w\hich\af4\dbch\af31505\loch\f4 oH42CB8523UdKE%2B6dsw%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2FILMerge%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%\hich\af4\dbch\af31505\loch\f4 
+7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520349504%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=73ySd49h5gcqiGS1xohabF
+\hich\af4\dbch\af31505\loch\f4 n\hich\af4\dbch\af31505\loch\f4 woH42CB8523UdKE%2B6dsw%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b70030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d0025003200460064006f0074006e006500740025003200460049004c004d00650072006700650025003200460062006c006f0062002500320046
 006d00610073007400650072002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b002e0063006f006d002500370043006400
@@ -1150,45 +1174,46 @@ CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f9144
 00310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003400390035003000340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f00
 69004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e003000250033004400250037004300310030
 00300030002600730064006100740061003d00370033007900530064003400390068003500670063007100690047005300310078006f0068006100620046006e0077006f00480034003200430042003800350032003300550064004b0045002500320042003600640073007700250033004400260072006500730065007200
-7600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030043006f9800002d0000003000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/dotnet/ILMerge/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 
+7600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030043006f9800002d000000300000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ILMerge/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 MIT License
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All Rights Reserved
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this soft\hich\af4\dbch\af31505\loch\f4 
-ware and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit 
-\hich\af4\dbch\af31505\loch\f4 p\hich\af4\dbch\af31505\loch\f4 ersons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
+\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 rge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHO\hich\af4\dbch\af31505\loch\f4 
-UT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N
+\hich\af4\dbch\af31505\loch\f4 
+O EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 System.Buffers v.4.5.1
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
-\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributo\hich\af4\dbch\af31505\loch\f4 rs
+\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights
-\hich\af4\dbch\af31505\loch\f4  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Softwar\hich\af4\dbch\af31505\loch\f4 
+e"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, s
+\hich\af4\dbch\af31505\loch\f4 u\hich\af4\dbch\af31505\loch\f4 bject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice\hich\af4\dbch\af31505\loch\f4  shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDIN\hich\af4\dbch\af31505\loch\f4 
+G BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 System.Memory v.4.5.4
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
-\par \hich\af4\dbch\af31505\loch\f4 Copyri\hich\af4\dbch\af31505\loch\f4 ght (c) .NET Foundation and Contributors
+\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, i\hich\af4\dbch\af31505\loch\f4 
-ncluding without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted,\hich\af4\dbch\af31505\loch\f4 
+ free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, su
+\hich\af4\dbch\af31505\loch\f4 b\hich\af4\dbch\af31505\loch\f4 license, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyr\hich\af4\dbch\af31505\loch\f4 ight notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
@@ -1216,48 +1241,19 @@ IDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NO
 \par \hich\af4\dbch\af31505\loch\f4 C\hich\af4\dbch\af31505\loch\f4 opyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of ch\hich\af4\dbch\af31505\loch\f4 
-arge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, a
-\hich\af4\dbch\af31505\loch\f4 n\hich\af4\dbch\af31505\loch\f4 d/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restricti\hich\af4\dbch\af31505\loch\f4 
+on, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the S\hich\af4\dbch\af31505\loch\f4 oftware.
+\par \hich\af4\dbch\af31505\loch\f4 The above \hich\af4\dbch\af31505\loch\f4 copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT H
-\hich\af4\dbch\af31505\loch\f4 OLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHAN\hich\af4\dbch\af31505\loch\f4 
+TABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECT
+\hich\af4\dbch\af31505\loch\f4 I\hich\af4\dbch\af31505\loch\f4 ON WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 System.Text.Encoding.CodePages v.4.5.0 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Sof\hich\af4\dbch\af31505\loch\f4 
-tware without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 conditions:
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO TH\hich\af4\dbch\af31505\loch\f4 
-E WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FRO
-\hich\af4\dbch\af31505\loch\f4 M\hich\af4\dbch\af31505\loch\f4 , OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-\par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Rapidjson v.1.1.0:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4 
- 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any per\hich\af4\dbch\af31505\loch\f4 
-son obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copie
-\hich\af4\dbch\af31505\loch\f4 s\hich\af4\dbch\af31505\loch\f4 
- of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOF\hich\af4\dbch\af31505\loch\f4 
-TWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
-\par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Mono.Cecil v.0.11.4:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2008 - 2015 Jb Evain
-\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2008 - 2011 Novell, Inc.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
@@ -1265,104 +1261,126 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-\par \hich\af4\dbch\af31505\loch\f4 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N\hich\af4\dbch\af31505\loch\f4 
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N
+\hich\af4\dbch\af31505\loch\f4 
 O EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+\par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid9658238 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Rapidjson v.1.1.0:
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4 
+ 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), \hich\af4\dbch\af31505\loch\f4 
+to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subjec
+\hich\af4\dbch\af31505\loch\f4 t\hich\af4\dbch\af31505\loch\f4  to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT \hich\af4\dbch\af31505\loch\f4 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHER
+\hich\af4\dbch\af31505\loch\f4 W\hich\af4\dbch\af31505\loch\f4 ISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+\par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Mono.Cecil v.0.11.4:
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2008 - 2015 Jb Evain
+\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2008 - 2011 Novell, Inc.
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to an\hich\af4\dbch\af31505\loch\f4 
+y person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+\hich\af4\dbch\af31505\loch\f4 c\hich\af4\dbch\af31505\loch\f4 opies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 T\hich\af4\dbch\af31505\loch\f4 HE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+\par \hich\af4\dbch\af31505\loch\f4 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE L\hich\af4\dbch\af31505\loch\f4 
+IABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 LaunchDarkly.Clientsdk v.2.0.1:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright 2018 Catamorphic, Co.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file excep\hich\af4\dbch\af31505\loch\f4 t in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
+\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000312452f63002200650006013500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://ww\hich\af4\dbch\af31505\loch\f4 
-w.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the Lice\hich\af4\dbch\af31505\loch\f4 
-nse for the specific language governing permissions and limitations under the License.
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab000312452f6300220065000601350000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  Unless required by applicable law or agreed to in writing, software distributed under the \hich\af4\dbch\af31505\loch\f4 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 CommandLineParser v.2.8.0:
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 The MIT Lice\hich\af4\dbch\af31505\loch\f4 nse (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2005 - 2015 Giacomo Stelluti Scala & Contributors
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any p\hich\af4\dbch\af31505\loch\f4 
-erson obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop
-\hich\af4\dbch\af31505\loch\f4 i\hich\af4\dbch\af31505\loch\f4 es of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-\par 
-\par \hich\af4\dbch\af31505\loch\f4 THE \hich\af4\dbch\af31505\loch\f4 
-SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIA
-\hich\af4\dbch\af31505\loch\f4 B\hich\af4\dbch\af31505\loch\f4 
-LE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-\par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Nlohmann.json v.3.7.3
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2013-2022 Niels Lohm\hich\af4\dbch\af31505\loch\f4 ann
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without re\hich\af4\dbch\af31505\loch\f4 
+striction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modif
-\hich\af4\dbch\af31505\loch\f4 y, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-\par \hich\af4\dbch\af31505\loch\f4 furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 The\hich\af4\dbch\af31505\loch\f4  above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF \hich\af4\dbch\af31505\loch\f4 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+\hich\af4\dbch\af31505\loch\f4 C\hich\af4\dbch\af31505\loch\f4 ONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Nlohmann.json v.3.7.3
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2013-2022 Niels Lohmann
+\par 
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation\hich\af4\dbch\af31505\loch\f4 
+ files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+
+\par \hich\af4\dbch\af31505\loch\f4 fu\hich\af4\dbch\af31505\loch\f4 rnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \hich\af4\dbch\af31505\loch\f4 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR 
-\hich\af4\dbch\af31505\loch\f4 I\hich\af4\dbch\af31505\loch\f4 N CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS \hich\af4\dbch\af31505\loch\f4 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+\hich\af4\dbch\af31505\loch\f4 O\hich\af4\dbch\af31505\loch\f4 F CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Autodesk Artifakt Fonts
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Licensing information: \'a9\loch\f4  Autodesk, Inc. All Rights Reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The Artifakt font software is Autodesk proprietary and confidential, and may be used only by\hich\af4\dbch\af31505\loch\f4 
- authorized users and only for Autodesk business purposes. Any use not authorized by Autodesk is not permitted and is an infringement of Autodesk's intellectual property rights as well as a breach of your agreement with Autodesk. Go to }
-{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://br\hich\af4\dbch\af31505\loch\f4 and.autodesk.com/brand-system/typography }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\insrsid1784394 {\*\datafield 
+\par \hich\af4\dbch\af31505\loch\f4 The Artifakt font software is Autode\hich\af4\dbch\af31505\loch\f4 
+sk proprietary and confidential, and may be used only by authorized users and only for Autodesk business purposes. Any use not authorized by Autodesk is not permitted and is an infringement of Autodesk's intellectual property rights as well as a breach of
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 your agreement with Autodesk. Go to }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK https://brand.autodesk.com/brand-system/typography }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7e000000680074007400700073003a002f002f006200720061006e0064002e006100750074006f006400650073006b002e0063006f006d002f006200720061006e0064002d00730079007300740065006d002f007400
-790070006f006700720061007000680079000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006f1454008e005c8f17016600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-https://brand.autodesk.com/brand-system/typography}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  for detailed usage guidelines on \hich\af4\dbch\af31505\loch\f4 
-when and how to use the Artifakt designer collection.
+790070006f006700720061007000680079000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006f1454008e005c8f1701660000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://brand.autodesk.com/bra
+\hich\af4\dbch\af31505\loch\f4 nd-system/typography}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+ for detailed usage guidelines on when and how to use the Artifakt designer collection.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 DirectX
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/DirectX%20SDK%20EULA.txt" }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfe000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f0044006900720065006300740058002000530044004b
-002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300410065027800390013017300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030041006502780039001301730000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLI\hich\af4\dbch\af31505\loch\f4 
-NK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/directx%20redist.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/inst\hich\af4\dbch\af31505\loch\f4 
+all/Extra/DirectX/License%20Agreements/directx%20redist.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfa000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f00640069007200650063007400780020007200650064
-006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003126d002e00002a3a00a22a7300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt
+006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003126d002e00002a3a00a22a730048}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http\hich\af4\dbch\af31505\loch\f4 
+s://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\kerning1\insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 ImageMagick
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://imagemagick.org/script/license.php }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f0069006d006100670065006d0061006700690063006b002e006f00720067002f007300630072006900700074002f006c006900630065006e00730065002e0070006800
-70000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006500650003493500724b5300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect
+70000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006500650003493500724b530000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
 \par 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 LiveCharts
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://v0.lvch\hich\af4\dbch\af31505\loch\f4 arts.com/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://v0.lvcharts.com/ }{\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f00760030002e006c0076006300680061007200740073002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00032c6b007300455600
-00cf577400}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://v0.lvcharts.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
+00cf57740000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://v0.lvcharts.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
 \par \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2016 Alberto Rodriguez & LiveCharts contributors
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/Liv\hich\af4\dbch\af31505\loch\f4 e-Charts/Live-Charts/blob/master/LICENSE.TXT }{\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid1784394 
-{\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/Live-Charts/Live-Charts/blob/master/LICENSE.TXT }{\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004c006900760065002d004300680061007200740073002f004c006900760065002d0043006800610072007400
-73002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00036838007200008e00003b8e1400}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 
+73002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00036838007200008e00003b8e140000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/Live-Charts/Live-Charts/blob/master/LICENSE.TXT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\lang1053\langfe2052\langnp1053\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Magick.NET.Core
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/dlemstra/Magick.NET/blob/main/License.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/dl\hich\af4\dbch\af31505\loch\f4 emstra/Magick.NET/blob/main/License.txt }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b92000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006c0065006d0073007400720061002f004d0061006700690063006b002e004e00450054002f0062006c00
-6f0062002f006d00610069006e002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00034c538c73007100d30018430900}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe2052\langnp1053\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/dlemstra\hich\af4\dbch\af31505\loch\f4 /Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+6f0062002f006d00610069006e002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00034c538c73007100d3001843090000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\lang1053\langfe2052\langnp1053\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Microsoft 2015 C Runtime DLLs, msvcp140.dll, msvcr140.dll
@@ -1370,149 +1388,147 @@ https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/Licen
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba000000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00760069007300750061006c0073007400
-7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310035002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab000379432f2e004a00040063433500}}}{\fldrslt {
+7500640069006f002f00700072006f00640075006300740069006e0066006f002f0032003000310035002d007200650064006900730074007200690062007500740069006f006e002d00760073000000795881f43b1d7f48af2c825dc485276300000000a5ab000379432f2e004a0004006343350000}}}{\fldrslt {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://docs.microsoft.com/en-us/visualstudio/productinfo/2015-redistribution-vs
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Open XML SDK
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/OfficeDev/Open-XML-SDK }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004f00660066006900630065004400650076002f004f00700065006e002d0058004d004c002d00530044004b00
-0000795881f43b1d7f48af2c825dc485276300000000a5ab00032274004c98000000000d000400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/OfficeDev/Open-XML-SDK}}}\sectd \ltrsect
+0000795881f43b1d7f48af2c825dc485276300000000a5ab00032274004c98000000000d00040000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://github.com/OfficeDev/Open-XML-SDK}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.co\hich\af4\dbch\af31505\loch\f4 m/OfficeDev/Open-XML-SDK/blob/main/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004f00660066006900630065004400650076002f004f00700065006e002d0058004d004c002d00530044004b00
-2f0062006c006f0062002f006d00610069006e002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003024f0072001c0068005e000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+2f0062006c006f0062002f006d00610069006e002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003024f0072001c0068005e00000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\lang1053\langfe2052\langnp1053\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Prism
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERL\hich\af4\dbch\af31505\loch\f4 INK "http://msdn.microsoft.com/en-us/library/gg406140.aspx" }{
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/library/gg406140.aspx" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8400000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f006c006900620072006100720079002f006700
-67003400300036003100340030002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab00032072009400550030005200355a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 
+67003400300036003100340030002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab00032072009400550030005200355a00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/gg406140.aspx
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://msdn.microsoft.com/en-us/library/gg405489(PandP.40).aspx" }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9800000068007400740070003a002f002f006d00730064006e002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f006c006900620072006100720079002f006700
-67003400300035003400380039002800500061006e00640050002e003400300029002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab00033a6f0034010000c8001a00194f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library/\hich\af4\dbch\af31505\loch\f4 gg405489(PandP.40).aspx
+67003400300035003400380039002800500061006e00640050002e003400300029002e0061007300700078000000795881f43b1d7f48af2c825dc485276300000000a5ab00033a6f0034010000c8001a00194f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 http://msdn.microsoft.com/en-us/library\hich\af4\dbch\af31505\loch\f4 /gg405489(PandP.40).aspx
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Python Standard Library
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/library/" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b62000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900620072006100720079002f000000795881f43b1d7f48
-af2c825dc485276300000000a5ab00032c6200430000002200b600006f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
+af2c825dc485276300000000a5ab00032c6200430000002200b600006f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 
-YPERLINK "https://docs.python.org/2.7/license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
+\linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/license.html" }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900630065006e00730065002e00680074006d006c000000
-795881f43b1d7f48af2c825dc485276300000000a5ab00032050006100710121007200004e}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html
-
+795881f43b1d7f48af2c825dc485276300000000a5ab00032050006100710121007200004e00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 
+https://docs.python.org/2.7/license.html
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 
-\par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Python Modules}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf27\highlight8\insrsid9658238 
+\par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Python Modules}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf28\highlight8\insrsid9658238 
 \par }\pard \ltrpar\ql \li0\ri0\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://numpy.org/ }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f006e0075006d00700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000312720073000000000055006e39}}}{\fldrslt {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://numpy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License: Distributed under a liberal}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf28\highlight8\insrsid9658238 \~}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f006e0075006d00700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000312720073000000000055006e3900}}}{\fldrslt 
+{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://numpy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License: Distributed under a liberal}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf29\highlight8\insrsid9658238 \~}
 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006d00700079002f006e0075006d00700079002f0062006c006f0062002f006d00610069006e002f00
-4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030f6f006c00fb00000004000050}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf29\highlight8\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 BSD license}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
+4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030f6f006c00fb00000004000050d4}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf30\highlight8\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 BSD license
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pandas.pydata.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e000000680074007400700073003a002f002f00700061006e006400610073002e007000790064006100740061002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00033a3b2f00
-000100000038000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://pandas.pydata.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
+000100000038000000ba}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https:\hich\af4\dbch\af31505\loch\f4 //pandas.pydata.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\lang1053\langfe2052\langnp1053\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 :}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  BSD 3-Clause "New" or "Revised" License}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf30\insrsid9658238 
+\fs22\cf31\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://scipy.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f00730063006900700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00037b6514750000000000eb010072}}}{\fldrslt {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://scipy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License\hich\af4\dbch\af31505\loch\f4 :}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Distributed under a liberal}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f00730063006900700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00037b6514750000000000eb01007210}}}{\fldrslt 
+{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://scipy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Distributed under a liberal}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006d00700079002f006e0075006d00700079002f0062006c006f0062002f006d00610069006e002f00
-4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000322612f69000000000030002200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf29\highlight8\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 BSD license}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
+4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000322612f690000000000300022007e}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf30\highlight8\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 BSD license
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pypi.org/project/openpyxl/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e000000680074007400700073003a002f002f0070007900700069002e006f00720067002f00700072006f006a006500630074002f006f00700065006e007000790078006c002f000000795881f43b1d7f48af2c825d
-c485276300000000a5ab000332361466000100000000004120}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/openpyxl/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+c485276300000000a5ab00033236146600010000000000412083}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/openpyxl/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License:\~MIT License (MIT)}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf27\highlight8\insrsid9658238 
+\fs22\cf28\highlight8\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://matplotlib.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b48000000680074007400700073003a002f002f006d006100740070006c006f0074006c00690062002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003066d004d0b0078790000
-006675}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://matp\hich\af4\dbch\af31505\loch\f4 lotlib.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00667500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://m\hich\af4\dbch\af31505\loch\f4 atplotlib.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 : 
 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Matplotlib only uses BSD compatible code, and its license is based on the\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/3/license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b66000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0033002f006c006900630065006e00730065002e00680074006d006c000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab0003222edd6f002e5d460000000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 PSF}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf25\insrsid9658238 \~\hich\af4\dbch\af31505\loch\f4 license}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf28\highlight8\insrsid9658238 
+3b1d7f48af2c825dc485276300000000a5ab0003222edd6f002e5d460000000000a5}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 PSF}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf25\insrsid9658238 \~\hich\af4\dbch\af31505\loch\f4 license}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf29\highlight8\insrsid9658238 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pypi.org/project/Pillow/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5a000000680074007400700073003a002f002f0070007900700069002e006f00720067002f00700072006f006a006500630074002f00500069006c006c006f0077002f000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab000300142a6900887f3000f3000074}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/Pillow/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf28\highlight8\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \~
-\hich\af4\dbch\af31505\loch\f4 Historical Permission Notice}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  and Disclaimer (HPND) }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf27\highlight8\insrsid9658238 
+00000000a5ab000300142a6900887f3000f300007400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/Pillow/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf29\highlight8\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \~
+\hich\af4\dbch\af31505\loch\f4 Historical Permission Notice}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4  and Disclaimer (HPND) }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf28\highlight8\insrsid9658238 
 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 SimplexNoise
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://unlicense.org/" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b46000000680074007400700073003a002f002f0075006e006c006900630065006e00730065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300b88000009c003000000000
-00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://unlicense.org/
+0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 https://unlicense.org/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \lang1053\langfe2052\kerning1\langnp1053\insrsid9658238 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Xceed Extended WPF Toolkit
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 YPERLINK "https://opensource.org/licenses/ms-pl.html" }{
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://opensource.org/licenses/ms-pl.html" }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006d0073002d0070006c002e00680074006d00
-6c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300eaff00008b58580000000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
+6c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300eaff00008b5858000000000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
 Microsoft Public License
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be2000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007800630065006500640073006f006600740077006100720065002f0077007000660074006f006f006c006b00
 690074002f0062006c006f0062002f0030006500640034006500640038003400310035003200640036006100330065003200610036003200370066003200650066003000350066003800320036003200370066006400610066003300660063002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f
-48af2c825dc485276300000000a5ab0003005d800000cb7f4c0000000061}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
+48af2c825dc485276300000000a5ab0003005d800000cb7f4c000000006100}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe2052\langnp1036\insrsid9658238\charrsid15220234 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
 \b\fs22\cf25\lang1036\langfe2052\kerning1\langnp1036\insrsid9658238\charrsid15220234 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af40\afs20 \ltrch\fcs0 \b\f40\fs20\lang1036\langfe2052\kerning1\langnp1036\insrsid9658238\charrsid15220234 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Microsoft.Web.WebView2 v.1.0.1264.42
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid9658238 \hich\af4\dbch\af31505\loch\f4 Copyright (C) Microsoft Corporation. All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without
+\par \hich\af4\dbch\af31505\loch\f4 Redistribution and us\hich\af4\dbch\af31505\loch\f4 e in source and binary forms, with or without
 \par \hich\af4\dbch\af31505\loch\f4 modification, are permitted provided that the following conditions are
 \par \hich\af4\dbch\af31505\loch\f4 met:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4    * Redistributions of source code must retain the a\hich\af4\dbch\af31505\loch\f4 bove copyright
+\par \hich\af4\dbch\af31505\loch\f4    * Redistributions of source code must retain the above copyright
 \par \hich\af4\dbch\af31505\loch\f4 notice, this list of conditions and the following disclaimer.
 \par \hich\af4\dbch\af31505\loch\f4    * Redistributions in binary form must reproduce the above
 \par \hich\af4\dbch\af31505\loch\f4 copyright notice, this list of conditions and the following disclaimer
-\par \hich\af4\dbch\af31505\loch\f4 in the documentation and/or other materials pro\hich\af4\dbch\af31505\loch\f4 vided with the
+\par \hich\af4\dbch\af31505\loch\f4 in the documentation and/or other materials provided with the
 \par \hich\af4\dbch\af31505\loch\f4 distribution.
-\par \hich\af4\dbch\af31505\loch\f4    * The name of Microsoft Corporation, or the names of its contributors 
+\par \hich\af4\dbch\af31505\loch\f4    * The name of Microsoft Corporation, or the n\hich\af4\dbch\af31505\loch\f4 ames of its contributors 
 \par \hich\af4\dbch\af31505\loch\f4 may not be used to endorse or promote products derived from this
 \par \hich\af4\dbch\af31505\loch\f4 software without specific prior written permission.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE CO\hich\af4\dbch\af31505\loch\f4 PYRIGHT HOLDERS AND CONTRIBUTORS
-\par \hich\af4\dbch\af31505\loch\f4 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+\par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+\par \hich\af4\dbch\af31505\loch\f4 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIE\hich\af4\dbch\af31505\loch\f4 S, INCLUDING, BUT NOT
 \par \hich\af4\dbch\af31505\loch\f4 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 \par \hich\af4\dbch\af31505\loch\f4 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-\par \hich\af4\dbch\af31505\loch\f4 OWNER OR CONTRIBUT\hich\af4\dbch\af31505\loch\f4 ORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-\par \hich\af4\dbch\af31505\loch\f4 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+\par \hich\af4\dbch\af31505\loch\f4 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+\par \hich\af4\dbch\af31505\loch\f4 SPECIAL, EXEMPLARY, OR CO\hich\af4\dbch\af31505\loch\f4 NSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 \par \hich\af4\dbch\af31505\loch\f4 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 \par \hich\af4\dbch\af31505\loch\f4 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 \par \hich\af4\dbch\af31505\loch\f4 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-\par \hich\af4\dbch\af31505\loch\f4 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+\par \hich\af4\dbch\af31505\loch\f4 (INCLUDI\hich\af4\dbch\af31505\loch\f4 NG NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 \par \hich\af4\dbch\af31505\loch\f4 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid1784394 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid1784394 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid1784394 \hich\af4\dbch\af31505\loch\f4 Lucene.Net
-\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 \hich\af4\dbch\af31505\loch\f4 H\hich\af4\dbch\af31505\loch\f4 YPERLINK "https://lucenenet.apache.org/"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf26\insrsid1784394 {\*\datafield 
+\par }{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://lucenenet.apache.org/"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54000000680074007400700073003a002f002f006c007500630065006e0065006e00650074002e006100700061006300680065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-0003804f65150000009200ff004c78}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid11167982\charrsid11167982 \hich\af4\dbch\af31505\loch\f4 https://lucenenet.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+0003804f65150000009200ff004c7800}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid11167982\charrsid11167982 \hich\af4\dbch\af31505\loch\f4 https://lucenenet.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\insrsid11167982\charrsid3998130 \hich\af4\dbch\af31505\loch\f4 apache}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid11167982\charrsid11167982 \hich\af4\dbch\af31505\loch\f4 .org/}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf26\insrsid1784394 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid1784394 }}\pard\plain \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid1784394 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 
@@ -1520,30 +1536,29 @@ https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f826
  HYPERLINK "}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid14298549\charrsid1784394 \hich\af4\dbch\af31505\loch\f4 https://github.com/apache/lucenenet/blob/master/LICENSE.txt}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid14298549 
 \hich\af4\dbch\af31505\loch\f4 " }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid3998130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006100700061006300680065002f006c007500630065006e0065006e00650074002f0062006c006f0062002f00
-6d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003580000d46bcc00000049}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid14298549\charrsid14700233 
+6d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003580000d46bcc0000004900}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid14298549\charrsid14700233 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/apache/lucenenet/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid1784394 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14298549 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14298549\charrsid14298549 \hich\af4\dbch\af31505\loch\f4 Copyright 2022 Apache Lucene.NET
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache Li\hich\af4\dbch\af31505\loch\f4 cense, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at}{\rtlch\fcs1 
+\par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); yo\hich\af4\dbch\af31505\loch\f4 u may not use this file except in compliance with the License.  You may obtain a copy of the License at}{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14298549 \hich\af4\dbch\af31505\loch\f4  }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14298549 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\insrsid14298549\charrsid14298549 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14298549 \hich\af4\dbch\af31505\loch\f4 " }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\insrsid3998130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000380000b8586400ed}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid14298549\charrsid14700233 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000380000b8586400ed00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid14298549\charrsid14700233 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14298549 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid14298549\charrsid14298549 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the Li\hich\af4\dbch\af31505\loch\f4 
 cense is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\insrsid14298549 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid3998130 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3998130 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\lang1036\langfe2052\kerning1\langnp1036\insrsid3998130\charrsid15220234 
-\hich\af4\dbch\af31505\loch\f4 Microsoft.Extensions.Configuration.Json \hich\af4\dbch\af31505\loch\f4 v6.0.0
+\hich\af4\dbch\af31505\loch\f4 Microsoft.Extensions.Configuration.Json v6.0.0
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid3998130\charrsid3998130 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid3998130\charrsid4611777 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf26\kerning1\insrsid4611777\charrsid4611777 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b88000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f00720075006e00740069006d0065002f0062006c006f0062002f006d006100
-69006e002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000110000001500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf26\kerning1\insrsid3998130\charrsid4611777 
-\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/ru\hich\af4\dbch\af31505\loch\f4 ntime/blob/main/LICENSE.TXT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid3998130\charrsid4611777 
-
+69006e002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000011000000150000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf26\kerning1\insrsid3998130\charrsid4611777 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/dotnet/runtime/blob/main/LICENSE.TXT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid3998130\charrsid4611777 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf26\kerning1\insrsid4611777 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4611777 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 
 Copyright (c) .NET Foundation and Contributors
@@ -1552,19 +1567,19 @@ Copyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 of this software and associated documentation files (the "Software"), to deal}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 
 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 in the Software without restriction, including without limitation the rights}{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 copies of the Software, and\hich\af4\dbch\af31505\loch\f4  to permit persons to whom the Software is}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 furnished to do so, subject to the following conditions:
+\ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 to use, copy, modify, me\hich\af4\dbch\af31505\loch\f4 
+rge, publish, distribute, sublicense, and/or sell}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 
+\hich\af4\dbch\af31505\loch\f4 copies of the Software, and to permit persons to whom the Software is}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 furnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "A\hich\af4\dbch\af31505\loch\f4 S IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 
-\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE}{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAG\hich\af4\dbch\af31505\loch\f4 ES OR OTHER}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 
+\hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN N\hich\af4\dbch\af31505\loch\f4 
+O EVENT SHALL THE}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 
 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777 \hich\af4\dbch\af31505\loch\f4 I}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4611777\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 N THE}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
@@ -1573,43 +1588,46 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAG\hich\af4\dbch\af3150
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3998130 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3998130 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3998130\charrsid3998130 \hich\af4\dbch\af31505\loch\f4 CsvHelper v30.0.1}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3998130 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid3998130\charrsid3998130 \hich\af4\dbch\af31505\loch\f4 Apache 2.0
-\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid3998130\charrsid4611777 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/JoshClose/CsvHelp\hich\af4\dbch\af31505\loch\f4 er/blob/master/LICENSE.txt" }
-{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid4611777\charrsid4611777 {\*\datafield 
+\par }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid3998130\charrsid4611777 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf26\kerning1\insrsid4611777\charrsid4611777 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a006f007300680043006c006f00730065002f00430073007600480065006c007000650072002f0062006c00
-6f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000087018f13060000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+6f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000087018f1306000048}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \cs19\fs22\ul\cf26\kerning1\insrsid3998130\charrsid4611777 \hich\af4\dbch\af31505\loch\f4 https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf26\kerning1\insrsid3998130\charrsid4611777 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4611777 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12653622 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777\charrsid14298549 \hich\af4\dbch\af31505\loch\f4 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 
 \hich\af4\dbch\af31505\loch\f4  }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  HYPERLINK "}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777\charrsid14298549 
-\hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 \hich\af4\dbch\af31505\loch\f4 " }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 {\*\datafield 
+\hich\af4\dbch\af31505\loch\f4 http://\hich\af4\dbch\af31505\loch\f4 www.apache.org/licenses/LICENSE-2.0}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 \hich\af4\dbch\af31505\loch\f4 " }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\insrsid4611777 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ff00003701ff660073}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid4611777\charrsid14700233 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ff00003701ff66007300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid4611777\charrsid14700233 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4611777\charrsid14298549 \hich\af4\dbch\af31505\loch\f4 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS\hich\af4\dbch\af31505\loch\f4 
- IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf25\insrsid12653622\charrsid12653622 
+Unless required by applicable law or agreed to in writ\hich\af4\dbch\af31505\loch\f4 
+ing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.}{
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid12653622 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3998130 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3998130 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4484117 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid4484117\charrsid9377761 \hich\af4\dbch\af31505\loch\f4 Prism.Core v8.1.97
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4484117 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid4484117\charrsid9377761 \hich\af4\dbch\af31505\loch\f4 Pr
+\hich\af4\dbch\af31505\loch\f4 ism.Core v8.1.97
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid4484117\charrsid9377761 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par }{\rtlch\fcs1 \af4 \ltrch\fcs0 \cs19\ul\cf26\insrsid4484117\charrsid9377761 \hich\af4\dbch\af31505\loch\f4 https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid4484117\charrsid9377761 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid4484117 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid4484117\charrsid12335516 \hich\af4\dbch\af31505\loch\f4 Copyright (c) Prism Library
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 All rights reserved. Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software\hich\af4\dbch\af31505\loch\f4 
-"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, su
-\hich\af4\dbch\af31505\loch\f4 b\hich\af4\dbch\af31505\loch\f4 ject to the following conditions: 
+\par \hich\af4\dbch\af31505\loch\f4 
+All rights reserved. Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to
+\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice sh\hich\af4\dbch\af31505\loch\f4 all be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDIN\hich\af4\dbch\af31505\loch\f4 
-G BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-\hich\af4\dbch\af31505\loch\f4  \hich\af4\dbch\af31505\loch\f4 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\hich\af4\dbch\af31505\loch\f4 
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEAL
+\hich\af4\dbch\af31505\loch\f4 I\hich\af4\dbch\af31505\loch\f4 NGS IN THE SOFTWARE.
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3998130 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid3998130 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://lucenenet.apache.org/"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid3998130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54000000680074007400700073003a002f002f006c007500630065006e0065006e00650074002e006100700061006300680065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-0003804f657a000000050001000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid3998130 
+0003804f657a00000005000100000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid3998130 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12653622 }}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12653622 \rtlch\fcs1 \af4\afs24\alang1025 
 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp2052 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid12653622 \hich\af4\dbch\af31505\loch\f4 
 MimeMapping}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid12653622\charrsid3998130 \hich\af4\dbch\af31505\loch\f4  v}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid12653622 \hich\af4\dbch\af31505\loch\f4 2.}{
@@ -1619,25 +1637,26 @@ MimeMapping}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid
 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid12653622\charrsid9731339 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid12653622 \hich\af4\dbch\af31505\loch\f4 " }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid12653622 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b56000000680074007400700073003a002f002f006c006900630065006e007300650073002e006e0075006700650074002e006f00720067002f004d00490054000000795881f43b1d7f48af2c825dc485276300000000
-a5ab00030087006e00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\kerning1\insrsid12653622\charrsid10299691 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+a5ab00030087006e0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\kerning1\insrsid12653622\charrsid10299691 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\cf26\kerning1\insrsid12653622 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 \hich\af4\dbch\af31505\loch\f4 Copyright (c) <year> <copyright holders>}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy \hich\af4\dbch\af31505\loch\f4 of\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf25\insrsid12653622\charrsid9731339 
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy\hich\af4\dbch\af31505\loch\f4  of\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf25\insrsid12653622\charrsid9731339 
 \hich\af4\dbch\af31505\loch\f4 this software and associated documentation files}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 \~\hich\af4\dbch\af31505\loch\f4 
-(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and\hich\af4\dbch\af31505\loch\f4 
- to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, an\hich\af4\dbch\af31505\loch\f4 
+d to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf25\insrsid12653622\charrsid9731339 \hich\af4\dbch\af31505\loch\f4 (including the next paragraph)}{\rtlch\fcs1 
-\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 \~\hich\af4\dbch\af31505\loch\f4 shall be included in all copies or substantial portions of the Software.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622 
+\af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 \~\hich\af4\dbch\af31505\loch\f4 shall be included in all copies or substantial portions of the Softwar\hich\af4\dbch\af31505\loch\f4 e.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf25\insrsid12653622 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 
 \par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\~}{
 \rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf25\insrsid12653622\charrsid9731339 \hich\af4\dbch\af31505\loch\f4 THE AUTHORS OR COPYRIGHT HOLDERS}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid12653622\charrsid9731339 \~
 \hich\af4\dbch\af31505\loch\f4 BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.}{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf21\insrsid12653622\charrsid9731339 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3998130 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid3998130 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3346706 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3346706\charrsid15019625 \hich\af4\dbch\af31505\loch\f4 DotNetProjects.Extend
-\hich\af4\dbch\af31505\loch\f4 ed.Wpf.Toolkit v5.0.103
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid3346706\charrsid15019625 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3346706 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf25\kerning1\insrsid3346706\charrsid15019625 \hich\af4\dbch\af31505\loch\f4 
+DotNetProjects.Extended.Wpf.Toolkit v5.0.103
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\kerning1\insrsid3346706\charrsid15019625 \hich\af4\dbch\af31505\loch\f4 M\hich\af4\dbch\af31505\loch\f4 icrosoft Public License
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3346706 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf26\insrsid3346706\charrsid15019625 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md
 \par 
@@ -1645,24 +1664,25 @@ https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md
 This license governs use of the accompanying software. If you use the software, you \hich\af4\dbch\af31505\loch\f4 accept this license. If you do not accept the license, do not use the software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 1. Definitions
-\par \hich\af4\dbch\af31505\loch\f4 The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law. A "contribution" is the or\hich\af4\dbch\af31505\loch\f4 
-iginal software, or any additions or changes to the software. A "contributor" is any person that distributes its contribution under this license. "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-\par \hich\af4\dbch\af31505\loch\f4 2. Grant of Right\hich\af4\dbch\af31505\loch\f4 s
 \par \hich\af4\dbch\af31505\loch\f4 
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare deriva
-\hich\af4\dbch\af31505\loch\f4 tive works of its contribution, and distribute its contribution or any derivative works that you create.
-\par \hich\af4\dbch\af31505\loch\f4 (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a no\hich\af4\dbch\af31505\loch\f4 
-n-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-\par \hich\af4\dbch\af31505\loch\f4 3. Conditio\hich\af4\dbch\af31505\loch\f4 ns and Limitations
-\par \hich\af4\dbch\af31505\loch\f4 (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-\par \hich\af4\dbch\af31505\loch\f4 (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your \hich\af4\dbch\af31505\loch\f4 patent license from such contributor to the software ends automatically.
-
-\par \hich\af4\dbch\af31505\loch\f4 (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-\par \hich\af4\dbch\af31505\loch\f4 (D) If you distribute an\hich\af4\dbch\af31505\loch\f4 
-y portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so und
-\hich\af4\dbch\af31505\loch\f4 e\hich\af4\dbch\af31505\loch\f4 r a license that complies with this license.
-\par \hich\af4\dbch\af31505\loch\f4 (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees, or conditions. You may have additional consumer rights under your local laws which th
-\hich\af4\dbch\af31505\loch\f4 is license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law. A "contribution" is the original software, or any additions or changes to the software. A "contributor" is any person tha
+\hich\af4\dbch\af31505\loch\f4 t\hich\af4\dbch\af31505\loch\f4  distributes its contribution under this license. "Licensed patents" are a contributor's patent claims that read directly on its contribution.
+\par \hich\af4\dbch\af31505\loch\f4 2. Grant of Rights
+\par \hich\af4\dbch\af31505\loch\f4 (A) Copyright Grant- Subject to the terms of this license, including the license conditions an\hich\af4\dbch\af31505\loch\f4 
+d limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that yo
+\hich\af4\dbch\af31505\loch\f4 u\hich\af4\dbch\af31505\loch\f4  create.
+\par \hich\af4\dbch\af31505\loch\f4 
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use,
+\hich\af4\dbch\af31505\loch\f4  sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+\par \hich\af4\dbch\af31505\loch\f4 3. Conditions and Limitations
+\par \hich\af4\dbch\af31505\loch\f4 (A) No Trademark License- This license does not grant you rights to use any c\hich\af4\dbch\af31505\loch\f4 ontributors' name, logo, or trademarks.
+\par \hich\af4\dbch\af31505\loch\f4 (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+\par \hich\af4\dbch\af31505\loch\f4 (C) If you distribute a\hich\af4\dbch\af31505\loch\f4 ny portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
+\par \hich\af4\dbch\af31505\loch\f4 (D) If you distribute any portion of the software in source code form, you may do so only under this license by includin\hich\af4\dbch\af31505\loch\f4 
+g a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+\par \hich\af4\dbch\af31505\loch\f4 (E) The software is licensed "as-is." You bear the \hich\af4\dbch\af31505\loch\f4 
+risk of using it. The contributors give no express warranties, guarantees, or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclu
+\hich\af4\dbch\af31505\loch\f4 d\hich\af4\dbch\af31505\loch\f4 e the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3998130 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf25\insrsid3346706 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
@@ -1807,8 +1827,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e0af
-a87291c4d901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000030d6
+cb0eacecd901feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -132,7 +132,7 @@
   </ItemGroup>
   <ItemGroup> 
     <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.18.0.2485" />
-    <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
+    <PackageReference Include="AvalonEdit" Version="4.3.1.9430" CopyXML="true" />
     <PackageReference Include="Greg" Version="2.5.0.5076" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Libraries/DSIronPython/DSIronPython.csproj
+++ b/src/Libraries/DSIronPython/DSIronPython.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>DSIronPython</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="AvalonEdit" Version="6.3.0.90" />
+	<PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
 	<PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />
 	<PackageReference Include="IronPython" Version="2.7.9" />
 	<PackageReference Include="IronPython.StdLib" Version="2.7.9" />

--- a/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNodeModelsWpf.csproj
@@ -40,7 +40,7 @@
     <None Remove="Resources\zoom-out_hover.png" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="AvalonEdit" Version="6.3.0.90" />
+	<PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
 	<PackageReference Include="FontAwesome.WPF" Version="4.7.0.9" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)'=='net48' ">

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -15,7 +15,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
+	  <PackageReference Include="AvalonEdit" Version="4.3.1.9430" />
       <PackageReference Include="Moq" Version="4.18.4" />
 	  <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
 	  <PackageReference Include="Greg" Version="2.5.0.5076">

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>DynamoPythonTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.3.0.90"/>
+    <PackageReference Include="AvalonEdit" Version="4.3.1.9430"/>
     <PackageReference Include="NUnit" Version="2.6.3" />
     <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.18.0.2485" />
     <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />

--- a/test/Libraries/IronPythonTests/IronPythonTests.csproj
+++ b/test/Libraries/IronPythonTests/IronPythonTests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>IronPythonTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="AvalonEdit" Version="6.3.0.90"/>
+	<PackageReference Include="AvalonEdit" Version="4.3.1.9430"/>
 	<PackageReference Include="NUnit" Version="2.6.3" />
     <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="2.18.0.2485" />
     <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />


### PR DESCRIPTION
### Purpose

DYN-6263: Revert avalonedit version

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
