### PR TITLE
DYN-6524 Packages Tour Regression

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -482,7 +482,7 @@ namespace Dynamo.DocumentationBrowser
 
                 object[] jsParameters = new object[] { breadBrumbsArray[i], sectionType, "true" };
                 //Create the array for the paramateres that will be sent to the WebBrowser.InvokeScript Method
-                object[] parametersInvokeScript = new object[] { "collapseExpandPackage", jsParameters };
+                object[] parametersInvokeScript = new object[] { "expandPackageDiv", jsParameters };
 
                 ResourceUtilities.ExecuteJSFunction(DynamoView, parametersInvokeScript);
                 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -14,6 +14,7 @@ using Dynamo.PackageManager.UI;
 using Dynamo.PackageManager.ViewModels;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
+using Dynamo.Wpf.ViewModels.GuidedTour;
 using Dynamo.Wpf.Views.GuidedTour;
 using Newtonsoft.Json.Linq;
 using static Dynamo.PackageManager.PackageManagerSearchViewModel;
@@ -495,18 +496,30 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// <param name="e">Event Arguments</param>
         internal void ExecuteAutomaticPackage_Click(object sender, RoutedEventArgs e)
         {
-            CollapseExpandPackage(CurrentExecutingStep);
+            var nextButton = (sender as Button);
+            if (nextButton == null) return;
+
+            var popupVM = (nextButton.DataContext as PopupWindowViewModel);
+            if(popupVM == null) return;
+
+            if (popupVM.Step == null) return;
+            ExpandPackage(popupVM.Step);
         }
 
         /// <summary>
-        /// This method will call the collapseExpandPackage javascript method with reflection, so the package expander in LibraryView will be clicked
+        /// This method will call the expandPackageDiv javascript method with reflection, so the package expander in LibraryView will be clicked
         /// </summary>
-        internal static void CollapseExpandPackage(Step stepInfo)
+        internal static void ExpandPackage(Step stepInfo)
         {
-            CurrentExecutingStep = stepInfo;
-            var firstUIAutomation = stepInfo.UIAutomation.FirstOrDefault();
-            if (firstUIAutomation == null || firstUIAutomation.JSParameters.Count == 0) return;
-            object[] parametersInvokeScript = new object[] { firstUIAutomation.JSFunctionName, new object[] { firstUIAutomation.JSParameters.FirstOrDefault() } };
+            var expandUIAutomation = stepInfo.UIAutomation.Where(automation => automation.JSFunctionName == "expandPackageDiv").FirstOrDefault();
+            if (expandUIAutomation == null || expandUIAutomation.JSParameters.Count == 0) return;
+
+            //Expand the Sample Package Div when clicking the next button in Step8
+            object[] parametersInvokeScript = new object[] { expandUIAutomation.JSFunctionName, new object[] { expandUIAutomation.JSParameters[0], expandUIAutomation.JSParameters[1] } };
+            ResourceUtilities.ExecuteJSFunction(stepInfo.MainWindow, stepInfo.HostPopupInfo, parametersInvokeScript);
+
+            //Expand the Package nodes when clicking the next button in Step8
+            parametersInvokeScript = new object[] { expandUIAutomation.JSFunctionName, new object[] { "Examples", "LibraryItemGroupText" } };
             ResourceUtilities.ExecuteJSFunction(stepInfo.MainWindow, stepInfo.HostPopupInfo, parametersInvokeScript);
         }
 
