### PR TITLE
[WIP] async code and dispose in tests

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -111,8 +111,6 @@ namespace Dynamo.DocumentationBrowser
 
         protected virtual void Dispose(bool disposing)
         {
-            System.Console.WriteLine("documentationBrowser dispose called");
-
             // Cleanup
             this.viewModel.LinkChanged -= NavigateToPage;
             if (this.documentationBrowser != null)
@@ -174,7 +172,6 @@ namespace Dynamo.DocumentationBrowser
                 //Initialize the CoreWebView2 component otherwise we can't navigate to a web page
                 hasBeenInitialized = documentationBrowser.EnsureCoreWebView2Async().ContinueWith((_) => {
 
-                    System.Console.WriteLine("documentationBrowser.EnsureCoreWebView2Async() done");
                     if (isDisposing) return;
 
                     this.documentationBrowser.CoreWebView2.WebMessageReceived += CoreWebView2OnWebMessageReceived;

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -111,6 +111,8 @@ namespace Dynamo.DocumentationBrowser
 
         protected virtual void Dispose(bool disposing)
         {
+            System.Console.WriteLine("documentationBrowser dispose called");
+
             // Cleanup
             this.viewModel.LinkChanged -= NavigateToPage;
             if (this.documentationBrowser != null)
@@ -171,6 +173,8 @@ namespace Dynamo.DocumentationBrowser
                 }
                 //Initialize the CoreWebView2 component otherwise we can't navigate to a web page
                 hasBeenInitialized = documentationBrowser.EnsureCoreWebView2Async().ContinueWith((_) => {
+
+                    System.Console.WriteLine("documentationBrowser.EnsureCoreWebView2Async() done");
                     if (isDisposing) return;
 
                     this.documentationBrowser.CoreWebView2.WebMessageReceived += CoreWebView2OnWebMessageReceived;

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -178,7 +178,7 @@ namespace Dynamo.DocumentationBrowser
 
         public override void Shutdown()
         {
-            Dispose();
+            // Do nothing for now 
         }
 
         private void OnInsertFile(object sender, InsertDocumentationLinkEventArgs e)

--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -97,7 +97,7 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="timeoutms">will return empty string if we don't finish reading all data in the timeout provided in milliseconds.</param>
         /// <returns></returns>
-        protected virtual async Task<string> GetData(int timeoutms)
+        protected virtual string GetData(int timeoutms)
         {
             var readStdOutTask = Task.Run(() =>
             {
@@ -145,7 +145,8 @@ namespace Dynamo.Utilities
                     return writer.ToString();
                 }
             });
-            var completedTask = await Task.WhenAny(readStdOutTask, Task.Delay(TimeSpan.FromMilliseconds(timeoutms)));
+
+            var completedTask = Task.WhenAny(readStdOutTask, Task.Delay(TimeSpan.FromMilliseconds(timeoutms))).Result;
             //if the completed task was our read std out task, then return the data
             //else we timed out, so return an empty string.
             return completedTask == readStdOutTask ? readStdOutTask.Result : string.Empty;

--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -146,10 +146,7 @@ namespace Dynamo.Utilities
                 }
             });
 
-            var completedTask = Task.WhenAny(readStdOutTask, Task.Delay(TimeSpan.FromMilliseconds(timeoutms))).Result;
-            //if the completed task was our read std out task, then return the data
-            //else we timed out, so return an empty string.
-            return completedTask == readStdOutTask ? readStdOutTask.Result : string.Empty;
+            return readStdOutTask.Wait(timeoutms) ? readStdOutTask.Result : string.Empty;
         }
 
         protected void RaiseMessageLogged(string message)

--- a/src/DynamoUtilities/DynamoFeatureFlagsManager.cs
+++ b/src/DynamoUtilities/DynamoFeatureFlagsManager.cs
@@ -64,7 +64,7 @@ namespace DynamoUtilities
         {
 
             //wait for response
-            var dataFromCLI = GetData(featureFlagTimeoutMs).Result;    
+            var dataFromCLI = GetData(featureFlagTimeoutMs);    
             //convert from json string to dictionary.
             try
             {

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -73,9 +73,7 @@ namespace Dynamo.Utilities
                 return GetCantCommunicateErrorMessage();
             }
 
-            var output = GetData(processCommunicationTimeoutms);
-
-            return output.Result;
+            return GetData(processCommunicationTimeoutms);
         }
 
         /// <summary>
@@ -104,7 +102,7 @@ namespace Dynamo.Utilities
 
             var output = GetData(processCommunicationTimeoutms);
 
-           return output.Result;
+           return output;
         }
 
         /// <summary>

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -123,6 +123,8 @@ namespace Dynamo.LibraryViewExtensionWebView2
             {
                 WebBrowserUserDataFolder = webBrowserUserDataFolder.FullName;
             }
