### PR TITLE
DYN-6488: remove package version limitation

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -18,7 +18,6 @@ using Dynamo.PackageManager;
 using Dynamo.Search.SearchElements;
 using Dynamo.UI;
 using Dynamo.UI.Controls;
-using Dynamo.Updates;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Properties;
@@ -3898,10 +3897,7 @@ namespace Dynamo.Controls
             CultureInfo culture)
         {
             if (value is string nullOrEmptyString && String.IsNullOrEmpty(nullOrEmptyString)) return Visibility.Visible;
-            if (value is string zeroString && zeroString.Equals("0"))
-            {
-                return Visibility.Visible;
-            }
+            
             return Visibility.Collapsed;
         }
 


### PR DESCRIPTION
### Purpose

A small PR that removes the limitation for Major version number to be 0. The only requirement at this point is that the full build version cannot be `0.0.0`

Addresses this jira issue: https://jira.autodesk.com/browse/DYN-6488

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/b91bf833-ae1d-4cdc-8788-5e9222d9d290)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now allows package version to start with 0
- cannot have 0.0.0 package version

### Reviewers

@avidit
@reddyashish

### FYIs

@QilongTang