@@ -975,6 +988,25 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private static void RunButton_Click(object sender, RoutedEventArgs e)
         {
             CurrentExecutingGuide.NextStep(CurrentExecutingStep.Sequence);
+        }
+
+        /// <summary>
+        /// In the the Package is expanded this method will call a js method that will collapse the <div></div>
+        /// </summary>
+        internal static void CollapsePackageDiv(Step stepInfo, StepUIAutomation uiAutomationData, bool enableFunction, GuideFlow currentFlow)
+        {
+            CurrentExecutingStep = stepInfo;
+            if (uiAutomationData == null) return;
+            string jsFunctionName = uiAutomationData.JSFunctionName;
+            //Create the array for the paramateres that will be sent to the WebBrowser.InvokeScript Method
+            object[] parametersInvokeScript = new object[] { jsFunctionName, new object[] { uiAutomationData.JSParameters[0], uiAutomationData.JSParameters[1] } };
+
+            //Only will be executed when entering to the Step8 (when leaving Step8 the div should be expanded)
+            if(enableFunction == true)
+            {
+                //Execute the JS function with the provided parameters
+                ResourceUtilities.ExecuteJSFunction(CurrentExecutingStep.MainWindow, CurrentExecutingStep.HostPopupInfo, parametersInvokeScript);
+            }            
         }
     }
 }

