### PR TITLE
Pm reset selected known hosts

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -92,7 +93,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Package Publish entry, binded to the host multi-selection option
         /// </summary>
-        public class HostComboboxEntry
+        public class HostComboboxEntry : NotificationObject 
         {
             /// <summary>
             /// Name of the host
@@ -102,7 +103,16 @@ namespace Dynamo.PackageManager
             /// <summary>
             /// Boolean indicates if the host entry is selected
             /// </summary>
-            public bool IsSelected { get; set; }
+            private bool _isSelected;
+            public bool IsSelected
+            {
+                get { return _isSelected; }
+                set
+                {
+                    _isSelected = value;
+                    RaisePropertyChanged(nameof(IsSelected));
+                }
+            }
 
             /// <summary>
             /// Constructor
@@ -112,6 +122,14 @@ namespace Dynamo.PackageManager
             {
                 HostName = hostName;
                 IsSelected = false;
+            }
+
+            /// <summary>
+            /// Reset the state of the `IsSelected` property without raising update
+            /// </summary>
+            internal void ResetState()
+            {
+                this._isSelected = false;
             }
         }
 
@@ -190,6 +208,7 @@ namespace Dynamo.PackageManager
                 {
                     _isNewVersion = value;
                     RaisePropertyChanged("IsNewVersion");
+                    RaisePropertyChanged("CanEditName");
                 }
             }
         }
@@ -1105,6 +1124,14 @@ namespace Dynamo.PackageManager
         private void ClearAllEntries()
         {
             if (DynamoModel.IsTestMode) return;
+
+            try
+            {
+                this.KnownHosts.ForEach(host => host.ResetState());
+                this.KnownHosts.ForEach(host => host.IsSelected = false);
+            }
+            catch { Exception ex; }
+
             // this function clears all the entries of the publish package dialog
             this.Name = string.Empty;
             this.RepositoryUrl = string.Empty;
@@ -1134,8 +1161,8 @@ namespace Dynamo.PackageManager
             this.AdditionalFiles = new ObservableCollection<string>();
             this.Dependencies = new ObservableCollection<PackageDependency>();
             this.Assemblies = new List<PackageAssembly>();
+            this.SelectedHostsString = string.Empty;    
             this.SelectedHosts = new List<String>();
-            this.SelectedHostsString = string.Empty;
             this.copyrightHolder = string.Empty;
             this.copyrightYear = string.Empty;
             this.RootFolder = string.Empty;
@@ -1470,12 +1497,13 @@ namespace Dynamo.PackageManager
         private void UpdateDependencies()
         {
             Dependencies.Clear();
-            GetAllDependencies().ToList().ForEach(Dependencies.Add);
+            GetAllDependencies()?.ToList().ForEach(Dependencies.Add);
         }
 
         private IEnumerable<PackageDependency> GetAllDependencies()
         {
             var pmExtension = dynamoViewModel.Model.GetPackageManagerExtension();
+            if (pmExtension == null) return null;
             var pkgLoader = pmExtension.PackageLoader;
 
             // all workspaces
@@ -2160,7 +2188,7 @@ namespace Dynamo.PackageManager
                 AppendPackageContents();
 
                 Package.Dependencies.Clear();
-                GetAllDependencies().ToList().ForEach(Package.Dependencies.Add);
+                GetAllDependencies()?.ToList().ForEach(Package.Dependencies.Add);
 
                 Package.HostDependencies = Enumerable.Empty<string>();
                 Package.HostDependencies = SelectedHosts;


### PR DESCRIPTION
### Purpose

Fixes an issue where the Known Host filters will remain selected in-between form resets in the Publish Package tab. 

#### Fix
![reset known filters](https://github.com/DynamoDS/Dynamo/assets/5354594/ff77061c-e920-4412-9bd6-6cca6a0e7f73)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now resets selected known hosts between publish package usages/resets

### Reviewers

@reddyashish 
@avidit

### FYIs

@QilongTang 