### PR TITLE
DYN-6470 Improve Dynamo PreferenceSettings.Instance singleton behavior.

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -48,12 +48,14 @@ namespace Dynamo.Configuration
     /// </summary>
     public class PreferenceSettings : NotificationObject, IPreferences, IRenderPrecisionPreference, IDisablePackageLoadingPreferences, ILogSource, IHideAutocompleteMethodOptions
     {
+        internal static PreferenceSettings dynamoModelRuntimePreferenceSettings;
+
         internal readonly static Lazy<PreferenceSettings>
             lazy = new Lazy<PreferenceSettings>
             (() => PreferenceSettings.Load(PathManager.Instance.PreferenceFilePath));
 
         [XmlIgnore]
-        public static PreferenceSettings Instance { get { return lazy.Value; } }
+        public static PreferenceSettings Instance { get { return dynamoModelRuntimePreferenceSettings ?? lazy.Value; } }
 
         private string numberFormat;
         private string lastUpdateDownloadPath;

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -48,14 +48,12 @@ namespace Dynamo.Configuration
     /// </summary>
     public class PreferenceSettings : NotificationObject, IPreferences, IRenderPrecisionPreference, IDisablePackageLoadingPreferences, ILogSource, IHideAutocompleteMethodOptions
     {
-        internal static PreferenceSettings dynamoModelRuntimePreferenceSettings;
-
         internal readonly static Lazy<PreferenceSettings>
             lazy = new Lazy<PreferenceSettings>
             (() => PreferenceSettings.Load(PathManager.Instance.PreferenceFilePath));
 
         [XmlIgnore]
-        public static PreferenceSettings Instance { get { return dynamoModelRuntimePreferenceSettings ?? lazy.Value; } }
+        public static PreferenceSettings Instance { get; internal set; } = lazy.Value;
 
         private string numberFormat;
         private string lastUpdateDownloadPath;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -692,6 +692,10 @@ namespace Dynamo.Models
             OnRequestUpdateLoadBarStatus(new SplashScreenLoadEventArgs(Resources.SplashScreenInitPreferencesSettings, 30));
 
             PreferenceSettings = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
+
+            //Set the DynamoModel.PreferenceSetting as a static reference to the PreferenceSetting class for use in PreferenceSettings.Instance
+            PreferenceSettings.dynamoModelRuntimePreferenceSettings = PreferenceSettings;
+
             if (PreferenceSettings != null)
             {
                 SetUICulture(PreferenceSettings.Locale);
@@ -780,6 +784,9 @@ namespace Dynamo.Models
                 {
                     var isFirstRun = PreferenceSettings.IsFirstRun;
                     PreferenceSettings = migrator.PreferenceSettings;
+
+                    //Set the DynamoModel.PreferenceSetting as a static reference to the PreferenceSetting class for use in PreferenceSettings.Instance
+                    PreferenceSettings.dynamoModelRuntimePreferenceSettings = PreferenceSettings;
 
                     // Preserve the preference settings for IsFirstRun as this needs to be set
                     // only by UsageReportingManager

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -788,9 +788,6 @@ namespace Dynamo.Models
                     var isFirstRun = PreferenceSettings.IsFirstRun;
                     PreferenceSettings = migrator.PreferenceSettings;
 
-                    //Set the DynamoModel.PreferenceSetting as a static reference to the PreferenceSetting class for use in PreferenceSettings.Instance
-                    PreferenceSettings.dynamoModelRuntimePreferenceSettings = PreferenceSettings;
-
                     // Preserve the preference settings for IsFirstRun as this needs to be set
                     // only by UsageReportingManager
                     PreferenceSettings.IsFirstRun = isFirstRun;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -304,7 +304,8 @@ namespace Dynamo.Models
         /// <summary>
         ///     Preference settings for this instance of Dynamo.
         /// </summary>
-        public readonly PreferenceSettings PreferenceSettings;
+        [Obsolete("this will be removed in 4.0")]
+        public PreferenceSettings PreferenceSettings => PreferenceSettings.Instance;
 
         /// <summary>
         ///     Node Factory, used for creating and intantiating loaded Dynamo nodes.
@@ -491,9 +492,6 @@ namespace Dynamo.Models
         {
             Dispose();
             PreferenceSettings.SaveInternal(pathManager.PreferenceFilePath);
-
-            //Remove reference on shutdown
-            PreferenceSettings.dynamoModelRuntimePreferenceSettings = null;
 
             OnCleanup();
 
@@ -694,10 +692,7 @@ namespace Dynamo.Models
 
             OnRequestUpdateLoadBarStatus(new SplashScreenLoadEventArgs(Resources.SplashScreenInitPreferencesSettings, 30));
 
-            PreferenceSettings = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
-
-            //Set the DynamoModel.PreferenceSetting as a static reference to the PreferenceSetting class for use in PreferenceSettings.Instance
-            PreferenceSettings.dynamoModelRuntimePreferenceSettings = PreferenceSettings;
+            PreferenceSettings.Instance = (PreferenceSettings)CreateOrLoadPreferences(config.Preferences);
 
             if (PreferenceSettings != null)
             {
@@ -786,7 +781,7 @@ namespace Dynamo.Models
                 if (migrator != null)
                 {
                     var isFirstRun = PreferenceSettings.IsFirstRun;
-                    PreferenceSettings = migrator.PreferenceSettings;
+                    PreferenceSettings.Instance = migrator.PreferenceSettings;
 
                     // Preserve the preference settings for IsFirstRun as this needs to be set
                     // only by UsageReportingManager

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -492,6 +492,9 @@ namespace Dynamo.Models
             Dispose();
             PreferenceSettings.SaveInternal(pathManager.PreferenceFilePath);
 
+            //Remove reference on shutdown
+            PreferenceSettings.dynamoModelRuntimePreferenceSettings = null;
+
             OnCleanup();
 
             DynamoSelection.DestroyInstance();

--- a/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
+++ b/test/Libraries/DynamoPythonTests/PythonTestsWithLogging.cs
@@ -33,16 +33,15 @@ namespace DynamoPythonTests
         [Test]
         public void DynamoPrintLogsToConsole()
         {
-            var expectedOutput = ".*Greeting CPython node: Hello from Python3!!!" + Environment.NewLine
-                + ".*Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
-                + ".*Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
-                + ".*Multiple print parameter node: Hello Dynamo Print !!!" + Environment.NewLine
-                + ".*Print separator parameter node: Hello_Dynamo_Print_!!!" + Environment.NewLine
-                + ".*`!\"£\\$%\\^&\\*\\(\\)_\\+-\\[\\{\\]\\}#~'@;:\\|\\\\,<\\.>/\\? Special character node: Lot's of special characters!!!" + Environment.NewLine
-                + ".*";
+            var expectedOutput = "Greeting CPython node: Hello from Python3!!!" + Environment.NewLine
+                  + "Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
+                  + "Greeting CPython String node: Hello from Python3!!!" + Environment.NewLine
+                  + "Multiple print parameter node: Hello Dynamo Print !!!" + Environment.NewLine
+                  + "Print separator parameter node: Hello_Dynamo_Print_!!!" + Environment.NewLine
+                  + @"`!£$%^&*()_+-[{]}#~'@;:|\,<.>/? Special character node: Lot's of special characters!!!";
 
             CurrentDynamoModel.OpenFileFromPath(Path.Combine(TestDirectory, "core", "python", "DynamoPrint.dyn"));
-            StringAssert.IsMatch(expectedOutput, CurrentDynamoModel.Logger.LogText);
+            StringAssert.Contains(expectedOutput, CurrentDynamoModel.Logger.LogText);
         }
 
         [Test]

--- a/test/core/python/DynamoPrint.dyn
+++ b/test/core/python/DynamoPrint.dyn
@@ -387,8 +387,8 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "`!\"£$%^&*()_+-[{]}#~'@;:|\\,<.>/? Special character node",
         "Id": "da61a0ad7b024ec3bc05c63503a70358",
+        "Name": "`!£$%^&*()_+-[{]}#~'@;:|\\,<.>/? Special character node",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,


### PR DESCRIPTION
### Purpose

The purpose of the PR is to improve the singleton behavior of the `PreferenceSettings.Instance`.  Currently it is very easy to utilize the Instance with the assumption that it is connected to the `DynamoModel.PrefenceSettings` (previously how you would access runtime Preferences via API) and will stay in sync.  This is not the case and they can diverge in state and data can be lost regardless of how often the Preference are saved to disk by the API user.  This PR improve the Instance method synchronization by connecting directly to the DynamoModel.PreferenceSettings when it is available.  There are still scenarios where the two access points can get out of sync but this should change cover most scenarios until we can unify the access points to a single reference object. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

### Reviewers

@QilongTang @mjkkirschner @BogdanZavu 

### FYIs

@twastvedt 
