### PR TITLE
graphic helpers - 2.19 hotfix cherry pick to master

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2603,7 +2603,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Show Grid.
+        ///   Looks up a localized string similar to _Show Helpers.
         /// </summary>
         public static string DynamoViewViewMenuShowGrid {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2603,7 +2603,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Show Helpers.
+        ///   Looks up a localized string similar to _Show Grid.
         /// </summary>
         public static string DynamoViewViewMenuShowGrid {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -970,8 +970,8 @@ Don't worry, you'll have the option to save your work.</value>
     <comment>View menu | Show console</comment>
   </data>
   <data name="DynamoViewViewMenuShowGrid" xml:space="preserve">
-    <value>_Show Grid</value>
-    <comment>View menu | Show Grid</comment>
+    <value>_Show Helpers</value>
+    <comment>View menu | Show Helpers</comment>
   </data>
   <data name="DynamoViewViewMenuZoom" xml:space="preserve">
     <value>_Zoom</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -970,8 +970,8 @@ Don't worry, you'll have the option to save your work.</value>
     <comment>View menu | Show console</comment>
   </data>
   <data name="DynamoViewViewMenuShowGrid" xml:space="preserve">
-    <value>_Show Helpers</value>
-    <comment>View menu | Show Helpers</comment>
+    <value>_Show Grid</value>
+    <comment>View menu | Show Grid</comment>
   </data>
   <data name="DynamoViewViewMenuZoom" xml:space="preserve">
     <value>_Zoom</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -677,8 +677,8 @@
     <comment>View menu | Navigate background 3D preview</comment>
   </data>
   <data name="DynamoViewViewMenuShowGrid" xml:space="preserve">
-    <value>_Show Grid</value>
-    <comment>View menu | Show Grid</comment>
+    <value>_Show Helpers</value>
+    <comment>View menu | Show Helpers</comment>
   </data>
   <data name="DynamoViewViewMenuShowBackground3DPreview" xml:space="preserve">
     <value>Showing Background 3D Preview</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -677,8 +677,8 @@
     <comment>View menu | Navigate background 3D preview</comment>
   </data>
   <data name="DynamoViewViewMenuShowGrid" xml:space="preserve">
-    <value>_Show Helpers</value>
-    <comment>View menu | Show Helpers</comment>
+    <value>_Show Grid</value>
+    <comment>View menu | Show Grid</comment>
   </data>
   <data name="DynamoViewViewMenuShowBackground3DPreview" xml:space="preserve">
     <value>Showing Background 3D Preview</value>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -195,7 +195,7 @@ namespace Dynamo.ViewModels
                     selectedUnits = value;
                     RaisePropertyChanged(nameof(SelectedUnits));
 
-                    if (UseHostScaleUnits) return;
+                    if (UseHostScaleUnits && IsDynamoRevit) return;
 
                     var result = Enum.TryParse(selectedUnits, out Configurations.Units currentUnit);
                     if (!result) return;

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -206,6 +206,14 @@ namespace Dynamo.ViewModels
                         preferenceSettings.GraphicScaleUnit = value;
                         preferenceSettings.GridScaleFactor = (float)units;
                         dynamoViewModel.UpdateGraphicHelpersScaleCommand.Execute(null);
+
+                        // We have turn the grid visilibilty on
+                        // Check the current visibility settings, and turn it back off 
+                        if (!preferenceSettings.IsBackgroundGridVisible)
+                        {
+                            dynamoViewModel.ToggleBackgroundGridVisibilityCommand.Execute(null);    // switch 'on'
+                            dynamoViewModel.ToggleBackgroundGridVisibilityCommand.Execute(null);    // switch 'off'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Purpose

This is a hot-fix for an issue preventing Graphic Elements Scale to take effect in Dynamo. The `UseHostScaleUnits` preference that controls if Revit scale units should be used was acting even if Dynamo was used without a host. 
~~**Show Grid** renamed to **Show Helpers**~~

#### Graphic Scale Units under Dynamo and Revit

![dyanmo units](https://github.com/DynamoDS/Dynamo/assets/5354594/8c12b991-68df-4ee4-9726-c0ccda3b11ab)

![revit metric](https://github.com/DynamoDS/Dynamo/assets/5354594/a970c1c4-122e-4857-b156-808416735fbc)

#### Serializing settings
![image](https://github.com/DynamoDS/Dynamo/assets/5354594/3c2dc4b9-6670-4158-b8e9-3549654b2fbf)

#### Separate settings `.xaml` files for Dynamo and Revit
![image](https://github.com/DynamoDS/Dynamo/assets/5354594/c2a5770c-a5f6-4cbb-8be0-3fe5f8d28732)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

- graphic scale units not taking effect in Dynamo - added check to disable host settings interfering with Dynamo settings
~~- renamed resource for Show Grid to Show Helpers~~

### Reviewers

@QilongTang 
@reddyashish 

### FYIs

@Amoursol 
