### PR TITLE
DYN-5961 Set Dynamo locale based on setting or host

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -245,9 +245,7 @@ namespace Dynamo.Applications
         {
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
             PathManager.Instance.AssignHostPathAndIPathResolver(string.Empty, pathResolver);
-
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo(PreferenceSettings.Instance.Locale);
-            Thread.CurrentThread.CurrentCulture = new CultureInfo(PreferenceSettings.Instance.Locale);
+            DynamoModel.SetUICulture(PreferenceSettings.Instance.Locale);
             DynamoModel.OnDetectLanguage();
 
             // Preload ASM and display corresponding message on splash screen
@@ -284,9 +282,7 @@ namespace Dynamo.Applications
         {
             IPathResolver pathResolver = CreatePathResolver(false, string.Empty, string.Empty, string.Empty);
             PathManager.Instance.AssignHostPathAndIPathResolver(string.Empty, pathResolver);
-
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo(PreferenceSettings.Instance.Locale);
-            Thread.CurrentThread.CurrentCulture = new CultureInfo(PreferenceSettings.Instance.Locale);
+            DynamoModel.SetUICulture(PreferenceSettings.Instance.Locale);
             DynamoModel.OnDetectLanguage();
 
             // Preload ASM and display corresponding message on splash screen
@@ -425,8 +421,7 @@ namespace Dynamo.Applications
             if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
             {
                 // Change the application locale, if a locale information is supplied.
-                Thread.CurrentThread.CurrentUICulture = new CultureInfo(cmdLineArgs.Locale);
-                Thread.CurrentThread.CurrentCulture = new CultureInfo(cmdLineArgs.Locale);
+                DynamoModel.SetUICulture(cmdLineArgs.Locale);
                 libgLocale = cmdLineArgs.Locale;
             }
             else

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -377,7 +377,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Supported locales as a list
         /// </summary>
-        internal static readonly List<string> SupportedLocaleList = new List<string>() { "en-US", "cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "ja-JP", "ko-KR", "pl-PL", "pt-BR", "ru-RU", "zh-CN", "zh-TW" };
+        internal static readonly List<string> SupportedLocaleList = new List<string>() { "Default", "en-US", "cs-CZ", "de-DE", "es-ES", "fr-FR", "it-IT", "ja-JP", "ko-KR", "pl-PL", "pt-BR", "ru-RU", "zh-CN", "zh-TW" };
 
         /// <summary>
         /// Supported languages and locales as a dictionary in the current thread locale

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -681,10 +681,11 @@ namespace Dynamo.Models
             PreferenceSettings = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
             if (PreferenceSettings != null)
             {
-                // In a integration case, respect default setting to use the host locale
-                if (!PreferenceSettings.Locale.Equals(Configuration.Configurations.SupportedLocaleList.First()) && HostAnalyticsInfo.HostName != string.Empty)
+                // Setting the locale for Dynamo from loaded Preferences only when
+                // In a non-in-process integration case (when HostAnalyticsInfo.HostName is unspecified)
+                // Language is specified, otherwise Default setting means following host locale
+                if (string.IsNullOrEmpty(HostAnalyticsInfo.HostName) || !PreferenceSettings.Locale.Equals(Configuration.Configurations.SupportedLocaleList.First()))
                 {
-                    // Setting the locale for Dynamo from loaded Preferences
                     SetUICulture(PreferenceSettings.Locale);
                 }
                 PreferenceSettings.PropertyChanged += PreferenceSettings_PropertyChanged;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -681,6 +681,12 @@ namespace Dynamo.Models
             PreferenceSettings = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
             if (PreferenceSettings != null)
             {
+                // In a integration case, respect default setting to use the host locale
+                if (!PreferenceSettings.Locale.Equals(Configuration.Configurations.SupportedLocaleList.First()) && HostAnalyticsInfo.HostName != string.Empty)
+                {
+                    // Setting the locale for Dynamo from loaded Preferences
+                    SetUICulture(PreferenceSettings.Locale);
+                }
                 PreferenceSettings.PropertyChanged += PreferenceSettings_PropertyChanged;
                 PreferenceSettings.MessageLogged += LogMessage;
             }
@@ -2697,6 +2703,15 @@ namespace Dynamo.Models
         #endregion
 
         #region public methods
+
+        /// <summary>
+        /// Set UI culture based on preferences
+        /// </summary>
+        public static void SetUICulture(string locale)
+        {
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo(locale == "Default" ? "en-US" : locale);
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(locale == "Default" ? "en-US" : locale);
+        }
 
         /// <summary>
         ///     Add a new HomeWorkspace and set as current

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -570,7 +570,7 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to English,Čeština,Deutsch,Español,Français,Italiano,日本語,한국어,Polski,Português (Brasil),Русский,简体中文,繁體中文.
+        ///   Looks up a localized string similar to Default,English,Čeština,Deutsch,Español,Français,Italiano,日本語,한국어,Polski,Português (Brasil),Русский,简体中文,繁體中文.
         /// </summary>
         public static string DynamoLanguages_noxlate {
             get {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -900,7 +900,7 @@ This package likely contains an assembly that is blocked. You will need to load 
     <value>Example file added to workspace. Run mode changed to Manual.</value>
   </data>
   <data name="DynamoLanguages_noxlate" xml:space="preserve">
-    <value>English,Čeština,Deutsch,Español,Français,Italiano,日本語,한국어,Polski,Português (Brasil),Русский,简体中文,繁體中文</value>
+    <value>Default,English,Čeština,Deutsch,Español,Français,Italiano,日本語,한국어,Polski,Português (Brasil),Русский,简体中文,繁體中文</value>
   </data>
   <data name="FormulaDSConversionFailure" xml:space="preserve">
     <value>Formula failed to convert to DesignScript code. Please edit the formula manually to use it in a CodeBlock node.</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -903,7 +903,7 @@ This package likely contains an assembly that is blocked. You will need to load 
     <value>Example file added to workspace. Run mode changed to Manual.</value>
   </data>
   <data name="DynamoLanguages_noxlate" xml:space="preserve">
-    <value>English,Čeština,Deutsch,Español,Français,Italiano,日本語,한국어,Polski,Português (Brasil),Русский,简体中文,繁體中文</value>
+    <value>Default,English,Čeština,Deutsch,Español,Français,Italiano,日本語,한국어,Polski,Português (Brasil),Русский,简体中文,繁體中文</value>
   </data>
   <data name="FormulaDSConversionFailure" xml:space="preserve">
     <value>Formula failed to convert to DesignScript code. Please edit the formula manually to use it in a CodeBlock node.</value>

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -70,7 +70,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.ViewExtensionSettings.Count, 0);
             Assert.AreEqual(settings.DefaultRunType, RunType.Automatic);
             Assert.AreEqual(settings.DynamoPlayerFolderGroups.Count, 0);
-            Assert.AreEqual(settings.Locale, "en-US");
+            Assert.AreEqual(settings.Locale, "Default");
 
             // Save
             settings.Save(tempPath);
@@ -89,7 +89,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.ViewExtensionSettings.Count, 0);
             Assert.AreEqual(settings.DefaultRunType, RunType.Automatic);
             Assert.AreEqual(settings.DynamoPlayerFolderGroups.Count, 0);
-            Assert.AreEqual(settings.Locale, "en-US");
+            Assert.AreEqual(settings.Locale, "Default");
 
             // Change setting values
             settings.SetIsBackgroundPreviewActive("MyBackgroundPreview", false);


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

Introduce Default option in Language switch, which sets Dynamo locale based on setting or host, pending some testing

Screenshot:
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/77bb677a-6731-45f3-91f1-bb1604451bbf)

Behavior:

- `Default` will be the default option for fresh Dynamo launch
- `Default` option in DynamoSandbox means `en-US`
- `Default` option in Dynamo in-process integration means following the host locale setting, based on the fact both DynamoRevit and DynamoC3D modifies `HostAnalyticsInfo` object
- `Default` option in Dynamo out-of-process integration means `en-US` or following host locale setting, depending on if integrator modifies `HostAnalyticsInfo` object
- Dynamo still respect if user picked specific language option


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Set Dynamo locale based on setting or host

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
