### PR TITLE
DYN-6359 Calculating the ShortcutToolbar Right menu width only when it's loaded

### DIFF
--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
@@ -38,6 +38,7 @@ namespace Dynamo.UI.Controls
             get { return shortcutBarRightSideItems; }
         }
         private readonly Core.AuthenticationManager authManager;
+        public readonly DynamoViewModel DynamoViewModel;
 
         /// <summary>
         /// Construct a ShortcutToolbar.
@@ -45,6 +46,7 @@ namespace Dynamo.UI.Controls
         /// <param name="dynamoViewModel"></param>
         public ShortcutToolbar(DynamoViewModel dynamoViewModel)
         {
+            DynamoViewModel = dynamoViewModel;
             shortcutBarItems = new ObservableCollection<ShortcutBarItem>();
             shortcutBarRightSideItems = new ObservableCollection<ShortcutBarItem>();
 
@@ -68,6 +70,7 @@ namespace Dynamo.UI.Controls
         {
             IsSaveButtonEnabled = false;
             IsExportMenuEnabled = false;
+            DynamoViewModel.OnRequestShorcutToolbarLoaded(RightMenu.ActualWidth);
         }
 
         private void SignOutHandler(LoginState status)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
@@ -171,6 +171,15 @@ namespace Dynamo.ViewModels
             }
         }
 
+        internal event Action<double> RequestShorcutToolbarLoaded;
+        public void OnRequestShorcutToolbarLoaded(double rightMenuActualWidth)
+        {
+            if (RequestShorcutToolbarLoaded != null)
+            {
+                RequestShorcutToolbarLoaded(rightMenuActualWidth);
+            }
+        }
+
         internal event Action <object> RequestExportWorkSpaceAsImage;
         private void OnRequestExportWorkSpaceAsImage(object parameter)
         {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -279,11 +279,6 @@ namespace Dynamo.Controls
             CalculateWindowMinWidth();
         }
 
-        protected override async void OnContentRendered(EventArgs e)
-        {
-            base.OnContentRendered(e);
-            toolBarRightMenuWidth = shortcutBar.RightMenu.ActualWidth;
-        }
         private void OnRequestExportWorkSpaceAsImage(object parameter)
         {
             var workspace = this.ChildOfType<WorkspaceView>();
@@ -1351,6 +1346,8 @@ namespace Dynamo.Controls
             //ABOUT WINDOW
             dynamoViewModel.RequestAboutWindow += DynamoViewModelRequestAboutWindow;
 
+            dynamoViewModel.RequestShorcutToolbarLoaded += onRequestShorcutToolbarLoaded;
+
             LoadNodeViewCustomizations();
             SubscribeNodeViewCustomizationEvents();
 
@@ -1382,6 +1379,15 @@ namespace Dynamo.Controls
                 this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(null); };
             }
             loaded = true;
+        }
+
+        /// <summary>
+        /// Assign the value to the toolBarRightMenuWidth when the ShortcutToolbar is loaded
+        /// </summary>
+        /// <param name="rightMenuActualWidth"></param>
+        private void onRequestShorcutToolbarLoaded(double rightMenuActualWidth)
+        {
+            toolBarRightMenuWidth = rightMenuActualWidth;
         }
 
         private void GuideFlowEvents_GuidedTourStart(GuidedTourStateEventArgs args)
@@ -2004,6 +2010,7 @@ namespace Dynamo.Controls
             this.dynamoViewModel.Model.WorkspaceHidden -= OnWorkspaceHidden;
             this.dynamoViewModel.RequestEnableShortcutBarItems -= DynamoViewModel_RequestEnableShortcutBarItems;
             this.dynamoViewModel.RequestExportWorkSpaceAsImage -= OnRequestExportWorkSpaceAsImage;
+            this.dynamoViewModel.RequestShorcutToolbarLoaded -= onRequestShorcutToolbarLoaded;
 
             this.Dispose();
             sharedViewExtensionLoadedParams?.Dispose();

--- a/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/WorkspaceDependencyViewExtensionTests.cs
@@ -195,6 +195,7 @@ namespace DynamoCoreWpfTests
         [Test]
         public void DependencyRegenCrashingDynamoTest()
         {
+            this.View.WindowState = WindowState.Maximized;
             RaiseLoadedEvent(this.View);
             var extensionManager = View.viewExtensionManager;
             extensionManager.Add(viewExtension);


### PR DESCRIPTION
### Purpose

Fixing the bug https://jira.autodesk.com/browse/DYN-6359, getting the width of the ShortcutToolbar right menu only when it's loaded instead of getting it when DynamoView is rendered, it covers both when DynamoView is displaying directly and after the Splashscreen.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB


### Reviewers
@mjkkirschner 
@QilongTang 

### FYIs
@Enzo707 
