### PR TITLE
Update DynamoVisualProgramming.ServiceCoreRuntime.nuspec file target

### DIFF
--- a/tools/NuGet/template-net60-core/DynamoVisualProgramming.ServiceCoreRuntime.nuspec
+++ b/tools/NuGet/template-net60-core/DynamoVisualProgramming.ServiceCoreRuntime.nuspec
@@ -17,6 +17,6 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="**" target="lib\net6.0\linux\" exclude="en-US\fallback_docs\*"/>
+        <file src="**" target="lib\net6.0\" exclude="en-US\fallback_docs\*"/>
     </files>
 </package>


### PR DESCRIPTION
### Purpose

To mitigate `dotnet restore` error:
```
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
#11 1.838 --------------------------------------------------------------------------------------
#11 9.008   Determining projects to restore...
#11 88.45 /app/build_scripts/build.csproj : error NU1202: Package DynamoVisualProgramming.ServiceCoreRuntime 3.0.0-beta6283 is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Package DynamoVisualProgramming.ServiceCoreRuntime 3.0.0-beta6283 does not support any target frameworks.
#11 88.77   Failed to restore /app/build_scripts/build.csproj (in 1.28 min).
```
updated the target in nuspec file.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section** 


### Reviewers

@DynamoDS/dynamo 
