### PR TITLE
attempt to fix tests - again.

### DIFF
--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -714,7 +714,7 @@ namespace DynamoCoreWpfTests
             return GetSidebarDocsBrowserContents();
         }
 
-        [Test]
+        [Test,Category("Failure")]
         public void AddGraphInSpecificLocationToWorkspace()
         {
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -764,7 +764,6 @@ namespace DynamoCoreWpfTests
             }
             //Validates that we have 5 nodes the CurrentWorkspace (after the graph was added)
             Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Nodes.Count(), 5);
-            //do not remove this dispatch flush call unless you know what you are doing.
             DispatcherUtil.DoEvents();
         }
 


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

attempts to fix the nunit runner crashes we have been seeing on master-15. It appears to me that the documentation browser tests will `await` the webview2 call `EnsureCoreWebView2Async` - unfortunately in Nunit3 even with the methods marked as `STA` -  the task will actually run on a thread pool thread - then we'll get an exception from WebView2 as it will check what thread it was constructed on and which is currently initializing it are the same. This will throw as the test runner thread and the thread pool thread are not the same thread.

WebView2 requires thread affinity - ie only touch the webview2 members from the same thread that created it.

To fix the issue we can force Nunit to use a singleThreadedSyncContext by making the test `async` ... kind of a bummer, we could also implement that sync context ourselves, but this is faster for the time being. I am hoping to file a bug with Nunit.

To further explain the issue for the curious - this only shows up under specific circumstances:
1. a test tries to start a webview2 instance and awaits its initialization.
2. the dispatcher is flushed, this will kick off the task as nunit is capturing the dispatcher sync context.
3. the test is long enough, that it does not exit before the task actually starts... some tests that I have not fixed also initialize a webview, but they are either fast enough they exit before the initialization task starts, or there is no dispatcher call.

It's critcal to understand that a dispatcher.DoEvents call in a future test, will also kick off the `awaited` task... 

⚠️ If you do something that puts tasks into the dispatcher in a test, flush the dispatcher before your test ends.


