### PR TITLE
Pm update-vm-cherrypick

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -113,6 +113,24 @@ namespace Dynamo.PackageManager.ViewModels
         public PackageManagerSearchElementViewModel(PackageManagerSearchElement element, bool canLogin) : this(element, canLogin, true)
         {}
 
+        /// <summary>
+        /// A property showing if the currently logged-in user owns the package
+        /// </summary>
+        private bool isOwner = false;
+        public bool IsOnwer
+        {
+            get
+            {
+                return isOwner;
+            }
+
+            internal set
+            {   
+                isOwner = value;
+                RaisePropertyChanged(nameof(IsOnwer));
+            }
+        }
+
         private bool canInstall;
         /// <summary>
         /// A Boolean flag reporting whether or not the user can install this SearchElement's package.

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -651,8 +651,12 @@ namespace Dynamo.PackageManager
             var pkgs = PackageManagerClientViewModel.CachedPackageList.Where(x => x.Maintainers != null && x.Maintainers.Contains(name)).ToList();
             foreach(var pkg in pkgs)
             {
-                var p = new PackageManagerSearchElementViewModel(pkg, false);
+                var p = new PackageManagerSearchElementViewModel(pkg,
+                                                                 PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
+                                                                 CanInstallPackage(pkg.Name));
                 p.RequestDownload += this.PackageOnExecuted;
+                p.RequestShowFileDialog += this.OnRequestShowFileDialog;
+                p.IsOnwer = true;
 
                 myPackages.Add(p);
             }
@@ -666,6 +670,7 @@ namespace Dynamo.PackageManager
             foreach (var ele in this.SearchMyResults)
             {
                 ele.RequestDownload -= PackageOnExecuted;
+                ele.RequestShowFileDialog -= OnRequestShowFileDialog;
             }
 
             this.SearchMyResults = null;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerViewModel.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
+using Dynamo.PackageManager.ViewModels;
+using Dynamo.UI.Commands;
 using Dynamo.ViewModels;
 using NotificationObject = Dynamo.Core.NotificationObject;
 
@@ -25,7 +28,20 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// PublishPackageViewModel containing information about all the published packages
         /// </summary>
-        public PublishPackageViewModel PublishPackageViewModel { get; set; }
+        ///
+        private PublishPackageViewModel publishPackageViewModel;
+        public PublishPackageViewModel PublishPackageViewModel
+        {
+            get { return publishPackageViewModel; }
+            set
+            {
+                if (publishPackageViewModel != value)
+                {
+                    publishPackageViewModel = value;
+                    RaisePropertyChanged(nameof(PublishPackageViewModel));
+                }
+            }
+        }
 
         /// <summary>
         /// Returns all installed packages
@@ -37,6 +53,7 @@ namespace Dynamo.PackageManager
         /// </summary>
         public ObservableCollection<PackageFilter> Filters => installedPackagesViewModel.Filters;
 
+        public DelegateCommand PublishNewVersionCommand { get; set; }
 
         //Width of the PackageManagerView the default value is 1076
         public double Width
@@ -89,6 +106,21 @@ namespace Dynamo.PackageManager
             if (String.IsNullOrEmpty(PreferencesViewModel?.SelectedPackagePathForInstall))
             {
                 PreferencesViewModel.SelectedPackagePathForInstall = dynamoViewModel.PreferenceSettings.SelectedPackagePathForInstall;
+            }
+
+            PublishNewVersionCommand = new DelegateCommand(PublishNewPackageVersionRelayCommand);
+        }
+
+
+        private void PublishNewPackageVersionRelayCommand(object obj)
+        {
+            var searchElement = obj as PackageManagerSearchElementViewModel;
+            if(searchElement != null)
+            {
+                var localPackage = LocalPackages.First(x => x.Model.Name.Equals(searchElement.Name));
+
+                if (localPackage == null) { return; }
+                localPackage.PublishNewPackageVersionCommand.Execute();
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -92,7 +93,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Package Publish entry, binded to the host multi-selection option
         /// </summary>
-        public class HostComboboxEntry
+        public class HostComboboxEntry : NotificationObject 
         {
             /// <summary>
             /// Name of the host
@@ -102,7 +103,19 @@ namespace Dynamo.PackageManager
             /// <summary>
             /// Boolean indicates if the host entry is selected
             /// </summary>
-            public bool IsSelected { get; set; }
+            private bool _isSelected;
+            public bool IsSelected
+            {
+                get { return _isSelected; }
+                set
+                {
+                    if (_isSelected != value)
+                    {
+                        _isSelected = value;
+                        RaisePropertyChanged(nameof(IsSelected));
+                    }
+                }
+            }
 
             /// <summary>
             /// Constructor
@@ -190,6 +203,7 @@ namespace Dynamo.PackageManager
                 {
                     _isNewVersion = value;
                     RaisePropertyChanged("IsNewVersion");
+                    RaisePropertyChanged("CanEditName");
                 }
             }
         }
@@ -1134,8 +1148,9 @@ namespace Dynamo.PackageManager
             this.AdditionalFiles = new ObservableCollection<string>();
             this.Dependencies = new ObservableCollection<PackageDependency>();
             this.Assemblies = new List<PackageAssembly>();
-            this.SelectedHosts = new List<String>();
+            this.KnownHosts.ForEach(host => { host.IsSelected = false; });
             this.SelectedHostsString = string.Empty;
+            this.SelectedHosts = new List<String>();
             this.copyrightHolder = string.Empty;
             this.copyrightYear = string.Empty;
             this.RootFolder = string.Empty;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1493,6 +1493,10 @@ namespace Dynamo.Controls
 
                 if (packageManagerWindow.IsLoaded && IsLoaded) packageManagerWindow.Owner = this;
             }
