### PR TITLE
DYN-5656 Dynamo UI Blocking Action

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -42,6 +42,7 @@ using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.Views;
 using Dynamo.Wpf.Views.Debug;
 using Dynamo.Wpf.Views.FileTrust;
+using Dynamo.Wpf.Views.GuidedTour;
 using Dynamo.Wpf.Windows;
 using HelixToolkit.Wpf.SharpDX;
 using ICSharpCode.AvalonEdit;
@@ -2317,7 +2318,45 @@ namespace Dynamo.Controls
 
         internal void EnableEnvironment(bool isEnabled)
         {
-            this.mainGrid.IsEnabled = isEnabled;
+            this.mainGrid.IsEnabled = isEnabled;       
+        }
+
+        /// <summary>
+        /// Adds/Removes an overlay so the user won't be able to interact with the background (this behavior was implemented for Dynamo and for Library)
+        /// </summary>
+        /// <param name="isEnabled">True if the overlay is enable otherwise will be false</param>
+        internal void EnableOverlayBlocker(bool isEnabled)
+        {
+            object[] parametersInvokeScript = new object[] { "fullOverlayVisible", new object[] { isEnabled } };
+            ResourceUtilities.ExecuteJSFunction(this, parametersInvokeScript);
+
+            if (isEnabled)
+            {
+                //By default the shortcutsBarGrid has a ZIndex = 1 then will be shown over the overlay that's why we need to change the ZIndex
+                Panel.SetZIndex(shortcutsBarGrid, 0);
+                var backgroundElement = new GuideBackground(this)
+                {
+                    Name = "BackgroundBlocker",
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Visibility = Visibility.Visible
+                };
+
+                //adds the overlay to the main Dynamo grid
+                mainGrid.Children.Add(backgroundElement);
+                Grid.SetColumnSpan(backgroundElement, 5);
+                Grid.SetRowSpan(backgroundElement, 6);
+            }
+            else
+            {
+                //Restoring the ZIndex value to the default one.
+                Panel.SetZIndex(shortcutsBarGrid, 1);
+                var backgroundElement = mainGrid.Children.OfType<GuideBackground>().FirstOrDefault();
+                if (backgroundElement != null)
+                {
+                    mainGrid.Children.Remove(backgroundElement);
+                }
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml.cs
@@ -98,6 +98,7 @@ namespace Dynamo.Wpf.Views
             stylesCustomColors = new ObservableCollection<CustomColorItem>();
             UpdateZoomScaleValueLabel(LibraryZoomScalingSlider, lblZoomScalingValue);
             UpdateZoomScaleValueLabel(PythonZoomScalingSlider, lblPythonScalingValue);
+            dynamoView.EnableOverlayBlocker(true);
         }
 
         /// <summary>
@@ -171,6 +172,7 @@ namespace Dynamo.Wpf.Views
 
             dynViewModel.PreferencesViewModel.TrustedPathsViewModel.PropertyChanged -= TrustedPathsViewModel_PropertyChanged;
             dynViewModel.CheckCustomGroupStylesChanges(originalCustomGroupStyles);
+            (this.Owner as DynamoView).EnableOverlayBlocker(false);
 
             Close();
         }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -68,6 +68,7 @@ namespace Dynamo.PackageManager.UI
                 Categories.PackageManager);
 
             this.dynamoView = dynamoView;
+            dynamoView.EnableOverlayBlocker(true);
         }
 
         private void OnRequestShowFileDialog(object sender, PackagePathEventArgs e)
@@ -130,6 +131,7 @@ namespace Dynamo.PackageManager.UI
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             Analytics.TrackEvent(Actions.Close, Categories.PackageManager);
+            (this.Owner as DynamoView).EnableOverlayBlocker(false);
 
             Close();
         }

--- a/src/LibraryViewExtensionWebView2/web/library/library.html
+++ b/src/LibraryViewExtensionWebView2/web/library/library.html
@@ -88,11 +88,25 @@
             margin-top: 0.15rem;
             vertical-align: top !important;
         }
+
+        #overlay {
+            position: fixed;
+            display: none;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(0,0,0,0.5);
+            z-index: 2;
+        }
     </style>
 
 </head>
 
 <body onresize="bodyResizeEvent()">
+    <div id="overlay"></div>
     <!-- Placeholders must exist before all other scripts that try to access them -->
     <div class="OuterMostContainer" id="libraryContainerPlaceholder"></div>
     <!-- The main library view component -->
@@ -412,6 +426,14 @@
             });
 
             document.dispatchEvent(kbEvent);
+        }
+
+        //This function will show the overlay over the Library when the Preferences/PackageManagerSearch are opened otherwiser is not visible
+        function fullOverlayVisible(enableOverlay) {
+            if (enableOverlay)
+                document.getElementById("overlay").style.display = "block";
+            else
+                document.getElementById("overlay").style.display = "none";
         }
     </script>
 


### PR DESCRIPTION
### Purpose

I've implementing the functionality of adding the GuideBackground (overlay) when the Preferences panel or the PackageSearchWindow are opened and removing it when those windows are closed. In this way when we have the GuideBackground the user won't be able to interact with the background. I've added this functionality in the DynamoView but due that the GuideBackground is not working with the Library, I had to implement the overlay functionality in the library.html and the functions needed to set the overlay from .NET.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

 Implementing the functionality of adding the GuideBackground (overlay)

### Reviewers

@reddyashish 

### FYIs

@QilongTang 