### PR TITLE
stop loading UI nodes during DynamoCOre test

### DIFF
--- a/src/DynamoCore/Core/NodeModelAssemblyLoader.cs
+++ b/src/DynamoCore/Core/NodeModelAssemblyLoader.cs
@@ -79,8 +79,12 @@ namespace Dynamo.Models
             }
         }
 
+        /// <summary>
+        /// Should be used only in tests
+        /// </summary>
+        internal static event Func<string, bool> shouldLoadAssemblyPath;
         #endregion
-        
+
         #region Methods
         /// <summary>
         /// Load all types which inherit from NodeModel whose assemblies are located in
@@ -131,6 +135,13 @@ namespace Dynamo.Models
             var result = new List<TypeLoadData>();
             var result2 = new List<TypeLoadData>();
 
+            if (Models.DynamoModel.IsTestMode)
+            {
+                if (shouldLoadAssemblyPath.GetInvocationList().Length > 0) {
+                    allDynamoAssemblyPaths = allDynamoAssemblyPaths.Where((path) => shouldLoadAssemblyPath(path)).ToList();
+                }
+            }
+            
             foreach (var assemblyPath in allDynamoAssemblyPaths)
             {
                 var fn = Path.GetFileName(assemblyPath);

--- a/src/DynamoCore/Core/NodeModelAssemblyLoader.cs
+++ b/src/DynamoCore/Core/NodeModelAssemblyLoader.cs
@@ -137,7 +137,7 @@ namespace Dynamo.Models
 
             if (Models.DynamoModel.IsTestMode)
             {
-                if (shouldLoadAssemblyPath.GetInvocationList().Length > 0) {
+                if (shouldLoadAssemblyPath != null) {
                     allDynamoAssemblyPaths = allDynamoAssemblyPaths.Where((path) => shouldLoadAssemblyPath(path)).ToList();
                 }
             }

--- a/test/DynamoCoreTests/Setup.cs
+++ b/test/DynamoCoreTests/Setup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Dynamo.Models;
 using Dynamo.Utilities;
 using NUnit.Framework;
 
@@ -8,6 +9,15 @@ using NUnit.Framework;
     public class Setup
     {
         private AssemblyHelper assemblyHelper;
+
+        private bool NodeModelAssemblyLoader_shouldLoadAssemblyPath(string assemblyPath)
+        {
+            if (assemblyPath.Contains("WPF", StringComparison.OrdinalIgnoreCase) || assemblyPath.Contains("UI", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            return true;
+        }
 
         [OneTimeSetUp]
         public void RunBeforeAllTests()
@@ -24,6 +34,7 @@ using NUnit.Framework;
 
             assemblyHelper = new AssemblyHelper(moduleRootFolder.FullName, resolutionPaths);
             AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
+            NodeModelAssemblyLoader.shouldLoadAssemblyPath += NodeModelAssemblyLoader_shouldLoadAssemblyPath;
         }
 
         [OneTimeTearDown]
@@ -31,5 +42,6 @@ using NUnit.Framework;
         {
             AppDomain.CurrentDomain.AssemblyResolve -= assemblyHelper.ResolveAssembly;
             assemblyHelper = null;
+            NodeModelAssemblyLoader.shouldLoadAssemblyPath -= NodeModelAssemblyLoader_shouldLoadAssemblyPath;
         }
     }

--- a/test/DynamoCoreTests/Setup.cs
+++ b/test/DynamoCoreTests/Setup.cs
@@ -10,6 +10,11 @@ using NUnit.Framework;
     {
         private AssemblyHelper assemblyHelper;
 
+        /// <summary>
+        /// Skip loading WPF nodes during DynamoCore tests because they will fail to load and will generate too many useless logs
+        /// </summary>
+        /// <param name="assemblyPath"></param>
+        /// <returns></returns>
         private bool NodeModelAssemblyLoader_shouldLoadAssemblyPath(string assemblyPath)
         {
             if (assemblyPath.Contains("WPF", StringComparison.OrdinalIgnoreCase) || assemblyPath.Contains("UI", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
DynamoCoreTEsts will try to load all nodes in the bin/nodes subfolder which include WPF and UI nodes.
They will all fail to load because WPF dependencies are missing and will generate a lot of useless logs.

In this PR I am actively skipping WPF and UI nodes (by name) when running DynamoCoreTEsts tests