### PR TITLE
PM - resolve lingering binding issues

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -256,6 +256,8 @@
                                     Content="{Binding CanInstall, Converter={StaticResource InstalledButtonTextConverter}}"
                                     DockPanel.Dock="Right"
                                     ToolTipService.ShowOnDisabled="True"
+                                    Loaded="DropDownInstallButton_Loaded"
+                                    Unloaded="DropDownInstallButton_Unloaded"
                                     IsEnabled="{Binding IsEnabledForInstall}">
                                 <Button.Style>
                                     <Style TargetType="Button">
@@ -276,7 +278,6 @@
                                                                         Visibility="{Binding CanInstall, Converter={StaticResource BoolToVisibilityCollapsedConverter}}"
                                                                         BorderThickness="0"
                                                                         Cursor="Hand"
-                                                                        Click="DropDownInstallButton_OnClick"
                                                                         Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
                                                                     <Image Source=" /DynamoCoreWpf;component/UI/Images/caret_drop_down.png"
                                                                            Width="7"

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
@@ -149,13 +149,12 @@ namespace Dynamo.PackageManager.UI
             return;
         }
 
-       
 
         private void DropDownInstallButton_OnClick(object sender, RoutedEventArgs e)
         {
             var button = sender as Button;
-            if (button == null) { return; }
-                       
+            if (button == null || button.DataContext == null) { return; }
+
             var contextMenu = new ContextMenu();
             var commandBinding = new Binding("DownloadLatestToCustomPathCommand");
             commandBinding.Source = button.DataContext;
@@ -187,6 +186,37 @@ namespace Dynamo.PackageManager.UI
 
             // Open the context menu when the left mouse button is pressed
             contextMenu.IsOpen = true;            
-        }   
+        }
+
+        // Attach the 'context menu' button to the parent button
+        private void DropDownInstallButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            var installButton = sender as Button;
+            if (installButton != null)
+            {
+                var dropDownInstallButton = installButton.Template.FindName("dropDownInstallButton", installButton) as Button;
+                if (dropDownInstallButton != null)
+                {
+                    dropDownInstallButton.Click -= DropDownInstallButton_OnClick;
+
+                    // Now that the parent button is loaded, we can assign the Click event to the context menu button
+                    dropDownInstallButton.Click += DropDownInstallButton_OnClick;
+                }
+            }
+        }
+
+        // Dispose of DropDownInstallButton_OnClick when the parent button is unloaded
+        private void DropDownInstallButton_Unloaded(object sender, RoutedEventArgs e)
+        {
+            var installButton = sender as Button;
+            if (installButton != null)
+            {
+                var dropDownInstallButton = installButton.Template.FindName("dropDownInstallButton", installButton) as Button;
+                if (dropDownInstallButton != null)
+                {
+                    dropDownInstallButton.Click -= DropDownInstallButton_OnClick;
+                }
+            }
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
@@ -271,14 +271,14 @@
                                                                           DataContext="{Binding PackageManagerViewModel}"
                                                                           VerticalAlignment="Stretch"
                                                                           Height="650"
-                                                                          Visibility="{Binding PackageManagerViewModel.LocalPackages, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}" />
+                                                                          Visibility="{Binding LocalPackages, Converter={StaticResource ListHasMoreThanNItemsToVisibilityConverter}}" />
 
 
-                                    <!--Empty list screen-->
+                                    <!--Empty list screen-->    
                                     <StackPanel Orientation="Vertical"
                                                 VerticalAlignment="Center"
                                                 HorizontalAlignment="Center"
-                                                Margin="0 0 0 73"
+                                                Margin="0 127 0 0"
                                                 Visibility="{Binding PackageManagerViewModel.LocalPackages, Converter={StaticResource EmptyListToVisibilityConverter }}">
                                         <Image HorizontalAlignment="Center"
                                                VerticalAlignment="Center"


### PR DESCRIPTION
### Purpose

2 binding issues that would throw errors but won't cause a crash or malfunction of the package manager. Those were now resolved with this PR.

- install-package button drop-down context menu (to specific folder) - the drop-down context menu button is part of the style of the parent button. Assigning a click-handler to it would cause an error if the parent button was not assigned already. 
- incorrect assignment of `installedPackages` Visibility property, now fixed

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- fixed null exception when trying to assign a click handler on a context menu button when the parent button
- also fixed another incorrect binding issue to the `installedPackages` visibility property

### Reviewers

@mjkkirschner 
@reddyashish 

### FYIs


