### PR TITLE
DYN-6493: reset page order when discarding publish package form

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
@@ -1,16 +1,6 @@
-using Dynamo.Logging;
-using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
-using DynamoUtilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
 using Views.PackageManager.Pages;
 
 namespace Dynamo.PackageManager.UI

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
@@ -1,3 +1,9 @@
+using Dynamo.Logging;
+using Dynamo.Models;
+using Dynamo.UI;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Utilities;
+using DynamoUtilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -5,12 +11,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Dynamo.Logging;
-using Dynamo.Models;
-using Dynamo.UI;
-using Dynamo.ViewModels;
-using Dynamo.Wpf.Utilities;
-using DynamoUtilities;
 using Views.PackageManager.Pages;
 
 namespace Dynamo.PackageManager.UI
@@ -328,6 +328,22 @@ namespace Dynamo.PackageManager.UI
             {
                 PublishPackageViewModel.CancelCommand.Execute();
             }
+        }
+
+        /// <summary>
+        /// Navigates back to the starting page 
+        /// </summary>
+        internal void ResetPageOrder()
+        {
+            currentPage = 0;
+            int stepIndex = Breadcrumbs.IndexOf((string)PublishPages[0].Tag);
+            for (int i = Breadcrumbs.Count - 1; i > stepIndex; i--)
+            {
+                Breadcrumbs.RemoveAt(i);
+            }
+            this.mainFrame.NavigationService.Navigate(PublishPages[currentPage]);
+            this.breadcrumbsNavigation.Visibility = Visibility.Collapsed;
+            ToggleButtonRowVisibility(0);
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
@@ -1,6 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
+using DynamoUtilities;
 using Views.PackageManager.Pages;
 
 namespace Dynamo.PackageManager.UI

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -1,16 +1,7 @@
 using Dynamo.Controls;
-using Dynamo.Logging;
-using Dynamo.Models;
 using Dynamo.UI;
-using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
-using DynamoUtilities;
-using System;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace Dynamo.PackageManager.UI
 {

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
 using Dynamo.Controls;
 using Dynamo.Logging;
 using Dynamo.Models;
@@ -11,6 +6,11 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
 using DynamoUtilities;
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Dynamo.PackageManager.UI
 {
@@ -228,6 +228,11 @@ namespace Dynamo.PackageManager.UI
                 {
                     PackageManagerViewModel.PublishPackageViewModel.CancelCommand.Execute();
                     selectedTab.IsSelected = true;
+                    var pmPublishControl = this.packageManagerPublish as PackageManagerPublishControl;
+                    if (pmPublishControl != null)
+                    {
+                        pmPublishControl.ResetPageOrder();
+                    }
                 }
                 else
                 {

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -1,7 +1,16 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using Dynamo.Controls;
+using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.UI;
+using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
+using DynamoUtilities;
 
 namespace Dynamo.PackageManager.UI
 {


### PR DESCRIPTION
### Purpose

This PR addresses this jira issue https://jira.autodesk.com/browse/DYN-6493. When navigating away from the Publish tab, the UI now goes back to the first page (only when modifications were done and reset is performed).

![reset page order](https://github.com/DynamoDS/Dynamo/assets/5354594/f7fa35f0-1956-4ebe-84ee-3b9997728a55)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- goes back to the first page when navigating away from the tab (on cancel only)

### Reviewers

@reddyashish 

### FYIs

@avidit