+
+            InitializeAsync();
         }
 
         private void DynamoViewModel_PreferencesWindowChanged(object sender, EventArgs e)
@@ -361,8 +363,6 @@ namespace Dynamo.LibraryViewExtensionWebView2
                 browser.CoreWebView2.Settings.IsZoomControlEnabled = true;
             }, TaskScheduler.FromCurrentSynchronizationContext());
             await isInitialized;
-
-            if (isDisposing) return;
         }
 
         private void CoreWebView2_WebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs args)
@@ -429,11 +429,6 @@ namespace Dynamo.LibraryViewExtensionWebView2
         {
             string msg = "Browser Loaded";
             LogToDynamoConsole(msg);
-
-            if (!isDisposing)
-            {
-                InitializeAsync();
-            }
         }
 
         // This enum is for matching the modifier keys between C# and javaScript

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -351,16 +351,19 @@ namespace Dynamo.LibraryViewExtensionWebView2
                 };
             }
 
-            isInitialized = browser.EnsureCoreWebView2Async().ContinueWith((_) =>
+            if (isInitialized == null)
             {
-                if (isDisposing) return;
+                isInitialized = browser.EnsureCoreWebView2Async().ContinueWith((_) =>
+                {
+                    if (isDisposing) return;
 
-                this.browser.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
-                twoWayScriptingObject = new ScriptingObject(this);
-                //register the interop object into the browser.
-                this.browser.CoreWebView2.AddHostObjectToScript("bridgeTwoWay", twoWayScriptingObject);
-                browser.CoreWebView2.Settings.IsZoomControlEnabled = true;
-            }, TaskScheduler.FromCurrentSynchronizationContext());
+                    this.browser.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
+                    twoWayScriptingObject = new ScriptingObject(this);
+                    //register the interop object into the browser.
+                    this.browser.CoreWebView2.AddHostObjectToScript("bridgeTwoWay", twoWayScriptingObject);
+                    browser.CoreWebView2.Settings.IsZoomControlEnabled = true;
+                }, TaskScheduler.FromCurrentSynchronizationContext());
+            }
             await isInitialized;
         }
 

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -123,8 +123,6 @@ namespace Dynamo.LibraryViewExtensionWebView2
             {
                 WebBrowserUserDataFolder = webBrowserUserDataFolder.FullName;
             }
-
-            InitializeAsync();
         }
 
         private void DynamoViewModel_PreferencesWindowChanged(object sender, EventArgs e)
@@ -323,6 +321,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
             browser = view.mainGrid.Children.OfType<WebView2>().FirstOrDefault();
             browser.Loaded += Browser_Loaded;
             browser.SizeChanged += Browser_SizeChanged;
+            InitializeAsync();
 
             LibraryViewController.SetupSearchModelEventsObserver(browser, dynamoViewModel.Model.SearchModel,
                     this, this.customization);

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -295,19 +295,13 @@ namespace Dynamo.Notifications
             }
         }
 
-        public async void Dispose()
+        private void Dispose(bool disposing)
         {
-            isDisposing = true;
-
             if (notificationUIPopup == null) return;
 
             notificationUIPopup.IsOpen = false;
             if (notificationUIPopup.webView != null)
             {
-                if (Models.DynamoModel.IsTestMode && isInitialized != null)
-                {
-                    await isInitialized;
-                }
                 notificationUIPopup.webView.Visibility = Visibility.Hidden;
                 notificationUIPopup.webView.Loaded -= WebView_Loaded;
 
@@ -324,6 +318,22 @@ namespace Dynamo.Notifications
                 }
                 notificationUIPopup.webView.Dispose();
             }
+        }
+
+        public async void Dispose()
+        {
+            isDisposing = true;
+
+            if (Models.DynamoModel.IsTestMode && isInitialized != null)
+            {
+                GC.SuppressFinalize(this);
+                await isInitialized;
+                Dispose(true);
+                return;
+            }
+
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -102,7 +102,7 @@ namespace Dynamo.Notifications
             {
                 InitializeBrowserAsync();
                 RequestNotifications();
-            }   
+            }
         }
 
         private async void InitializeBrowserAsync()
