### PR TITLE
my packages empty screen user not logged in

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1026,15 +1026,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Crash report from Dynamo {0}.
-        /// </summary>
-        public static string CrashPromptGithubNewIssueTitle {
-            get {
-                return ResourceManager.GetString("CrashPromptGithubNewIssueTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Create.
         /// </summary>
         public static string CreateMember {
@@ -5808,6 +5799,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Once signed in, you can find your published packages here..
+        /// </summary>
+        public static string PackageManagerUserNotSignedPackagesSubMessage {
+            get {
+                return ResourceManager.GetString("PackageManagerUserNotSignedPackagesSubMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name of the package cannot contain.
         /// </summary>
         public static string PackageNameCannotContainTheseCharacters {
@@ -6020,6 +6020,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PackagerManageNoPublishedPackagesSubMessage {
             get {
                 return ResourceManager.GetString("PackagerManageNoPublishedPackagesSubMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign in to your Dynamo account to view your published packages..
+        /// </summary>
+        public static string PackagerManageUserNotSignedPackagesMessage {
+            get {
+                return ResourceManager.GetString("PackagerManageUserNotSignedPackagesMessage", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2961,6 +2961,12 @@ This package will be unloaded after the next Dynamo restart.</value>
   <data name="PackageManagerNoInstalledPackagesSubMessage" xml:space="preserve">
     <value>Once you install a package, you can find it here.</value>
   </data>
+  <data name="PackagerManageUserNotSignedPackagesMessage" xml:space="preserve">
+    <value>Sign in to your Dynamo account to view your published packages.</value>
+  </data>
+  <data name="PackageManagerUserNotSignedPackagesSubMessage" xml:space="preserve">
+    <value>Once signed in, you can find your published packages here.</value>
+  </data>
   <data name="PackageManagerSearchPackagesButton" xml:space="preserve">
     <value>Search for Packages</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1303,6 +1303,12 @@ Don't worry, you'll have the option to save your work.</value>
   </data>
   <data name="PackageManagerNoInstalledPackagesSubMessage" xml:space="preserve">
     <value>Once you install a package, you can find it here.</value>
+  </data>    
+  <data name="PackagerManageUserNotSignedPackagesMessage" xml:space="preserve">
+    <value>Sign in to your Dynamo account to view your published packages.</value>
+  </data>
+  <data name="PackageManagerUserNotSignedPackagesSubMessage" xml:space="preserve">
+    <value>Once signed in, you can find your published packages here.</value>
   </data>
   <data name="PackageManagerSearchPackagesButton" xml:space="preserve">
     <value>Search for Packages</value>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -476,6 +476,11 @@ namespace Dynamo.PackageManager
         public PackageManagerClientViewModel PackageManagerClientViewModel { get; private set; }
 
         /// <summary>
+        /// A getter boolean identifying if the user is currently logged in
+        /// </summary>
+        public bool IsLoggedIn { get { return PackageManagerClientViewModel.AuthenticationManager.IsLoggedIn(); } }
+
+        /// <summary>
         /// Current selected filter hosts
         /// </summary>
         public List<string> SelectedHosts { get; set; }
@@ -634,8 +639,6 @@ namespace Dynamo.PackageManager
             // We should have already populated the CachedPackageList by this step
             if (PackageManagerClientViewModel.CachedPackageList == null ||
                 !PackageManagerClientViewModel.CachedPackageList.Any()) return;
-            // We need the user to be logged in, otherwise there is no point in runnig this routine
-            if (PackageManagerClientViewModel.LoginState != Greg.AuthProviders.LoginState.LoggedIn) return;
 
             List<PackageManagerSearchElementViewModel> myPackages = new List<PackageManagerSearchElementViewModel>();
 
@@ -1591,6 +1594,8 @@ namespace Dynamo.PackageManager
             SearchAndUpdateResults(String.Empty); // reset the search text property
             InitialResultsLoaded = false;
             TimedOut = false;
+
+            ClearMySearchResults();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
@@ -377,13 +377,37 @@
                                                Height="Auto"
                                                Margin="0 0 0 50"
                                                Source="pack://application:,,,/DynamoCoreWpf;component/UI/Images/PackageManager/empty-state-first-use-light-gray.png"></Image>
-                                        <TextBlock Style="{StaticResource LabelStyle}"
-                                                   FontSize="18px"
-                                                   Text="{x:Static p:Resources.PackagerManageNoPublishedPackagesMessage}" />
-                                        <TextBlock Style="{StaticResource SubLabelStyle}"
-                                                   FontSize="13px"
-                                                   HorizontalAlignment="Center"
-                                                   Text="{x:Static p:Resources.PackagerManageNoPublishedPackagesSubMessage}" />
+                                        <TextBlock FontSize="18px">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource LabelStyle}">
+                                                    <Setter Property="Text" Value="{x:Static p:Resources.PackagerManageNoPublishedPackagesMessage}"/> 
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding PackageManagerViewModel.PackageSearchViewModel.IsLoggedIn}" Value="True">
+                                                            <Setter Property="Text" Value="{x:Static p:Resources.PackagerManageNoPublishedPackagesMessage}" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding PackageManagerViewModel.PackageSearchViewModel.IsLoggedIn}" Value="False">
+                                                            <Setter Property="Text" Value="{x:Static p:Resources.PackagerManageUserNotSignedPackagesMessage}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock FontSize="13px"
+                                                   HorizontalAlignment="Center">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource SubLabelStyle}">
+                                                    <Setter Property="Text" Value="{x:Static p:Resources.PackagerManageNoPublishedPackagesSubMessage}"/> 
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding PackageManagerViewModel.PackageSearchViewModel.IsLoggedIn}" Value="True">
+                                                            <Setter Property="Text" Value="{x:Static p:Resources.PackagerManageNoPublishedPackagesSubMessage}" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding PackageManagerViewModel.PackageSearchViewModel.IsLoggedIn}" Value="False">
+                                                            <Setter Property="Text" Value="{x:Static p:Resources.PackageManagerUserNotSignedPackagesSubMessage}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
                                         <Button Content="{x:Static p:Resources.PackageManagerPublishPackageButton}"
                                                 Margin="0 25"
                                                 Background="#0696D7"


### PR DESCRIPTION
### Purpose

A new empty screen message added when the user has not logged in. When going to the `MyPackages` tab, if the user has not logged in yet, the following screen will prompt them to.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/e340e4a5-b882-49f3-b793-20eb9ab1bae2)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now displays empty screen message if the user has not logged in

### Reviewers

@reddyashish 

### FYIs

@Amoursol 
