### PR TITLE
Update LibG nuget version

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -21,7 +21,7 @@ All other brand names, product names or trademarks belong to their respective ho
 Autodesk Cloud and Desktop Components
 This Product or Service may incorporate or use background Autodesk online and desktop technology components.  For information about these components, see Autodesk Cloud Platform Components and Autodesk Desktop Platform Components.
 
-LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRevitAuth, AGET, IDSDK, IDSDK Wrapper, ForgeUnits.NET, ForgeUnits.Schemas, and Autodesk.GeometryPrimitive are closed source files licensed by Autodesk under the license that can be found here https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf
+LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRevitAuth, AGET, IDSDK, IDSDK Wrapper, ForgeUnits.NET, ForgeUnits.Schemas, and Autodesk.GeometryPrimitives.Dynamo are closed source files licensed by Autodesk under the license that can be found here https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf
 
 
 Third-Party Trademarks, Software Credits and Attributions

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -124,7 +124,7 @@ HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cl
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid10758048 .
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid10758048 
 \par }\pard \ltrpar\ql \li0\ri0\sb168\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid10758048 \hich\af4\dbch\af31505\loch\f4 
-LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRevitAuth, AGET, IDSDK, IDSDK Wrapper, ForgeUnits.NET, ForgeUnits.Schemas,, and Autodesk.GeometryPrimitive}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRevitAuth, AGET, IDSDK, IDSDK Wrapper, ForgeUnits.NET, ForgeUnits.Schemas,, and Autodesk.GeometryPrimitives.Dynamo}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid10758048 \hich\af4\dbch\af31505\loch\f4  are closed source files licensed by Autodesk under the license that can be found here }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang2057\langfe1033\langnp2057\insrsid10758048 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid6388473 
 {\*\datafield 

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -28,8 +28,8 @@
   <ItemGroup Label="Common dependencies">
     <PackageReference Include="Autodesk.IDSDK" Version="1.1.6" />
     <PackageReference Include="Greg" Version="3.0.0.3175" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="3.0.0.3175" GeneratePathProperty="true" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" GeneratePathProperty="true" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_229_0_0" Version="3.0.0.3331" GeneratePathProperty="true" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" CopyXML="true" />
 	<PackageReference Include="RestSharp" Version="108.0.1" CopyXML="true" />
 	<PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -138,7 +138,7 @@
       <PackageReference Include="HelixToolkit.Core.Wpf" Version="2.24.0" />
       <PackageReference Include="HelixToolkit.SharpDX.Core.Wpf" Version="2.24.0" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-      <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+      <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="FontAwesome5" Version="2.1.11" />
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
     <PackageReference Include="Greg" Version="3.0.0.3175" />

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -40,7 +40,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -18,7 +18,7 @@
     <None Remove="AnalysisImages.resources" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">
       <Project>{7858fa8c-475f-4b8e-b468-1f8200778cf8}</Project>
       <Name>DynamoCore</Name>

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -19,7 +19,7 @@
     <Compile Remove="GeometryColor.cs" />
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">

--- a/src/Libraries/GeometryColor/GeometryColor.csproj
+++ b/src/Libraries/GeometryColor/GeometryColor.csproj
@@ -14,7 +14,7 @@
     <NoWarn>MSB3539;CS1591;NUnit2005;NUnit2007;CS0618;CS0612;CS0672</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">

--- a/src/Libraries/GeometryUI/GeometryUI.csproj
+++ b/src/Libraries/GeometryUI/GeometryUI.csproj
@@ -17,7 +17,7 @@
 	 </ReferenceCopyLocalPaths>
 	</ItemDefinitionGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -21,7 +21,7 @@
 	</ReferenceCopyLocalPaths>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="Controls\ExportWithUnitsControl.xaml">

--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -14,7 +14,7 @@
     <NoWarn>MSB3539;CS1591;NUnit2005;NUnit2007;CS0618;CS0612;CS0672</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="MIConvexHull" version="1.1.17.411" CopyPDB="true" />
 	  <PackageReference Include="StarMath" version="2.0.17.1019" CopyPDB="true" />
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
         <PackageReference Include="Greg" Version="3.0.0.3175" />
-        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
         <PackageReference Include="Magick.NET.Core" Version="7.0.1" />
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>AnalysisTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
+++ b/test/Libraries/DynamoPythonTests/DynamoPythonTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
+++ b/test/Libraries/GeometryColorTests/GeometryColorTests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>DisplayTests</AssemblyName>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/test/Libraries/TestServices/TestServices.csproj
+++ b/test/Libraries/TestServices/TestServices.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>TestServices</AssemblyName>
   </PropertyGroup>
   <ItemGroup>         
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3241" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.3421" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>


### PR DESCRIPTION
### Purpose

Update the LibG nuget references.  Note this does have a change in file name due to the shift from Autodesk.GeometryPrimitives.dll to Autodesk.GeometryPrimitives.Dynamo.dll.  This is also updated in the licensing

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

NA

### Reviewers

@aparajit-pratap @sm6srw 

### FYIs

@QilongTang 
