### PR TITLE
Fixing Search Regressions

### DIFF
--- a/test/DynamoCoreTests/SearchModelTests.cs
+++ b/test/DynamoCoreTests/SearchModelTests.cs
@@ -284,7 +284,7 @@ namespace Dynamo.Tests
             AddNodeElementToSearchIndex(element2);
             search.Add(element3);
             AddNodeElementToSearchIndex(element3);
-            var results = search.Search("Category.Child", CurrentDynamoModel.LuceneUtility);
+            var results = search.Search("Category.Child.", CurrentDynamoModel.LuceneUtility);
             Assert.AreEqual(3, results.Count());
         }
 

--- a/test/DynamoCoreWpfTests/SearchSideEffects.cs
+++ b/test/DynamoCoreWpfTests/SearchSideEffects.cs
@@ -125,7 +125,7 @@ namespace Dynamo.Tests
         public void LuceneSearchNodesByCategoryValidation()
         {
             Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), ViewModel.Model.CurrentWorkspace);
-            string category = "Core.Input";
+            string category = "Core.Input.";
 
             // Search and check that the results are correct based in the node name provided for the searchTerm
             var nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(category);
@@ -187,7 +187,7 @@ namespace Dynamo.Tests
             List<string> expectedSearchResults1 = new List<string> { "number", "number slider", "round" };
 
             string searchTerm2 = "list.join";
-            List<string> expectedSearchResults2 = new List<string> { "join", "list create", "list.map" };
+            List<string> expectedSearchResults2 = new List<string> { "join", "list create", "range" };
 
             // Search and check that the results are correct based in the node name provided for the searchTerm
             var nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(searchTerm);


### PR DESCRIPTION
### Purpose

Fixing Regressions reported after my changes related to Category Based Search.
For the test SearchingForACategoryReturnsAllItsChildren now with my changes related to category based search the term "Category.Child" will be searching the nodes with Category = Category and Name=Child so that's why was not returning results adding an extra "." in the search term fixed it.

The same case for the test LuceneSearchNodesByCategoryValidation, was expecting all the nodes under the category "Core.Input" so we have to add an extra "." in the search term.

For the test LuceneSearchNodesOrderingValidation I have to change a node due that with my changes the order changed and now is one position below (for the search term "list.join" we only guarante that the items at the top will be Category = list and the name starts with "join").

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Regressions reported after my changes related to Category Based Search.

### Reviewers

@QilongTang 
@reddyashish 

### FYIs


