### PR TITLE
port remove fix

### DIFF
--- a/src/DynamoCoreWpf/Controls/DynamoNodeButton.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoNodeButton.cs
@@ -4,7 +4,6 @@ using System.Windows.Controls;
 using Dynamo.Controls;
 using Dynamo.Graph;
 using Dynamo.Models;
-using Dynamo.UI;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
@@ -67,23 +66,28 @@ namespace Dynamo.Nodes
             //
             if (null != this.model && (!string.IsNullOrEmpty(this.eventName)))
             {
-                MessageBoxResult result = MessageBoxResult.None;
+                // Only show the prompt if it is a Python node
+                var nodeVM = (sender as DynamoNodeButton)?.DataContext as NodeViewModel;
+                if (nodeVM?.NodeModel is PythonNodeModels.PythonNode)
+                {                    
+                    MessageBoxResult result = MessageBoxResult.None;
 
-                if (eventName.Equals("RemoveInPort") && ShowWarningForRemovingInPort)
-                {
-                    result = MessageBoxService.Show
-                    (
-                        Owner,
-                        Dynamo.Wpf.Properties.Resources.MessageRemovePythonPort,
-                        Dynamo.Wpf.Properties.Resources.RemovePythonPortWarningMessageBoxTitle,
-                        MessageBoxButton.OKCancel,
-                        MessageBoxImage.Information
-                    );
-                }
+                    if (eventName.Equals("RemoveInPort") && ShowWarningForRemovingInPort)
+                    {
+                        result = MessageBoxService.Show
+                        (
+                            Owner,
+                            Dynamo.Wpf.Properties.Resources.MessageRemovePythonPort,
+                            Dynamo.Wpf.Properties.Resources.RemovePythonPortWarningMessageBoxTitle,
+                            MessageBoxButton.OKCancel,
+                            MessageBoxImage.Information
+                        );
+                    }
 
-                if (result == MessageBoxResult.Cancel)
-                {
-                    return;
+                    if (result == MessageBoxResult.Cancel)
+                    {
+                        return;
+                    }
                 }
 
                 var command = new DynamoModel.ModelEventCommand(model.GUID, eventName);


### PR DESCRIPTION
### Purpose

A small fix to only show warning message when removing ports on Python nodes.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB 

### Release Notes

- now only shows warning prompt if the node is a Python node

### Reviewers

@QilongTang 

### FYIs

@reddyashish 
