### PR TITLE
DYN-6055 Lucene Search Category Based.

### DIFF
--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -143,9 +143,19 @@ namespace Dynamo.Configuration
             Name,
 
             /// <summary>
+            /// NameSplitted - The name of the node splitted using just the last part (e.g. List.Chop we will be using just Chop)
+            /// </summary>
+            NameSplitted,
+
+            /// <summary>
             /// FullCategoryName - The category of the node
             /// </summary>
             FullCategoryName,
+
+            /// <summary>
+            /// CategorySplitted - For this case we will be using just the last Category (the last word after the dot separator in FullCategoryName)
+            /// </summary>
+            CategorySplitted,
 
             /// <summary>
             /// Description - The description of the node
@@ -182,7 +192,9 @@ namespace Dynamo.Configuration
         /// Nodes Fields to be indexed by Lucene Search
         /// </summary>
         public static string[] NodeIndexFields = { nameof(NodeFieldsEnum.Name),
+                                                   nameof(NodeFieldsEnum.NameSplitted),                                  
                                                    nameof(NodeFieldsEnum.FullCategoryName),
+                                                   nameof(NodeFieldsEnum.CategorySplitted),
                                                    nameof(NodeFieldsEnum.Description),
                                                    nameof(NodeFieldsEnum.SearchKeywords),
                                                    nameof(NodeFieldsEnum.DocName),

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -163,7 +163,9 @@ namespace Dynamo.Utilities
             if (DynamoModel.IsTestMode && startConfig.StorageType == LuceneStorage.FILE_SYSTEM) return null;
 
             var name = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Name), string.Empty, Field.Store.YES);
+            var nameSplitted = new TextField(nameof(LuceneConfig.NodeFieldsEnum.NameSplitted), string.Empty, Field.Store.YES);
             var fullCategory = new TextField(nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), string.Empty, Field.Store.YES);
+            var categorySplitted = new TextField(nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted), string.Empty, Field.Store.YES);          
             var description = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Description), string.Empty, Field.Store.YES);
             var keywords = new TextField(nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
             var docName = new StringField(nameof(LuceneConfig.NodeFieldsEnum.DocName), string.Empty, Field.Store.YES);
@@ -172,8 +174,10 @@ namespace Dynamo.Utilities
 
             var d = new Document()
             {
-                fullCategory,
                 name,
+                nameSplitted,
+                fullCategory,
+                categorySplitted,                
                 description,
                 keywords,
                 fullDoc,
@@ -269,9 +273,26 @@ namespace Dynamo.Utilities
 
             var booleanQuery = new BooleanQuery();
             string searchTerm = QueryParser.Escape(SearchTerm);
+            var bCategoryBasedSearch = searchTerm.Contains('.') ? true : false;
 
             foreach (string f in fields)
             {
+                //Needs to be again due that now a query can contain different values per field (e.g. CategorySplitted:list, Name:tr)
+                searchTerm = QueryParser.Escape(SearchTerm);
+                if (bCategoryBasedSearch == true)
+                {
+                    //This code section should be only executed if the search criteria is CategoryBased like "category.nodename"
+                    if (f != nameof(LuceneConfig.NodeFieldsEnum.NameSplitted) &&
+                        f != nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted))
+                        continue;
+
+                    var categorySearchBased = searchTerm.Split('.');
+                    if (f == nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted))
+                        searchTerm = categorySearchBased[0];
+                    else
+                        searchTerm = categorySearchBased[1];
+                }
+
                 FuzzyQuery fuzzyQuery;
                 if (searchTerm.Length > LuceneConfig.FuzzySearchMinimalTermLength)
                 {
@@ -279,13 +300,30 @@ namespace Dynamo.Utilities
                     booleanQuery.Add(fuzzyQuery, Occur.SHOULD);
                 }
 
+                //For normal search we don't consider the fields NameSplitted and CategorySplitted
+                if ((f == nameof(LuceneConfig.NodeFieldsEnum.NameSplitted) ||
+                    f == nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted)) && bCategoryBasedSearch == false)
+                    continue;
+
+                //This case is for when the user type something like "list.", I mean, not specifying the node name or part of it
+                if (string.IsNullOrEmpty(searchTerm))
+                    continue;
+
                 var fieldQuery = CalculateFieldWeight(f, searchTerm);
                 var wildcardQuery = CalculateFieldWeight(f, searchTerm, true);
 
-                booleanQuery.Add(fieldQuery, Occur.SHOULD);
-                booleanQuery.Add(wildcardQuery, Occur.SHOULD);
+                if (bCategoryBasedSearch && f == nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted))
+                {
+                    booleanQuery.Add(fieldQuery, Occur.MUST);
+                    booleanQuery.Add(wildcardQuery, Occur.MUST);
+                }
+                else
+                {
+                    booleanQuery.Add(fieldQuery, Occur.SHOULD);
+                    booleanQuery.Add(wildcardQuery, Occur.SHOULD);
+                }
 
