### PR TITLE
DYN-6535 Search DynamoRevit

### DIFF
--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -143,9 +143,19 @@ namespace Dynamo.Configuration
             Name,
 
             /// <summary>
+            /// NameSplitted - The name of the node splitted using just the last part (e.g. List.Chop we will be using just Chop)
+            /// </summary>
+            NameSplitted,
+
+            /// <summary>
             /// FullCategoryName - The category of the node
             /// </summary>
             FullCategoryName,
+
+            /// <summary>
+            /// CategorySplitted - For this case we will be using just the last Category (the last word after the dot separator in FullCategoryName)
+            /// </summary>
+            CategorySplitted,
 
             /// <summary>
             /// Description - The description of the node
@@ -182,7 +192,9 @@ namespace Dynamo.Configuration
         /// Nodes Fields to be indexed by Lucene Search
         /// </summary>
         public static string[] NodeIndexFields = { nameof(NodeFieldsEnum.Name),
+                                                   nameof(NodeFieldsEnum.NameSplitted),
                                                    nameof(NodeFieldsEnum.FullCategoryName),
+                                                   nameof(NodeFieldsEnum.CategorySplitted),
                                                    nameof(NodeFieldsEnum.Description),
                                                    nameof(NodeFieldsEnum.SearchKeywords),
                                                    nameof(NodeFieldsEnum.DocName),

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3266,7 +3266,18 @@ namespace Dynamo.Models
             if (LuceneUtility.addedFields == null) return;
 
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), node.FullCategoryName);
+
+            var categoryParts = node.FullCategoryName.Split('.');
+            string categoryParsed = categoryParts.Length > 1 ? categoryParts[categoryParts.Length - 1] : node.FullCategoryName;
+            //In case the search criteria is like "filesystem.replace" we will be storing the value "filesystem" inside the CategorySplitted field
+            LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted), categoryParsed);
+
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), node.Name);
+
+            var nameParts = node.Name.Split('.');
+            string nameParsed = nameParts.Length > 1 ? nameParts[nameParts.Length - 1] : node.Name;
+            LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.NameSplitted), nameParsed);
+
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), node.Description);
             if (node.SearchKeywords.Count > 0) LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Parameters), node.Parameters ?? string.Empty);

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -119,7 +119,9 @@ namespace Dynamo.Utilities
             if (DynamoModel.IsTestMode && currentStorageType == LuceneStorage.FILE_SYSTEM) return null;
 
             var name = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Name), string.Empty, Field.Store.YES);
+            var nameSplitted = new TextField(nameof(LuceneConfig.NodeFieldsEnum.NameSplitted), string.Empty, Field.Store.YES);
             var fullCategory = new TextField(nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), string.Empty, Field.Store.YES);
+            var categorySplitted = new TextField(nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted), string.Empty, Field.Store.YES);
             var description = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Description), string.Empty, Field.Store.YES);
             var keywords = new TextField(nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
             var docName = new StringField(nameof(LuceneConfig.NodeFieldsEnum.DocName), string.Empty, Field.Store.YES);
@@ -128,8 +130,10 @@ namespace Dynamo.Utilities
 
             var d = new Document()
             {
-                fullCategory,
                 name,
+                nameSplitted,
+                fullCategory,
+                categorySplitted,
                 description,
                 keywords,
                 fullDoc,
@@ -218,6 +222,8 @@ namespace Dynamo.Utilities
         internal string CreateSearchQuery(string[] fields, string SearchTerm)
         {
             int fuzzyLogicMaxEdits = LuceneConfig.FuzzySearchMinEdits;
+
+            SearchTerm = SearchTerm.Replace(" ", "");
             // Use a larger max edit value - more tolerant with typo when search term is longer than threshold
             if (SearchTerm.Length > LuceneConfig.FuzzySearchMaxEditsThreshold)
             {
@@ -226,9 +232,30 @@ namespace Dynamo.Utilities
 
             var booleanQuery = new BooleanQuery();
             string searchTerm = QueryParser.Escape(SearchTerm);
+            var bCategoryBasedSearch = searchTerm.Contains('.') ? true : false;
 
             foreach (string f in fields)
             {
+                //Needs to be again due that now a query can contain different values per field (e.g. CategorySplitted:list, Name:tr)
+                searchTerm = QueryParser.Escape(SearchTerm);
+                if (bCategoryBasedSearch == true)
+                {
+                    //This code section should be only executed if the search criteria is CategoryBased like "category.nodename"
+                    if (f != nameof(LuceneConfig.NodeFieldsEnum.NameSplitted) &&
+                        f != nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted))
+                        continue;
+
+                    var categorySearchBased = searchTerm.Split('.');
+                    //In the case the search criteria is like "Core.File.FileSystem.a" it will take only the last two sections Category=FileSystem and Name=a*
+                    if (categorySearchBased.Length > 1 && !string.IsNullOrEmpty(categorySearchBased[categorySearchBased.Length - 2]))
+                    {
+                        if (f == nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted))
+                            searchTerm = categorySearchBased[categorySearchBased.Length - 2];
+                        else
+                            searchTerm = categorySearchBased[categorySearchBased.Length - 1];
+                    }
+                }
+
                 FuzzyQuery fuzzyQuery;
                 if (searchTerm.Length > LuceneConfig.FuzzySearchMinimalTermLength)
                 {
@@ -236,35 +263,27 @@ namespace Dynamo.Utilities
                     booleanQuery.Add(fuzzyQuery, Occur.SHOULD);
                 }
 
+                //For normal search we don't consider the fields NameSplitted and CategorySplitted
+                if ((f == nameof(LuceneConfig.NodeFieldsEnum.NameSplitted) ||
+                    f == nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted)) && bCategoryBasedSearch == false)
+                    continue;
+
+                //This case is for when the user type something like "list.", I mean, not specifying the node name or part of it
+                if (string.IsNullOrEmpty(searchTerm))
+                    continue;
+
                 var fieldQuery = CalculateFieldWeight(f, searchTerm);
                 var wildcardQuery = CalculateFieldWeight(f, searchTerm, true);
 
-                booleanQuery.Add(fieldQuery, Occur.SHOULD);
-                booleanQuery.Add(wildcardQuery, Occur.SHOULD);
-
-                if (searchTerm.Contains(' ') || searchTerm.Contains('.'))
+                if (bCategoryBasedSearch && f == nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted))
                 {
-                    foreach (string s in searchTerm.Split(' ', '.'))
-                    {
-                        if (string.IsNullOrEmpty(s)) continue;
-
-                        if (s.Length > LuceneConfig.FuzzySearchMinimalTermLength)
-                        {
-                            fuzzyQuery = new FuzzyQuery(new Term(f, s), LuceneConfig.FuzzySearchMinEdits);
-                            booleanQuery.Add(fuzzyQuery, Occur.SHOULD);
-                        }
-                        wildcardQuery = new WildcardQuery(new Term(f, "*" + s + "*"));
-
-                        if (f.Equals(nameof(LuceneConfig.NodeFieldsEnum.Name)))
-                        {
-                            wildcardQuery.Boost = LuceneConfig.WildcardsSearchNameParsedWeight;
-                        }
-                        else
-                        {
-                            wildcardQuery.Boost = LuceneConfig.FuzzySearchWeight;
-                        }
-                        booleanQuery.Add(wildcardQuery, Occur.SHOULD);
-                    }
+                    booleanQuery.Add(fieldQuery, Occur.MUST);
+                    booleanQuery.Add(wildcardQuery, Occur.MUST);
+                }
+                else
+                {
+                    booleanQuery.Add(fieldQuery, Occur.SHOULD);
+                    booleanQuery.Add(wildcardQuery, Occur.SHOULD);
                 }
             }
             return booleanQuery.ToString();
