### PR TITLE
Feature [DYN-5197] dismiss NotificationsPanel by clicking outside the panel

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -107,6 +107,7 @@ namespace Dynamo.Notifications
         private void View_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             dynamoView.Closing -= View_Closing;
+            dynamoView.PreviewMouseDown -= DynamoView_PreviewMouseDown;
             SuspendCoreWebviewAsync();
         }
 

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -83,6 +83,7 @@ namespace Dynamo.Notifications
             dynamoView.LocationChanged += DynamoView_LocationChanged;
             notificationsButton.Click += NotificationsButton_Click;
             dynamoView.Closing += View_Closing;
+            dynamoView.PreviewMouseDown += DynamoView_PreviewMouseDown;
 
             notificationUIPopup = new NotificationUI
             {
@@ -274,6 +275,17 @@ namespace Dynamo.Notifications
         {
             notificationUIPopup.Placement = PlacementMode.Bottom;
             notificationUIPopup.UpdatePopupLocation();
+        }
+
+        /// <summary>
+        /// Dismiss notifications panel by clicking outside the panel
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void DynamoView_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (!notificationUIPopup.IsOpen) return;
+            notificationUIPopup.IsOpen = false;
         }
 
         /// <summary>


### PR DESCRIPTION
![Screen Recording 2023-12-04 at 16 15 09](https://github.com/DynamoDS/Dynamo/assets/111511512/7357e2fe-1f34-4d89-b08b-54626b1aeae8)

### Purpose

Ref.: [DYN-5197](https://jira.autodesk.com/browse/DYN-5197) This allows the user to dismiss the NotificationsPanel by clicking outside the panel.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

This PR Implements a PreviewMouseDown event at dynamoView for toggling NotificationsPanel "`isOpen`" state by clicking outside the panel.

### Reviewers

@QilongTang 

### FYIs

@avidit 
