### PR TITLE
[Cherry-Pick] Index writing only once during DynamoModel initialization (#14447)

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1015,6 +1015,8 @@ namespace Dynamo.Models
             State = DynamoModelState.StartedUIless;
             // This event should only be raised at the end of this method.
             DynamoReady(new ReadyParams(this));
+            // Write index to disk only once
+            LuceneUtility.CommitWriterChanges();
         }
 
         private void SearchModel_ItemProduced(NodeModel node)
@@ -1475,8 +1477,6 @@ namespace Dynamo.Models
                     AddNodeTypeToSearchIndex(searchElement, iDoc);
                 }
 
-                LuceneUtility.CommitWriterChanges();
-
                 Action<CustomNodeInfo> infoUpdatedHandler = null;
                 infoUpdatedHandler = newInfo =>
                 {
@@ -1652,12 +1652,6 @@ namespace Dynamo.Models
             }
 
             CustomNodeManager.AddUninitializedCustomNodesInPath(pathManager.CommonDefinitions, IsTestMode);
-
-            // Initialize searcher, if the applyAllDeletes is true all buffered deletes on documents will be applied (made visible) in the returned reader
-            // When running parallel tests several are trying to write in the AppData folder then the job
-            // is failing and in a wrong state so we prevent to initialize Lucene index writer during test mode.
-            // Without the index files on disk, the dirReader cant be initialized correctly. So does the searcher.
-            LuceneUtility.CommitWriterChanges();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference to the tracking task that it is part or all of the solution for.

### Declarations

[Cherry-Pick] Index writing only once during DynamoModel initialization (#14447)

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers



### FYIs

@DynamoDS/dynamo 