### PR TITLE
Switch Dynamo to net8.0

### DIFF
--- a/src/Config/CS_SDK.props
+++ b/src/Config/CS_SDK.props
@@ -6,7 +6,7 @@
     <PlatformTarget >x64</PlatformTarget>
     <!--Use the property DotNet to set TargetFramework from commandline without forcing it on all projects-->
     <!--Ex. DynamoServices uses TargetFramework netstandard2.0 -->
-    <DotNet>net6.0</DotNet>
+    <DotNet>net8.0</DotNet>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">16.0</VisualStudioVersion>
     <TargetFramework>$(DotNet)</TargetFramework>
     <FileAlignment>512</FileAlignment>

--- a/src/build.xml
+++ b/src/build.xml
@@ -5,7 +5,7 @@
 <PropertyGroup>
     <Solution>Dynamo.All.sln</Solution>
     <Platform>Any CPU</Platform>
-    <DotNet>net6.0</DotNet>
+    <DotNet>net8.0</DotNet>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <NuGetPath>$(MSBuildProjectDirectory)\..\tools\Nuget\NuGet.exe</NuGetPath>
  </PropertyGroup>


### PR DESCRIPTION
### Purpose

This pull request does:
* switch Dynamo to use net8.0 by default.

Devs: VS 2022 version 17.8 or later is needed in order to compile and run Dynamo after this change.

Everyone else: Dynamo Sandbox will prompt you to download NET8.0 SDK if you don't have it. Just follow the instructions and you should be good. See https://dynamobim.org/dynamo-daily-builds-and-net6-8/.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
