### PR TITLE
DYN-6313 ML NodeAutoComplete TOU related UX

### DIFF
--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml
@@ -361,7 +361,7 @@
                         <MenuItem Header="{x:Static p:Resources.RecommendedNodes}"
                                   x:Name="miMLRecommendation"
                                   Click="OnSuggestion_Click"
-                                  IsCheckable="True"
+                                  IsCheckable="{Binding Path=IsMLAutocompleteTOUApproved, Mode=OneWay}"
                                   IsChecked="{Binding Path=IsDisplayingMLRecommendation, Mode=OneWay, Converter={StaticResource BinaryRadioButtonCheckedConverter},ConverterParameter=True}"
                                   Visibility="{Binding HideAutocompleteMethodOptions, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"/>
                         <MenuItem Header="{x:Static p:Resources.ObjectType}"

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -385,8 +385,16 @@ namespace Dynamo.UI.Controls
             MenuItem selectedSuggestion = sender as MenuItem;
             if (selectedSuggestion.Name.Contains(nameof(Models.NodeAutocompleteSuggestion.MLRecommendation)))
             {
-                ViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = Models.NodeAutocompleteSuggestion.MLRecommendation;
-                Analytics.TrackEvent(Actions.Switch, Categories.Preferences, nameof(NodeAutocompleteSuggestion.MLRecommendation));
+                if(ViewModel.IsMLAutocompleteTOUApproved)
+                {
+                    ViewModel.dynamoViewModel.PreferenceSettings.DefaultNodeAutocompleteSuggestion = Models.NodeAutocompleteSuggestion.MLRecommendation;
+                    Analytics.TrackEvent(Actions.Switch, Categories.Preferences, nameof(NodeAutocompleteSuggestion.MLRecommendation));
+                }
+                else
+                {
+                    ViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow("Please agree to MLNodeAutoComplete TOU before proceeding");
+                    // Do nothing for now, do not report analytics since the switch did not happen
+                }
             }
             else
             {
@@ -396,6 +404,9 @@ namespace Dynamo.UI.Controls
             ViewModel.PopulateAutoCompleteCandidates();
         }
 
