### PR TITLE
DYN-6286 WebView2 Upgrade

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
@@ -116,7 +116,7 @@
     <EmbeddedResource Include="Docs\syntaxHighlight.html" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -133,7 +133,7 @@
     <PackageReference Include="FontAwesome5" Version="2.1.11" />
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
     <PackageReference Include="Greg" Version="2.5.0.5076" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	<PackageReference Include="RestSharp" Version="106.12.0" />
 	<PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />

--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -177,7 +177,7 @@
     <EmbeddedResource Include="web\library\resources\Tessellation.Voronoi.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Dynamo.Microsoft.Xaml.Behaviors">

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -58,7 +58,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FontAwesome5" Version="2.1.11" />
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
+		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
 	</ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
         <Reference Include="PresentationCore" />


### PR DESCRIPTION
### Purpose

I've upgraded WebView2 from 1.0.1264.42 to1.0.2045.28 in the next projects using Nuget Manager:
- DocumentationBrowserViewExtension
- DynamoCoreWpf
- LibraryViewExtensionWebView2
- Notifications

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB 

### Release Notes

I've upgraded WebView2 from 1.0.1264.42 to1.0.2045.28


### Reviewers

@QilongTang 

### FYIs

