### PR TITLE
Dyn 6311 checksum generation

### DIFF
--- a/src/DynamoCore/Configuration/GraphChecksumItem.cs
+++ b/src/DynamoCore/Configuration/GraphChecksumItem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.ObjectModel;
+using Dynamo.Core;
+using Dynamo.Properties;
+
+namespace Dynamo.Configuration
+{
+    /// <summary>
+    /// Represents the stringified version of the nodes connections from a graph
+    /// </summary>
+    public class GraphChecksumItem : NotificationObject
+    {
+        private string graphId;
+        private string checksum;
+
+        public string GraphId
+        {
+            get { return graphId; }
+            set
+            {
+                graphId = value;
+                RaisePropertyChanged(nameof(GraphId));
+            }
+        }
+
+        public string Checksum
+        {
+            get { return checksum; }
+            set
+            {
+                checksum = value;
+                RaisePropertyChanged(nameof(Checksum));
+            }
+        }
+    }
+}

--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Dynamo.Configuration;
 using Dynamo.Graph.Connectors;
 
 namespace Dynamo.Interfaces
@@ -158,6 +159,11 @@ namespace Dynamo.Interfaces
         /// <param name="name">Background preview name</param>
         /// <param name="value">Active state to set</param>
         void SetIsBackgroundPreviewActive(string name, bool value);
+
+        /// <summary>
+        /// Return a list of GraphChecksumItems
+        /// </summary>
+        List<GraphChecksumItem> GraphChecksumItemsList { get; set; }
     }
 
     /// <summary>

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -470,6 +470,11 @@ namespace Dynamo.Configuration
         /// </summary>
         private List<string> trustedLocations { get; set; } = new List<string>();
 
+        /// <summary>
+        /// Return a list of GraphChecksumItems
+        /// </summary>
+        public List<GraphChecksumItem> GraphChecksumItemsList { get; set; }
+
         // This function is used to deserialize the trusted locations manually
         // so that the TrustedLocation propertie's setter does not need to be public.
         private List<string> DeserializeTrustedLocations(XmlNode preferenceSettingsElement)
@@ -921,6 +926,7 @@ namespace Dynamo.Configuration
             ReadNotificationIds = new List<string>();
             DynamoPlayerFolderGroups = new List<DynamoPlayerFolderGroup>();
             backupLocation = string.Empty;
+            GraphChecksumItemsList = new List<GraphChecksumItem>();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2097,8 +2097,13 @@ namespace Dynamo.ViewModels
                 Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
                 CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController, saveContext);
                 if (!isBackup) AddToRecentFiles(path);
-                if (currentWorkspaceViewModel?.IsHomeSpace ?? true)
-                    Model.Logger.Log("The Workspace is valid for FDX : " + (HomeSpace.HasRunWithoutCrash && Model.CurrentWorkspace.IsValidForFDX).ToString());
+                
+                if (currentWorkspaceViewModel?.IsHomeSpace ?? true && HomeSpace.HasRunWithoutCrash && Model.CurrentWorkspace.IsValidForFDX)
+                {
+                    Model.Logger.Log("The Workspace is valid for FDX");
+                    Model.Logger.Log("The Workspace checksum is : " + currentWorkspaceViewModel.CheckSum);
+                }
+                    
             }
             catch (Exception ex)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2101,7 +2101,7 @@ namespace Dynamo.ViewModels
                 if (currentWorkspaceViewModel?.IsHomeSpace ?? true && HomeSpace.HasRunWithoutCrash && Model.CurrentWorkspace.IsValidForFDX)
                 {
                     Model.Logger.Log("The Workspace is valid for FDX");
-                    Model.Logger.Log("The Workspace checksum is : " + currentWorkspaceViewModel.CheckSum);
+                    Model.Logger.Log("The Workspace checksum is : " + currentWorkspaceViewModel.Checksum);
                 }
                     
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -358,6 +358,18 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Returns the Uuid property of the seralized Workspace
+        /// </summary>
+        [JsonIgnore]
+        internal string GraphId { get; set; }
+
+        /// <summary>
+        /// Returns the Json representation of the current graph
+        /// </summary>
+        [JsonIgnore]
+        internal JObject JsonRepresentation { get; set; }
+
+        /// <summary>
         /// Returns the stringified representation of the connected nodes
         /// </summary>
         [JsonIgnore]
