### PR TITLE
DYN-6468 Add Guard for circular references that can impact Stringify.JSON and Remember node

### DIFF
--- a/src/Libraries/CoreNodeModels/Logic/Gate.cs
+++ b/src/Libraries/CoreNodeModels/Logic/Gate.cs
@@ -16,10 +16,10 @@ namespace CoreNodeModels.Logic
     [NodeSearchTags(nameof(Resources.GateSearchTags), typeof(Resources))]
     [InPortNames(">")]
     [InPortTypes("object")]
-    [InPortDescriptions(nameof(Resources.GateInPortToolTip), nameof(Resources))]
+    [InPortDescriptions(typeof(Resources), nameof(Resources.GateInPortToolTip))]
     [OutPortNames(">")]
     [OutPortTypes("object")]
-    [OutPortDescriptions(nameof(Resources.GateOutPortToolTip), nameof(Resources))]
+    [OutPortDescriptions(typeof(Resources), nameof(Resources.GateOutPortToolTip))]
     [IsDesignScriptCompatible]
     public class Gate : NodeModel
     {

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -13,6 +13,8 @@ using System.Runtime.Versioning;
 using Dynamo.Events;
 using Dynamo.Logging;
 using Dynamo.Session;
+using System.Globalization;
+using System.Text;
 
 namespace DSCore
 {
@@ -188,8 +190,9 @@ namespace DSCore
         /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
         public static string StringifyJSON([ArbitraryDimensionArrayImport] object values)
         {
-            return JsonConvert.SerializeObject(values,
-                new JsonConverter[]
+            var settings = new JsonSerializerSettings()
+            {
+                Converters = new JsonConverter[]
                 {
                     new DictConverter(),
                     new DesignScriptGeometryConverter(),
@@ -198,9 +201,66 @@ namespace DSCore
 #if _WINDOWS
                     new PNGImageConverter(),
 #endif
-                });
+                }
+            };
+
+            StringBuilder sb = new StringBuilder(256);
+            using (var writer = new StringWriter(sb, CultureInfo.InvariantCulture))
+            {
+                using (var jsonWriter = new MaxDepthJsonTextWriter(writer))
+                {
+                    JsonSerializer.Create(settings).Serialize(jsonWriter, values);
+                }
+                return writer.ToString();
+            }
         }
 
+        /// <summary>
+        /// Subclass of JsonTextWriter that limits a maximum supported object depth to prevent circular reference crashes when serializing arbitrary .NET objects types.
+        /// </summary>
+        private class MaxDepthJsonTextWriter : JsonTextWriter
+        {
+            private readonly int maxDepth = 15;
+            private int depth = 0;
+
+            public MaxDepthJsonTextWriter(TextWriter writer) : base(writer) { }
+
+            public override void WriteStartArray()
+            {
+                base.WriteStartArray();
+                depth++;
+                CheckDepth();
+            }
+
+            public override void WriteEndArray()
+            {
+                base.WriteEndArray();
+                depth--;
+                CheckDepth();
+            }
+
+            public override void WriteStartObject()
+            {
+                base.WriteStartObject();
+                depth++;
+                CheckDepth();
+            }
+
+            public override void WriteEndObject()
+            {
+                base.WriteEndObject();
+                depth--;
+                CheckDepth();
+            }
+
+            private void CheckDepth()
+            {
+                if (depth > maxDepth)
+                {
+                    throw new JsonSerializationException(string.Format("Depth {0} Exceeds MaxDepth {1} at path \"{2}\"", depth, maxDepth, Path));
+                }
+            }
+        }
 
         #region Converters
         /// <summary>

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -257,7 +257,7 @@ namespace DSCore
             {
                 if (depth > maxDepth)
                 {
-                    throw new JsonSerializationException(string.Format("Depth {0} Exceeds MaxDepth {1} at path \"{2}\"", depth, maxDepth, Path));
+                    throw new JsonSerializationException(string.Format(Properties.Resources.Exception_Serialize_Depth_Unsupported, depth, maxDepth, Path));
                 }
             }
         }

