### PR TITLE
close toast notifications fix

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
@@ -140,7 +140,7 @@ namespace Dynamo.PackageManager.UI
         private void CloseToastButton_OnClick(object sender, RoutedEventArgs e)
         {
             var PkgSearchVM = this.DataContext as PackageManagerSearchViewModel;
-            if (PkgSearchVM != null) { return; }
+            if (PkgSearchVM == null) { return; }
 
             Button button = sender as Button;
 


### PR DESCRIPTION

### Purpose

A small bugfix where Toast notifications showing package download at the bottom of the UI would not close. This PR addresses this issue. 

#### Changes
![close toast notifications ](https://github.com/DynamoDS/Dynamo/assets/5354594/9685a0b0-9e67-4df3-b376-309ca5002fd4)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- simple typo fix solved the issue

### Reviewers

@avidit
@reddyashish

### FYIs

@Amoursol 
