### PR TITLE
Node AutoComplete ML TOU file path resolve issue

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml.cs
@@ -41,7 +41,7 @@ namespace Dynamo.UI.Prompts
 
             // Resolve and load ML Node Autocomplete Consent file
             var mlNodeAutocompleteFile = "MLNodeAutocompleteConsent.rtf";
-            if (viewModel.Model.PathManager.ResolveDocumentPath(ref adpAnalyticsFile))
+            if (viewModel.Model.PathManager.ResolveDocumentPath(ref mlNodeAutocompleteFile))
                 MLNodeAutocompleteConsent.File = mlNodeAutocompleteFile;
             // Initialize the checkbox to the current value
             AgreeToMLAutocompleteTOUCheckbox.IsChecked = dynamoViewModel.PreferenceSettings.IsMLAutocompleteTOUApproved;


### PR DESCRIPTION
### Purpose

This PR fixes a Node AutoComplete ML TOU file path resolve issue, this bug is only reproducible in a integration case seems.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@avidit 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
