### PR TITLE
more fixes for webview2 tests

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -6,6 +6,7 @@ using System.Web;
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Logging;
+using Dynamo.Models;
 using Dynamo.Utilities;
 using DynamoUtilities;
 using Microsoft.Web.WebView2.Core;
@@ -216,7 +217,14 @@ namespace Dynamo.DocumentationBrowser
         #region ILogSource Implementation
         private void Log(string message)
         {
-            viewModel.MessageLogged?.Invoke(LogMessage.Info(message));
+            if (DynamoModel.IsTestMode)
+            {
+                System.Console.WriteLine(message);
+            }
+            else
+            {
+                viewModel?.MessageLogged?.Invoke(LogMessage.Info(message));
+            }
         }
         #endregion
     }

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json;
 using Microsoft.Web.WebView2.Wpf;
 using Dynamo.Utilities;
 using Dynamo.Configuration;
+using Dynamo.Models;
 
 namespace Dynamo.Notifications
 {
@@ -345,10 +346,22 @@ namespace Dynamo.Notifications
         {
             if (initState == AsyncMethodState.Started)
             {
-                logger?.Log("NotificationCenterController is being disposed but async initialization is still not done");
+                Log("NotificationCenterController is being disposed but async initialization is still not done");
             }
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        private void Log(string msg)
+        {
+            if (DynamoModel.IsTestMode)
+            {
+                System.Console.WriteLine(msg);
+            }
+            else
+            {
+                logger?.Log(msg);
+            }
         }
     }
 }

--- a/test/DynamoCoreWpfTests/Utility/DispatcherUtil.cs
+++ b/test/DynamoCoreWpfTests/Utility/DispatcherUtil.cs
@@ -14,7 +14,6 @@ namespace DynamoCoreWpfTests.Utility
         /// <summary>
         ///     Force the Dispatcher to empty it's queue
         /// </summary>
-        [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public static void DoEvents()
         {
             var frame = new DispatcherFrame();
@@ -24,14 +23,13 @@ namespace DynamoCoreWpfTests.Utility
         }
 
         /// <summary>
-        /// Force the Dispatcher to empty it's queue every 100 ms for a maximum 4 seconds or until
+        /// Force the Dispatcher to empty it's queue every 100 ms for a maximum 20 seconds or until
         /// the check function returns true.
         /// </summary>
         /// <param name="check">When check returns true, the even loop is stopped.</param>
-        [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public static void DoEventsLoop(Func<bool> check = null)
         {
-            const int max_count = 40;
+            const int max_count = 200;
 
             int count = 0;
             while (true)

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -206,6 +206,9 @@ namespace DynamoCoreWpfTests
             // Act
             var tabsBeforeExternalEventTrigger = this.ViewModel.SideBarTabItems.Count;
             this.ViewModel.OpenDocumentationLinkCommand.Execute(docsEvent);
+
+            WaitForWebView2Initialization();
+
             var tabsAfterExternalEventTrigger = this.ViewModel.SideBarTabItems.Count;
             var htmlContent = GetSidebarDocsBrowserContents();
 


### PR DESCRIPTION
Increased timeout for DoLoopEvents: as more and more test run, the thread queue gets congested and DoEvents takes longer and longer.
Some tests do not set the Logger properly in some Views, so I converted to COnsole.WriteLine during tests
MIssed one test that was initializing webview2