### PR TITLE
pm bring back toast notifications 

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -93,8 +93,56 @@
     </UserControl.Resources>
 
     <Grid Background="Transparent">
+        <Grid.Resources>            
+            <!--  Local style for ListBoxItems, used in the package search results  -->
+            <Style TargetType="{x:Type ListBoxItem}">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                            <Border
+                                x:Name="Border"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                SnapsToDevicePixels="true">
+                                <ContentPresenter
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Border>
+                            <!--  Overwriting default WPF triggers to stop ListBoxItems appearing with default styling  -->
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsSelected" Value="true">
+                                    <Setter TargetName="Border" Property="Background" Value="Transparent" />
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                                </Trigger>
+                                <MultiTrigger>
+                                    <MultiTrigger.Conditions>
+                                        <Condition Property="IsSelected" Value="true" />
+                                        <Condition Property="Selector.IsSelectionActive" Value="false" />
+                                    </MultiTrigger.Conditions>
+                                    <Setter TargetName="Border" Property="Background" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightBrushKey}}" />
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}}" />
+                                </MultiTrigger>
+                                <Trigger Property="IsEnabled" Value="false">
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="Transparent" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <ListBox Name="myPackagesListBox"
@@ -577,6 +625,325 @@
                                    VerticalAlignment="Bottom"
                                    Fill="{StaticResource DarkMidGreyBrush}" />
 
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <!--  Download bar: A stacking list of (up to 3) most-recently downloaded packages. Appears when the user installs a package.  -->
+        <ListBox
+            Name="DownloadsListBox"
+            Grid.Row="1"
+            Margin="0,5,0,0"
+            Background="Transparent"
+            BorderThickness="0"
+            IsHitTestVisible="True"
+            ItemsSource="{Binding Path=Downloads, UpdateSourceTrigger=PropertyChanged}"
+            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+            ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <!--  Ensure the stackpanel fills bottom-to-top  -->
+                        <VirtualizingStackPanel VerticalAlignment="Bottom" />
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+                <ListBox.ItemTemplate>
+
+                    <!--  Template for displaying downloaded package details to the user  -->
+                    <DataTemplate>
+                        <Grid>
+                            <!--  Contains everything except for the download status flag  -->
+                            <Border
+                            Name="mainBody"
+                            Padding="15,10"
+                            Background="#4E4E4E"
+                            CornerRadius="3">
+                                <Grid Height="40">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="23" />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <!--  Download Icon  -->
+                                    <Image
+                                    Name="downloadCompletedIcon"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="0"
+                                    Width="16"
+                                    Height="16"
+                                    VerticalAlignment="Center"
+                                    Margin="0 0 0 14"
+                                    Source="/DynamoCoreWpf;component/UI/Images/icon-shape.png"
+                                    Visibility="Collapsed" />
+                                    <Image
+                                    Name="downloadingIcon"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="0"
+                                    Width="16"
+                                    Height="16"
+                                    VerticalAlignment="Center"
+                                    Margin="0 0 0 14"
+                                    RenderTransformOrigin="0.5,0.5"
+                                    Source="/DynamoCoreWpf;component/UI/Images/Progress circle.png"
+                                    Visibility="Visible">
+                                        <Image.RenderTransform>
+                                            <RotateTransform x:Name="AnimatedRotateTransform" Angle="0" />
+                                        </Image.RenderTransform>
+                                        <Image.Triggers>
+                                            <EventTrigger RoutedEvent="Window.Loaded">
+                                                <BeginStoryboard>
+                                                    <Storyboard>
+                                                        <DoubleAnimation
+                                                        By="10"
+                                                        FillBehavior="Stop"
+                                                        RepeatBehavior="Forever"
+                                                        Storyboard.TargetName="AnimatedRotateTransform"
+                                                        Storyboard.TargetProperty="Angle"
+                                                        To="360"
+                                                        Duration="0:0:0.5" />
+                                                    </Storyboard>
+                                                </BeginStoryboard>
+                                            </EventTrigger>
+                                        </Image.Triggers>
+                                    </Image>
+
+                                    <!--  Package Name  -->
+                                    <TextBlock
+                                    Name="name"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Margin="10,0,0,0"
+                                    VerticalAlignment="Bottom"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="14"
+                                    Foreground="#F5F5F5"
+                                    Text="{Binding Path=Name}"
+                                    TextTrimming="CharacterEllipsis" />
+
+                                    <!--  Error Message  -->
+                                    <TextBlock
+                                    Name="error"
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    Margin="10,0,0,0"
+                                    VerticalAlignment="Top"
+                                    FontSize="10"
+                                    Foreground="White"
+                                    Text="{Binding Path=ErrorString}"
+                                    TextTrimming="CharacterEllipsis" />
+
+                                    <!--  Download State  -->
+                                    <TextBlock
+                                    Name="downloadState"
+                                    Grid.Row="0"
+                                    Grid.Column="2"
+                                    Margin="0,0,0,2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Bottom"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="10"
+                                    Foreground="#F5F5F5"
+                                    Text="{Binding Path=DownloadState, Converter={StaticResource PackageDownloadStateToStringConverter}}" />
+
+                                    <!--  Version  -->
+                                    <TextBlock
+                                    Name="version"
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    VerticalAlignment="Top"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="10"
+                                    Foreground="#F5F5F5"
+                                    Text="{Binding Path=VersionName}" />
+                                    <Button
+                                    Name="closeDownloadToastButton"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="3"
+                                    Width="16"
+                                    Height="16"
+                                    Margin="10,0,0,0"
+                                    Background="{StaticResource PrimaryCharcoal300Brush}"
+                                    BorderThickness="0"
+                                    Click="CloseToastButton_OnClick"
+                                    DockPanel.Dock="Right"
+                                    Style="{StaticResource CloseButtonStyle}" />
+                                </Grid>
+                            </Border>
+
+                            <!--  The download status flag, which changes colour to reflect the downloadState  -->
+                            <Border
+                            Name="downloadStatusFlag"
+                            Width="3"
+                            HorizontalAlignment="Left"
+                            Background="Transparent"
+                            CornerRadius="3,0,0,3" />
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="{x:Static p:Resources.PackageStateUnknown}">
+                                <DataTrigger.Setters>
+                                    <Setter TargetName="downloadStatusFlag" Property="Background" Value="#CC000000" />
+                                </DataTrigger.Setters>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="{x:Static p:Resources.PackageDownloadStateDownloaded}">
+                                <DataTrigger.Setters>
+                                    <Setter TargetName="downloadStatusFlag" Property="Background" Value="Gray" />
+                                </DataTrigger.Setters>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="{x:Static p:Resources.PackageDownloadStateDownloading}">
+                                <DataTrigger.Setters>
+                                    <Setter TargetName="downloadStatusFlag" Property="Background" Value="#0696D7" />
+                                </DataTrigger.Setters>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="{x:Static p:Resources.PackageDownloadStateError}">
+                                <DataTrigger.Setters>
+                                    <Setter TargetName="downloadStatusFlag" Property="Background" Value="#DD2222" />
+                                    <Setter TargetName="downloadCompletedIcon" Property="Source" Value="/DynamoCoreWpf;component/UI/Images/package_error.png" />
+                                </DataTrigger.Setters>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                <DataTrigger.Setters>
+                                    <Setter TargetName="downloadStatusFlag" Property="Background" Value="#6A9728" />
+                                    <Setter TargetName="downloadCompletedIcon" Property="Visibility" Value="Visible" />
+                                    <Setter TargetName="downloadingIcon" Property="Visibility" Value="Collapsed" />
+                                </DataTrigger.Setters>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="{x:Static p:Resources.PackageDownloadStateInstalling}">
+                                <DataTrigger.Setters>
+                                    <Setter TargetName="downloadStatusFlag" Property="Background" Value="#0696D7" />
+                                </DataTrigger.Setters>
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+        <!--  Infected status bar: A stacking list of (up to 3) most-recently published packages which were infected. Appears when the user opens package manager search window.  -->
+        <ListBox
+            Name="InfectedListBox"
+            Grid.Row="2"
+            Margin="0,5,0,0"
+            Background="Transparent"
+            BorderThickness="0"
+            IsHitTestVisible="True"
+            ItemsSource="{Binding Path=InfectedPackages, UpdateSourceTrigger=PropertyChanged}"
+            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+            ScrollViewer.VerticalScrollBarVisibility="Disabled">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <!--  Ensure the stackpanel fills bottom-to-top  -->
+                    <VirtualizingStackPanel VerticalAlignment="Bottom" />
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+
+                <!--  Template for displaying downloaded package details to the user  -->
+                <DataTemplate>
+                    <Grid>
+                        <!--  Contains everything except for the download status flag  -->
+                        <Border
+                            Name="imainBody"
+                            Padding="15,10"
+                            Background="#4E4E4E"
+                            CornerRadius="3">
+                            <Grid Height="40">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="23" />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <Image
+                                    Name="downloadCompletedIcon"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="0"
+                                    Width="16"
+                                    Height="16"
+                                    VerticalAlignment="Center"
+                                    Margin="0 0 0 14"   
+                                    Source="/DynamoCoreWpf;component/UI/Images/package_error.png"
+                                    Visibility="Visible" />
+                                <!--  Package Name  -->
+                                <TextBlock
+                                    Name="iname"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Margin="10,0,0,0"
+                                    VerticalAlignment="Bottom"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="14"
+                                    Foreground="#F5F5F5"
+                                    Text="{Binding Path=InfectedPackageName}"
+                                    TextTrimming="CharacterEllipsis" />
+
+                                <TextBlock
+                                    Name="imsg"
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    Margin="10,0,0,0"
+                                    VerticalAlignment="Top"
+                                    FontSize="10"
+                                    Foreground="White"
+                                    Text="{x:Static p:Resources.InfectedPackageMessageString}"
+                                    TextTrimming="CharacterEllipsis" />
+
+                                <!--  Upload State  -->
+                                <TextBlock
+                                    Name="icreateDate"
+                                    Grid.Row="0"
+                                    Grid.Column="2"
+                                    Margin="0,0,0,2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Bottom"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="10"
+                                    Foreground="#F5F5F5"
+                                    Text="{x:Static p:Resources.InfectedPackageErrorString}" />
+
+                                <!--  Version  -->
+                                <TextBlock
+                                    Name="iversion"
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    VerticalAlignment="Top"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="10"
+                                    Foreground="#F5F5F5"
+                                    Text="{Binding Path=InfectedPackageVersion}" />
+                                <Button
+                                    Name="closeiToastButton"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="3"
+                                    Width="16"
+                                    Height="16"
+                                    Margin="10,0,0,0"
+                                    Background="{StaticResource PrimaryCharcoal300Brush}"
+                                    BorderThickness="0"
+                                    Click="CloseToastButton_OnClick"
+                                    DockPanel.Dock="Right"
+                                    Style="{StaticResource CloseButtonStyle}" />
+                            </Grid>
+                        </Border>
+                        <Border
+                            Name="idownloadStatusFlag"
+                            Width="3"
+                            HorizontalAlignment="Left"
+                            Background="LightCoral"
+                            CornerRadius="3,0,0,3" />
                     </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
