### PR TITLE
Pm remove duplicate dyf file warning from preview generation process

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -2411,22 +2411,6 @@ namespace Dynamo.PackageManager
                          .ToList();
             try
             {
-                var unqualifiedFiles = GetAllUnqualifiedFiles();
-
-                if (files == null || files.Count() < 1 || unqualifiedFiles.Count() > 0)
-                {
-                    string filesCannotBePublished = null;
-                    foreach (var file in unqualifiedFiles)
-                    {
-                        filesCannotBePublished = filesCannotBePublished + file + "\n";
-                    }
-                    string FileNotPublishMessage = string.Format(Resources.FileNotPublishMessage, filesCannotBePublished);
-                    UploadState = PackageUploadHandle.State.Error;
-                    MessageBoxResult response = DynamoModel.IsTestMode ? MessageBoxResult.OK : MessageBoxService.Show(Owner, FileNotPublishMessage, Resources.FileNotPublishCaption, MessageBoxButton.OK, MessageBoxImage.Error);
-
-                    return;
-                }
-
                 // Generate the Package Name, either based on the user 'Description', or the root path name, if no 'Description' yet
                 var packageName = !string.IsNullOrEmpty(Name) ? Name : Path.GetFileName(publishPath);
                 var rootItemPreview = RetainFolderStructureOverride ?


### PR DESCRIPTION
### Purpose

This PR addresses this jira issue: 

Historically, Dynamo will warn the user and fail to publish a package locally if using an 'unqualified' file, such as a .dyf file already under package control. (Below was recreated this behavior on 2.19). I have incorrectly added this check and warning as part of the `preview` build generation. This PR removes this additional warning but leaves the historic dynamo code.



### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- dynamo would issue a warning and fail to publish a package if an 'unqualified' file is being used, such as a dyf file already under package control
- this check is done when publishing the package locally, but I have incorrectly added it to the process of creating a build preview, which stops the process for both local and online submit workflow


### Reviewers



### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
