### PR TITLE
DYN-6362 Refresh Packages Tour Bug

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -262,11 +262,20 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 dynamoViewModel.OnEnableShortcutBarItems(true);
 
+                EnableDynamoUI();
+
                 //Hide guide background overlay
                 guideBackgroundElement.Visibility = Visibility.Hidden;
                 GuidesValidationMethods.CurrentExecutingGuide = null;
                 tourStarted = false;
             }
+        }
+
+        private void EnableDynamoUI()
+        {
+            var dynamoView = mainRootElement as DynamoView;
+            if (dynamoView != null)
+                dynamoView.EnableEnvironment(true);
         }
 
         /// <summary>
@@ -297,6 +306,7 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private void ExitTourButton_Click(object sender, RoutedEventArgs e)
         {
             exitGuideWindow.IsOpen = false;
+            EnableDynamoUI();
             GuideFlowEvents.OnGuidedTourExited(currentGuide.Name);
             ExitTour();
         }

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -393,7 +393,12 @@ namespace Dynamo.Wpf.UI.GuidedTour
             packageManagerViewModel.PropertyChanged -= searchPackagesPropertyChanged.Invoke;
 
             //Enable the DynamoView.mainGrid so the user will be able to interact with Dynamo
-            (packageManager.Owner as DynamoView).EnableEnvironment(true);
+            var dynamoView = packageManager.Owner as DynamoView;
+            if (dynamoView != null)
+            {
+                dynamoView.EnableEnvironment(true);
+            }
+          
             packageManager.Close();
             
         }


### PR DESCRIPTION
### Purpose

Bug reported by @avidit when testing the Packages Guide
I've added three validations for enabling the Dynamo UI when the Packages Tour is closed so in this way we will be preventing the UI Blocked bug.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Bug reported by @avidit when testing the Packages Guide

### Reviewers

@QilongTang 

### FYIs

@avidit 
