### PR TITLE
Outdated error message for upload package version field

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4083,7 +4083,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must provide a Major version as a non-negative integer..
+        ///   Looks up a localized string similar to Provide major, minor, and build version number..
         /// </summary>
         public static string MajorVersionNonNegative {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1229,7 +1229,7 @@ Failed to publish file(s):
     <value>Library</value>
   </data>
   <data name="MajorVersionNonNegative" xml:space="preserve">
-    <value>You must provide a Major version as a non-negative integer.</value>
+    <value>Provide major, minor, and build version number.</value>
     <comment>ErrorString</comment>
   </data>
   <data name="Manual" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1776,7 +1776,7 @@ Note: Incorrect folder structure may affect the functionality of packages that r
     <comment>ErrorString</comment>
   </data>
   <data name="MajorVersionNonNegative" xml:space="preserve">
-    <value>You must provide a Major version as a non-negative integer.</value>
+    <value>Provide major, minor, and build version number.</value>
     <comment>ErrorString</comment>
   </data>
   <data name="MinorVersionNonNegative" xml:space="preserve">


### PR DESCRIPTION
### Purpose

This PR addresses this https://jira.autodesk.com/browse/DYN-6497 issue.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/9821a1a6-1676-411c-9f03-2c166e48e4fa)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

@reddyashish 

### FYIs

@avidit 