--- a/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
+++ b/src/DynamoCoreWpf/UI/GuidedTour/dynamo_guides.json
@@ -738,10 +738,18 @@
 					{
 						"Sequence": 1,
 						"ControlType": "function",
+						"Name": "CollapsePackageDiv",
+						"JSFunctionName": "collapsePackageDiv",
+						"JSParameters": [ "SampleLibraryUI", "LibraryItemText" ],
+						"Action": "execute"
+					},
+					{
+						"Sequence": 2,
+						"ControlType": "function",
 						"WindowName": "PopupWindow",
 						"Name": "SubscribeNextButtonClickEvent",
 						"Action": "execute",
-						"JSFunctionName": "collapseExpandPackage",
+						"JSFunctionName": "expandPackageDiv",
 						"JSParameters": [ "SampleLibraryUI", "LibraryItemText" ],
 						"AutomaticHandlers": [
 							{
@@ -752,7 +760,7 @@
 						]
 					},
 					{
-						"Sequence": 2,
+						"Sequence": 3,
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "setOverlay",
@@ -760,7 +768,7 @@
 						"Action": "execute"
 					},
 					{
-						"Sequence": 3,
+						"Sequence": 4,
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "subscribePackageClickedEvent",
@@ -768,7 +776,7 @@
 						"Action": "execute"
 					},
 					{
-						"Sequence": 4,
+						"Sequence": 5,
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "getDocumentClientRect",
@@ -776,7 +784,7 @@
 						"Action": "execute"
 					},
 					{
-						"Sequence": 5,
+						"Sequence": 6,
 						"ControlType": "function",
 						"Name": "LibraryScrollToBottom",
 						"JSFunctionName": "scrollToBottom",
@@ -784,7 +792,7 @@
 						"Action": "execute"
 					},
 					{
-						"Sequence": 6,
+						"Sequence": 7,
 						"ControlType": "function",
 						"Name": "CalculateLibraryItemLocation",
 						"JSFunctionName": "getDocumentClientRect",
@@ -821,7 +829,7 @@
 				},
 				"UIAutomation": [
 					{
-						"Sequence": 0,
+						"Sequence": 1,
 						"ControlType": "JSFunction",
 						"Name": "InvokeJSFunction",
 						"JSFunctionName": "setOverlay",
@@ -829,27 +837,19 @@
 						"Action": "execute"
 					},
 					{
-						"Sequence": 1,
-						"ControlType": "JSFunction",
-						"Name": "InvokeJSFunction",
-						"Action": "execute",
-						"JSFunctionName": "collapseExpandPackage",
-						"JSParameters": [ "SampleLibraryUI", "LibraryItemText" ]
-					},
-					{
 						"Sequence": 2,
-						"ControlType": "JSFunction",
-						"Name": "InvokeJSFunction",
-						"Action": "execute",
-						"JSFunctionName": "collapseExpandPackage",
-						"JSParameters": [ "Examples", "LibraryItemGroupText" ]
-					},
-					{
-						"Sequence": 3,
 						"ControlType": "function",
 						"Name": "LibraryScrollToBottom",
 						"JSFunctionName": "scrollToBottom",
 						"JSParameters": [],
+						"Action": "execute"
+					},
+					{
+						"Sequence": 3,
+						"ControlType": "JSFunction",
+						"Name": "InvokeJSFunction",
+						"JSFunctionName": "expandPackageDiv",
+						"JSParameters": [ "Examples", "LibraryItemGroupText" ],
 						"Action": "execute"
 					}
 				]
@@ -998,7 +998,7 @@
 						"WindowName": "LibraryView",
 						"Name": "InvokeJSFunction",
 						"Action": "execute",
-						"JSFunctionName": "collapseExpandPackage",
+						"JSFunctionName": "expandPackageDiv",
 						"JSParameters": [ "Geometry", "LibraryItemText" ]
 					},
 					{
@@ -1007,7 +1007,7 @@
 						"WindowName": "LibraryView",
 						"Name": "InvokeJSFunction",
 						"Action": "execute",
-						"JSFunctionName": "collapseExpandPackage",
+						"JSFunctionName": "expandPackageDiv",
 						"JSParameters": [ "Abstract", "LibraryItemGroupText" ]
 					},
 					{
@@ -1016,7 +1016,7 @@
 						"WindowName": "LibraryView",
 						"Name": "InvokeJSFunction",
 						"Action": "execute",
-						"JSFunctionName": "collapseExpandPackage",
+						"JSFunctionName": "expandPackageDiv",
 						"JSParameters": [ "CoordinateSystem", "LibraryItemGroupText" ]
 					},
 					{

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -249,7 +249,11 @@
             }
             if (found_div != null) {
                 if (enableHighlight == true) {
-                    glowAnimation(found_div, true);
+                    //Validates that the div is not already highlighted
+                    var currentAttibute = found_div.getAttribute("id");
+                    if (currentAttibute == null || !currentAttibute.includes("glow_")) {
+                        glowAnimation(found_div, true);
+                    }                  
                 }
                 else {
                     glowAnimation(found_div, false);
@@ -307,7 +311,7 @@
         }
 
         //This will execute a click over a specific <div> that contains the package content
-        function collapseExpandPackage(packageName, libraryClassName) {
+        function expandPackageDiv(packageName, libraryClassName) {
             var found_div = findPackageDiv(packageName, libraryClassName);
             if (found_div == null) {
                 return;
@@ -315,6 +319,18 @@
             var containerCatDiv = found_div.parentNode.parentNode;
             var itemBodyContainer = containerCatDiv.getElementsByClassName(libraryClassName)[0];
             if (!itemBodyContainer.parentElement.parentElement.className.includes('expanded')) {
+                itemBodyContainer.click();
+            }
+        }
+
+        function collapsePackageDiv(packageName, libraryClassName) {
+            var found_div = findPackageDiv(packageName, libraryClassName);
+            if (found_div == null) {
+                return;
+            }
+            var containerCatDiv = found_div.parentNode.parentNode;
+            var itemBodyContainer = containerCatDiv.getElementsByClassName(libraryClassName)[0];
+            if (itemBodyContainer.parentElement.parentElement.className.includes('expanded')) {
                 itemBodyContainer.click();
             }
         }


### PR DESCRIPTION
### Purpose

I did several updates for the Packages guide:
I've splitted the functionality of collapseExpandPackage so now we will have one method for collapse and another one for expand, so the function collapseExpandPackage was renamed to expandPackageDiv. Some Steps in the dynamo_guides.json were modified to stick to the functionality of expanding the package when passing from Step8 to Step9. Finally I added a validation in the function that highlight a div so if the div is already highlighted when we don't add the functionality ( this will prevent showing the orange rectangle when closing the guide ).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

I did several updates for the Packages guide:

### Reviewers

@QilongTang 

### FYIs

@avidit 
