### PR TITLE
DYN-9999 : consolidate host analytics info usage

### DIFF
--- a/src/DynamoCore/Extensions/ReadyParams.cs
+++ b/src/DynamoCore/Extensions/ReadyParams.cs
@@ -76,12 +76,6 @@ namespace Dynamo.Extensions
         }
 
         /// <summary>
-        /// HostInfo object, Useful to determine what host context Dynamo is running in.
-        /// </summary>
-        internal HostAnalyticsInfo HostInfo => DynamoModel.HostAnalyticsInfo;
-
-
-        /// <summary>
         /// Event that is raised when the Dynamo Logger logs a notification.
         /// This event passes the notificationMessage to any subscribers
         /// </summary>

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -6,6 +6,7 @@ using Autodesk.Analytics.ADP;
 using Autodesk.Analytics.Core;
 using Autodesk.Analytics.Events;
 using Dynamo.Models;
+using Dynamo.Updates;
 using Microsoft.Win32;
 
 namespace Dynamo.Logging
@@ -73,6 +74,7 @@ namespace Dynamo.Logging
     {
         private readonly ManualResetEventSlim serviceInitialized = new ManualResetEventSlim(false);
         private readonly object trackEventLockObj = new object();
+        private readonly string AppVersion = Process.GetCurrentProcess().ProcessName + "-" + UpdateManager.GetProductVersion();
 
         /// <summary>
         /// A dummy IDisposable class
@@ -119,7 +121,7 @@ namespace Dynamo.Logging
             Session.Start();
 
             //Dynamo app version.
-            var appversion = string.IsNullOrEmpty(hostAnalyticsInfo.AppVersion) ? DynamoModel.AppVersion : hostAnalyticsInfo.AppVersion;
+            var appversion = string.IsNullOrEmpty(hostAnalyticsInfo.AppVersion) ? AppVersion : hostAnalyticsInfo.AppVersion;
 
             var hostName = string.IsNullOrEmpty(hostAnalyticsInfo.HostName) ? "Dynamo" : hostAnalyticsInfo.HostName;
 

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -6,7 +6,6 @@ using Autodesk.Analytics.ADP;
 using Autodesk.Analytics.Core;
 using Autodesk.Analytics.Events;
 using Dynamo.Models;
-using Dynamo.Updates;
 using Microsoft.Win32;
 
 namespace Dynamo.Logging

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -119,7 +119,7 @@ namespace Dynamo.Logging
             Session.Start();
 
             //Dynamo app version.
-            var appversion = DynamoModel.AppVersion;
+            var appversion = string.IsNullOrEmpty(hostAnalyticsInfo.AppVersion) ? DynamoModel.AppVersion : hostAnalyticsInfo.AppVersion;
 
             var hostName = string.IsNullOrEmpty(hostAnalyticsInfo.HostName) ? "Dynamo" : hostAnalyticsInfo.HostName;
 

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -74,7 +74,6 @@ namespace Dynamo.Logging
     {
         private readonly ManualResetEventSlim serviceInitialized = new ManualResetEventSlim(false);
         private readonly object trackEventLockObj = new object();
-        private readonly string AppVersion = Process.GetCurrentProcess().ProcessName + "-" + UpdateManager.GetProductVersion();
 
         /// <summary>
         /// A dummy IDisposable class
@@ -120,9 +119,6 @@ namespace Dynamo.Logging
             //Setup Analytics service, and StabilityCookie.
             Session.Start();
 
-            //Dynamo app version.
-            var appversion = string.IsNullOrEmpty(hostAnalyticsInfo.AppVersion) ? AppVersion : hostAnalyticsInfo.AppVersion;
-
             var hostName = string.IsNullOrEmpty(hostAnalyticsInfo.HostName) ? "Dynamo" : hostAnalyticsInfo.HostName;
 
             hostInfo = new HostContextInfo() { ParentId = hostAnalyticsInfo.ParentId, SessionId = hostAnalyticsInfo.SessionId };
@@ -133,7 +129,7 @@ namespace Dynamo.Logging
                 buildId = $"{version.Major}.{version.Minor}.{version.Build}"; // BuildId has the following format major.minor.build, ex: 2.5.1
                 releaseId = $"{version.Major}.{version.Minor}.0"; // ReleaseId has the following format: major.minor.0; ex: 2.5.0
             }
-            product = new ProductInfo() { Id = "DYN", Name = hostName, VersionString = appversion, AppVersion = appversion, BuildId = buildId, ReleaseId = releaseId };
+            product = new ProductInfo() { Id = "DYN", Name = hostName, BuildId = buildId, ReleaseId = releaseId };
         }
 
         private void RegisterADPTracker(Service service)

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -129,7 +129,7 @@ namespace Dynamo.Logging
                 buildId = $"{version.Major}.{version.Minor}.{version.Build}"; // BuildId has the following format major.minor.build, ex: 2.5.1
                 releaseId = $"{version.Major}.{version.Minor}.0"; // ReleaseId has the following format: major.minor.0; ex: 2.5.0
             }
