### PR TITLE
DYN-6010 Enable Node Help Docs Sharing DYN files

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -27,7 +27,7 @@ namespace Dynamo.DocumentationBrowser
         internal string WebBrowserUserDataFolder { get; set; }
         internal string FallbackDirectoryName { get; set; }
         //This folder will be used to store images and dyn files previosuly located in /rootDirectory/en-US/fallback_docs so we don't need to copy all those files per each language
-        internal const string SharedDocsDirectoryName = "NodeHelpSharedDocs";
+        internal static readonly string SharedDocsDirectoryName = "NodeHelpSharedDocs";
 
         //Path in which the virtual folder for loading images will be created
         internal string VirtualFolderPath { get; set; }

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -446,7 +446,9 @@ namespace Dynamo.DocumentationBrowser
         private string DynamoGraphFromMDFilePath(string path)
         {
             path = HttpUtility.UrlDecode(path);
-            return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path)) + ".dyn";
+            var rootLevelDir = Path.GetDirectoryName(path);
+            var imagesLocation = Path.Combine(new DirectoryInfo(rootLevelDir).Parent.Parent.FullName, DocumentationBrowserView.SharedDocsDirectoryName);
+            return Path.Combine(imagesLocation, Path.GetFileNameWithoutExtension(path)) + ".dyn";
         }
 
 

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -138,7 +138,7 @@
     <Copy SourceFiles="$(SolutionDir)..\doc\distrib\InstrumentationConsent.rtf" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="$(SolutionDir)..\doc\distrib\ADPAnalyticsConsent.rtf" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(NodeHelpMDFiles)" DestinationFolder="$(OutputPath)\en-US\fallback_docs\" />
-	<Copy SourceFiles="@(NodeHelpDYNFiles)" DestinationFolder="$(OutputPath)\en-US\fallback_docs\" />
+	<Copy SourceFiles="@(NodeHelpDYNFiles)" DestinationFolder="$(OutputPath)\NodeHelpSharedDocs\" />
 	<Copy SourceFiles="@(NodeHelpTXTFiles)" DestinationFolder="$(OutputPath)\en-US\fallback_docs\" />
 	<Copy SourceFiles="@(NodeHelpSATFiles)" DestinationFolder="$(OutputPath)\en-US\fallback_docs\" />
     <Copy SourceFiles="@(NodeHelpJpgImageFiles)" DestinationFolder="$(OutputPath)\NodeHelpSharedDocs\" />


### PR DESCRIPTION
### Purpose

Sharing DYN files for DocumentationBrowser so they won't be duplicated for each language.
The NodeHelpSharedDocs folder already exists then I just modified the DynamoCore.csproj so the dyn files will be copied to the shared folder NodeHelpSharedDocs (then the en-US/fallbacks_docs folder won't contain dyn files anymore). So when inserting a graph DocumentationBrowser will be using the dyn files stored in the NodeHelpSharedDocs  folder.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

Sharing DYN files for DocumentationBrowser so they won't be duplicated for each language.


### Reviewers

@QilongTang 

### FYIs