@@ -129,5 +129,30 @@ namespace Dynamo.PackageManager.UI
             cm.PlacementTarget = sender as Button;
             cm.IsOpen = true;
         }
+
+
+
+        /// <summary>
+        /// Fires when the user clicks the 'X' button to dismiss a package toast notification.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void CloseToastButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            var PkgSearchVM = this.DataContext as PackageManagerSearchViewModel;
+            if (PkgSearchVM != null) { return; }
+
+            Button button = sender as Button;
+
+            if (button.DataContext is PackageDownloadHandle packageDownloadHandle)
+            {
+                PkgSearchVM.ClearToastNotificationCommand.Execute(packageDownloadHandle);
+            }
+            else if (button.DataContext is PackageManagerSearchElement packageSearchElement)
+            {
+                PkgSearchVM.ClearToastNotificationCommand.Execute(packageSearchElement);
+            }
+            return;
+        }
     }
 }


### PR DESCRIPTION
### Purpose

A small PR part of the package manager work. Reinstates the toast notification prompts informing the user of the status of a package download. This functionality existed before, and is just being brought back into the new UI unchanged but for a few minor design tweaks as per the recent design guides.

#### Visual changes
![toast notifications](https://github.com/DynamoDS/Dynamo/assets/5354594/c7f8f49e-c238-43f6-b162-425f5b996133)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- when downloading package, use will get notified with a short status message in the bottom-hand side of the UI
- this message existed before, it is now brought back in the UI
- slight visual update to the toast notification as per Figma

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