@@ -296,6 +296,8 @@ namespace Dynamo.Notifications
 
         private void Dispose(bool disposing)
         {
+            System.Console.WriteLine("NotificationCenterControl dispose called");
+
             if (notificationUIPopup == null) return;
 
             notificationUIPopup.IsOpen = false;

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -100,13 +100,15 @@ namespace Dynamo.Notifications
             // This ensures no network traffic when Notification center feature is turned off
             if (dynamoViewModel.PreferenceSettings.EnableNotificationCenter && !dynamoViewModel.Model.NoNetworkMode ) 
             {
-                InitializeBrowserAsync();
+                notificationUIPopup.webView.Loaded += InitializeBrowserAsync;
                 RequestNotifications();
             }
         }
 
-        private async void InitializeBrowserAsync()
+        private async void InitializeBrowserAsync(object sender, RoutedEventArgs e)
         {
+            if (isDisposing) return;
+
             if (webBrowserUserDataFolder != null)
             {
                 //This indicates in which location will be created the WebView2 cache folder
@@ -302,6 +304,7 @@ namespace Dynamo.Notifications
             if (notificationUIPopup.webView != null)
             {
                 notificationUIPopup.webView.Visibility = Visibility.Hidden;
+                notificationUIPopup.webView.Loaded -= InitializeBrowserAsync;
                 if (notificationUIPopup.webView.CoreWebView2 != null)
                 {
                     notificationUIPopup.webView.CoreWebView2.Stop();

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -296,8 +296,6 @@ namespace Dynamo.Notifications
 
         private void Dispose(bool disposing)
         {
-            System.Console.WriteLine("NotificationCenterControl dispose called");
-
             if (notificationUIPopup == null) return;
 
             notificationUIPopup.IsOpen = false;

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -100,27 +100,26 @@ namespace Dynamo.Notifications
             // This ensures no network traffic when Notification center feature is turned off
             if (dynamoViewModel.PreferenceSettings.EnableNotificationCenter && !dynamoViewModel.Model.NoNetworkMode ) 
             {
-                if (webBrowserUserDataFolder != null)
-                {
-                    //This indicates in which location will be created the WebView2 cache folder
-                    notificationUIPopup.webView.CreationProperties = new CoreWebView2CreationProperties()
-                    {
-                        UserDataFolder = webBrowserUserDataFolder.FullName
-                    };
-                }
-                notificationUIPopup.webView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
-                notificationUIPopup.webView.Loaded += WebView_Loaded;
-                notificationUIPopup.webView.NavigationCompleted += WebView_NavigationCompleted;
-
+                InitializeBrowserAsync();
                 RequestNotifications();
             }   
         }
 
-        private void WebView_Loaded(object sender, RoutedEventArgs e)
+        private async void InitializeBrowserAsync()
         {
-            if (isDisposing) return;
+            if (webBrowserUserDataFolder != null)
+            {
+                //This indicates in which location will be created the WebView2 cache folder
+                notificationUIPopup.webView.CreationProperties = new CoreWebView2CreationProperties()
+                {
+                    UserDataFolder = webBrowserUserDataFolder.FullName
+                };
+            }
+            notificationUIPopup.webView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
+            notificationUIPopup.webView.NavigationCompleted += WebView_NavigationCompleted;
 
             isInitialized = notificationUIPopup.webView.EnsureCoreWebView2Async();
+            await isInitialized;
         }
 
         private void WebView_NavigationCompleted(object sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationCompletedEventArgs e)
@@ -303,8 +302,6 @@ namespace Dynamo.Notifications
             if (notificationUIPopup.webView != null)
             {
                 notificationUIPopup.webView.Visibility = Visibility.Hidden;
-                notificationUIPopup.webView.Loaded -= WebView_Loaded;
-
                 if (notificationUIPopup.webView.CoreWebView2 != null)
                 {
                     notificationUIPopup.webView.CoreWebView2.Stop();

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -68,6 +68,7 @@ namespace Dynamo.Notifications
                     BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
                 }
                 notificationsMenuItem = null;
+                notificationCenterController?.Dispose();
                 disposed = true;
             }
         }

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -64,7 +64,7 @@ namespace Dynamo
         [SetUp]
         public virtual void Setup()
         {
-            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.MethodName);
+            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.Name);
             SetupDirectories();
 
             if (assemblyHelper == null)
@@ -98,7 +98,7 @@ namespace Dynamo
             {
                 AppDomain.CurrentDomain.AssemblyResolve -= assemblyHelper.ResolveAssembly;
             }
-            System.Console.WriteLine("Finish test: " + TestContext.CurrentContext.Test.MethodName);
+            System.Console.WriteLine("Finish test: " + TestContext.CurrentContext.Test.Name);
         }
 
         public string GetNewFileNameOnTempPath(string fileExtension = "dyn")

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -64,6 +64,7 @@ namespace Dynamo
         [SetUp]
         public virtual void Setup()
         {
+            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.MethodName);
             SetupDirectories();
 
             if (assemblyHelper == null)
@@ -97,6 +98,7 @@ namespace Dynamo
             {
                 AppDomain.CurrentDomain.AssemblyResolve -= assemblyHelper.ResolveAssembly;
             }
+            System.Console.WriteLine("Finish test: " + TestContext.CurrentContext.Test.MethodName);
         }
 
         public string GetNewFileNameOnTempPath(string fileExtension = "dyn")

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Threading;
 using CoreNodeModels.Input;
 using Dynamo.Configuration;
 using Dynamo.Controls;
@@ -819,7 +820,7 @@ namespace DynamoCoreWpfTests
 
             //create the view
             View = new DynamoView(ViewModel);
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -14,6 +14,7 @@ using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.Nodes;
 using Dynamo.Scheduler;
+using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using DynamoCoreWpfTests.Utility;
 using DynamoShapeManager;
@@ -78,7 +79,7 @@ namespace DynamoCoreWpfTests
             View = new DynamoView(ViewModel);
             View.Show();
 
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
         }
 
         protected static void RaiseLoadedEvent(FrameworkElement element)
@@ -109,6 +110,8 @@ namespace DynamoCoreWpfTests
         [TearDown]
         public void Exit()
         {
+            DispatcherUtil.DoEvents();
+
             //Ensure that we leave the workspace marked as
             //not having changes.
             ViewModel.HomeSpace.HasUnsavedChanges = false;

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -41,7 +41,7 @@ namespace DynamoCoreWpfTests
         [SetUp]
         public virtual void Start()
         {
-            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.MethodName);
+            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.Name);
             var assemblyPath = Assembly.GetExecutingAssembly().Location;
             preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
             preloader.Preload();
@@ -142,7 +142,7 @@ namespace DynamoCoreWpfTests
             {
                 Console.WriteLine(ex.StackTrace);
             }
-            System.Console.WriteLine("Exit test: " + TestContext.CurrentContext.Test.MethodName);
+            System.Console.WriteLine("Exit test: " + TestContext.CurrentContext.Test.Name);
         }
 
         protected virtual void GetLibrariesToPreload(List<string> libraries)

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -111,8 +111,6 @@ namespace DynamoCoreWpfTests
         [TearDown]
         public void Exit()
         {
-            DispatcherUtil.DoEvents();
-
             //Ensure that we leave the workspace marked as
             //not having changes.
             ViewModel.HomeSpace.HasUnsavedChanges = false;

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -41,6 +41,7 @@ namespace DynamoCoreWpfTests
         [SetUp]
         public virtual void Start()
         {
+            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.MethodName);
             var assemblyPath = Assembly.GetExecutingAssembly().Location;
             preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
             preloader.Preload();
@@ -141,6 +142,7 @@ namespace DynamoCoreWpfTests
             {
                 Console.WriteLine(ex.StackTrace);
             }
+            System.Console.WriteLine("Exit test: " + TestContext.CurrentContext.Test.MethodName);
         }
 
         protected virtual void GetLibrariesToPreload(List<string> libraries)

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerUITests.cs
@@ -1133,10 +1133,13 @@ namespace DynamoCoreWpfTests.PackageManager
                 .Returns(MessageBoxResult.OK);
             MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
 
-            //actually perform the download & install operations
-            pmVmMock.Object.ExecutePackageDownload(id, pkgVer, "");
+            Task.Run(() => {
+                // This test runs on a single thread (using DispatcherSyncronizationContext)
+                // We need to run the async ExecutePackageDownload function in a separate thread so that the Thread.Sleep call does not cause a deadlock
+                //actually perform the download & install operations
+                pmVmMock.Object.ExecutePackageDownload(id, pkgVer, "");
+            }).Wait();
 
-            //wait a bit.
             Thread.Sleep(500);
 
             //assert that all downloads are complete before installs,

