### PR TITLE
DYN-6313 Block recommended nodes when TOU not accepted

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -221,6 +221,12 @@ namespace Dynamo.Views
                         if (popup == NodeAutoCompleteSearchBar)
                         {
                             if (ViewModel.NodeAutoCompleteSearchViewModel.PortViewModel == null) return;
+                            // if the MLRecommendation is default but user not accepting TOU, display notification
+                            if (ViewModel.NodeAutoCompleteSearchViewModel.IsDisplayingMLRecommendation && !ViewModel.NodeAutoCompleteSearchViewModel.IsMLAutocompleteTOUApproved)
+                            {
+                                ViewModel.DynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Wpf.Properties.Resources.NotificationToAgreeMLNodeautocompleteTOU, true);
+                                return;
+                            }
                             // Force the Child visibility to change here because
                             // 1. Popup isOpen change does not necessarily update the child control before it take effect
                             // 2. Dynamo rely on child visibility change hander to setup Node AutoComplete control


### PR DESCRIPTION
### Purpose

Block recommended nodes when TOU is not accepted.

![MLNodeAutoCompleteTOUDisagree_3](https://github.com/DynamoDS/Dynamo/assets/3942418/4c6a30d7-99bd-4b6d-ac68-e5f8b90b17ec)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Block recommended nodes when TOU is not accepted.

### Reviewers



### FYIs

@DynamoDS/dynamo