### PR TITLE
pm-update-ui-cherrypick

### DIFF
--- a/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
@@ -52,10 +52,12 @@
                                  GroupName="PackageFilters"
                                  IsChecked="{Binding Path=IsChecked, Mode=TwoWay}"
                                  Style="{StaticResource {x:Type ToggleButton}}"
-                                 FontSize="10"
+                                 FontSize="11"
                                  FontFamily="Artifakt Element"
                                  FontWeight="Medium"
                                  HorizontalAlignment="Center"
+                                 VerticalAlignment="Center"
+                                 VerticalContentAlignment="Center"
                                  BorderThickness="1"
                                  BorderBrush="Transparent"
                                  UseLayoutRounding="True"
@@ -121,7 +123,7 @@
                                                 </TextBlock>
                                                 <TextBlock Text="{Binding Path=Model.VersionName}"
                                                                MinWidth="70"
-                                                               FontSize="11"
+                                                               FontSize="12"
                                                                VerticalAlignment="Center"
                                                                Foreground="{StaticResource PreferencesWindowFontColor}"></TextBlock>
                                                
@@ -255,7 +257,8 @@
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding Path=Name}"
                                                                            Foreground="{StaticResource PreferencesWindowFontColor}"
-                                                                           FontSize="9"
+                                                                           FontSize="11"
+                                                                           FontWeight="Regular"
                                                                            TextTrimming="CharacterEllipsis" />
                                                         </DataTemplate>
                                                     </ItemsControl.ItemTemplate>
@@ -279,7 +282,8 @@
                                                             <TextBlock Name="Label"
                                                                            Text="{Binding Path=Name}"
                                                                            Foreground="{StaticResource PreferencesWindowFontColor}"
-                                                                           FontSize="9"
+                                                                           FontSize="11"
+                                                                           FontWeight="Regular"
                                                                            TextTrimming="CharacterEllipsis" />
 
                                                             <DataTemplate.Triggers>
@@ -312,7 +316,8 @@
                                                             <TextBlock Name="Label"
                                                                            Text="{Binding Path=Name}"
                                                                            Foreground="{StaticResource PreferencesWindowFontColor}"
-                                                                           FontSize="9"
+                                                                           FontSize="11"
+                                                                           FontWeight="Regular"
                                                                            TextTrimming="CharacterEllipsis" />
 
                                                             <DataTemplate.Triggers>
@@ -334,7 +339,7 @@
                                                         Margin="0,0,0,5">
 
                                                 <Label Content="{x:Static p:Resources.InstalledPackageViewAdditionalFileLabel}"
-                                                           FontSize="11"
+                                                           FontSize="12"
                                                        Padding="0,5,5,5"
                                                            Foreground="{StaticResource PreferencesWindowFontColor}"></Label>
                                                 <ItemsControl Name="AdditionalFiles"