-            product = new ProductInfo() { Id = "DYN", Name = hostName, BuildId = buildId, ReleaseId = releaseId };
+            product = new ProductInfo() { Id = "DYN", Name = hostName, VersionString = "", AppVersion = "", BuildId = buildId, ReleaseId = releaseId };
         }
 
         private void RegisterADPTracker(Service service)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -104,6 +104,8 @@ namespace Dynamo.Models
         public string ParentId;
         // Dynamo host session id for analytics purpose.
         public string SessionId;
+        /// AppVersion provided by host for analytics purpose.
+        public string AppVersion;
     }
 
     /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -284,18 +284,6 @@ namespace Dynamo.Models
         public readonly NodeSearchModel SearchModel;
 
         /// <summary>
-        ///     The application version string for analytics reporting APIs
-        /// </summary>
-        internal static string AppVersion
-        {
-            get
-            {
-                return Process.GetCurrentProcess().ProcessName + "-"
-                    + Core.PathManager.Instance.GetProductVersion();
-            }
-        }
-
-        /// <summary>
         ///     Debugging settings for this instance of Dynamo.
         /// </summary>
         public readonly DebugSettings DebugSettings;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -104,7 +104,9 @@ namespace Dynamo.Models
         public string ParentId;
         // Dynamo host session id for analytics purpose.
         public string SessionId;
-        ///  The application version string for analytics reporting APIs
+        /// The application version string for analytics reporting APIs.
+        /// If no AppVersion identifier is provided, a default version will be computed
+        /// based on the current process name and executing assembly version.
         public string AppVersion;
     }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -104,7 +104,7 @@ namespace Dynamo.Models
         public string ParentId;
         // Dynamo host session id for analytics purpose.
         public string SessionId;
-        /// AppVersion provided by host for analytics purpose.
+        ///  The application version string for analytics reporting APIs
         public string AppVersion;
     }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -104,10 +104,6 @@ namespace Dynamo.Models
         public string ParentId;
         // Dynamo host session id for analytics purpose.
         public string SessionId;
-        /// The application version string for analytics reporting APIs.
-        /// If no AppVersion identifier is provided, a default version will be computed
-        /// based on the current process name and executing assembly version.
-        public string AppVersion;
     }
 
     /// <summary>

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -56,8 +56,6 @@ namespace Dynamo.UI.Views
         /// </summary>
         internal AuthenticationManager authManager;
 
-        internal HostAnalyticsInfo hostAnalyticsInfo;
-
         /// <summary>
         /// Dynamo View Model reference
         /// </summary>
@@ -84,7 +82,6 @@ namespace Dynamo.UI.Views
                 // When view model is closed, we need to close the splash screen if it is displayed.
                 viewModel.RequestClose += SplashScreenRequestClose;
                 authManager = viewModel.Model.AuthenticationManager;
-                hostAnalyticsInfo = DynamoModel.HostAnalyticsInfo;
             }
         }
 
@@ -518,7 +515,7 @@ namespace Dynamo.UI.Views
         {
             CloseWasExplicit = true;
 
-            if (string.IsNullOrEmpty(hostAnalyticsInfo.HostName))
+            if (string.IsNullOrEmpty(DynamoModel.HostAnalyticsInfo.HostName))
             {
                 Application.Current?.Shutdown();
                 Analytics.TrackEvent(Actions.Close, Categories.SplashScreenOperations);

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -50,10 +50,9 @@ namespace Dynamo.PackageManager
         {
             get { return "FCABC211-D56B-4109-AF18-F434DFE48139"; }
         }
-        internal HostAnalyticsInfo HostInfo { get; private set; }
 
         // Current host, empty if sandbox, null when running tests
-        internal virtual string Host => HostInfo.HostName;
+        internal virtual string Host => DynamoModel.HostAnalyticsInfo.HostName;
 
         /// <summary>
         ///     Manages loading of packages (property meant solely for tests)
@@ -177,7 +176,6 @@ namespace Dynamo.PackageManager
             (sp.CurrentWorkspaceModel as WorkspaceModel).CollectingCustomNodePackageDependencies += GetCustomNodePackageFromID;
             (sp.CurrentWorkspaceModel as WorkspaceModel).CollectingNodePackageDependencies += GetNodePackageFromAssemblyName;
             currentWorkspace = (sp.CurrentWorkspaceModel as WorkspaceModel);
-            HostInfo = ReadyParams.HostInfo;
         }
 
         public void Shutdown()


### PR DESCRIPTION
### Purpose
Allow a host integrator to provide an AppVersion for analytics purpose.
Consolidate usage of internal HostAnalyticsInfo - the only instance of HostAnalyticsInfo will be stored as a static in DynamoModel and used as needed across Dynamo. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB
