### PR TITLE
make wrapper more easily mockable

### DIFF
--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -102,7 +102,7 @@ namespace Dynamo.Utilities
         {
             var readStdOutTask = Task.Run(() =>
             {
-                if (process.HasExited)
+                if (CheckIfProcessHasExited())
                 {
                     return string.Empty;
                 }
@@ -180,7 +180,10 @@ namespace Dynamo.Utilities
         /// <returns>Returns error message</returns>
         protected abstract string GetCantCommunicateErrorMessage();
  
-
+        protected virtual bool CheckIfProcessHasExited()
+        {
+            return process.HasExited;
+        }
 
     }
 }

--- a/test/Libraries/DynamoUtilitiesTests/CLIWrapperTests.cs
+++ b/test/Libraries/DynamoUtilitiesTests/CLIWrapperTests.cs
@@ -17,7 +17,6 @@ namespace DynamoUtilitiesTests
         /// </summary>
         private class HangingCLIWrapper: Dynamo.Utilities.CLIWrapper
         {
-            private string relativePath = Path.Combine("DynamoFeatureFlags", "DynamoFeatureFlags.exe");
             protected override string GetCantStartErrorMessage()
             {
                 throw new NotImplementedException();
@@ -29,12 +28,11 @@ namespace DynamoUtilitiesTests
             }
             internal HangingCLIWrapper()
             {
-                StartProcess(relativePath, null);
             }
 
             internal string GetData()
             {
-                return GetData(2000, () => { return startofDataToken; });
+                return GetData(4000, () => { return startofDataToken; });
             }
 
             protected override void StartProcess(string relativeEXEPath, string argString)
@@ -57,7 +55,7 @@ namespace DynamoUtilitiesTests
         {
             internal new string GetData()
             {
-                return GetData(2000, () => { Thread.Sleep(4000);return ""; });
+                return GetData(4000, () => { Thread.Sleep(8000);return ""; });
             }
         }
 


### PR DESCRIPTION
### Purpose

@saintentropy reported that one of the new CLIWrapper tests was not stable - it looks to me like it relied on the process not exiting immediately, but that on faster machines this was possible, so I've removed the actual wrapped feature flags process from the test and mocked a response instead that should reliably timeout.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