+        /// <summary>
+        /// Dispose the control
+        /// </summary>
         public void Dispose()
         {
             NodeAutoCompleteSearchControl_Unloaded(this,null);

--- a/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NodeAutoCompleteSearchControl.xaml.cs
@@ -392,7 +392,7 @@ namespace Dynamo.UI.Controls
                 }
                 else
                 {
-                    ViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow("Please agree to MLNodeAutoComplete TOU before proceeding");
+                    ViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Res.NotificationToAgreeMLNodeautocompleteTOU);
                     // Do nothing for now, do not report analytics since the switch did not happen
                 }
             }

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5072,7 +5072,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In order to access the Recommended Nodes feature please accept the dedicated Terms of Use located under Dynamo —&gt; Agreement to Collect Usability Data..
+        ///   Looks up a localized string similar to To access the Recommended Nodes feature please read Dynamo —&gt; Agreement and Terms of Use then accept..
         /// </summary>
         public static string NotificationToAgreeMLNodeautocompleteTOU {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5072,6 +5072,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to In order to access the Recommended Nodes feature please accept the dedicated Terms of Use located under Dynamo —&gt; Agreement to Collect Usability Data..
+        /// </summary>
+        public static string NotificationToAgreeMLNodeautocompleteTOU {
+            get {
+                return ResourceManager.GetString("NotificationToAgreeMLNodeautocompleteTOU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to null.
         /// </summary>
         public static string NullString {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5072,7 +5072,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To access the Recommended Nodes feature please read Dynamo —&gt; Agreement and Terms of Use then accept..
+        ///   Looks up a localized string similar to To access the Recommended Nodes feature, please read and accept Dynamo &gt; Agreement and Terms of Use..
         /// </summary>
         public static string NotificationToAgreeMLNodeautocompleteTOU {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3853,6 +3853,6 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>Element Binding allows a two-way interaction between Dynamo and the host application like Revit or Civil3D where a user can select an element in the host document and have Dynamo "bind" that element to a node in the workspace.</value>
   </data>
   <data name="NotificationToAgreeMLNodeautocompleteTOU" xml:space="preserve">
-    <value>To access the Recommended Nodes feature please read Dynamo —&gt; Agreement and Terms of Use then accept.</value>
+    <value>To access the Recommended Nodes feature, please read and accept Dynamo &gt; Agreement and Terms of Use.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3853,6 +3853,6 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>Element Binding allows a two-way interaction between Dynamo and the host application like Revit or Civil3D where a user can select an element in the host document and have Dynamo "bind" that element to a node in the workspace.</value>
   </data>
   <data name="NotificationToAgreeMLNodeautocompleteTOU" xml:space="preserve">
-    <value>In order to access the Recommended Nodes feature please accept the dedicated Terms of Use located under Dynamo —&gt; Agreement to Collect Usability Data.</value>
+    <value>To access the Recommended Nodes feature please read Dynamo —&gt; Agreement and Terms of Use then accept.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1413,7 +1413,7 @@ To avoid unintended behavior, uninstall the conflicting loaded package(s), resta
   <data name="NameNeedMoreCharacters" xml:space="preserve">
     <value>Must be at least 3 characters</value>
     <comment>ErrorString</comment>
-  </data>    
+  </data>
   <data name="PackageManagerProvidePackageName" xml:space="preserve">
     <value>Provide package name</value>
     <comment>ErrorString</comment>
@@ -1905,7 +1905,7 @@ Want to publish a different package?</value>
   </data>
   <data name="PublishPackageViewPackageVersionTooltip" xml:space="preserve">
     <value>A version name helps a submitter keep track of updates to the package. When a new version of a package is added, version number must be increased.</value>
-  </data>    
+  </data>
   <data name="PublishPackageViewPublisherWebsiteTooltip" xml:space="preserve">
     <value>Website link for the package.</value>
   </data>
@@ -3236,12 +3236,12 @@ To install the latest version of a package, click Install. \n
   <data name="PublishPackageViewNodeLibrary" xml:space="preserve">
     <value>Node Library</value>
   </data>
-    <data name="PublishPackageRetainFolderStructureTooltip" xml:space="preserve">
+  <data name="PublishPackageRetainFolderStructureTooltip" xml:space="preserve">
     <value>When this setting is enabled, the folder structure of uploaded files will be retained. Otherwise, files will be placed into predefined folders.
 
 Note: Incorrect folder structure may affect the functionality of packages that rely on the correct file organization. When in doubt, leave this setting off.
     </value>
-  </data>    
+  </data>
   <data name="PublishPackageNodeLibraryTooltip" xml:space="preserve">
     <value>DLL file containing types and methods that Dynamo imports as nodes. Mark ZeroTouch, NodeModel, or NodeViewCustomization DLLs and types you want to import into Dynamo as node libraries.</value>
   </data>
@@ -3851,5 +3851,8 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   </data>
   <data name="ElementBindingDesc" xml:space="preserve">
     <value>Element Binding allows a two-way interaction between Dynamo and the host application like Revit or Civil3D where a user can select an element in the host document and have Dynamo "bind" that element to a node in the workspace.</value>
+  </data>
+  <data name="NotificationToAgreeMLNodeautocompleteTOU" xml:space="preserve">
+    <value>In order to access the Recommended Nodes feature please accept the dedicated Terms of Use located under Dynamo —&gt; Agreement to Collect Usability Data.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3840,6 +3840,6 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>Element Binding allows a two-way interaction between Dynamo and the host application like Revit or Civil3D where a user can select an element in the host document and have Dynamo "bind" that element to a node in the workspace.</value>
   </data>
   <data name="NotificationToAgreeMLNodeautocompleteTOU" xml:space="preserve">
-    <value>To access the Recommended Nodes feature please read Dynamo —&gt; Agreement and Terms of Use then accept.</value>
+    <value>To access the Recommended Nodes feature, please read and accept Dynamo &gt; Agreement and Terms of Use.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1686,7 +1686,7 @@ If the toggle is off custom packages that are not already loaded will load once 
   </data>
   <data name="PublishPackageViewCopyrightHolderTooltip" xml:space="preserve">
     <value>The package's copyright holder.</value>
-  </data>    
+  </data>
   <data name="PublishPackageViewLicenceTooltip" xml:space="preserve">
     <value>The package's licence.</value>
   </data>
@@ -3838,5 +3838,8 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   </data>
   <data name="ElementBindingDesc" xml:space="preserve">
     <value>Element Binding allows a two-way interaction between Dynamo and the host application like Revit or Civil3D where a user can select an element in the host document and have Dynamo "bind" that element to a node in the workspace.</value>
+  </data>
+  <data name="NotificationToAgreeMLNodeautocompleteTOU" xml:space="preserve">
+    <value>In order to access the Recommended Nodes feature please accept the dedicated Terms of Use located under Dynamo —&gt; Agreement to Collect Usability Data.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3840,6 +3840,6 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>Element Binding allows a two-way interaction between Dynamo and the host application like Revit or Civil3D where a user can select an element in the host document and have Dynamo "bind" that element to a node in the workspace.</value>
   </data>
   <data name="NotificationToAgreeMLNodeautocompleteTOU" xml:space="preserve">
-    <value>In order to access the Recommended Nodes feature please accept the dedicated Terms of Use located under Dynamo —&gt; Agreement to Collect Usability Data.</value>
+    <value>To access the Recommended Nodes feature please read Dynamo —&gt; Agreement and Terms of Use then accept.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1086,6 +1086,17 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// If MLAutocompleteTOU is approved
+        /// </summary>
+        internal bool IsMLAutocompleteTOUApproved
+        {
+            get
+            {
+                return preferenceSettings.IsMLAutocompleteTOUApproved;
+            }
+        }
+
+        /// <summary>
         /// Controls if the the Node autocomplete Machine Learning option is checked for the radio buttons
         /// </summary>
         public bool NodeAutocompleteMachineLearningIsChecked

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -77,6 +77,17 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// If MLAutocompleteTOU is approved
+        /// </summary>
+        public bool IsMLAutocompleteTOUApproved
+        {
+            get
+            {
+                return dynamoViewModel.PreferenceSettings.IsMLAutocompleteTOUApproved;
+            }
+        }
+
+        /// <summary>
         /// If true, autocomplete method options are hidden from UI 
         /// </summary>
         public bool HideAutocompleteMethodOptions

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -893,18 +893,21 @@
                                                     <ColumnDefinition x:Name="colMachineLearning" Width="Auto"/>
                                                     <ColumnDefinition x:Name="colMLbetaTag" Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
-                                                <RadioButton Grid.Column="0" 
+                                                <RadioButton Grid.Column="0"
+                                                     x:Name="ObjectTypeRadioButton"
                                                      MinWidth="90"
                                                      Margin="-3,0,20,0"
                                                      Style="{StaticResource RunSettingsRadioButtons}"
                                                      IsChecked="{Binding Path=NodeAutocompleteMachineLearningIsChecked, Converter={StaticResource BinaryRadioButtonCheckedConverter},ConverterParameter=False}"
                                                      Content="{x:Static p:Resources.ObjectType}"
                                                      IsEnabled="{Binding Path=NodeAutocompleteIsChecked}"/>
-                                                <RadioButton Grid.Column="1" 
+                                                <RadioButton Grid.Column="1"
+                                                     x:Name="RecommendedNodesRadioButton"
                                                      MinWidth="90"
                                                      Style="{StaticResource RunSettingsRadioButtons}"
                                                      IsChecked="{Binding Path=NodeAutocompleteMachineLearningIsChecked, Converter={StaticResource BinaryRadioButtonCheckedConverter},ConverterParameter=True}"
                                                      Content="{x:Static p:Resources.RecommendedNodes}"
+                                                     Click="RecommendedNodesRadioButton_Click"
                                                      IsEnabled="{Binding Path=NodeAutocompleteIsChecked}"/>
                                                 <!--Beta tag-->
                                                 <Label Grid.Column="2"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -18,6 +18,7 @@ using Dynamo.Core;
 using Dynamo.Logging;
 using Dynamo.UI;
 using Dynamo.ViewModels;
+using static Dynamo.ViewModels.SearchViewModel;
 using Res = Dynamo.Wpf.Properties.Resources;
 
 namespace Dynamo.Wpf.Views
@@ -649,6 +650,17 @@ namespace Dynamo.Wpf.Views
         {
             this.CloseButton_Click(this.CloseButton, e);
             this.dynViewModel.ShowPackageManager(Dynamo.Wpf.Properties.Resources.PackageManagerInstalledPackagesTab);
+        }
+
+        private void RecommendedNodesRadioButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!viewModel.IsMLAutocompleteTOUApproved)
+            {
+                dynViewModel.MainGuideManager.CreateRealTimeInfoWindow(Res.NotificationToAgreeMLNodeautocompleteTOU);
+                // Reset back to object type recommendations
+                RecommendedNodesRadioButton.IsChecked = false;
+                ObjectTypeRadioButton.IsChecked = true;
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose

A followup of https://github.com/DynamoDS/Dynamo/pull/14625. If the user does not agree on ML NodeAutoComplete TOU, switching to ML NodeAutoComplet will be blocked with notification shown below.

After:
![MLNodeAutoCompleteTOUDisagree_1](https://github.com/DynamoDS/Dynamo/assets/3942418/68343e08-8a52-4b81-99ba-9d791f09486a)

![MLNodeAutoCompleteTOUDisagree_2](https://github.com/DynamoDS/Dynamo/assets/3942418/381efa45-37dc-4dc5-b775-303bcafd33ba)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
