### PR TITLE
DYN-6517: For net8.0 builds, allow Md2Html.exe to run on net8 runtime version 8.0.0-rc.2.23479.6 or later.

### DIFF
--- a/src/Tools/Md2Html/Md2Html.csproj
+++ b/src/Tools/Md2Html/Md2Html.csproj
@@ -12,7 +12,7 @@
         <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>false</SelfContained>
-        <RuntimeFrameworkVersion Condition=" $(DotNet.Contains('net8.0')) ">8.0.0-rc.2.23479.6</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion Condition=" $(DotNet.Contains('net8.0')) ">8.0.0-rc.1.23420.5</RuntimeFrameworkVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CommandLineParser">

--- a/src/Tools/Md2Html/Md2Html.csproj
+++ b/src/Tools/Md2Html/Md2Html.csproj
@@ -12,6 +12,7 @@
         <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>false</SelfContained>
+        <RuntimeFrameworkVersion Condition=" $(DotNet.Contains('net8.0')) ">8.0.0-rc.2.23479.6</RuntimeFrameworkVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CommandLineParser">


### PR DESCRIPTION
### Purpose

This pull request does:
* allow Md2Html.exe to run on net8 runtime version 8.0.0-rc.2.23479.6 or later for net8 builds.

Md2Html.exe is published as a single file and the problem here is that there is no way to override the runtimeconfig.json file that is embedded in Md2Html.exe. So for now, we allow it to run on version 8.0.0-rc.2.23479.6 or later.
This is a temporary fix for Civil that should be reverted when AutoCAD has updated to net8.0 final.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