@@ -344,9 +349,10 @@
                                                     <ItemsControl.ItemTemplate>
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding Path=RelativePath}"
-                                                                           Foreground="{StaticResource PreferencesWindowFontColor}"
-                                                                           FontSize="9"
-                                                                           TextTrimming="CharacterEllipsis" />
+                                                                       Foreground="{StaticResource PreferencesWindowFontColor}"
+                                                                       FontSize="12"
+                                                                       FontWeight="Regular"
+                                                                       TextTrimming="CharacterEllipsis" />
                                                         </DataTemplate>
                                                     </ItemsControl.ItemTemplate>
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5745,6 +5745,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Publish Version.
+        /// </summary>
+        public static string PackageManagerMyPackagesPublishVersion {
+            get {
+                return ResourceManager.GetString("PackageManagerMyPackagesPublishVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to My Packages.
         /// </summary>
         public static string PackageManagerMyPackagesTab {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3612,6 +3612,9 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="PackageDeprecatedTooltip" xml:space="preserve">
     <value>This package is outdated and cannot be installed.</value>
   </data>
+  <data name="PackageManagerMyPackagesPublishVersion" xml:space="preserve">
+    <value>Publish Version</value>
+  </data>
   <data name="SplashScreenViewExtensions" xml:space="preserve">
     <value>Loading View Extensions...</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3599,6 +3599,9 @@ You can manage this in Preferences -&gt; Security.</value>
   <data name="PackageDeprecatedTooltip" xml:space="preserve">
     <value>This package is outdated and cannot be installed.</value>
   </data>
+ <data name="PackageManagerMyPackagesPublishVersion" xml:space="preserve">
+    <value>Publish Version</value>
+  </data>
   <data name="SplashScreenViewExtensions" xml:space="preserve">
     <value>Loading View Extensions...</value>
   </data>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -53,6 +53,7 @@
     <Color x:Key="DefaultBorderBrushDarkColor">Black</Color>
     <Color x:Key="GenericMouseOverBackgroundColor">#808080</Color>
 
+    <SolidColorBrush x:Key="BorderPressedColorBrush" Color="{DynamicResource BorderPressedColor}"/>
     <SolidColorBrush x:Key="GenericBorderBackgroundColorBrush" Color="#3c3c3c"/>    
     <SolidColorBrush x:Key="GenericMouseOverBackgroundColorBrush" Color="{DynamicResource GenericMouseOverBackgroundColor}"/>    
 
@@ -1022,7 +1023,7 @@
         <Setter Property="CaretBrush" Value="{StaticResource PrimaryCharcoal200Brush}" />
         <Setter Property="Padding" Value="10,12,10,8"/>
         <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
-        <Setter Property="FontSize" Value="12px" />
+        <Setter Property="FontSize" Value="14px" />
         <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
 
@@ -3421,11 +3422,19 @@
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
                     <Grid>
-                        <Image Name="menuIcon"  Width="16" Height="16" Source="pack://application:,,,/DynamoCoreWpf;component/UI/Images/menu_16_16.png"/>
+                        <Border Width="16" Height="16" Background="Transparent" BorderThickness="0">
+                            <Path Name="menuIcon"
+                                  Width="16"
+                                  Height="16"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Fill="{DynamicResource MidGreyBrush}"
+                                  Data="M7.5 3C8.32843 3 9 2.32843 9 1.5C9 0.671573 8.32843 0 7.5 0C6.67157 0 6 0.671573 6 1.5C6 2.32843 6.67157 3 7.5 3ZM7.5 9C8.32843 9 9 8.32843 9 7.5C9 6.67157 8.32843 6 7.5 6C6.67157 6 6 6.67157 6 7.5C6 8.32843 6.67157 9 7.5 9ZM9 13.5C9 14.3284 8.32843 15 7.5 15C6.67157 15 6 14.3284 6 13.5C6 12.6716 6.67157 12 7.5 12C8.32843 12 9 12.6716 9 13.5Z"/>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="menuIcon" Property="Source" Value="pack://application:,,,/DynamoCoreWpf;component/UI/Images/menu-hover-16px.png" />
+                            <Setter TargetName="menuIcon" Property="Fill" Value="{DynamicResource BorderPressedColorBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value=".5" />
@@ -3434,7 +3443,7 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>
+    </Style>    
 
     <Style x:Key="CtaButtonStyle" TargetType="Button">
         <Setter Property="HorizontalAlignment" Value="Right" />
@@ -4242,7 +4251,7 @@
 
     <Style x:Key="PackageManagerTab" TargetType="{x:Type TabItem}">
         <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="FontSize" Value="15" />
+        <Setter Property="FontSize" Value="14" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -259,6 +259,7 @@
                                     IsEnabled="{Binding IsEnabledForInstall}">
                                 <Button.Style>
                                     <Style TargetType="Button">
+                                        <Setter Property="Visibility" Value="Visible"/>
                                         <Setter Property="Template">
                                             <Setter.Value>
                                                 <ControlTemplate TargetType="{x:Type Button}">
@@ -329,12 +330,9 @@
                                                                                 </DataTrigger>
                                                                                 <MultiDataTrigger>
                                                                                     <MultiDataTrigger.Conditions>
-                                                                                        <Condition Binding="{Binding Path=IsDeprecated}"
-                                                                                                   Value="False" />
-                                                                                        <Condition Binding="{Binding Path=CanInstall}"
-                                                                                                   Value="True" />
-                                                                                        <Condition Binding="{Binding Path=IsEnabledForInstall}"
-                                                                                                   Value="True" />
+                                                                                        <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
+                                                                                        <Condition Binding="{Binding Path=CanInstall}" Value="True" />
+                                                                                        <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                                     </MultiDataTrigger.Conditions>
                                                                                     <Setter Property="Fill">
                                                                                         <Setter.Value>
@@ -350,54 +348,117 @@
                                                         </Grid>
                                                     </Border>
                                                     <ControlTemplate.Triggers>
-                                                        <Trigger Property="IsMouseOver"
-                                                                 Value="True">
-                                                            <Setter TargetName="ButtonBorder"
-                                                                    Property="BorderBrush"
-                                                                    Value="#4A4A4A" />
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#4A4A4A" />
                                                         </Trigger>
-                                                        <Trigger Property="IsPressed"
-                                                                 Value="True">
-                                                            <Setter TargetName="ButtonBorder"
-                                                                    Property="BorderBrush"
-                                                                    Value="#5F5F5F" />
+                                                        <Trigger Property="IsPressed" Value="True">
+                                                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#5F5F5F" />
                                                         </Trigger>
-                                                        <DataTrigger Binding="{Binding IsDeprecated}"
-                                                                     Value="True">
-                                                            <Setter Property="TextBlock.Opacity"
-                                                                    Value="0.5" />
-                                                            <Setter Property="TextBlock.Foreground"
-                                                                    Value="#84D7CE" />
-                                                            <Setter Property="ToolTip"
-                                                                    Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
+                                                        <DataTrigger Binding="{Binding IsDeprecated}" Value="True">
+                                                            <Setter Property="TextBlock.Opacity" Value="0.5" />
+                                                            <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
+                                                            <Setter Property="ToolTip" Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding CanInstall}"
-                                                                     Value="False">
-                                                            <Setter Property="TextBlock.Foreground"
-                                                                    Value="#999999" />
-                                                            <Setter Property="Opacity"
-                                                                    Value="1" />
+                                                        <DataTrigger Binding="{Binding CanInstall}" Value="False">
+                                                            <Setter Property="TextBlock.Foreground" Value="#999999" />
+                                                            <Setter Property="Opacity" Value="1" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding IsEnabledForInstall}"
-                                                                     Value="False">
-                                                            <Setter Property="TextBlock.Foreground"
-                                                                    Value="#999999" />
-                                                            <Setter Property="TextBlock.Opacity"
-                                                                    Value="1" />
+                                                        <DataTrigger Binding="{Binding IsEnabledForInstall}" Value="False">
+                                                            <Setter Property="TextBlock.Foreground" Value="#999999" />
+                                                            <Setter Property="TextBlock.Opacity" Value="1" />
                                                         </DataTrigger>
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding Path=IsDeprecated}"
-                                                                           Value="False" />
-                                                                <Condition Binding="{Binding Path=CanInstall}"
-                                                                           Value="True" />
-                                                                <Condition Binding="{Binding Path=IsEnabledForInstall}"
-                                                                           Value="True" />
+                                                                <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
+                                                                <Condition Binding="{Binding Path=CanInstall}" Value="True" />
+                                                                <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                             </MultiDataTrigger.Conditions>
-                                                            <Setter Property="TextBlock.Opacity"
-                                                                    Value="1" />
-                                                            <Setter Property="TextBlock.Foreground"
-                                                                    Value="#84D7CE" />
+                                                            <Setter Property="TextBlock.Opacity" Value="1" />
+                                                            <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
+                                                        </MultiDataTrigger>
+                                                        <MultiDataTrigger>
+                                                            <MultiDataTrigger.Conditions>
+                                                                <Condition Binding="{Binding Path=CanInstall}" Value="False"/>
+                                                                <Condition Binding="{Binding Path=IsOnwer}" Value="True"/>
+                                                            </MultiDataTrigger.Conditions>
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </MultiDataTrigger>
+                                                    </ControlTemplate.Triggers>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
+
+
+                            <!--  Publish Version Button  -->
+                            <Button Name="publishButton"
+                                    Content="{x:Static p:Resources.PackageManagerMyPackagesPublishVersion}"
+                                    Command="{Binding Path=PackageManagerViewModel.PublishNewVersionCommand,
+                                                      RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
+                                    CommandParameter="{Binding}"
+                                    DockPanel.Dock="Right"
+                                    ToolTipService.ShowOnDisabled="True"
+                                    IsEnabled="{Binding IsEnabledForInstall}">
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="{x:Type Button}">
+                                                    <Border Name="ButtonBorder"
+                                                            Height="25"
+                                                            Padding="5,0"
+                                                            BorderThickness="2"
+                                                            CornerRadius="2">
+                                                        <Grid x:Name="publishPackageGrid">
+
+                                                            <DockPanel LastChildFill="False">
+                                                                <TextBlock Name="textBlock"
+                                                                           Padding="4,4,4,3"
+                                                                           VerticalAlignment="Center"
+                                                                           Cursor="Hand"
+                                                                           DockPanel.Dock="Right"
+                                                                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                                           FontSize="11"
+                                                                           Text="{TemplateBinding Content}" />
+                                                                <Rectangle Width="10"
+                                                                           Height="10"
+                                                                           VerticalAlignment="Center"
+                                                                           DockPanel.Dock="Left">
+                                                                    <Rectangle.Fill>
+                                                                        <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/Add - default.png" />
+                                                                    </Rectangle.Fill>
+                                                                </Rectangle>
+                                                            </DockPanel>
+                                                        </Grid>
+                                                    </Border>
+                                                    <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#4A4A4A" />
+                                                        </Trigger>
+                                                        <Trigger Property="IsPressed" Value="True">
+                                                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#5F5F5F" />
+                                                        </Trigger>
+                                                        <DataTrigger Binding="{Binding IsDeprecated}" Value="True">
+                                                            <Setter Property="TextBlock.Opacity" Value="0.5" />
+                                                            <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
+                                                            <Setter Property="ToolTip" Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
+                                                        </DataTrigger>
+                                                        <MultiDataTrigger>
+                                                            <MultiDataTrigger.Conditions>
+                                                                <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
+                                                            </MultiDataTrigger.Conditions>
+                                                            <Setter Property="TextBlock.Opacity" Value="1" />
+                                                            <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
+                                                        </MultiDataTrigger>
+                                                        <MultiDataTrigger>
+                                                            <MultiDataTrigger.Conditions>
+                                                                <Condition Binding="{Binding Path=CanInstall}" Value="False"/>
+                                                                <Condition Binding="{Binding Path=IsOnwer}" Value="True"/>
+                                                            </MultiDataTrigger.Conditions>
+                                                            <Setter Property="Visibility" Value="Visible"/>
                                                         </MultiDataTrigger>
                                                     </ControlTemplate.Triggers>
                                                 </ControlTemplate>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
@@ -32,7 +32,7 @@
             <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
             <controls:EmptyListToVisibilityConverter x:Key="EmptyListToVisibilityConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
+            
             <Style x:Key="PkgMngTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="Width" Value="Auto" />
                 <Setter Property="Margin" Value="0 5" />
@@ -111,7 +111,7 @@
                            Grid.Column="0"
                            Margin="14,16,0,0"
                            TextAlignment="Left"
-                           FontSize="18"
+                           FontSize="20"
                            FontFamily="Helvetica"
                            HorizontalAlignment="Left"
                            Width="459" />
@@ -509,7 +509,7 @@
                                                 HorizontalAlignment="Stretch">
                                         <TextBlock FontFamily="{StaticResource ArtifaktElementRegular}"
                                                    Foreground="{StaticResource PreferencesWindowFontColor}"
-                                                   FontSize="13"
+                                                   FontSize="14"
                                                    Margin="0 5 0 20">
                                             <Run Text="{x:Static p:Resources.PackageManagerSettingsRunPrefix}" />
                                             <Hyperlink Click="OnPackageManagerSettingsHyperlinkClicked"
@@ -521,7 +521,7 @@
                                         </TextBlock>
                                         <Label Content="{x:Static p:Resources.PreferencesViewPackageDownloadDirectory}"
                                                Padding="5,5,5,5"
-                                               FontSize="13"
+                                               FontSize="14"
                                                Foreground="{StaticResource PreferencesWindowFontColor}">
                                             <Label.ToolTip>
                                                 <ToolTip Content="{x:Static p:Resources.PreferencesPackageDownloadDirectoryTooltip}"
@@ -541,7 +541,7 @@
 
                                         <Label Content="{x:Static p:Resources.PackagePathPreferencesTitle}"
                                                Padding="5,5,5,5"
-                                               FontSize="13"
+                                               FontSize="14"
                                                Foreground="{StaticResource PreferencesWindowFontColor}">
                                             <Label.ToolTip>
                                                 <ToolTip Content="{x:Static p:Resources.PreferencesPackageDownloadDirectoryTooltip}"

--- a/src/DynamoCoreWpf/Views/PackageManager/Pages/PublishPackagePublishPage.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Pages/PublishPackagePublishPage.xaml
@@ -539,7 +539,7 @@
                                     <CheckBox Name="HostEntry"
                                               Checked="HostEntry_CheckStateChanged"
                                               Content="{Binding HostName}"
-                                              IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                              IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                               Style="{StaticResource ComboBoxCheckBoxStyle}"
                                               Tag="{RelativeSource FindAncestor,
                                                             AncestorType={x:Type ComboBox}}"


### PR DESCRIPTION
### Purpose

Merging the last changes of the package manager PR has been difficult because of continuous test failures caused by the changes. This PR cherry-picks only the UI-related changes inside this https://github.com/DynamoDS/Dynamo/pull/14655 (which was reverted here https://github.com/DynamoDS/Dynamo/pull/14689)

This PR should not trigger any test issues, as the changes are only on the UI xaml side.

<img width="807" alt="image" src="https://github.com/DynamoDS/Dynamo/assets/5354594/57191059-5038-4e14-811f-b5771c3b38c3">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- only UI related cherrypick which should not trigger any test issues

### Reviewers

@reddyashish 
@QilongTang 

### FYIs

@mjkkirschner 
