### PR TITLE
reduce test log noise

### DIFF
--- a/src/Config/CS_SDK.props
+++ b/src/Config/CS_SDK.props
@@ -57,7 +57,9 @@
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <DefineConstants>$(DefineConstants);_LINUX</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(UILib)' == 'true' AND $(RuntimeIdentifier.Contains('win'))">
+  <!--If we are building the Dynamo.All.sln and if current project is a test project, then include windows and wpf references so that tests can load UI nodes -->
+  <!--If UILib is true and we are targeting windows, then include windows and wpf references -->
+  <PropertyGroup Condition=" ( '$(SolutionName)' == 'Dynamo.All' AND '$(TestProject)' == 'true' ) OR ( '$(UILib)' == 'true' AND $(RuntimeIdentifier.Contains('win')) )">
     <TargetFramework>$(TargetFramework)-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/build.xml
+++ b/src/build.xml
@@ -3,7 +3,8 @@
     ToolsVersion="16.0"
     DefaultTargets="Build">
 <PropertyGroup>
-    <Solution>Dynamo.All.sln</Solution>
+    <SolutionName>Dynamo.All</SolutionName>
+    <Solution>$(SolutionName).sln</Solution>
     <Platform>Any CPU</Platform>
     <DotNet>net8.0</DotNet>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -22,7 +23,7 @@
 
 <Target Name="RestorePackages">
   <Exec Condition="!Exists($(NuGetPath))" Command="powershell.exe -ExecutionPolicy ByPass -Command Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $(NuGetPath)" />
-  <Exec Command="dotnet restore $(Solution) --runtime=$(RuntimeIdentifier) -p:DotNet=$(DotNet)"/>
+  <Exec Command="dotnet restore $(Solution) --runtime=$(RuntimeIdentifier) -p:DotNet=$(DotNet) -p:SolutionName=$(SolutionName)"/>
 </Target>
 
 </Project>


### PR DESCRIPTION
Issue:
DynamoCoreTests and a couple of others are still targeting net6 (core, no wpf) because they are also part of the DynamoCore.sln
However a lot of tests in these projects still try to load/handle UI packages (that have WPF and windows references).

Fix:
In this PR I set all test projects that build part of the Dynamo.All.sln as UI libs (add windows and WPF references)
When building DynamoCore.sln we will still have the issue.

The proper fix would be to completely move out all UI related test from our core test. Until that happens we are going to see errors like "WindowsBase.dll not found" when running tests on DynamoCore