### PR TITLE
Pm binding conversion error

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/NumericUpDownControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/NumericUpDownControl.xaml.cs
@@ -43,24 +43,25 @@ namespace Dynamo.PackageManager.UI
                 new FrameworkPropertyMetadata("0"));
 
         // The Value of the numerical up/down control. Bind to this property
-        public int Value
+        public string Value
         {
-            get { return (int)GetValue(ValueProperty); }
+            get { return (string)GetValue(ValueProperty); }
             set { SetValue(ValueProperty, value); }
         }
 
         // Using a DependencyProperty as the backing store for Value. 
         public static readonly DependencyProperty ValueProperty =
             DependencyProperty.Register("Value",
-                typeof(int),
+                typeof(string),
                 typeof(NumericUpDownControl),
-                new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, new PropertyChangedCallback(OnValuePropertyChanged)));
+                new FrameworkPropertyMetadata("0", FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, new PropertyChangedCallback(OnValuePropertyChanged)));
 
         // Setting the input TextBox 
         private static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var numericUpDownControl = d as NumericUpDownControl;
             numericUpDownControl.inputField.Text = e.NewValue.ToString();
+            if (String.IsNullOrEmpty(e.NewValue.ToString())) return;
             if (numericUpDownControl.watermarkLabel.Visibility == Visibility.Visible)
             {
                 numericUpDownControl.watermarkLabel.Visibility = Visibility.Collapsed;
@@ -79,11 +80,11 @@ namespace Dynamo.PackageManager.UI
         #region UI utility functions
         private void spinnerUp_Click(object sender, RoutedEventArgs e)
         {
-            if (string.IsNullOrEmpty(   inputField.Text))
+            if (string.IsNullOrEmpty(inputField.Text))
             {
                 if (Int32.TryParse(watermarkLabel.Content as string, out int watermarkValue))
                 {
-                    Value = ++watermarkValue;
+                    Value = (++watermarkValue).ToString();
                     return;
                 }
                 else
@@ -93,7 +94,7 @@ namespace Dynamo.PackageManager.UI
             }
             if (Int32.TryParse(inputField.Text, out int value))
             {
-                Value = ++value;
+                Value = (++value).ToString();
             };
         }
 
@@ -101,9 +102,9 @@ namespace Dynamo.PackageManager.UI
         {
             if (string.IsNullOrEmpty(inputField.Text))
             {
-                if (Int32.TryParse(watermarkLabel.Content as string, out int watermarkValue))
+                if (Int32.TryParse(watermarkLabel.Content as string, out int watermarkValue) && watermarkValue > 0)
                 {
-                    Value = --watermarkValue;
+                    Value = (--watermarkValue).ToString();
                     return;
                 }
                 else
@@ -113,9 +114,8 @@ namespace Dynamo.PackageManager.UI
             }
             if (Int32.TryParse(inputField.Text, out int value))
             {
-                // Allows positive whole numbers
-                if (value <= 0) return;
-                Value = --value;
+                if (value == 0) return;
+                Value = (--value).ToString();
             };
         }
 
@@ -133,7 +133,7 @@ namespace Dynamo.PackageManager.UI
         {
             if (Int32.TryParse(inputField.Text, out int value))
             {
-                Value = value;
+                Value = value.ToString();
             };
         }
 


### PR DESCRIPTION
### Purpose

A small PR addressing binding issues with the Numerical Up/Down custom user control. 

This PR cherry-picks and updates some of the changes from https://github.com/DynamoDS/Dynamo/pull/14506. The old one will be closed in favor of multiple smaller PRs.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- previously the dependency property of the numeric control was an integer, which would work, but would be raising a conversion error in the background

### Reviewers

@reddyashish 
@mjkkirschner 

### FYIs

@Amoursol 
