### PR TITLE
DateToPackageLabelConverterTest added

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1500,11 +1500,15 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (!(value is PackageManagerSearchElement packageManagerSearchElement)) return Visibility.Collapsed;
+            if (!(value is Dynamo.PackageManager.PackageManagerSearchElement packageManagerSearchElement)) return String.Empty;
             if (packageManagerSearchElement.IsDeprecated) return Resources.PackageManagerPackageDeprecated;
 
             DateTime.TryParse(packageManagerSearchElement.LatestVersionCreated, out DateTime dateLastUpdated);
-            TimeSpan difference = DateTime.Now - dateLastUpdated;
+
+            // For testing purposes
+            var test = DateTime.TryParse((string)parameter, out DateTime testDate);
+            TimeSpan difference = test ? testDate - dateLastUpdated : DateTime.Now - dateLastUpdated;
+
             int numberVersions = packageManagerSearchElement.Header.num_versions;
 
             if (numberVersions > 1)

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
@@ -11,6 +12,7 @@ using Dynamo.Search;
 using Dynamo.Search.SearchElements;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
+using Greg.Responses;
 using NUnit.Framework;
 
 namespace DynamoCoreWpfTests
@@ -53,6 +55,71 @@ namespace DynamoCoreWpfTests
             array[1] = "";
             result = converter.Convert(array, null, null, null);
             Assert.AreEqual(Visibility.Collapsed, result);
+        }
+
+        [Test]
+        public void DateToPackageLabelConverterTest()
+        {
+            // Arrange
+            string packageCreatedDateString = "2021-10-22 13:30:45";
+            string packageUpdatedDateString = "2021-11-20 13:30:45";
+            string packageTooOldDateString = "2021-11-22 13:30:45";
+            string packageVersionNumber = "1.0.0.0";
+            string formItFilterName = "FormIt";
+
+            var tmpPackageVersion = new PackageVersion { version = packageVersionNumber, host_dependencies = new List<string> { formItFilterName }, created = packageCreatedDateString };
+
+            var converter = new DateToPackageLabelConverter();
+            var pkgDep = new PackageHeader()
+            {
+                name = "dep",
+                deprecated = true,
+                versions = new List<PackageVersion> { tmpPackageVersion },
+                num_versions = 1
+            };
+
+            var pkgSingle = new PackageHeader()
+            {
+                name = "single",
+                deprecated = false,
+                versions = new List<PackageVersion> { tmpPackageVersion },
+                num_versions = 1
+            };
+
+            var pkgMultiple = new PackageHeader()
+            {
+                name = "miltiple",
+                deprecated = false,
+                versions = new List<PackageVersion> { tmpPackageVersion },
+                num_versions = 3
+            };
+
+
+            // Act/Assert
+
+            // If we don't provide a PackageManagerSearchElement value, converter returns and empty string
+            var result = converter.Convert(String.Empty, null, null, null);
+            Assert.AreEqual(String.Empty, result);
+
+            // If the package is deprecated, returns "Deprecated"
+            var element = new Dynamo.PackageManager.PackageManagerSearchElement(pkgDep);
+            result = converter.Convert(element, null, null, null);
+            Assert.AreEqual(Dynamo.Wpf.Properties.Resources.PackageManagerPackageDeprecated, result);
+
+            // If the package is has only 1 version, and it's less than 30 days old, returns "New"
+            element = new Dynamo.PackageManager.PackageManagerSearchElement(pkgSingle);
+            result = converter.Convert(element, null, packageUpdatedDateString, null);
+            Assert.AreEqual(Dynamo.Wpf.Properties.Resources.PackageManagerPackageNew, result);
+
+            // If the package is has multiple versions, and it's less than 30 days old, returns "New"
+            element = new Dynamo.PackageManager.PackageManagerSearchElement(pkgMultiple);
+            result = converter.Convert(element, null, packageUpdatedDateString, null);
+            Assert.AreEqual(Dynamo.Wpf.Properties.Resources.PackageManagerPackageUpdated, result);
+
+            // If the package is more than 30 days old, returns an empty string
+            element = new Dynamo.PackageManager.PackageManagerSearchElement(pkgMultiple);
+            result = converter.Convert(element, null, packageTooOldDateString, null);
+            Assert.AreEqual(String.Empty, result);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

A small PR testing the DateToPackageLabelConverterTest converter. According to the converter description: 


> Used to determine the text which appears next to a package when it's either
> - brand new or has been recently updated.
> - If the package was updated in the last 30 days it says 'Updated'.
> - If the package is brand new (only has 1 version) and is less than 30 days it says 'New'.

We are asserting that behavior. 

This PR cherry-picks and updates some of the changes from https://github.com/DynamoDS/Dynamo/pull/14506. The old one will be closed in favor of multiple smaller PRs.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- converter test added

### Reviewers

@mjkkirschner 
@reddyashish 

### FYIs

@Amoursol 
