### PR TITLE
Set Roll Forward to Major for some tools

### DIFF
--- a/src/DynamoCLI/DynamoCLI.csproj
+++ b/src/DynamoCLI/DynamoCLI.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <ProjectGuid>{5F9AE581-6781-4A4C-A262-1B06CD27208B}</ProjectGuid>
     <OutputType>Exe</OutputType>
+	<RollForward>Major</RollForward>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoCLI</RootNamespace>
     <AssemblyName>DynamoCLI</AssemblyName>

--- a/src/DynamoWPFCLI/DynamoWPFCLI.csproj
+++ b/src/DynamoWPFCLI/DynamoWPFCLI.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup>
     <ProjectGuid>{F7FD9395-35D5-474D-8AD1-9904817E70D3}</ProjectGuid>
     <OutputType>Exe</OutputType>
+	<RollForward>Major</RollForward>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoWPFCLI</RootNamespace>
     <AssemblyName>DynamoWPFCLI</AssemblyName>

--- a/src/Tools/DynamoFeatureFlags/DynamoFeatureFlags.csproj
+++ b/src/Tools/DynamoFeatureFlags/DynamoFeatureFlags.csproj
@@ -4,6 +4,7 @@
   </ImportGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+	<RollForward>Major</RollForward>
     <OutputPath>$(OutputPath)\DynamoFeatureFlags\</OutputPath>
   </PropertyGroup>
 

--- a/src/Tools/Md2Html/Md2Html.csproj
+++ b/src/Tools/Md2Html/Md2Html.csproj
@@ -5,6 +5,7 @@
     <PropertyGroup>
         <ProjectGuid>{0893F745-CB1A-427A-8E87-CA927273039A}</ProjectGuid>
         <OutputType>Exe</OutputType>
+		<RollForward>Major</RollForward>
         <RootNamespace>Md2Html</RootNamespace>
         <AssemblyName>Md2Html</AssemblyName>
         <SharedOutputPath>$(OutputPath)\Md2Html\</SharedOutputPath>
@@ -29,6 +30,7 @@
         <CallTarget Targets="Publish" />
         <Exec Command="if not exist $(SharedOutputPath) mkdir $(SharedOutputPath)"/>
         <Copy Condition=" '$(RuntimeIdentifier)' == 'win10-x64' " SourceFiles="$(OutputPath)$(RuntimeIdentifier)\publish\Md2Html.exe" DestinationFolder="$(SharedOutputPath)" />
+        <Copy Condition=" '$(RuntimeIdentifier)' == 'win10-x64' " SourceFiles="$(OutputPath)\Md2Html.runtimeconfig.json" DestinationFolder="$(SharedOutputPath)" />
         <Copy Condition=" '$(RuntimeIdentifier)' == 'linux-x64' " SourceFiles="$(OutputPath)$(RuntimeIdentifier)\publish\Md2Html" DestinationFolder="$(SharedOutputPath)" />
     </Target>
 </Project>


### PR DESCRIPTION
### Purpose

Set Roll Forward to Major for:
* DynamoFeatureFlags.exe
* MD2Html.exe
* DynamoCLI
* DynamoWPFCLI

This works very well on machines where NET7 and not NET6 runtime is installed.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
