### PR TITLE
Pm name validation fix, page navigate fix

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPublishControl.xaml.cs
@@ -32,9 +32,35 @@ namespace Dynamo.PackageManager.UI
             InitializeComponent();
 
             this.Loaded += InitializeContext;
+            this.DataContextChanged += PackageManagerPublishControl_DataContextChanged;
+        }
+
+        private void PackageManagerPublishControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(this.DataContext is PublishPackageViewModel)) return;
+
+            ResetDataContext();
+            SetDataContext();
         }
 
         private void InitializeContext(object sender, RoutedEventArgs e)
+        {
+            SetDataContext();
+
+            this.Loaded -= InitializeContext;
+        }
+
+        private void ResetDataContext()
+        {
+            if (PublishPackageViewModel != null)
+            {
+                PublishPackageViewModel.PublishSuccess -= PackageViewModelOnPublishSuccess;
+                PublishPackageViewModel.RequestShowFolderBrowserDialog -= OnRequestShowFolderBrowserDialog;
+            }
+
+            PublishPackageViewModel = null; 
+        }
+        private void SetDataContext()
         {
             // Set the owner of this user control
             this.Owner = Window.GetWindow(this);
@@ -42,7 +68,7 @@ namespace Dynamo.PackageManager.UI
             PublishPackageViewModel = this.DataContext as PublishPackageViewModel;
             PublishPackageViewModel.Owner = this.Owner;
 
-            if(PublishPackageViewModel != null )
+            if (PublishPackageViewModel != null)
             {
                 PublishPackageViewModel.PublishSuccess += PackageViewModelOnPublishSuccess;
                 PublishPackageViewModel.RequestShowFolderBrowserDialog += OnRequestShowFolderBrowserDialog;
@@ -78,6 +104,8 @@ namespace Dynamo.PackageManager.UI
             NavButtonStacks = null;
 
             Breadcrumbs?.Clear();
+            
+            this.DataContextChanged -= PackageManagerPublishControl_DataContextChanged;
         }
 
         private void InitializePages()

--- a/src/DynamoCoreWpf/Views/PackageManager/Pages/PublishPackagePublishPage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Pages/PublishPackagePublishPage.xaml.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Navigation;
 
@@ -11,7 +12,7 @@ namespace Dynamo.PackageManager.UI
     {
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
-            if (value is string name && name.TrimEnd().Length > 2)
+            if (IsValidName((string)value))
             {
                 // Validation succeeded
                 return ValidationResult.ValidResult;
@@ -20,6 +21,11 @@ namespace Dynamo.PackageManager.UI
             // Validation failed
             return new ValidationResult(false, Wpf.Properties.Resources.NameNeedMoreCharacters);
         }
+        public static bool IsValidName(string value)
+        {
+            return (value is string name && name.TrimEnd().Length > 2);
+        }
+
     }
 
 
@@ -136,11 +142,36 @@ namespace Dynamo.PackageManager.UI
         {
             var textBox = sender as TextBox;
             if (textBox == null) return;
+            if (e.Key == Key.System) return;
+
+            int caretIndex = textBox.CaretIndex; // Store the caret index
 
             // Prevents text starting with a space
             if (e.Key == System.Windows.Input.Key.Space && string.IsNullOrWhiteSpace(textBox.Text))
             {
-                e.Handled = true; 
+                e.Handled = true;
+                return;
+            }
+
+            if (string.IsNullOrEmpty(textBox.Text)) { return; }
+
+            // In case we are using the Backspace to remove characters, the validation error will stop the Name property from being updated 
+            if (textBox.Name.Equals("packageNameInput") && e.Key == Key.Back && !PackageNameLengthValidationRule.IsValidName(textBox.Text.Substring(0, textBox.Text.Length - 1)))
+            {
+                e.Handled = true;
+
+                if (!string.IsNullOrEmpty(PublishPackageViewModel.Name))
+                {
+                    // Manually remove the last character from the Name property, as the validation error will not update the Name property
+                    PublishPackageViewModel.Name = PublishPackageViewModel.Name.Substring(0, PublishPackageViewModel.Name.Length - 1);
+
+                    // Trigger re-validation explicitly
+                    var expression = textBox.GetBindingExpression(TextBox.TextProperty);
+                    expression?.UpdateSource();
+
+                    textBox.CaretIndex = caretIndex - 1 >= 0 ? caretIndex - 1 : 0;
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
### Purpose

This PR contains 2 fixes pertaining to the publish package tab
- a more detailed handling of the `Name` field validation making sure the different text warnings are toggled in the correct order
- makes sure the datacontext of the PackageManagerPublishControl is correctly set

#### Changes

![name validation fix](https://github.com/DynamoDS/Dynamo/assets/5354594/b2553e07-065d-4c7e-906d-333d83b3d8b4)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- fine-tune name validation and warning display
- also fixes issue when navigating away from the publish page and setting up the datacontext of the PackageManagerPublishControl

### Reviewers

@reddyashish 
@avidit

### FYIs

@QilongTang 
