### PR TITLE
clear keywords on reset

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1,16 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
-using System.Windows;
-using System.Windows.Forms;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
@@ -24,6 +11,19 @@ using DynamoUtilities;
 using Greg.Requests;
 using Prism.Commands;
 using PythonNodeModels;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Forms;
 using Double = System.Double;
 using NotificationObject = Dynamo.Core.NotificationObject;
 using String = System.String;
@@ -1115,6 +1115,7 @@ namespace Dynamo.PackageManager
             this.RootFolder = string.Empty;
             this.ClearMarkdownDirectory();
             this.ClearPackageContents();
+            this.KeywordsCollection?.Clear();
         }
 
         /// <summary>


### PR DESCRIPTION


### Purpose

Addresses this jira issue: [DYN-6519](https://jira.autodesk.com/browse/DYN-6519)

#### Note
At the moment, the keyword `tags` (bubbles, pills) are just decorative and are not taken into account when submitting the publish package form. The actual keyword values are still taken from the textbox input. Swapping with the current functionality requires a bit more work and cannot be done for 3.0 release.

![keywords](https://github.com/DynamoDS/Dynamo/assets/5354594/76687bb7-4f39-45ea-9072-979885a8ac9d)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- now correctly clears the keyword pills on reset

### Reviewers

@reddyashish 

### FYIs

@avidit 