--- a/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace DSCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Depth {0} Exceeds MaxDepth {1} at path &quot;{2}&quot;.
+        /// </summary>
+        internal static string Exception_Serialize_Depth_Unsupported {
+            get {
+                return ResourceManager.GetString("Exception_Serialize_Depth_Unsupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This type of Geometry is not able to be serialized..
         /// </summary>
         internal static string Exception_Serialize_DesignScript_Unsupported {

--- a/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
@@ -147,6 +147,9 @@
   <data name="Exception_Deserialize_Unsupported_Cache" xml:space="preserve">
     <value>The stored data can not be loaded.</value>
   </data>
+  <data name="Exception_Serialize_Depth_Unsupported" xml:space="preserve">
+    <value>Depth {0} Exceeds MaxDepth {1} at path "{2}"</value>
+  </data>
   <data name="Exception_Serialize_DesignScript_Unsupported" xml:space="preserve">
     <value>This type of Geometry is not able to be serialized.</value>
   </data>

--- a/src/Libraries/CoreNodes/Properties/Resources.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.resx
@@ -147,6 +147,9 @@
   <data name="Exception_Deserialize_Unsupported_Cache" xml:space="preserve">
     <value>The stored data can not be loaded.</value>
   </data>
+  <data name="Exception_Serialize_Depth_Unsupported" xml:space="preserve">
+    <value>Depth {0} Exceeds MaxDepth {1} at path "{2}"</value>
+  </data>
   <data name="Exception_Serialize_DesignScript_Unsupported" xml:space="preserve">
     <value>This type of Geometry is not able to be serialized.</value>
   </data>

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.ZeroTouch;
 using DynamoUnits;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -190,6 +191,25 @@ namespace Dynamo.Tests
 
             // Verify values match when parsing JSON via Python
             AssertPreviewValue("cdad5bf1-f5f7-47f4-a119-ad42e5084cfa", true);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void SerializingObjectOverMaximumDepthFailes()
+        {
+            // Load test graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Serialization_Depth_Fail.dyn");
+            OpenModel(path);
+
+            var node = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("cc45bec3172e40dab4d967e9dd81cbdd"));
+
+            var expectedWarning = "Exceeds MaxDepth";
+
+            Assert.AreEqual(node.State, ElementState.Warning);
+            AssertPreviewValue("cc45bec3172e40dab4d967e9dd81cbdd", null);
+            Assert.AreEqual(node.Infos.Count, 1);
+            Assert.IsTrue(node.Infos.Any(x => x.Message.Contains(expectedWarning) && x.State == ElementState.Warning));
         }
 
         [Test]

--- a/test/core/json/JSON_Serialization_Depth_Fail.dyn
+++ b/test/core/json/JSON_Serialization_Depth_Fail.dyn
@@ -1,0 +1,147 @@
+{
+  "Uuid": "4fac373f-9349-4b71-975a-9cf02784050b",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "JSON_Serialization_Depth_Fail",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "498b579729a04e099c8209d4888fec47",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "32dfd39fdd044440aabe4c81155f1622",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "[1,[2,[3,[4,[5,[6,[7,[8,[9,[10,[11,[12,[13,[14,[15,[false]]]]]]]]]]]]]]]];"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "cc45bec3172e40dab4d967e9dd81cbdd",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "ad169e7d7ebc4fe9bd3f3807ad53385a",
+          "Name": "values",
+          "Description": "A List of values\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c92ff66756e04454bc444cad9ed6eb43",
+          "Name": "json",
+          "Description": "A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "DSCore.Data.StringifyJSON@var[]..[]",
+      "Replication": "Auto",
+      "Description": "Stringify converts an arbitrary value or a list of arbitrary values to JSON. Replication can be used to apply the operation over a list, producing a list of JSON strings.\n\nData.StringifyJSON (values: var[]..[]): string"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "32dfd39fdd044440aabe4c81155f1622",
+      "End": "ad169e7d7ebc4fe9bd3f3807ad53385a",
+      "Id": "3775253b954646c9bb26d7ea0db8af10",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": null,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.0",
+      "Data": {}
+    },
+    {
+      "ExtensionGuid": "DFBD9CC0-DB40-457A-939E-8C8555555A9D",
+      "Name": "Generative Design",
+      "Version": "8.0",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.0.0.5795",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "498b579729a04e099c8209d4888fec47",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 74.5,
+        "Y": 257.5
+      },
+      {
+        "Id": "cc45bec3172e40dab4d967e9dd81cbdd",
+        "Name": "Data.StringifyJSON",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 855.5,
+        "Y": 260.5
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

In testing the Remember node we found that some classes of NET objects can cause Dynamo Crashes when Stringify.JSON tries to serialize the objects to JSON via json.net.  The main example cases were some types of Revit objects.  While it is expected that these objects should not serialize to json.  They should fail with a warning on the node and not a hard crash.

Todo 
- [x] Test
- [x] Add warning to localization.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

@mjkkirschner 

### FYIs

@jnealb 
