### PR TITLE
Pm reinstate description check

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -2352,6 +2352,12 @@ namespace Dynamo.PackageManager
                 return false;
             }
 
+            if (Description.Length <= 10)
+            {
+                ErrorString = Resources.DescriptionNeedMoreCharacters;
+                return false;
+            }
+
             if (MajorVersion.Length <= 0)
             {
                 ErrorString = Resources.MajorVersionNonNegative;


### PR DESCRIPTION
### Purpose

A small PR reinstating the Description field check. The check was removed from the UI but it remains as part of the Greg request API. The process of submitting a package online would fail without a description, which would contradict the UI form, so bringing back the check.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/91dac4cf-c6ad-47c7-9919-f6bb204c9c4d)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- brought back description check as publish online API still requires it

### Reviewers

@avidit
@reddyashish

### FYIs

@QilongTang
