### PR TITLE
bugfix [DYN-5197] re-enable dismiss notifications panel by clicking the bell

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -264,8 +264,12 @@ namespace Dynamo.Notifications
         /// <param name="e"></param>
         private void DynamoView_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            string popupBellID = "FontAwesome5.FontAwesome";
             if (!notificationUIPopup.IsOpen) return;
-            notificationUIPopup.IsOpen = false;
+            if(e.OriginalSource.ToString() != popupBellID)
+            {
+                notificationUIPopup.IsOpen = false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
![Screen Recording 2023-12-11 at 11 10 54](https://github.com/DynamoDS/Dynamo/assets/111511512/1f7bcfc1-e07d-4f24-ac01-beb11d8f3567)

### Purpose

This PR implements a fix that re-enable the dismiss notifications panel behaviour by clicking the bell icon.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB


### Reviewers

@QilongTang 

### FYIs

@avidit 