@@ -366,7 +378,7 @@ namespace Dynamo.ViewModels
             get
             {
                 List<string> nodeInfoConnections = new List<string>();
-                JObject jsonWorkspace = GetJsonRepresentation();
+                JObject jsonWorkspace = JsonRepresentation;
                 var nodes = jsonWorkspace["Nodes"];
 
                 List<string> nodeIds = new List<string>();
@@ -407,7 +419,7 @@ namespace Dynamo.ViewModels
                         outputIndex++;
                     }
                 }
-                return string.Join(",", nodeInfoConnections);
+                return nodeInfoConnections.Count > 0 ? string.Join(",", nodeInfoConnections) : string.Empty;
             }            
         }
 
@@ -686,16 +698,6 @@ namespace Dynamo.ViewModels
             ResetFitViewToggle(null);
         }
 
-        internal JObject GetJsonRepresentation(EngineController engine = null)
-        {
-            // Step 1: Serialize the workspace.
-            var json = Model.ToJson(engine);
-            var json_parsed = JObject.Parse(json);
-
-            // Step 2: Add the View.
-            return AddViewBlockToJSON(json_parsed);
-        }
-
         /// <summary>
         /// WorkspaceViewModel's Save method does a two-part serialization. First, it serializes the Workspace,
         /// then adds a View property to serialized Workspace, and sets its value to the serialized ViewModel.
@@ -757,6 +759,10 @@ namespace Dynamo.ViewModels
                 {
                     saveContent = jo.ToString();
                 }
+
+                JsonRepresentation = JObject.Parse(saveContent);
+                GraphId = JsonRepresentation.Properties().First(p => p.Name == "Uuid").Value.ToString();
+
                 File.WriteAllText(filePath, saveContent);
 
                 // Handle Workspace or CustomNodeWorkspace related non-serialization internal logic

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -361,7 +361,7 @@ namespace Dynamo.ViewModels
         /// Returns the stringified representation of the connected nodes
         /// </summary>
         [JsonIgnore]
