### PR TITLE
disable cancel button of no changes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1,3 +1,16 @@
+using Dynamo.Core;
+using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
+using Dynamo.PackageManager.UI;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Properties;
+using Dynamo.Wpf.Utilities;
+using DynamoUtilities;
+using Greg.Requests;
+using Prism.Commands;
+using PythonNodeModels;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -12,19 +25,6 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Forms;
-using Dynamo.Core;
-using Dynamo.Graph.Nodes.ZeroTouch;
-using Dynamo.Graph.Workspaces;
-using Dynamo.Models;
-using Dynamo.PackageManager.UI;
-using Dynamo.Utilities;
-using Dynamo.ViewModels;
-using Dynamo.Wpf.Properties;
-using Dynamo.Wpf.Utilities;
-using DynamoUtilities;
-using Greg.Requests;
-using Prism.Commands;
-using PythonNodeModels;
 using Double = System.Double;
 using NotificationObject = Dynamo.Core.NotificationObject;
 using String = System.String;
@@ -269,6 +269,7 @@ namespace Dynamo.PackageManager
                 {
                     _group = value;
                     RaisePropertyChanged("Group");
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -287,6 +288,7 @@ namespace Dynamo.PackageManager
                 {
                     _Description = value;
                     RaisePropertyChanged("Description");
+                    RaisePropertyChanged(nameof(HasChanges));
                     BeginInvoke(() =>
                     {
                         SubmitCommand.RaiseCanExecuteChanged();
@@ -315,6 +317,7 @@ namespace Dynamo.PackageManager
 
                     _Keywords = value;
                     RaisePropertyChanged("Keywords");
+                    RaisePropertyChanged(nameof(HasChanges));
                     KeywordList = value.Split(' ').Where(x => x.Length > 0).ToList();
                 }
             }
@@ -368,6 +371,7 @@ namespace Dynamo.PackageManager
                     if (value.Length != 1) value = value.TrimStart(new char[] { '0' });
                     _MinorVersion = value;
                     RaisePropertyChanged("MinorVersion");
+                    RaisePropertyChanged(nameof(HasChanges));
                     BeginInvoke(() =>
                     {
                         SubmitCommand.RaiseCanExecuteChanged();
@@ -394,6 +398,7 @@ namespace Dynamo.PackageManager
                     if (value.Length != 1) value = value.TrimStart(new char[] { '0' });
                     _BuildVersion = value;
                     RaisePropertyChanged("BuildVersion");
+                    RaisePropertyChanged(nameof(HasChanges));
                     BeginInvoke(() =>
                     {
                         SubmitCommand.RaiseCanExecuteChanged();
@@ -420,6 +425,7 @@ namespace Dynamo.PackageManager
                     if (value.Length != 1) value = value.TrimStart(new char[] { '0' });
                     _MajorVersion = value;
                     RaisePropertyChanged("MajorVersion");
+                    RaisePropertyChanged(nameof(HasChanges));
                     BeginInvoke(() =>
                     {
                         SubmitCommand.RaiseCanExecuteChanged();
@@ -443,6 +449,7 @@ namespace Dynamo.PackageManager
                 {
                     _license = value;
                     RaisePropertyChanged(nameof(License));
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -458,6 +465,7 @@ namespace Dynamo.PackageManager
             {
                 copyrightHolder = value;
                 RaisePropertyChanged(nameof(CopyrightHolder));
+                RaisePropertyChanged(nameof(HasChanges));
             }
         }
 
@@ -472,6 +480,7 @@ namespace Dynamo.PackageManager
             {
                 copyrightYear = value;
                 RaisePropertyChanged(nameof(CopyrightYear));
+                RaisePropertyChanged(nameof(HasChanges));
             }
         }
 
@@ -489,6 +498,7 @@ namespace Dynamo.PackageManager
                 {
                     _siteUrl = value;
                     RaisePropertyChanged("SiteUrl");
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -507,6 +517,7 @@ namespace Dynamo.PackageManager
                 {
                     _repositoryUrl = value;
                     RaisePropertyChanged("RepositoryUrl");
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -530,6 +541,8 @@ namespace Dynamo.PackageManager
                         SubmitCommand.RaiseCanExecuteChanged();
                         PublishLocallyCommand.RaiseCanExecuteChanged();
                     });
+
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -595,6 +608,7 @@ namespace Dynamo.PackageManager
                     SelectedHostsString = SelectedHostsString.Trim().TrimEnd(',');
                     RaisePropertyChanged( nameof(SelectedHosts));
                     RaisePropertyChanged( nameof(SelectedHostsString));
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -612,6 +626,7 @@ namespace Dynamo.PackageManager
                 {
                     selectedHostsString = value;
                     RaisePropertyChanged(nameof(SelectedHostsString));
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -773,6 +788,7 @@ namespace Dynamo.PackageManager
                 {
                     _additionalFiles = value;
                     RaisePropertyChanged("AdditionalFiles");
+                    RaisePropertyChanged(nameof(HasChanges));
                 }
             }
         }
@@ -798,6 +814,7 @@ namespace Dynamo.PackageManager
             {
                 dependencyNames = value; 
                 RaisePropertyChanged(nameof(DependencyNames));
+                RaisePropertyChanged(nameof(HasChanges));
             }
         }
 
@@ -906,7 +923,16 @@ namespace Dynamo.PackageManager
             {
                 _rootFolder = value;
                 RaisePropertyChanged(nameof(RootFolder));
+                RaisePropertyChanged(nameof(HasChanges));
             }
+        }
+
+        /// <summary>
+        /// Indicates if the user has made any changes to the current publish package form
+        /// </summary>
+        public bool HasChanges
+        {
+            get { return AnyUserChanges(); }
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml
@@ -365,6 +365,7 @@
                     <!--  Cancel  -->
                     <Button Click="CancelButton_Click"
                             Content="{x:Static p:Resources.CancelButton}"
+                            IsEnabled="{Binding HasChanges}"
                             DockPanel.Dock="Right"
                             Background="Transparent"
                             Foreground="White"


### PR DESCRIPTION
### Purpose

Addressing this jira https://jira.autodesk.com/browse/DYN-6500 issue. Disable the Cancel button if no changes are made to the current package publish form.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/e84cbe1e-b1b4-49ee-81bb-a74953e4d7f5)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- if there are no changes, disable the cancel button

### Reviewers

@reddyashish 

### FYIs

@avidit
