### PR TITLE
Allow Watch3D nodes to run in software mode

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
 using System.Xml;
@@ -393,12 +394,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var pixelShader4Supported = RenderCapability.IsPixelShaderVersionSupported(4, 0);
             var softwareEffectSupported = RenderCapability.IsShaderEffectSoftwareRenderingSupported;
             var maxTextureSize = RenderCapability.MaxHardwareTextureSize;
+            var renderMode = RenderOptions.ProcessRenderMode;
 
             logger.Log(string.Format("RENDER : Rendering Tier: {0}", renderingTier));
             logger.LogError(string.Format("RENDER : Pixel Shader 3 Supported: {0}", pixelShader3Supported));
             logger.Log(string.Format("RENDER : Pixel Shader 4 Supported: {0}", pixelShader4Supported));
             logger.Log(string.Format("RENDER : Software Effect Rendering Supported: {0}", softwareEffectSupported));
             logger.Log(string.Format("RENDER : Maximum hardware texture size: {0}", maxTextureSize));
+            logger.Log(string.Format("RENDER : RenderMode: {0}", renderMode));
         }
 
         private void RegisterModelEventhandlers(IDynamoModel dynamoModel)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -401,7 +401,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             logger.Log(string.Format("RENDER : Pixel Shader 4 Supported: {0}", pixelShader4Supported));
             logger.Log(string.Format("RENDER : Software Effect Rendering Supported: {0}", softwareEffectSupported));
             logger.Log(string.Format("RENDER : Maximum hardware texture size: {0}", maxTextureSize));
-            logger.Log(string.Format("RENDER : RenderMode: {0}", renderMode));
+            logger.Log(string.Format("RENDER : ProcessRenderMode: {0}", renderMode == RenderMode.Default ? "Hardware (with Software fallback)" : "Software" ));
         }
 
         private void RegisterModelEventhandlers(IDynamoModel dynamoModel)

--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
@@ -48,9 +48,6 @@ namespace Watch3DNodeModelsWpf
             var dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
             watch3dModel = model;
 
-//            var renderingTier = (RenderCapability.Tier >> 16);
-//            if (renderingTier < 2) return;
-
             var dynamoModel = dynamoViewModel.Model;
 
             var vmParams = new Watch3DViewModelStartupParams(dynamoModel);

--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,8 +48,8 @@ namespace Watch3DNodeModelsWpf
             var dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
             watch3dModel = model;
 
-            var renderingTier = (RenderCapability.Tier >> 16);
-            if (renderingTier < 2) return;
+//            var renderingTier = (RenderCapability.Tier >> 16);
+//            if (renderingTier < 2) return;
 
             var dynamoModel = dynamoViewModel.Model;
 

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -51,12 +51,6 @@ namespace DynamoCoreWpfTests
             var path = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Process) + ";" + Model.PathManager.DynamoCoreDirectory;
             Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
 
-//            var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
-//            if (renderingTier < 2)
-//            {
-//                Assert.Inconclusive("Hardware rendering is not available. Watch3D is not created.");
-//            }
-
             Open(@"UI\CoreUINodes.dyn");
             var nodeView = NodeViewWithGuid("6869c998-b819-4686-8849-6f36162c4182"); // NodeViewOf<Watch3D>();
             var watchView = nodeView.ChildrenOfType<Watch3DView>().FirstOrDefault();

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -51,11 +51,11 @@ namespace DynamoCoreWpfTests
             var path = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Process) + ";" + Model.PathManager.DynamoCoreDirectory;
             Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
 
-            var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
-            if (renderingTier < 2)
-            {
-                Assert.Inconclusive("Hardware rendering is not available. Watch3D is not created.");
-            }
+//            var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
+//            if (renderingTier < 2)
+//            {
+//                Assert.Inconclusive("Hardware rendering is not available. Watch3D is not created.");
+//            }
 
             Open(@"UI\CoreUINodes.dyn");
             var nodeView = NodeViewWithGuid("6869c998-b819-4686-8849-6f36162c4182"); // NodeViewOf<Watch3D>();


### PR DESCRIPTION
### Purpose
This pull request does:
* allow Watch3D nodes to run in software mode.

I think this is a leftover since the days when we supported WIndows 7/8. As far as I know, at least a software render should always be available in Windows 10/11.

This change also allows all Dynamo tests to pass on an ECS instance with GPU. These instances behaves as a multi GPU machine and for some reason, the RenderCapability object reports nothing useful. But everything points to that Dynamo is in hardware mode and the RenderMode object indicates this. 

I will also try to run all tests on an instance without GPU.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