-        public string CheckSum
+        public string Checksum
         {
             get
             {

--- a/test/core/CustomNodes/bar.dyf
+++ b/test/core/CustomNodes/bar.dyf
@@ -1,29 +1,179 @@
-<Workspace Version="1.0.1.1743" X="0" Y="0" zoom="1" Name="bar" Description="" ID="8c81a098-663a-4c0d-8582-39e7e7efaf22" Category="Dyfs">
-  <NamespaceResolutionMap />
-  <Elements>
-    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="5b906522-aad9-4e24-8ce9-1cded5324865" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="72" y="145.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
-      <Symbol value="x" />
-    </Dynamo.Graph.Nodes.CustomNodes.Symbol>
-    <Dynamo.Graph.Nodes.CustomNodes.Function guid="4a562844-3e52-4abb-b7cf-c67187671e5c" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="foo" x="232" y="93.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <ID value="f334adb3-084c-42ca-9085-ce6cf7401c4e" />
-      <Name value="foo" />
-      <Description value="" />
-      <Inputs>
-        <Input value="x" />
-      </Inputs>
-      <Outputs>
-        <Output value="r" />
-      </Outputs>
-    </Dynamo.Graph.Nodes.CustomNodes.Function>
-    <Dynamo.Graph.Nodes.CustomNodes.Output guid="9c686856-b82d-46ca-900d-a84553c1c1d1" type="Dynamo.Graph.Nodes.CustomNodes.Output" nickname="Output" x="428" y="187.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <Symbol value="" />
-    </Dynamo.Graph.Nodes.CustomNodes.Output>
-  </Elements>
-  <Connectors>
-    <Dynamo.Graph.Connectors.ConnectorModel start="5b906522-aad9-4e24-8ce9-1cded5324865" start_index="0" end="4a562844-3e52-4abb-b7cf-c67187671e5c" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="4a562844-3e52-4abb-b7cf-c67187671e5c" start_index="0" end="9c686856-b82d-46ca-900d-a84553c1c1d1" end_index="0" portType="0" />
-  </Connectors>
-  <Notes />
-  <Annotations />
-  <Presets />
-</Workspace>
+{
+  "Uuid": "8c81a098-663a-4c0d-8582-39e7e7efaf22",
+  "IsCustomNode": true,
+  "Category": "Dyfs",
+  "Description": "",
+  "Name": "bar",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "Parameter": {
+        "Name": "x",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null,
+        "Description": ""
+      },
+      "Id": "5b906522aad94e248ce91cded5324865",
+      "NodeType": "InputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d73c598554d840e6a1e9e94001989413",
+          "Name": "",
+          "Description": "Input Data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "f334adb3-084c-42ca-9085-ce6cf7401c4e",
+      "FunctionType": "Graph",
+      "Id": "4a5628443e524abbb7cfc67187671e5c",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "98f39a3d2a5e4705980720b7b8e3d59f",
+          "Name": "x",
+          "Description": "Input #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7f27308f49884638881681735d3b570b",
+          "Name": "r",
+          "Description": "Output #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": ""
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "Symbol": "",
+      "ElementResolver": null,
+      "Id": "9c686856b82d46ca900da84553c1c1d1",
+      "NodeType": "OutputNode",
+      "Inputs": [
+        {
+          "Id": "9914bd5aad274f2b8e621d763aab1eb5",
+          "Name": "",
+          "Description": "Output Data",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "d73c598554d840e6a1e9e94001989413",
+      "End": "98f39a3d2a5e4705980720b7b8e3d59f",
+      "Id": "5f43346472f947f08725650c8c122f1c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "7f27308f49884638881681735d3b570b",
+      "End": "9914bd5aad274f2b8e621d763aab1eb5",
+      "Id": "d87ce53d64c443fb9896128c5ce49370",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [
+    "f334adb3-084c-42ca-9085-ce6cf7401c4e"
+  ],
+  "NodeLibraryDependencies": [
+    {
+      "Name": "foo.dyf",
+      "ReferenceType": "DYFFile",
+      "Nodes": [
+        "4a5628443e524abbb7cfc67187671e5c"
+      ]
+    }
+  ],
+  "Author": "None provided",
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.0.0.5795",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "5b906522aad94e248ce91cded5324865",
+        "Name": "Input",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 72.0,
+        "Y": 145.5
+      },
+      {
+        "Id": "4a5628443e524abbb7cfc67187671e5c",
+        "Name": "foo",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 553.0,
+        "Y": 107.5
+      },
+      {
+        "Id": "9c686856b82d46ca900da84553c1c1d1",
+        "Name": "Output",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 697.0,
+        "Y": 420.5
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/CustomNodes/bar.dyf
+++ b/test/core/CustomNodes/bar.dyf
@@ -1,179 +1,29 @@
-{
-  "Uuid": "8c81a098-663a-4c0d-8582-39e7e7efaf22",
-  "IsCustomNode": true,
-  "Category": "Dyfs",
-  "Description": "",
-  "Name": "bar",
-  "ElementResolver": {
-    "ResolutionMap": {}
-  },
-  "Inputs": [],
-  "Outputs": [],
-  "Nodes": [
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
-      "Parameter": {
-        "Name": "x",
-        "TypeName": "var",
-        "TypeRank": -1,
-        "DefaultValue": null,
-        "Description": ""
-      },
-      "Id": "5b906522aad94e248ce91cded5324865",
-      "NodeType": "InputNode",
-      "Inputs": [],
-      "Outputs": [
-        {
-          "Id": "d73c598554d840e6a1e9e94001989413",
-          "Name": "",
-          "Description": "Input Data",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
-      "FunctionSignature": "f334adb3-084c-42ca-9085-ce6cf7401c4e",
-      "FunctionType": "Graph",
-      "Id": "4a5628443e524abbb7cfc67187671e5c",
-      "NodeType": "FunctionNode",
-      "Inputs": [
-        {
-          "Id": "98f39a3d2a5e4705980720b7b8e3d59f",
-          "Name": "x",
-          "Description": "Input #1",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "7f27308f49884638881681735d3b570b",
-          "Name": "r",
-          "Description": "Output #1",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": ""
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
-      "Symbol": "",
-      "ElementResolver": null,
-      "Id": "9c686856b82d46ca900da84553c1c1d1",
-      "NodeType": "OutputNode",
-      "Inputs": [
-        {
-          "Id": "9914bd5aad274f2b8e621d763aab1eb5",
-          "Name": "",
-          "Description": "Output Data",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [],
-      "Replication": "Disabled",
-      "Description": "A function output, use with custom nodes"
-    }
-  ],
-  "Connectors": [
-    {
-      "Start": "d73c598554d840e6a1e9e94001989413",
-      "End": "98f39a3d2a5e4705980720b7b8e3d59f",
-      "Id": "5f43346472f947f08725650c8c122f1c",
-      "IsHidden": "False"
-    },
-    {
-      "Start": "7f27308f49884638881681735d3b570b",
-      "End": "9914bd5aad274f2b8e621d763aab1eb5",
-      "Id": "d87ce53d64c443fb9896128c5ce49370",
-      "IsHidden": "False"
-    }
-  ],
-  "Dependencies": [
-    "f334adb3-084c-42ca-9085-ce6cf7401c4e"
-  ],
-  "NodeLibraryDependencies": [
-    {
-      "Name": "foo.dyf",
-      "ReferenceType": "DYFFile",
-      "Nodes": [
-        "4a5628443e524abbb7cfc67187671e5c"
-      ]
-    }
-  ],
-  "Author": "None provided",
-  "Bindings": [],
-  "View": {
-    "Dynamo": {
-      "ScaleFactor": 1.0,
-      "HasRunWithoutCrash": false,
-      "IsVisibleInDynamoLibrary": true,
-      "Version": "3.0.0.5795",
-      "RunType": "Manual",
-      "RunPeriod": "1000"
-    },
-    "Camera": {
-      "Name": "_Background Preview",
-      "EyeX": -17.0,
-      "EyeY": 24.0,
-      "EyeZ": 50.0,
-      "LookX": 12.0,
-      "LookY": -13.0,
-      "LookZ": -58.0,
-      "UpX": 0.0,
-      "UpY": 1.0,
-      "UpZ": 0.0
-    },
-    "ConnectorPins": [],
-    "NodeViews": [
-      {
-        "Id": "5b906522aad94e248ce91cded5324865",
-        "Name": "Input",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "ShowGeometry": true,
-        "X": 72.0,
-        "Y": 145.5
-      },
-      {
-        "Id": "4a5628443e524abbb7cfc67187671e5c",
-        "Name": "foo",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "ShowGeometry": true,
-        "X": 553.0,
-        "Y": 107.5
-      },
-      {
-        "Id": "9c686856b82d46ca900da84553c1c1d1",
-        "Name": "Output",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "ShowGeometry": true,
-        "X": 697.0,
-        "Y": 420.5
-      }
-    ],
-    "Annotations": [],
-    "X": 0.0,
-    "Y": 0.0,
-    "Zoom": 1.0
-  }
-}
+<Workspace Version="1.0.1.1743" X="0" Y="0" zoom="1" Name="bar" Description="" ID="8c81a098-663a-4c0d-8582-39e7e7efaf22" Category="Dyfs">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="5b906522-aad9-4e24-8ce9-1cded5324865" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="72" y="145.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <Symbol value="x" />
+    </Dynamo.Graph.Nodes.CustomNodes.Symbol>
+    <Dynamo.Graph.Nodes.CustomNodes.Function guid="4a562844-3e52-4abb-b7cf-c67187671e5c" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="foo" x="232" y="93.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <ID value="f334adb3-084c-42ca-9085-ce6cf7401c4e" />
+      <Name value="foo" />
+      <Description value="" />
+      <Inputs>
+        <Input value="x" />
+      </Inputs>
+      <Outputs>
+        <Output value="r" />
+      </Outputs>
+    </Dynamo.Graph.Nodes.CustomNodes.Function>
+    <Dynamo.Graph.Nodes.CustomNodes.Output guid="9c686856-b82d-46ca-900d-a84553c1c1d1" type="Dynamo.Graph.Nodes.CustomNodes.Output" nickname="Output" x="428" y="187.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <Symbol value="" />
+    </Dynamo.Graph.Nodes.CustomNodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="5b906522-aad9-4e24-8ce9-1cded5324865" start_index="0" end="4a562844-3e52-4abb-b7cf-c67187671e5c" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4a562844-3e52-4abb-b7cf-c67187671e5c" start_index="0" end="9c686856-b82d-46ca-900d-a84553c1c1d1" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>


### PR DESCRIPTION
### Purpose

Implementation of the task https://jira.autodesk.com/browse/DYN-6311 adding a function that returns the checksum of a graph, saving it in the preferences and comparing it to a previous version of the same file to detect a substantial checksum.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@RobertGlobant20 
@Enzo707 