@@ -274,8 +293,11 @@ namespace Dynamo.Utilities
         {
             WildcardQuery query;
 
+            //In case we are weighting the NameSplitted field then means that is a search based on Category of the type "cat.node" so we will be using the wilcard "category.node*" otherwise will be the normal wildcard
+            var termText = fieldName == nameof(LuceneConfig.NodeFieldsEnum.NameSplitted) ? searchTerm + "*" : "*" + searchTerm + "*";
+
             query = isWildcard == false ?
-                new WildcardQuery(new Term(fieldName, searchTerm)) : new WildcardQuery(new Term(fieldName, "*" + searchTerm + "*"));
+                new WildcardQuery(new Term(fieldName, searchTerm)) : new WildcardQuery(new Term(fieldName, termText));
 
             switch (fieldName)
             {
@@ -283,9 +305,19 @@ namespace Dynamo.Utilities
                     query.Boost = isWildcard == false?
                         LuceneConfig.SearchNameWeight :  LuceneConfig.WildcardsSearchNameWeight;
                     break;
+                case nameof(LuceneConfig.NodeFieldsEnum.NameSplitted):
+                    //Under this case the NameSplitted field will have less weight than CategorySplitted
+                    query.Boost = isWildcard == false ?
+                        LuceneConfig.SearchCategoryWeight : LuceneConfig.WildcardsSearchCategoryWeight;
+                    break;
                 case nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName):
                     query.Boost = isWildcard == false?
                         LuceneConfig.SearchCategoryWeight : LuceneConfig.WildcardsSearchCategoryWeight;
+                    break;
+                case nameof(LuceneConfig.NodeFieldsEnum.CategorySplitted):
+                    //Under this case the CategorySplitted field will have more weight than NameSplitted
+                    query.Boost = isWildcard == false ?
+                        LuceneConfig.SearchNameWeight : LuceneConfig.WildcardsSearchNameWeight;
                     break;
                 case nameof(LuceneConfig.NodeFieldsEnum.Description):
                     query.Boost = isWildcard == false ?

--- a/test/DynamoCoreTests/SearchModelTests.cs
+++ b/test/DynamoCoreTests/SearchModelTests.cs
@@ -284,7 +284,7 @@ namespace Dynamo.Tests
             AddNodeElementToSearchIndex(element2);
             search.Add(element3);
             AddNodeElementToSearchIndex(element3);
-            var results = search.Search("Category.Child", CurrentDynamoModel.LuceneUtility);
+            var results = search.Search("Category.Child.", CurrentDynamoModel.LuceneUtility);
             Assert.AreEqual(3, results.Count());
         }
 


### PR DESCRIPTION

### Purpose

Re-implementing the Lucene Search Category Based in Dynamo 2.19.4 branch for DynamoRevit. Also I've removed the empty spaces from the SearchTerm so search results will match nodes with a specific name after the spaces are removed. I've removed the section of foreach (string s in searchTerm.Split(' ', '.')) due that now all the empty spaces will be removed from the SearchTerm.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Re-implementing the Lucene Search Category Based in Dynamo 2.19.4 branch for DynamoRevit

### Reviewers

@QilongTang 
@reddyashish 

### FYIs

