### PR TITLE
DYN-6295 : analytics optimizations

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -224,6 +224,11 @@ namespace Dynamo.Applications
         /// <returns></returns>
         public static DynamoModel MakeCLIModel(string asmPath, string userDataFolder, string commonDataFolder, HostAnalyticsInfo info = new HostAnalyticsInfo())
         {
+            if (string.IsNullOrEmpty(info.HostName))
+            {
+                info.HostName = "Dynamo";
+            }
+
             // Preload ASM and display corresponding message on splash screen
             DynamoModel.OnRequestUpdateLoadBarStatus(new SplashScreenLoadEventArgs(Resources.SplashScreenPreLoadingAsm, 10));
             var isASMloaded = PreloadASM(asmPath, out string geometryFactoryPath, out string preloaderLocation);
@@ -243,6 +248,11 @@ namespace Dynamo.Applications
         /// <returns></returns>
         public static DynamoModel MakeCLIModel(string asmPath, string userDataFolder, string commonDataFolder, HostAnalyticsInfo info = new HostAnalyticsInfo(), bool isServiceMode = false)
         {
+            if (string.IsNullOrEmpty(info.HostName))
+            {
+                info.HostName = "Dynamo";
+            }
+
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
             PathManager.Instance.AssignHostPathAndIPathResolver(string.Empty, pathResolver);
 
@@ -282,6 +292,11 @@ namespace Dynamo.Applications
         /// <returns></returns>
         public static DynamoModel MakeModel(bool CLImode, string asmPath = "", HostAnalyticsInfo info = new HostAnalyticsInfo())
         {
+            if (string.IsNullOrEmpty(info.HostName))
+            {
+                info.HostName = "Dynamo";
+            }
+
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
             PathManager.Instance.AssignHostPathAndIPathResolver(string.Empty, pathResolver);
 
@@ -398,6 +413,11 @@ namespace Dynamo.Applications
             HostAnalyticsInfo info = new HostAnalyticsInfo(),
             bool isServiceMode = false)
         {
+            if (string.IsNullOrEmpty(info.HostName))
+            {
+                info.HostName = "Dynamo";
+            }
+
             var config = new DynamoModel.DefaultStartConfiguration
             {
                 GeometryFactoryPath = geometryFactoryPath,

--- a/src/DynamoCLI/CommandLineRunner.cs
+++ b/src/DynamoCLI/CommandLineRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -46,7 +46,7 @@ namespace DynamoCLI
                 Console.WriteLine("geometryFilePath option is only available when running DynamoWPFCLI, not DynamoCLI");
             }
 
-            model.HostAnalyticsInfo = cmdLineArgs.AnalyticsInfo;
+            DynamoModel.HostAnalyticsInfo = cmdLineArgs.AnalyticsInfo;
 
             cmdLineArgs.ImportedPaths.ToList().ForEach(path =>
             {

--- a/src/DynamoCore/Extensions/ReadyParams.cs
+++ b/src/DynamoCore/Extensions/ReadyParams.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Dynamo.Graph.Workspaces;
@@ -78,7 +78,7 @@ namespace Dynamo.Extensions
         /// <summary>
         /// HostInfo object, Useful to determine what host context Dynamo is running in.
         /// </summary>
-        internal HostAnalyticsInfo HostInfo => dynamoModel.HostAnalyticsInfo;
+        internal HostAnalyticsInfo HostInfo => DynamoModel.HostAnalyticsInfo;
 
 
         /// <summary>

--- a/src/DynamoCore/Extensions/StartupParams.cs
+++ b/src/DynamoCore/Extensions/StartupParams.cs
@@ -115,7 +115,7 @@ namespace Dynamo.Extensions
             this.pathManager = dynamoModel.PathManager;
             this.libraryLoader = new ExtensionLibraryLoader(dynamoModel);
             this.customNodeManager = dynamoModel.CustomNodeManager;
-            this.dynamoVersion = new Version(dynamoModel.Version);
+            this.dynamoVersion = new Version(DynamoModel.Version);
             this.preferences = dynamoModel.PreferenceSettings;
             this.linterManager = dynamoModel.LinterManager;
             this.IsGeometryLibraryLoaded = dynamoModel.IsASMLoaded;

--- a/src/DynamoCore/Logging/IAnalyticsSession.cs
+++ b/src/DynamoCore/Logging/IAnalyticsSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Dynamo.Models;
 
 namespace Dynamo.Logging
@@ -21,11 +21,10 @@ namespace Dynamo.Logging
         string SessionId { get; }
         
         /// <summary>
-        /// Starts the session for the given DynamoModel. 
+        /// Starts the session.
         /// The Session is closed when Dispose() is called.
         /// </summary>
-        /// <param name="model">DynamoModel</param>
-        void Start(DynamoModel model);
+        void Start();
         /// <summary>
         /// Returns a logger to record usage.
         /// </summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -199,7 +199,7 @@ namespace Dynamo.Models
         /// <summary>
         ///     This version of Dynamo.
         /// </summary>
-        public string Version
+        public static string Version
         {
             get { return DefaultUpdateManager.GetProductVersion().ToString(); }
         }
@@ -218,7 +218,7 @@ namespace Dynamo.Models
         /// <summary>
         /// Host analytics info
         /// </summary>
-        public HostAnalyticsInfo HostAnalyticsInfo { get; set; }
+        public static HostAnalyticsInfo HostAnalyticsInfo { get; set; }
 
         /// <summary>
         /// Boolean indication of launching Dynamo in service mode, this mode is optimized for minimal launch time, mostly leveraged by CLI or WPF CLI.
@@ -283,7 +283,7 @@ namespace Dynamo.Models
         /// <summary>
         ///     The application version string for analytics reporting APIs
         /// </summary>
-        internal virtual string AppVersion
+        internal static string AppVersion
         {
             get
             {
@@ -1643,6 +1643,7 @@ namespace Dynamo.Models
 #if DEBUG_LIBRARY
             DumpLibrarySnapshot(functionGroups);
 #endif
+
 
             // Load local custom nodes and locally imported libraries
             foreach (var path in pathManager.DefinitionDirectories)

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -528,7 +528,7 @@ namespace Dynamo.Models
             internal override void TrackAnalytics()
             {
                 // Log file open action and the number of nodes in the opened workspace
-                Dynamo.Logging.Analytics.TrackFileOperationEvent(
+                Dynamo.Logging.Analytics.TrackTaskFileOperationEvent(
                     FilePath,
                     Logging.Actions.Open,
                     dynamoModel.CurrentWorkspace.Nodes.Count());
@@ -628,7 +628,7 @@ namespace Dynamo.Models
             internal override void TrackAnalytics()
             {
                 // Log file open action and the number of nodes in the opened workspace
-                Dynamo.Logging.Analytics.TrackFileOperationEvent(
+                Dynamo.Logging.Analytics.TrackTaskFileOperationEvent(
                     FilePath,
                     Logging.Actions.Open,
                     dynamoModel.CurrentWorkspace.Nodes.Count());
@@ -705,7 +705,7 @@ namespace Dynamo.Models
             internal override void TrackAnalytics()
             {
                 // Log file open action and the number of nodes in the opened workspace
-                Dynamo.Logging.Analytics.TrackFileOperationEvent(
+                Dynamo.Logging.Analytics.TrackTaskFileOperationEvent(
                     "In memory json file",
                     Logging.Actions.Open,
                     dynamoModel.CurrentWorkspace.Nodes.Count());
@@ -1795,7 +1795,7 @@ namespace Dynamo.Models
 
             internal override void TrackAnalytics()
             {
-                Dynamo.Logging.Analytics.TrackCommandEvent(
+                Dynamo.Logging.Analytics.TrackTaskCommandEvent(
                     CmdOperation.ToString()); // "Undo" or "Redo"
             }
 

--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -238,9 +238,9 @@ namespace Dynamo.Wpf.Utilities
                     string appConfig = "";
                     if (model != null)
                     {
-                        var appName = GetHostAppName(model);
-                        appConfig = $@"<ProductInformation name=\""{appName}\"" build_version=\""{model.Version}\"" " +
-                                    $@"registry_version=\""{model.Version}\"" registry_localeID=\""{CultureInfo.CurrentCulture.LCID}\"" uptime=\""0\"" " +
+                        var appName = GetHostAppName();
+                        appConfig = $@"<ProductInformation name=\""{appName}\"" build_version=\""{DynamoModel.Version}\"" " +
+                                    $@"registry_version=\""{DynamoModel.Version}\"" registry_localeID=\""{CultureInfo.CurrentCulture.LCID}\"" uptime=\""0\"" " +
                                     $@"session_start_count=\""0\"" session_clean_close_count=\""0\"" current_session_length=\""0\"" />";
                     }
 
@@ -267,18 +267,14 @@ namespace Dynamo.Wpf.Utilities
             return false;
         }
 
-        internal static string GetHostAppName(DynamoModel model)
+        internal static string GetHostAppName()
         {
             //default to app name being process name, but prefer HostAnalyticsInfo.HostName
             //then legacy Model.HostName
             var appName = Process.GetCurrentProcess().ProcessName;
-            if (!string.IsNullOrEmpty(model.HostAnalyticsInfo.HostName))
+            if (!string.IsNullOrEmpty(DynamoModel.HostAnalyticsInfo.HostName))
             {
-                appName = model.HostAnalyticsInfo.HostName;
-            }
-            else if (!string.IsNullOrEmpty(model.HostName))
-            {
-                appName = model.HostName;
+                appName = DynamoModel.HostAnalyticsInfo.HostName;
             }
 
             return appName;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -486,7 +486,7 @@ namespace Dynamo.ViewModels
 
         public string Version
         {
-            get { return model.Version; }
+            get { return DynamoModel.Version; }
         }
 
         public string HostVersion
@@ -2762,7 +2762,7 @@ namespace Dynamo.ViewModels
         {
             OnRequestSaveImage(this, new ImageSaveEventArgs(parameters.ToString()));
 
-            Dynamo.Logging.Analytics.TrackCommandEvent("ImageCapture",
+            Dynamo.Logging.Analytics.TrackTaskCommandEvent("ImageCapture",
                 "NodeCount", CurrentSpace.Nodes.Count());
         }
 
@@ -3237,7 +3237,7 @@ namespace Dynamo.ViewModels
             {
                 BackgroundPreviewViewModel.ExportToSTL(_fileDialog.FileName, HomeSpace.Name);
 
-                Dynamo.Logging.Analytics.TrackCommandEvent("ExportToSTL");
+                Dynamo.Logging.Analytics.TrackTaskCommandEvent("ExportToSTL");
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1574,7 +1574,7 @@ namespace Dynamo.ViewModels
             Model.DoGraphAutoLayout();
             DynamoViewModel.RaiseCanExecuteUndoRedo();
 
-            Dynamo.Logging.Analytics.TrackCommandEvent("GraphLayout");
+            Dynamo.Logging.Analytics.TrackTaskCommandEvent("GraphLayout");
         }
 
         private static bool CanDoGraphAutoLayout(object o)
@@ -1646,7 +1646,7 @@ namespace Dynamo.ViewModels
                 DynamoViewModel.Model.CustomNodeManager.Collapse(selectedNodes,
                 selectedNotes, Model, DynamoModel.IsTestMode, args));
 
-            Dynamo.Logging.Analytics.TrackCommandEvent("NewCustomNode",
+            Dynamo.Logging.Analytics.TrackTaskCommandEvent("NewCustomNode",
                 "NodeCount", selectedNodes.Count());
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1049,7 +1049,7 @@ namespace Dynamo.ViewModels
             {
                 // HostAnalyticsInfo is not set when this is invoked??
                 //return this.dynamoViewModel.Model.HostAnalyticsInfo.HostName.Equals("Dynamo Revit");
-                var host = this.dynamoViewModel.Model.HostAnalyticsInfo.HostName;
+                var host = DynamoModel.HostAnalyticsInfo.HostName;
 
                 if (host != null)
                 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -882,7 +882,7 @@ namespace Dynamo.ViewModels
 
                 // Determine if there are any dependencies that are made with a newer version
                 // of Dynamo (this includes the root package)
-                var dynamoVersion = VersionUtilities.PartialParse(DynamoViewModel.Model.Version);
+                var dynamoVersion = VersionUtilities.PartialParse(DynamoModel.Version);
                 var futureDeps = newPackageHeaders.Where(dep => VersionUtilities.PartialParse(dep.engine_version) > dynamoVersion);
 
                 // If any of the required packages use a newer version of Dynamo, show a dialog to the user

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -211,7 +211,7 @@ namespace Dynamo.ViewModels
             request.Port.ListAtLevel = portInfo.Level;
 
             // Set host info
-            var hostName = string.IsNullOrEmpty(dynamoViewModel.Model.HostAnalyticsInfo.HostName) ? dynamoViewModel.Model.HostName : dynamoViewModel.Model.HostAnalyticsInfo.HostName;
+            var hostName = string.IsNullOrEmpty(DynamoModel.HostAnalyticsInfo.HostName) ? dynamoViewModel.Model.HostName : DynamoModel.HostAnalyticsInfo.HostName;
             var hostNameEnum = GetHostNameEnum(hostName);
 
             if (hostNameEnum != HostNames.None)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1428,7 +1428,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestRequestPackageManagerPublish(PublishPackageViewModel model)
         {
-            var cmd = Analytics.TrackCommandEvent("PublishPackage");
+            var cmd = Analytics.TrackTaskCommandEvent("PublishPackage");
             if (_pubPkgView == null)
             {
                 _pubPkgView = new PublishPackageView(model)
@@ -1436,7 +1436,7 @@ namespace Dynamo.Controls
                     Owner = this,
                     WindowStartupLocation = WindowStartupLocation.CenterOwner
                 };
-                _pubPkgView.Closed += (sender, args) => { _pubPkgView = null; cmd.Dispose(); };
+                _pubPkgView.Closed += (sender, args) => { _pubPkgView = null; Analytics.EndTaskCommandEvent(cmd) ; };
                 _pubPkgView.Show();
 
                 if (_pubPkgView.IsLoaded && IsLoaded) _pubPkgView.Owner = this;
@@ -1454,7 +1454,7 @@ namespace Dynamo.Controls
             if (!DisplayTermsOfUseForAcceptance())
                 return; // Terms of use not accepted.
 
-            var cmd = Analytics.TrackCommandEvent("SearchPackage");
+            var cmd = Analytics.TrackTaskCommandEvent("SearchPackage");
 
             // The package search view model is shared and can be shared by resources at the moment
             // If it hasn't been initialized yet, we do that here
@@ -1475,7 +1475,7 @@ namespace Dynamo.Controls
                     WindowStartupLocation = WindowStartupLocation.CenterOwner
                 };
 
-                _searchPkgsView.Closed += (sender, args) => { _searchPkgsView = null; cmd.Dispose(); };
+                _searchPkgsView.Closed += (sender, args) => { _searchPkgsView = null; Analytics.EndTaskCommandEvent(cmd); };
                 _searchPkgsView.Show();
 
                 if (_searchPkgsView.IsLoaded && IsLoaded) _searchPkgsView.Owner = this;
@@ -2202,7 +2202,7 @@ namespace Dynamo.Controls
             if (!DisplayTermsOfUseForAcceptance())
                 return; // Terms of use not accepted.
 
-            var cmd = Analytics.TrackCommandEvent("PackageManager");
+            var cmd = Analytics.TrackTaskCommandEvent("PackageManager");
             if (_pkgSearchVM == null)
             {
                 _pkgSearchVM = new PackageManagerSearchViewModel(dynamoViewModel.PackageManagerClientViewModel);
@@ -2221,7 +2221,7 @@ namespace Dynamo.Controls
                     WindowStartupLocation = WindowStartupLocation.CenterOwner
                 };
 
-                packageManagerWindow.Closed += (sender, args) => { packageManagerWindow = null; cmd.Dispose(); };
+                packageManagerWindow.Closed += (sender, args) => { packageManagerWindow = null; Analytics.EndTaskCommandEvent(cmd); };
                 packageManagerWindow.Show();
 
                 if (packageManagerWindow.IsLoaded && IsLoaded) packageManagerWindow.Owner = this;

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -36,7 +37,7 @@ namespace Dynamo.Wpf.Views
         // Used for tracking the manage package command event
         // This is not a command any more but we keep it
         // around in a compatible way for now
-        private IDisposable managePackageCommandEvent;
+        private Task<IDisposable> managePackageCommandEvent;
 
         //This list will be passed everytime that we create a new GroupStyle so the custom colors can remain
         internal ObservableCollection<CustomColorItem> stylesCustomColors;
@@ -367,7 +368,7 @@ namespace Dynamo.Wpf.Views
         {
             if (e.OriginalSource == e.Source)
             {
-                managePackageCommandEvent = Analytics.TrackCommandEvent("ManagePackage");
+                managePackageCommandEvent = Analytics.TrackTaskCommandEvent("ManagePackage");
             }
         }
 
@@ -375,7 +376,7 @@ namespace Dynamo.Wpf.Views
         {
             if (e.OriginalSource == e.Source)
             {
-                managePackageCommandEvent?.Dispose();
+                Analytics.EndTaskCommandEvent(managePackageCommandEvent);
             }
         }
 

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -183,7 +183,7 @@ namespace PythonNodeModelsWpf
         {
             try
             {
-                using (var cmd = Dynamo.Logging.Analytics.TrackCommandEvent("PythonEdit"))
+                using (var cmd = Dynamo.Logging.Analytics.TrackTaskCommandEvent("PythonEdit"))
                 {
                     if (editWindow != null)
                     {

--- a/src/NodeServices/Analytics.cs
+++ b/src/NodeServices/Analytics.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Threading.Tasks;
+using System.Xml.Linq;
 
 namespace Dynamo.Logging
 {
@@ -155,18 +157,60 @@ namespace Dynamo.Logging
         }
 
         /// <summary>
+        /// Creates a new task timed event with start state and tracks its start.
+        /// After the task is completed, disposing the returned event will record the event completion.
+        /// </summary>
+        /// <param name="category">Event category</param>
+        /// <param name="variable">Timed varaible name</param>
+        /// <param name="description">Event description</param>
+        /// <param name="value">A metric value associated with the event</param>
+        /// <returns>Task defined by an IDisposable event</returns>
+        public static Task<IDisposable> CreateTaskTimedEvent(Categories category, string variable, string description = "", int? value = null)
+        {
+            if (client == null)
+            {
+                return Task.FromResult(new Dummy() as IDisposable);
+            }
+
+            return client.CreateTaskTimedEvent(category, variable, description, value);
+        }
+
+        /// <summary>
         /// Creates a new command event of the given name. Start of the 
         /// command is tracked. When the event is disposed, it's completion is tracked.
         /// </summary>
         /// <param name="name">Command name</param>
         /// <param name="description">Event description</param>
         /// <param name="value">A metric value associated with the event</param>
-        /// <returns>Event as IDisposable</returns>
+        /// <returns>Task defined by an IDisposable event</returns>
         public static IDisposable TrackCommandEvent(string name, string description = "", int? value = null)
         {
             if (client == null) return new Dummy();
 
             return client.CreateCommandEvent(name, description, value);
+        }
+
+        /// <summary>
+        /// Creates a new command event task of the given name. Start of the 
+        /// command is tracked. When the task is completed and the event is disposed, it's completion is tracked.
+        /// </summary>
+        /// <param name="name">Command name</param>
+        /// <param name="description">Event description</param>
+        /// <param name="value">A metric value associated with the event</param>
+        /// <returns>Task defined by an IDisposable event</returns>
+        public static Task<IDisposable> TrackTaskCommandEvent(string name, string description = "", int? value = null)
+        {
+            if (client == null)
+            {                
+                return Task.FromResult(new Dummy() as IDisposable);
+            }
+
+            return client.CreateTaskCommandEvent(name, description, value);
+        }
+
+        public static void EndTaskCommandEvent(Task<IDisposable> taskEvent)
+        {
+            client?.EndEventTask(taskEvent);
         }
 
         /// <summary>
@@ -183,6 +227,25 @@ namespace Dynamo.Logging
             if (client == null) return new Dummy();
 
             return client.TrackFileOperationEvent(filepath, operation, size, description);
+        }
+
+        /// <summary>
+        /// Creates a new task file operation event and tracks the start of the event.
+        /// After the task is completed, disposing the returned event will record its completion.
+        /// </summary>
+        /// <param name="filepath">File path</param>
+        /// <param name="operation">File operation</param>
+        /// <param name="size">Size parameter</param>
+        /// <param name="description">Event description</param>
+        /// <returns>Task defined by an IDisposable event</returns>
+        public static Task<IDisposable> TrackTaskFileOperationEvent(string filepath, Actions operation, int size, string description = "")
+        {
+            if (client == null)
+            {
+                return Task.FromResult(new Dummy() as IDisposable);
+            }
+
+            return client.TrackTaskFileOperationEvent(filepath, operation, size, description);
         }
 
         /// <summary>

--- a/src/NodeServices/IAnalyticsClient.cs
+++ b/src/NodeServices/IAnalyticsClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Dynamo.Logging
 {
@@ -522,6 +523,17 @@ namespace Dynamo.Logging
         IDisposable CreateTimedEvent(Categories category, string variable, string description, int? value);
 
         /// <summary>
+        /// Creates a new task timed event with start state and tracks its start.
+        /// After task is compoleted, disposing the returnd event will record the event completion.
+        /// </summary>
+        /// <param name="category">Event category</param>
+        /// <param name="variable">Timed varaible name</param>
+        /// <param name="description">Event description</param>
+        /// <param name="value">A metric value associated with the event</param>
+        /// <returns>Event as IDisposable</returns>
+        Task<IDisposable> CreateTaskTimedEvent(Categories category, string variable, string description, int? value);
+
+        /// <summary>
         /// Creates a new command event of the given name. Start of the 
         /// command is tracked. When the event is disposed, it's completion is tracked.
         /// </summary>
@@ -530,6 +542,22 @@ namespace Dynamo.Logging
         /// <param name="value">A metric value associated with the event</param>
         /// <returns>Event as IDisposable</returns>
         IDisposable CreateCommandEvent(string name, string description, int? value);
+
+        /// <summary>
+        /// Creates a new task command event of the given name. Start of the 
+        /// command is tracked. When the task is completed and the event is disposed, it's completion is tracked.
+        /// </summary>
+        /// <param name="name">Command name</param>
+        /// <param name="description">Event description</param>
+        /// <param name="value">A metric value associated with the event</param>
+        /// <returns>Event as IDisposable</returns>
+        Task<IDisposable> CreateTaskCommandEvent(string name, string description, int? value);
+
+        /// <summary>
+        /// Waits for the given task to end so that it can dispose the event and
+        /// complete the tracking.
+        /// </summary>
+        void EndEventTask(Task<IDisposable> taskToEnd);
 
         /// <summary>
         /// Creates a new file operation event and tracks the start of the event.
@@ -541,6 +569,17 @@ namespace Dynamo.Logging
         /// <param name="description">Event description</param>
         /// <returns>Event as IDisposable</returns>
         IDisposable TrackFileOperationEvent(string filepath, Actions operation, int size, string description);
+
+        /// <summary>
+        /// Creates a new file operation task event and tracks the start of the event.
+        /// After the task is completed, disposing the returned event will record its completion.
+        /// </summary>
+        /// <param name="filepath">File path</param>
+        /// <param name="operation">File operation</param>
+        /// <param name="size">Size parameter</param>
+        /// <param name="description">Event description</param>
+        /// <returns>Event as IDisposable</returns>
+        Task<IDisposable> TrackTaskFileOperationEvent(string filepath, Actions operation, int size, string description);
 
         /// <summary>
         /// Logs usage data

--- a/test/DynamoCoreTests/AnalyticsTests.cs
+++ b/test/DynamoCoreTests/AnalyticsTests.cs
@@ -144,7 +144,7 @@ namespace Dynamo.Tests
             var session = new Mock<IAnalyticsSession>();
             session.Setup(s => s.UserId).Returns("DynamoTestUser");
             session.Setup(s => s.SessionId).Returns("UniqueSession");
-            session.Setup(s => s.Start(It.IsAny<DynamoModel>())).Callback(SetupServices);
+            session.Setup(s => s.Start()).Callback(SetupServices);
             return session.Object;
         }
 

--- a/test/DynamoCoreWpfTests/CrashReportingTests.cs
+++ b/test/DynamoCoreWpfTests/CrashReportingTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Windows.Threading;
 using Dynamo.Models;
@@ -196,17 +196,17 @@ namespace Dynamo.Tests
         public void TestAppNameSentToCER()
         {
             CurrentDynamoModel.HostName = null;
-            var name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
+            var name = CrashReportTool.GetHostAppName();
             //if both hostname and hostinfo.hostname are null, then use proc name.
             Assert.True(name.Contains("testhost") ||  name.Contains("nunit-agent"));
             CurrentDynamoModel.HostName = "dynamotestmock";
-            name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
+            name = CrashReportTool.GetHostAppName();
             //use hostname over proc name
             Assert.AreEqual(CurrentDynamoModel.HostName, name);
-            CurrentDynamoModel.HostAnalyticsInfo = new  HostAnalyticsInfo(){HostName = "123"};
-            name = CrashReportTool.GetHostAppName(CurrentDynamoModel);
+            DynamoModel.HostAnalyticsInfo = new  HostAnalyticsInfo(){HostName = "123"};
+            name = CrashReportTool.GetHostAppName();
             //prefer hostinfo.hostname over others.
-            Assert.AreEqual(CurrentDynamoModel.HostAnalyticsInfo.HostName, name);
+            Assert.AreEqual(DynamoModel.HostAnalyticsInfo.HostName, name);
         }
     }
 }

--- a/test/Libraries/CommandLineTests/CommandLineTests.cs
+++ b/test/Libraries/CommandLineTests/CommandLineTests.cs
@@ -95,7 +95,7 @@ namespace Dynamo.Tests
             string commandstring = $"-o {openpath} --HostName {hostName}";
 
             runner.Run(CommandstringToArgs(commandstring));
-            Assert.AreEqual(this.CurrentDynamoModel.HostAnalyticsInfo.HostName, "DynamoFormIt");
+            Assert.AreEqual(Dynamo.Models.DynamoModel.HostAnalyticsInfo.HostName, "DynamoFormIt");
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace Dynamo.Tests
             string commandstring = $"-o {openpath} -p {parentId}";
 
             runner.Run(CommandstringToArgs(commandstring));
-            Assert.AreEqual(this.CurrentDynamoModel.HostAnalyticsInfo.ParentId, "RVT&2022&MUI64&22.0.2.392");
+            Assert.AreEqual(Dynamo.Models.DynamoModel.HostAnalyticsInfo.ParentId, "RVT&2022&MUI64&22.0.2.392");
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace Dynamo.Tests
             string commandstring = $"-o {openpath} -s {sessionId}";
 
             runner.Run(CommandstringToArgs(commandstring));
-            Assert.AreEqual(this.CurrentDynamoModel.HostAnalyticsInfo.SessionId, "ABCDEFG");
+            Assert.AreEqual(Dynamo.Models.DynamoModel.HostAnalyticsInfo.SessionId, "ABCDEFG");
         }
 
         [Test]


### PR DESCRIPTION
### Purpose
Remove Analytics engine dependency on DynamoModel and perform all analytics operations on worker threads.
Twill give us a boos in performance of about 5-7% in startup time and avoid any slowness in ADP systems overall in all usage contexts.
For consumers like Dynamo Player and Generative Design is even more valuable because there is no need to instantiate a Dynamo model anymore and worry about the proper execution thread ( along with other changes Dynamo Player and GD will start instantly ).

There are some API braking changes but they are small and can be mediated in a different way if really needed (some are noted to be obsolete in 3.0 ).

DynamoModel.HostAnalyticsInfo
DynamoModel.Version 
DynamoModel.AppVersion
The above Dynamo utilities either don't belong there or can be made static. For the moment I chose to make them static but we can do something else.

No issues observed so far with the new approach.
The PR is actually intended for master will move it there soon... but could use some feedback in the meantime.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Reviewers
@DynamoDS/dynamo 

### FYIs
@jnealb 