--- a/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/PythonNodeCustomizationTests.cs
@@ -20,7 +20,7 @@ using PythonNodeModelsWpf;
 
 namespace DynamoCoreWpfTests
 {
-    [TestFixture, Category("Failure")]
+    [TestFixture]
     public class PythonNodeCustomizationTests : DynamoTestUIBase
     {
         bool bTextEnteringEventRaised = false;

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -144,6 +144,7 @@ namespace DynamoCoreWpfTests
             //There are times in which the URL contain characters like backslash (%5C) then they need to be replaced by the normal slash "/"
             htmlContent = htmlContent.Replace(@"%5C", "/");
 
+            DispatcherUtil.DoEvents();
             // Assert
             Assert.IsTrue(!string.IsNullOrEmpty(browserView.VirtualFolderPath));
             Assert.IsTrue(Directory.Exists(browserView.VirtualFolderPath));
@@ -714,7 +715,7 @@ namespace DynamoCoreWpfTests
             return GetSidebarDocsBrowserContents();
         }
 
-        [Test,Category("Failure")]
+        [Test]
         public void AddGraphInSpecificLocationToWorkspace()
         {
             //TODO see this issue:

--- a/test/Libraries/DynamoUtilitiesTests/CLIWrapperTests.cs
+++ b/test/Libraries/DynamoUtilitiesTests/CLIWrapperTests.cs
@@ -39,7 +39,7 @@ namespace DynamoUtilitiesTests
                 {   System.Threading.Thread.Sleep(100);
                     process.Kill();
                 });
-                return GetData(2000).Result;
+                return GetData(2000);
             }
         }
 

--- a/test/Libraries/SystemTestServices/SystemTestBase.cs
+++ b/test/Libraries/SystemTestServices/SystemTestBase.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Windows.Threading;
 using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Core;
@@ -207,7 +208,7 @@ namespace SystemTestServices
             View = new DynamoView(ViewModel);
             View.Show();
 
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
         }
 
         /// <summary>

--- a/test/Libraries/SystemTestServices/SystemTestBase.cs
+++ b/test/Libraries/SystemTestServices/SystemTestBase.cs
@@ -63,7 +63,7 @@ namespace SystemTestServices
         [SetUp]
         public virtual void Setup()
         {
-            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.MethodName);
+            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.Name);
             var testConfig = GetTestSessionConfiguration();
 
             if (assemblyResolver == null)
@@ -142,7 +142,7 @@ namespace SystemTestServices
                 Console.WriteLine(ex.StackTrace);
             }
 
-            System.Console.WriteLine("Finish test: " + TestContext.CurrentContext.Test.MethodName);
+            System.Console.WriteLine("Finish test: " + TestContext.CurrentContext.Test.Name);
         }
 
         [OneTimeTearDown]

--- a/test/Libraries/SystemTestServices/SystemTestBase.cs
+++ b/test/Libraries/SystemTestServices/SystemTestBase.cs
@@ -63,6 +63,7 @@ namespace SystemTestServices
         [SetUp]
         public virtual void Setup()
         {
+            System.Console.WriteLine("Start test: " + TestContext.CurrentContext.Test.MethodName);
             var testConfig = GetTestSessionConfiguration();
 
             if (assemblyResolver == null)
@@ -140,6 +141,8 @@ namespace SystemTestServices
             {
                 Console.WriteLine(ex.StackTrace);
             }
+
+            System.Console.WriteLine("Finish test: " + TestContext.CurrentContext.Test.MethodName);
         }
 
         [OneTimeTearDown]

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Media3D;
+using System.Windows.Threading;
 using System.Xml;
 using CoreNodeModels;
 using CoreNodeModels.Input;
@@ -119,7 +120,7 @@ namespace WpfVisualizationTests
             View = new DynamoView(ViewModel);
             View.Show();
 
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
         }
 
         /// <summary>


### PR DESCRIPTION
Issues:
1. Deadlock in Md2html during tests (could happen live too).
    GetData().Result will block the current thread. Inside GetData we have an await which will cause the main thread to poll for the status of the awaited task 
2. DocumentationBrowserView.NavigateToPage can sometimes be called from non UI thread and causes exceptions to be thrown when accessing UI components.
3. Exception `The calling thread cannot access this object because a different thread owns it` or something even weirder.
    UI tests were running on the threadpool sync context. This means that any async operation could be scheduled on the 
    threadpool. This can cause issues/exceptions with UI controls (like webview2)
4. System.ObjectDisposedException: `Cannot access a disposed object` or something even weirder . UI tests can finish faster that async operations can execute. This means that a UI control could get disposed even if internal async operations have not finished yet 