### PR TITLE
DYN-6308 : prioritize json over xaml

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -684,18 +684,18 @@ namespace Dynamo.Core
             Exception ex;
             try
             {
-                if (DynamoUtilities.PathHelper.isValidXML(path, out xmlDoc, out ex))
+                if (DynamoUtilities.PathHelper.isValidJson(path, out jsonDoc, out ex))
                 {
-                    if (!WorkspaceInfo.FromXmlDocument(xmlDoc, path, isTestMode, false, AsLogger(), out header))
+                    if (!WorkspaceInfo.FromJsonDocument(jsonDoc, path, isTestMode, false, AsLogger(), out header))
                     {
                         Log(String.Format(Properties.Resources.FailedToLoadHeader, path));
                         info = null;
                         return false;
                     }
                 }
-                else if (DynamoUtilities.PathHelper.isValidJson(path, out jsonDoc, out ex))
+                else if (DynamoUtilities.PathHelper.isValidXML(path, out xmlDoc, out ex))
                 {
-                    if (!WorkspaceInfo.FromJsonDocument(jsonDoc, path, isTestMode, false, AsLogger(), out header))
+                    if (!WorkspaceInfo.FromXmlDocument(xmlDoc, path, isTestMode, false, AsLogger(), out header))
                     {
                         Log(String.Format(Properties.Resources.FailedToLoadHeader, path));
                         info = null;
@@ -854,7 +854,14 @@ namespace Dynamo.Core
                 XmlDocument xmlDoc;
                 string strInput;
                 Exception ex;
-                if (DynamoUtilities.PathHelper.isValidXML(path, out xmlDoc, out ex))
+
+                if (DynamoUtilities.PathHelper.isValidJson(path, out strInput, out ex))
+                {
+                    WorkspaceInfo.FromJsonDocument(strInput, path, isTestMode, false, AsLogger(), out info);
+                    info.ID = functionId.ToString();
+                    return InitializeCustomNode(info, null, out workspace);
+                }
+                else if (DynamoUtilities.PathHelper.isValidXML(path, out xmlDoc, out ex))
                 {
                     if (WorkspaceInfo.FromXmlDocument(xmlDoc, path, isTestMode, false, AsLogger(), out info))
                     {
@@ -864,13 +871,6 @@ namespace Dynamo.Core
                             return InitializeCustomNode(info, xmlDoc, out workspace);
                         }
                     }
-                }
-                else if (DynamoUtilities.PathHelper.isValidJson(path, out strInput, out ex))
-                {
-                    // TODO: Skip Json migration for now
-                    WorkspaceInfo.FromJsonDocument(strInput, path, isTestMode, false, AsLogger(), out info);
-                    info.ID = functionId.ToString();
-                    return InitializeCustomNode(info, null, out workspace);
                 }
                 else throw ex;
                 Log(string.Format(Properties.Resources.CustomNodeCouldNotBeInitialized, customNodeInfo.Name));

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1947,11 +1947,12 @@ namespace Dynamo.Models
         /// execution mode specified in the file and set manual mode</param>
         public void OpenFileFromPath(string filePath, bool forceManualExecutionMode = false)
         {
-            XmlDocument xmlDoc;
-            Exception ex;
-            if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
+            
+            Exception ex;            
+            string fileContents;
+            if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
             {
-                OpenXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
+                OpenJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
                 return;
             }
             else
@@ -1961,24 +1962,20 @@ namespace Dynamo.Models
                 {
                     throw ex;
                 }
-                if (ex is System.Xml.XmlException)
-                {
-                    // XML opening failure can indicate that this file is corrupted XML or Json
-                    string fileContents;
 
-                    if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
-                    {
-                        OpenJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
-                        return;
-                    }
-                    else
-                    {
-                        // When Json opening also failed, either this file is corrupted or there
-                        // are other kind of failures related to Json de-serialization
-                        throw ex;
-                    }
+                XmlDocument xmlDoc;
+
+                // When Json opening failed, either this file is corrupted or file might be XML
+                if (ex is JsonReaderException && DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
+                {
+                    OpenXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
+                    return;
                 }
-            }
+                else
+                {
+                    throw ex;
+                }                
+            }            
         }
 
         /// <summary>
@@ -1988,11 +1985,12 @@ namespace Dynamo.Models
         /// <param name="forceManualExecutionMode"></param>
         public void InsertFileFromPath(string filePath, bool forceManualExecutionMode = false)
         {
-            XmlDocument xmlDoc;
             Exception ex;
-            if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
+            string fileContents;
+
+            if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
             {
-                InsertXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
+                InsertJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
                 return;
             }
             else
@@ -2002,24 +2000,20 @@ namespace Dynamo.Models
                 {
                     throw ex;
                 }
-                if (ex is System.Xml.XmlException)
-                {
-                    // XML opening failure can indicate that this file is corrupted XML or Json
-                    string fileContents;
 
-                    if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents, out ex))
+                if (ex is JsonReaderException)
+                {
+                    XmlDocument xmlDoc;
+                    if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc, out ex))
                     {
-                        InsertJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
+                        InsertXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
                         return;
                     }
-                    else
-                    {
-                        // When Json opening also failed, either this file is corrupted or there
-                        // are other kind of failures related to Json de-serialization
-                        throw ex;
-                    }
                 }
-
+                else
+                {
+                    throw ex;
+                }
             }
         }
 

--- a/src/Tools/NodeDocumentationMarkdownGenerator/MdFileInfo.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/MdFileInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Xml;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
@@ -73,13 +73,13 @@ namespace NodeDocumentationMarkdownGenerator
             WorkspaceInfo header = null;
             ILogger log = new DummyConsoleLogger();
 
-            if (DynamoUtilities.PathHelper.isValidXML(path, out XmlDocument xmlDoc, out Exception ex))
-            {
-                WorkspaceInfo.FromXmlDocument(xmlDoc, path, true, false, log, out header);
-            }
-            else if (DynamoUtilities.PathHelper.isValidJson(path, out string jsonDoc, out ex))
+            if (DynamoUtilities.PathHelper.isValidJson(path, out string jsonDoc, out Exception ex))
             {
                 WorkspaceInfo.FromJsonDocument(jsonDoc, path, true, false, log, out header);
+            }
+            else if (DynamoUtilities.PathHelper.isValidXML(path, out XmlDocument xmlDoc, out ex))
+            {
+                WorkspaceInfo.FromXmlDocument(xmlDoc, path, true, false, log, out header);
             }
             else throw ex;
 


### PR DESCRIPTION
### Purpose
Prioritize json loading over xaml loading.
A package with 100s of custom nodes (which is not that rare) will throw 100s of exceptions during loading.
This is a drag on performance and also pollutes the output window or log files.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB


