### PR TITLE
Dyn-5473 workspace toolbar

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -137,15 +137,17 @@
                 <Menu HorizontalAlignment="Right"
                       Style="{StaticResource MainMenu}"
                       Margin="0,0,10,0"
-                      IsMainMenu="True">
+                      IsMainMenu="True"
+                      Name="RightMenu">
                     <MenuItem Name="loginMenu" Margin="0,-3,-10,0">
                         <MenuItem.Header>
-                            <Button Name="LoginButton" Click="LoginButton_OnClick" Foreground="#DCDCDC" Padding="5,0,5,0">
+                            <Button Name="LoginButton" Click="LoginButton_OnClick" Foreground="#DCDCDC"
+                                    >
                                 <StackPanel FlowDirection="LeftToRight" Orientation="Horizontal">
 
                                     <Image Source="/DynamoCoreWpf;component/UI/Images/Profile_48px.png" Width="16" Height ="16"></Image>
 
-                                    <TextBlock Name="txtSignIn" Padding="10,5,5,5">
+                                    <TextBlock Name="txtSignIn" Padding="10,5,5,5" Visibility="{Binding ViewButtonsText, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                         <TextBlock.Style>
                                             <Style TargetType="{x:Type TextBlock}">
                                                 <Setter Property="Text" Value="{x:Static p:Resources.SignInButtonText}" />
@@ -237,7 +239,8 @@
                                            VerticalAlignment="Center"
                                            Margin="10 0 0 0"
                                            Foreground="#DCDCDC"
-                                           FontFamily="{StaticResource ArtifaktElementRegular}">
+                                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                                           Visibility="{Binding ViewButtonsText, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                 </TextBlock>
                             </StackPanel>
                         </MenuItem.Header>

--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -147,7 +147,7 @@
 
                                     <Image Source="/DynamoCoreWpf;component/UI/Images/Profile_48px.png" Width="16" Height ="16"></Image>
 
-                                    <TextBlock Name="txtSignIn" Padding="10,5,5,5" Visibility="{Binding ViewButtonsText, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock Name="txtSignIn" Padding="10,5,5,5" Visibility="{Binding ShowMenuItemText, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                         <TextBlock.Style>
                                             <Style TargetType="{x:Type TextBlock}">
                                                 <Setter Property="Text" Value="{x:Static p:Resources.SignInButtonText}" />
@@ -240,7 +240,7 @@
                                            Margin="10 0 0 0"
                                            Foreground="#DCDCDC"
                                            FontFamily="{StaticResource ArtifaktElementRegular}"
-                                           Visibility="{Binding ViewButtonsText, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                           Visibility="{Binding ShowMenuItemText, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                 </TextBlock>
                             </StackPanel>
                         </MenuItem.Header>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -831,11 +831,11 @@ namespace Dynamo.ViewModels
         }
 
         internal event EventHandler WindowRezised;
-        internal void OnWindowResized(object lessthan1000)
+        internal void OnWindowResized(object underThreshold)
         {
             if(WindowRezised != null)
             {
-                WindowRezised(lessthan1000, new EventArgs());
+                WindowRezised(underThreshold, new EventArgs());
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -830,11 +830,19 @@ namespace Dynamo.ViewModels
             }
         }
 
+        internal event EventHandler WindowRezised;
+        internal void OnWindowResized(object lessthan1000)
+        {
+            if(WindowRezised != null)
+            {
+                WindowRezised(lessthan1000, new EventArgs());
+            }
+        }
 
         internal event EventHandler PreferencesWindowChanged;
         internal void OnPreferencesWindowChanged(object preferencesView)
         {
-            if(PreferencesWindowChanged != null)
+            if (PreferencesWindowChanged != null)
             {
                 PreferencesWindowChanged(preferencesView, new EventArgs());
             }
@@ -2669,6 +2677,7 @@ namespace Dynamo.ViewModels
                 this.ShowStartPage = (Model.Workspaces.Count() <= 1);
                 RunSettings.ForceBlockRun = false;
                 OnEnableShortcutBarItems(false);
+                OnRequestCloseHomeWorkSpace();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
@@ -162,6 +162,15 @@ namespace Dynamo.ViewModels
             }
         }
 
+        internal event Action RequestCloseHomeWorkSpace;
+        private void OnRequestCloseHomeWorkSpace()
+        {
+            if (RequestCloseHomeWorkSpace != null)
+            {
+                RequestCloseHomeWorkSpace();
+            }
+        }
+
         internal event Action <object> RequestExportWorkSpaceAsImage;
         private void OnRequestExportWorkSpaceAsImage(object parameter)
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
@@ -1,6 +1,7 @@
 using Dynamo.Core;
 using Dynamo.UI.Commands;
 using Dynamo.ViewModels;
+using System;
 
 namespace Dynamo.Wpf.ViewModels.Core
 {
@@ -15,22 +16,24 @@ namespace Dynamo.Wpf.ViewModels.Core
         private AuthenticationManager authManager;
 
         private int notificationsNumber;
-        private bool viewButtonsText;
+        private bool showMenuItemText;
+        public readonly DynamoViewModel DynamoViewModel;
 
         public ShortcutToolbarViewModel(DynamoViewModel dynamoViewModel)
         {
+            this.DynamoViewModel = dynamoViewModel;
             NotificationsNumber = 0;
             authManager = dynamoViewModel.Model.AuthenticationManager;
             ValidateWorkSpaceBeforeToExportAsImageCommand = new DelegateCommand(dynamoViewModel.ValidateWorkSpaceBeforeToExportAsImage);
             SignOutCommand = new DelegateCommand(authManager.ToggleLoginState);
-            authManager.LoginStateChanged += (o) => { RaisePropertyChanged(nameof(LoginState)); };            
-            dynamoViewModel.WindowRezised += DynamoViewModel_WindowRezised;
-            ViewButtonsText = true;
+            authManager.LoginStateChanged += (o) => { RaisePropertyChanged(nameof(LoginState)); };
+            this.DynamoViewModel.WindowRezised += OnDynamoViewModelWindowRezised;
+            ShowMenuItemText = true;
         }
 
-        private void DynamoViewModel_WindowRezised(object sender, System.EventArgs e)
+        private void OnDynamoViewModelWindowRezised(object sender, System.EventArgs e)
         {
-            ViewButtonsText = !(bool)sender;
+            if (sender is Boolean) ShowMenuItemText = !(bool)sender;                
         }
 
         /// <summary>
@@ -79,17 +82,23 @@ namespace Dynamo.Wpf.ViewModels.Core
             }
         }
 
-        public bool ViewButtonsText
+        public bool ShowMenuItemText
         {
             get
             {
-                return viewButtonsText;
+                return showMenuItemText;
             }
             set
             {
-                viewButtonsText = value;
-                RaisePropertyChanged(nameof(ViewButtonsText));
+                showMenuItemText = value;
+                RaisePropertyChanged(nameof(ShowMenuItemText));
             }
+        }
+
+        public override void Dispose()
+        {
+            this.DynamoViewModel.WindowRezised -= OnDynamoViewModelWindowRezised;
+            base.Dispose();
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
@@ -15,6 +15,7 @@ namespace Dynamo.Wpf.ViewModels.Core
         private AuthenticationManager authManager;
 
         private int notificationsNumber;
+        private bool viewButtonsText;
 
         public ShortcutToolbarViewModel(DynamoViewModel dynamoViewModel)
         {
@@ -22,7 +23,14 @@ namespace Dynamo.Wpf.ViewModels.Core
             authManager = dynamoViewModel.Model.AuthenticationManager;
             ValidateWorkSpaceBeforeToExportAsImageCommand = new DelegateCommand(dynamoViewModel.ValidateWorkSpaceBeforeToExportAsImage);
             SignOutCommand = new DelegateCommand(authManager.ToggleLoginState);
-            authManager.LoginStateChanged += (o) => { RaisePropertyChanged(nameof(LoginState)); };
+            authManager.LoginStateChanged += (o) => { RaisePropertyChanged(nameof(LoginState)); };            
+            dynamoViewModel.WindowRezised += DynamoViewModel_WindowRezised;
+            ViewButtonsText = true;
+        }
+
+        private void DynamoViewModel_WindowRezised(object sender, System.EventArgs e)
+        {
+            ViewButtonsText = !(bool)sender;
         }
 
         /// <summary>
@@ -68,6 +76,19 @@ namespace Dynamo.Wpf.ViewModels.Core
                     return false;
                 }
                 return true;
+            }
+        }
+
+        public bool ViewButtonsText
+        {
+            get
+            {
+                return viewButtonsText;
+            }
+            set
+            {
+                viewButtonsText = value;
+                RaisePropertyChanged(nameof(ViewButtonsText));
             }
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ShortcutToolbarViewModel.cs
@@ -82,6 +82,9 @@ namespace Dynamo.Wpf.ViewModels.Core
             }
         }
 
+        /// <summary>
+        /// Indicates if a MenuItem display its text or not (only Icon)
+        /// </summary>
         public bool ShowMenuItemText
         {
             get

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -257,17 +257,17 @@ namespace Dynamo.Controls
 
         private void OnRequestCloseHomeWorkSpace()
         {
-            CalculateMinWidth();
+            CalculateWindowMinWidth();
         }
 
         private void OnWorkspaceHidden(WorkspaceModel workspace)
         {            
-            CalculateMinWidth();
+            CalculateWindowMinWidth();
         }
 
         private void OwnWorkspaceAdded(WorkspaceModel workspace)
         {            
-            CalculateMinWidth();
+            CalculateWindowMinWidth();
         }
 
         protected override async void OnContentRendered(EventArgs e)
@@ -1069,7 +1069,7 @@ namespace Dynamo.Controls
             dynamoViewModel.OnWindowResized(dynamoViewModel.Model.PreferenceSettings.WindowW <= threshold);            
         }
 
-        internal void CalculateMinWidth()
+        internal void CalculateWindowMinWidth()
         {
             List<TabItem> tabItems = WpfUtilities.ChildrenOfType<TabItem>(WorkspaceTabs).ToList();
             double tabItemsWidth = tabItems.Count > 0 ? tabItems[0].Width * tabItems.Count : 0;
@@ -1160,7 +1160,7 @@ namespace Dynamo.Controls
             shortcutBar.ShortcutBarItems.Add(undoButton);
             shortcutBar.ShortcutBarItems.Add(redoButton);
             
-            shortcutBarGrid.Children.Add(shortcutBar);            
+            shortcutBarGrid.Children.Add(shortcutBar);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -236,7 +236,7 @@ namespace Dynamo.Controls
             this.dynamoViewModel.RequestReturnFocusToView += OnRequestReturnFocusToView;
             this.dynamoViewModel.Model.WorkspaceSaving += OnWorkspaceSaving;
             this.dynamoViewModel.Model.WorkspaceOpened += OnWorkspaceOpened;
-            this.dynamoViewModel.Model.WorkspaceAdded += OwnWorkspaceAdded;
+            this.dynamoViewModel.Model.WorkspaceAdded += OnWorkspaceAdded;
             this.dynamoViewModel.Model.WorkspaceHidden += OnWorkspaceHidden;
             this.dynamoViewModel.RequestEnableShortcutBarItems += DynamoViewModel_RequestEnableShortcutBarItems;
             this.dynamoViewModel.RequestExportWorkSpaceAsImage += OnRequestExportWorkSpaceAsImage;
@@ -265,7 +265,7 @@ namespace Dynamo.Controls
             CalculateWindowMinWidth();
         }
 
-        private void OwnWorkspaceAdded(WorkspaceModel workspace)
+        private void OnWorkspaceAdded(WorkspaceModel workspace)
         {            
             CalculateWindowMinWidth();
         }
@@ -1059,24 +1059,33 @@ namespace Dynamo.Controls
             
             CalculateWindowThreshold();
         }
-        
-        internal void CalculateWindowThreshold()
+
+        /// <summary>
+        /// Returns the sum of the width of the library, the width of the tabs from the workspace and the width of the shortcut toolbar.
+        /// </summary>
+        /// <returns></returns>
+        internal double GetSumOfControlsWidth()
         {
             List<TabItem> tabItems = WpfUtilities.ChildrenOfType<TabItem>(WorkspaceTabs).ToList();
-            
             double tabItemsWidth = tabItems.Count > 0 ? tabItems[0].Width * tabItems.Count : 0;
-            double threshold = Convert.ToDouble(dynamoViewModel.LibraryWidth) + tabItemsWidth + toolBarRightMenuWidth + additionalWidth;
-            dynamoViewModel.OnWindowResized(dynamoViewModel.Model.PreferenceSettings.WindowW <= threshold);            
+            return Convert.ToDouble(dynamoViewModel.LibraryWidth) + tabItemsWidth + toolBarRightMenuWidth + additionalWidth;
         }
 
+        /// <summary>
+        /// Calculates the Window threshold to display the text or only icons in the shortcut toolbar
+        internal void CalculateWindowThreshold()
+        {            
+            dynamoViewModel.OnWindowResized(dynamoViewModel.Model.PreferenceSettings.WindowW <= GetSumOfControlsWidth());            
+        }
+
+        /// <summary>
+        /// Calculates the Window minimum width bearing in mind the width of the controls and the current Window width, it's necessary to avoid the shortcut toolbar (gray) overlap the custom node tab (black)
+        /// </summary>
         internal void CalculateWindowMinWidth()
         {
-            List<TabItem> tabItems = WpfUtilities.ChildrenOfType<TabItem>(WorkspaceTabs).ToList();
-            double tabItemsWidth = tabItems.Count > 0 ? tabItems[0].Width * tabItems.Count : 0;
-
             if (dynamoViewModel.Model.PreferenceSettings.WindowW > DefaultMinWidth)
             {
-                MinWidth = Convert.ToDouble(dynamoViewModel.LibraryWidth) + tabItemsWidth + toolBarRightMenuWidth + additionalWidth;
+                MinWidth = GetSumOfControlsWidth();
             }
             else
             {
@@ -1982,7 +1991,7 @@ namespace Dynamo.Controls
             this.dynamoViewModel.RequestReturnFocusToView -= OnRequestReturnFocusToView;
             this.dynamoViewModel.Model.WorkspaceSaving -= OnWorkspaceSaving;
             this.dynamoViewModel.Model.WorkspaceOpened -= OnWorkspaceOpened;
-            this.dynamoViewModel.Model.WorkspaceAdded -= OwnWorkspaceAdded;
+            this.dynamoViewModel.Model.WorkspaceAdded -= OnWorkspaceAdded;
             this.dynamoViewModel.Model.WorkspaceHidden -= OnWorkspaceHidden;
             this.dynamoViewModel.RequestEnableShortcutBarItems -= DynamoViewModel_RequestEnableShortcutBarItems;
             this.dynamoViewModel.RequestExportWorkSpaceAsImage -= OnRequestExportWorkSpaceAsImage;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -84,7 +84,13 @@ namespace Dynamo.Controls
         private bool isPSSCalledOnViewModelNoCancel = false;
         private readonly DispatcherTimer _workspaceResizeTimer = new DispatcherTimer { Interval = new TimeSpan(0, 0, 0, 0, 500), IsEnabled = false };
         private ViewLoadedParams sharedViewExtensionLoadedParams;
+        /// <summary>
+        /// keeps the width right menu of the ShourtcutBar
+        /// </summary>
         private double toolBarRightMenuWidth = 0;
+        /// <summary>
+        /// Keeps the additional Width based on the paddings and margins from the shorcutBar controls to calculate the whole Width
+        /// </summary>
         private double additionalWidth = 50;
 
         /// <summary>
@@ -103,6 +109,9 @@ namespace Dynamo.Controls
             get { return preferencesWindow; }
         }
 
+        /// <summary>
+        /// Keeps the default value of the Window's MinWidth to calculate it again later
+        /// </summary>
         internal double DefaultMinWidth = 0;
 
         /// <summary>
@@ -1067,7 +1076,7 @@ namespace Dynamo.Controls
         internal double GetSumOfControlsWidth()
         {
             List<TabItem> tabItems = WpfUtilities.ChildrenOfType<TabItem>(WorkspaceTabs).ToList();
-            double tabItemsWidth = tabItems.Count > 0 ? tabItems[0].Width * tabItems.Count : 0;
+            double tabItemsWidth = tabItems.Count > 0 ? (double.IsNaN(tabItems[0].Width) ? 0 : tabItems[0].Width) * tabItems.Count : 0;
             return Convert.ToDouble(dynamoViewModel.LibraryWidth) + tabItemsWidth + toolBarRightMenuWidth + additionalWidth;
         }
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/ViewExtensionTests.cs
@@ -20,6 +20,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void OnWorkspaceChangedExtensionIsNotified()
         {
+            this.View.WindowState = WindowState.Maximized;
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;
             extensionManager.Add(viewExtension);


### PR DESCRIPTION
### Purpose
Implementing the Tech debt https://jira.autodesk.com/browse/DYN-5473 to deal with the Toolbar overlapping over the workspace tabs.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@RobertGlobant20
@Enzo707 
