### PR TITLE
WIP Improve keydown events binding between dynamo and webview for library

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -357,13 +357,43 @@ namespace Dynamo.LibraryViewExtensionWebView2
             LogToDynamoConsole(msg);
         }
 
+        /// <summary>
+        /// Collect the main and modifier key from KeyEventArgs in order to pass
+        /// that data to eventDispatcher (located in library.html) which is responsible
+        /// for binding KeyDown events between dynamo and webview instances
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        ///
+
+        // This enum is for matching the modifier keys between C# and javaScript
+        enum ModifiersJS
+        {
+            none = 0,
+            altKey = 1,
+            ctrlKey = 2,
+            shiftKey = 4
+        }
+
+        // This enum is for define the events to be tracked
+        enum EventsTracked
+        {
+            Delete,
+            C
+        }
+
         private void Browser_KeyDown(object sender, KeyEventArgs e)
 
         {
-            if (e.Key == Key.Delete)
+            if (!Enum.IsDefined(typeof(EventsTracked), e.Key.ToString())) return;
+
+            var synteticEventData = new Dictionary<string, string>
             {
-                _ = ExecuteScriptFunctionAsync(browser, "eventDispatcher");
-            }
+                [Enum.GetName(typeof(ModifiersJS), e.KeyboardDevice.Modifiers).ToString()] = "true",
+                ["key"] = e.Key.ToString()
+            };
+
+            _ = ExecuteScriptFunctionAsync(browser, "eventDispatcher", synteticEventData);
         }
 
 

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -379,21 +379,23 @@ namespace Dynamo.LibraryViewExtensionWebView2
         enum EventsTracked
         {
             Delete,
-            C
+            C,
+            V
         }
 
         private void Browser_KeyDown(object sender, KeyEventArgs e)
 
         {
+
             if (!Enum.IsDefined(typeof(EventsTracked), e.Key.ToString())) return;
 
             var synteticEventData = new Dictionary<string, string>
             {
-                [Enum.GetName(typeof(ModifiersJS), e.KeyboardDevice.Modifiers).ToString()] = "true",
+                [Enum.GetName(typeof(ModifiersJS), e.KeyboardDevice.Modifiers)] = "true",
                 ["key"] = e.Key.ToString()
             };
 
-            _ = ExecuteScriptFunctionAsync(browser, "eventDispatcher", synteticEventData);
+            _= ExecuteScriptFunctionAsync(browser, "eventDispatcher", synteticEventData);
         }
 
 

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -389,16 +389,15 @@
 
         //This function will be dispatching javaScript keydown events based on Dynamo keydown events
         function eventDispatcher(eventKeyData) {
-
             const kbEvent = new KeyboardEvent('keydown', {
                 bubbles: true,
                 cancelable: true,
                 ...eventKeyData
             });
-
+             
             document.dispatchEvent(kbEvent);
         }
-    </script>
+        </script>
 
 </body>
 

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -387,13 +387,14 @@
              window.chrome.webview.postMessage(JSON.stringify({ "func": "ResizedEvent", "data": "" }));
         }
 
-        function eventDispatcher() {
+        //This function will be dispatching javaScript keydown events based on Dynamo keydown events
+        function eventDispatcher(eventKeyData) {
 
             const kbEvent = new KeyboardEvent('keydown', {
                 bubbles: true,
                 cancelable: true,
-                key: 'Delete',
-             });
+                ...eventKeyData
+            });
 
             document.dispatchEvent(kbEvent);
         }


### PR DESCRIPTION
### Purpose

This is an alternative approach for keydown events management within library, binding events between Dynamo and webview.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

This approach allow us to bind keyDown events between Dynamo and `webview` component without exposing a method through global object (window), just creating an event programmatically and dispatching it using JavaScript `dispatchEvent` method.

### Reviewers
@QilongTang 

### FYIs

@RobertGlobant20 