### PR TITLE
package manager votes - bugfix

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -74,7 +74,7 @@ namespace Dynamo.PackageManager
                 return pkgResponse.content;
             }, null);
 
-            return votes.has_upvoted;
+            return votes?.has_upvoted;
         }
 
         internal PackageManagerResult DownloadPackage(string packageId, string version, out string pathToPackage)


### PR DESCRIPTION
### Purpose

The default `null` return when fetching user votes was causing Dyanmo initialization to freeze due to an unhandled null value exception. This is a small fix to this bug. 

Thank you @saintentropy for raising this one up.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- bug fix causing users with no votes to not be able to start Dynamo because of an unhandled null exception

### Reviewers

@saintentropy 
@reddyashish 

### FYIs

@Amoursol 
