### PR TITLE
move from codedom to roslyn for package manager view extension tests

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -215,7 +215,7 @@
     <EmbeddedResource Include="Resources\DocumentationBrowserScriptsTest.html" />
   </ItemGroup>
 
-    <Target Name="MoveSomeTestDepsOutOfBin" AfterTargets="Build">
+    <Target Name="CopyRoslynToTestDepsFolder" AfterTargets="Build">
         <Message Importance="High" Text="copying test dependencies to test dependencies folder" />
         <!--roslyn compiler api and deps-->
         <Copy SourceFiles="$(PkgMicrosoft_CodeAnalysis_CSharp)\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll" DestinationFolder="$(TestDependenciesPath)" />

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -24,6 +24,17 @@
     </ItemGroup>
   <ItemGroup>
 	  <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
+
+      <!--roslyn compiler apis direct references so we can copy them to the test_dependencies folder-->
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" GeneratePathProperty="true">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" GeneratePathProperty="true">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      
     <PackageReference Include="Moq" Version="4.18.4" />
 	  <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
 	  <PackageReference Include="Greg" Version="3.0.0.3175">
@@ -203,4 +214,12 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\DocumentationBrowserScriptsTest.html" />
   </ItemGroup>
+
+    <Target Name="MoveSomeTestDepsOutOfBin" AfterTargets="Build">
+        <Message Importance="High" Text="copying test dependencies to test dependencies folder" />
+        <!--roslyn compiler api and deps-->
+        <Copy SourceFiles="$(PkgMicrosoft_CodeAnalysis_CSharp)\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll" DestinationFolder="$(TestDependenciesPath)" />
+        <Copy SourceFiles="$(PkgMicrosoft_CodeAnalysis_Common)\lib\netstandard2.0\Microsoft.CodeAnalysis.dll" DestinationFolder="$(TestDependenciesPath)" />
+
+    </Target>
 </Project>

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerViewExtensionTests.cs
@@ -1,8 +1,8 @@
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Dynamo.Configuration;
 using Dynamo.Core;
 using Dynamo.Interfaces;
@@ -19,7 +19,7 @@ using NUnit.Framework;
 
 namespace DynamoCoreWpfTests.PackageManager
 {
-    [TestFixture, Category("Failure")]
+    [TestFixture]
     class PackageManagerViewExtensionTests : DynamoTestUIBase
     {
         private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(ExecutingDirectory), "pkgs"); } }
@@ -139,15 +139,11 @@ namespace DynamoCoreWpfTests.PackageManager
                 .ToList();
             //The location of the .NET assemblies
             var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-            /*
-                * Adding some necessary .NET assemblies
-                * These assemblies couldn't be loaded correctly via the same construction as above,
-                * in specific the System.Runtime.
-                */
-            returnList.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "mscorlib.dll")));
-            returnList.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.dll")));
-            returnList.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Core.dll")));
             returnList.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")));
+
+            returnList.Add(MetadataReference.CreateFromFile(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DynamoCore.dll")));
+            returnList.Add(MetadataReference.CreateFromFile(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DynamoCoreWpf.dll")));
+
             return returnList.ToArray();
         }
 


### PR DESCRIPTION
### Purpose

* replaces codedom with roslyn
* roslyn binaries are copied to test_dependencies folder and resolved at test time.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