+            if (_pkgVM != null)
+            {
+                _pkgVM.PublishPackageViewModel = model;
+            }
 
             packageManagerWindow.Focus();
             packageManagerWindow.Navigate(Wpf.Properties.Resources.PackageManagerPublishTab);

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
@@ -32,9 +32,35 @@ namespace Dynamo.PackageManager.UI
             InitializeComponent();
 
             this.Loaded += InitializeContext;
+            this.DataContextChanged += PackageManagerPublishControl_DataContextChanged;
+        }
+
+        private void PackageManagerPublishControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(this.DataContext is PublishPackageViewModel)) return;
+
+            ResetDataContext();
+            SetDataContext();
         }
 
         private void InitializeContext(object sender, RoutedEventArgs e)
+        {
+            SetDataContext();
+
+            this.Loaded -= InitializeContext;
+        }
+
+        private void ResetDataContext()
+        {
+            if (PublishPackageViewModel != null)
+            {
+                PublishPackageViewModel.PublishSuccess -= PackageViewModelOnPublishSuccess;
+                PublishPackageViewModel.RequestShowFolderBrowserDialog -= OnRequestShowFolderBrowserDialog;
+            }
+
+            PublishPackageViewModel = null; 
+        }
+        private void SetDataContext()
         {
             // Set the owner of this user control
             this.Owner = Window.GetWindow(this);
@@ -42,7 +68,7 @@ namespace Dynamo.PackageManager.UI
             PublishPackageViewModel = this.DataContext as PublishPackageViewModel;
             PublishPackageViewModel.Owner = this.Owner;
 
-            if(PublishPackageViewModel != null )
+            if (PublishPackageViewModel != null)
             {
                 PublishPackageViewModel.PublishSuccess += PackageViewModelOnPublishSuccess;
                 PublishPackageViewModel.RequestShowFolderBrowserDialog += OnRequestShowFolderBrowserDialog;
@@ -78,6 +104,8 @@ namespace Dynamo.PackageManager.UI
             NavButtonStacks = null;
 
             Breadcrumbs?.Clear();
+            
+            this.DataContextChanged -= PackageManagerPublishControl_DataContextChanged;
         }
 
         private void InitializePages()

--- a/src/DynamoCoreWpf/Views/PackageManager/Pages/PublishPackagePublishPage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Pages/PublishPackagePublishPage.xaml.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Navigation;
 
@@ -11,7 +12,7 @@ namespace Dynamo.PackageManager.UI
     {
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
-            if (value is string name && name.TrimEnd().Length > 2)
+            if (IsValidName((string)value))
             {
                 // Validation succeeded
                 return ValidationResult.ValidResult;
@@ -20,6 +21,11 @@ namespace Dynamo.PackageManager.UI
             // Validation failed
             return new ValidationResult(false, Wpf.Properties.Resources.NameNeedMoreCharacters);
         }
+        public static bool IsValidName(string value)
+        {
+            return (value is string name && name.TrimEnd().Length > 2);
+        }
+
     }
 
 
@@ -136,11 +142,36 @@ namespace Dynamo.PackageManager.UI
         {
             var textBox = sender as TextBox;
             if (textBox == null) return;
+            if (e.Key == Key.System) return;
+
+            int caretIndex = textBox.CaretIndex; // Store the caret index
 
             // Prevents text starting with a space
             if (e.Key == System.Windows.Input.Key.Space && string.IsNullOrWhiteSpace(textBox.Text))
             {
-                e.Handled = true; 
+                e.Handled = true;
+                return;
+            }
+
+            if (string.IsNullOrEmpty(textBox.Text)) { return; }
+
+            // In case we are using the Backspace to remove characters, the validation error will stop the Name property from being updated 
+            if (textBox.Name.Equals("packageNameInput") && e.Key == Key.Back && !PackageNameLengthValidationRule.IsValidName(textBox.Text.Substring(0, textBox.Text.Length - 1)))
+            {
+                e.Handled = true;
+
+                if (!string.IsNullOrEmpty(PublishPackageViewModel.Name))
+                {
+                    // Manually remove the last character from the Name property, as the validation error will not update the Name property
+                    PublishPackageViewModel.Name = PublishPackageViewModel.Name.Substring(0, PublishPackageViewModel.Name.Length - 1);
+
+                    // Trigger re-validation explicitly
+                    var expression = textBox.GetBindingExpression(TextBox.TextProperty);
+                    expression?.UpdateSource();
+
+                    textBox.CaretIndex = caretIndex - 1 >= 0 ? caretIndex - 1 : 0;
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Closing in favor of:
- https://github.com/DynamoDS/Dynamo/pull/14722
- https://github.com/DynamoDS/Dynamo/pull/14723
- https://github.com/DynamoDS/Dynamo/pull/14724

### Purpose

Merging the last changes of the package manager PR has been difficult because of continuous test failures caused by the changes. This PR cherry-picks the non-UI-related changes inside this https://github.com/DynamoDS/Dynamo/pull/14655 (which was reverted here https://github.com/DynamoDS/Dynamo/pull/14689)

[Link to the first cherry-pick PR ](https://github.com/DynamoDS/Dynamo/pull/14704)

Also addresses concerns raised in this Jira issue: https://jira.autodesk.com/browse/DYN-6511

![publish version](https://github.com/DynamoDS/Dynamo/assets/5354594/c4ec744e-62bc-44ce-95b8-33300110c599)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- allows publishing new package version from MyPackages  tab
- pulls information from existing package and pre-populates the Publish Package form
- misc check fixes

### Reviewers

@reddyashish 
@avidit

### FYIs

@QilongTang 
