### PR TITLE
[CherryPick] Revert UI Blocking Function calls (#14766)

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -98,7 +98,6 @@ namespace Dynamo.Wpf.Views
             stylesCustomColors = new ObservableCollection<CustomColorItem>();
             UpdateZoomScaleValueLabel(LibraryZoomScalingSlider, lblZoomScalingValue);
             UpdateZoomScaleValueLabel(PythonZoomScalingSlider, lblPythonScalingValue);
-            dynamoView.EnableEnvironment(false);
         }
 
         /// <summary>
@@ -172,7 +171,6 @@ namespace Dynamo.Wpf.Views
 
             dynViewModel.PreferencesViewModel.TrustedPathsViewModel.PropertyChanged -= TrustedPathsViewModel_PropertyChanged;
             dynViewModel.CheckCustomGroupStylesChanges(originalCustomGroupStyles);
-            (this.Owner as DynamoView).EnableEnvironment(true);
 
             Close();
         }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -68,7 +68,6 @@ namespace Dynamo.PackageManager.UI
                 Categories.PackageManager);
 
             this.dynamoView = dynamoView;
-            dynamoView.EnableEnvironment(false);
         }
 
         private void OnRequestShowFileDialog(object sender, PackagePathEventArgs e)
@@ -131,7 +130,6 @@ namespace Dynamo.PackageManager.UI
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             Analytics.TrackEvent(Actions.Close, Categories.PackageManager);
-            (this.Owner as DynamoView).EnableEnvironment(true);
 
             Close();
         }


### PR DESCRIPTION
### Purpose

[CherryPick] Revert UI Blocking Function calls (#14766)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers



### FYIs

@DynamoDS/dynamo 