-                if (searchTerm.Contains(' ') || searchTerm.Contains('.'))
+                if (searchTerm.Contains(' '))
                 {
                     foreach (string s in searchTerm.Split(' ', '.'))
                     {
@@ -317,8 +355,10 @@ namespace Dynamo.Utilities
         {
             WildcardQuery query;
 
+            var termText = fieldName == nameof(LuceneConfig.NodeFieldsEnum.NameSplitted) ? searchTerm + "*" : "*" + searchTerm + "*";
+
             query = isWildcard == false ?
-                new WildcardQuery(new Term(fieldName, searchTerm)) : new WildcardQuery(new Term(fieldName, "*" + searchTerm + "*"));
+                new WildcardQuery(new Term(fieldName, searchTerm)) : new WildcardQuery(new Term(fieldName, termText));
 
             switch (fieldName)
             {
@@ -326,9 +366,19 @@ namespace Dynamo.Utilities
                     query.Boost = isWildcard == false?
                         LuceneConfig.SearchNameWeight :  LuceneConfig.WildcardsSearchNameWeight;
                     break;
+                case nameof(LuceneConfig.NodeFieldsEnum.NameSplitted):
+                    //Under this case the NameSplitted field will have less weight than CategorySplitted
+                    query.Boost = isWildcard == false ?
+                        LuceneConfig.SearchCategoryWeight : LuceneConfig.WildcardsSearchCategoryWeight;
+                    break;
                 case nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName):
                     query.Boost = isWildcard == false?
                         LuceneConfig.SearchCategoryWeight : LuceneConfig.WildcardsSearchCategoryWeight;
+                    break;
+                case nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted):
+                    //Under this case the CategorySplitted field will have more weight than NameSplitted
+                    query.Boost = isWildcard == false ?
+                        LuceneConfig.SearchNameWeight : LuceneConfig.WildcardsSearchNameWeight;
                     break;
                 case nameof(LuceneConfig.NodeFieldsEnum.Description):
                     query.Boost = isWildcard == false ?
@@ -431,7 +481,17 @@ namespace Dynamo.Utilities
             if (writer == null) return;
 
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), node.FullCategoryName);
+
+            var categoryParts = node.FullCategoryName.Split('.');
+            string categoryParsed = categoryParts.Length > 1 ? categoryParts[categoryParts.Length - 1] : node.FullCategoryName;
+            SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted), categoryParsed);
+
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), node.Name);
+
+            var nameParts = node.Name.Split('.');
+            string nameParsed = nameParts.Length > 1 ? nameParts[nameParts.Length - 1] : node.Name;
+            SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.NameSplitted), nameParsed);
+
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), node.Description);
             if (node.SearchKeywords.Count > 0)
             {

--- a/test/DynamoCoreWpfTests/SearchSideEffects.cs
+++ b/test/DynamoCoreWpfTests/SearchSideEffects.cs
@@ -141,6 +141,42 @@ namespace Dynamo.Tests
             }
         }
 
+        /// <summary>
+        /// This test validates several cases using Search Category Based (like "category.node")
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void LuceneValidateCategoryBasedSearch()
+        {
+            Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), ViewModel.Model.CurrentWorkspace);
+            string category = "FileSystem";
+            string nodeName = "F";
+            string searchTerm = category + "." + nodeName;
+
+            // Search and check that the results are correct based in the node name provided for the searchTerm
+            var nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(searchTerm);
+
+            //Take the first 5 elements in the results
+            var topFourResults = nodesResult.Take(5);
+            //Validate that the top 4 elements in the results start with "F"
+            Assert.That(topFourResults.Where(x => x.Name.StartsWith(nodeName)).Count() == 4, Is.True);
+            //Validate that the top 5 elements in the results belong to the FileSystem category
+            Assert.That(topFourResults.Where(x => x.Class.Equals(category)).Count() == 5);
+
+            nodeName = "Append";
+            searchTerm = category + "." + nodeName;
+            nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(searchTerm);
+            //Validate that the first in the node is AppendText
+            Assert.That(nodesResult.Take(1).First().Name.StartsWith(nodeName), Is.True);
+            //Validate that the first result belong to the FileSystem category
+            Assert.That(nodesResult.Take(1).First().Class == category, Is.True);
+
+            searchTerm = ".";
+            //This search should not return results since we are searching just for the "." char
+            nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(searchTerm);
+            Assert.That(nodesResult.Count() == 0, Is.True);
+        }
+
         //This test will validate that resulting nodes have a specific order
         [Test]
         [Category("UnitTests")]


### PR DESCRIPTION
### Purpose

Implemeting Lucene Search Category Based.
I've updated the Lucene Search in a way that if the user type the "." character then the search will be "category based" (e.g. the search criteria "list.r" will find all the nodes which belong to the list category and the node name starts with r). 
For this implementation I've indexed two new fields: NameSplitted and CategorySplitted. For NameSplitted when the node name contains the Category (like List.Shop) then we will be using the last part (after the "." character), the same case for CategorySplitted, we will be using the last part after the "." character.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Implemeting Lucene Search Category Based.

### Reviewers

@QilongTang 

### FYIs

@Amoursol 