### PR TITLE
REVIT-215698: Restrict where OnNodeModified is called.

### DIFF
--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -59,7 +59,7 @@ namespace CoreNodeModels
             set
             {
                 items = value;
-                RaisePropertyChanged("Items");
+                RaisePropertyChanged(nameof(Items));
             }
         }
 
@@ -106,7 +106,6 @@ namespace CoreNodeModels
                     selectedString = GetSelectedStringFromItem(Items.ElementAt(value));
                 }
 
-                OnNodeModified();
                 RaisePropertyChanged("SelectedIndex");
                 RaisePropertyChanged("SelectedString");
             }
@@ -137,12 +136,12 @@ namespace CoreNodeModels
                     if (item != null)
                     {
                         selectedIndex = Items.IndexOf(item);
-                        RaisePropertyChanged("SelectedIndex");
+                        RaisePropertyChanged(nameof(SelectedIndex));
                     }
                 }
 
                 selectedString = value;
-                RaisePropertyChanged("SelectedString");
+                RaisePropertyChanged(nameof(SelectedString));
             }
         }
 
@@ -202,6 +201,8 @@ namespace CoreNodeModels
                 {
                     Warning(Dynamo.Properties.Resources.NothingIsSelectedWarning);
                 }
+
+                OnNodeModified();
 
                 return true;
             }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
@@ -38,6 +38,11 @@ namespace CoreNodeModelsWpf.Nodes
             System.Windows.Controls.Grid.SetRow(combo, 0);
 
             combo.DropDownOpened += combo_DropDownOpened;
+            combo.SelectionChanged += delegate
+            {
+                if (combo.SelectedIndex != -1)
+                    model.OnNodeModified();
+            };
 
             combo.DataContext = model;
 


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

[REVIT-215698](https://jira.autodesk.com/browse/REVIT-215698)

#14122 fixed an issue where setting a dropdown's value (the `SelectedIndex` property) programatically didn't cause the node to recompute (`OnNodeModified` never called, so AST never rebuilt). However, Revit selection nodes change the node's value in `BuildOutputAst` (populate items and update `SelectedIndex`), causing an infinite loop. (It's surprising to me that it's ok to modify the node's value in `BuildOutputAst`. Is this something other nodes do?)

This PR moves the call to `OnNodeModified` up to `UpdateValueCore`, which is what is called when changing the node's value programatically, reducing the impact of #14122 and preventing the crash.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
