### PR TITLE
DYN-6580 - fix crash when attempting to open docs browser multiple times in quick succession.

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserView.xaml.cs
@@ -182,16 +182,21 @@ namespace Dynamo.DocumentationBrowser
 
                 initState = AsyncMethodState.Done;
             }
+            //if we make it this far, for example to do re-entry to to this method, while we're still
+            //initializing, don't do anything, just bail.
+            if(initState == AsyncMethodState.Done)
+            {
+                if (Directory.Exists(VirtualFolderPath))
+                {
+                    //Due that the Web Browser(WebView2 - Chromium) security CORS is blocking the load of resources like images then we need to create a virtual folder in which the image are located.
+                    this.documentationBrowser?.CoreWebView2?.SetVirtualHostNameToFolderMapping(VIRTUAL_FOLDER_MAPPING, VirtualFolderPath, CoreWebView2HostResourceAccessKind.DenyCors);
+                }
+                string htmlContent = this.viewModel.GetContent();
 
-            if(Directory.Exists(VirtualFolderPath))
-                //Due that the Web Browser(WebView2 - Chromium) security CORS is blocking the load of resources like images then we need to create a virtual folder in which the image are located.
-                this.documentationBrowser.CoreWebView2.SetVirtualHostNameToFolderMapping(VIRTUAL_FOLDER_MAPPING, VirtualFolderPath, CoreWebView2HostResourceAccessKind.DenyCors);
+                htmlContent = ResourceUtilities.LoadResourceAndReplaceByKey(htmlContent, "#fontStyle", fontStylePath);
 
-            string htmlContent = this.viewModel.GetContent();
-
-            htmlContent = ResourceUtilities.LoadResourceAndReplaceByKey(htmlContent, "#fontStyle", fontStylePath);
-
-            this.documentationBrowser.NavigateToString(htmlContent);
+                this.documentationBrowser.NavigateToString(htmlContent);
+            }
         }
 
         private void CoreWebView2OnWebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -220,6 +220,30 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void CanHandleDocsEventTriggeredFromDynamoViewModelMultipleTimes()
+        {
+            // Arrange
+            var docsEvent = new OpenDocumentationLinkEventArgs(new Uri(localDocsFileLink, UriKind.Relative));
+
+            // Act
+            var tabsBeforeExternalEventTrigger = this.ViewModel.SideBarTabItems.Count;
+            this.ViewModel.OpenDocumentationLinkCommand.Execute(docsEvent);
+            this.ViewModel.OpenDocumentationLinkCommand.Execute(docsEvent);
+            this.ViewModel.OpenDocumentationLinkCommand.Execute(docsEvent);
+
+            WaitForWebView2Initialization();
+
+            var tabsAfterExternalEventTrigger = this.ViewModel.SideBarTabItems.Count;
+            var htmlContent = GetSidebarDocsBrowserContents();
+
+            // Assert
+            Assert.IsFalse(docsEvent.IsRemoteResource);
+            Assert.AreEqual(0, tabsBeforeExternalEventTrigger);
+            Assert.AreEqual(1, tabsAfterExternalEventTrigger);
+            Assert.IsTrue(htmlContent.Contains(excelDocsFileHtmlHeader));
+        }
+
+        [Test]
         public void Displays404PageOnMissingDocFile()
         {
             // Arrange


### PR DESCRIPTION
### Purpose

When the `f1` hotkey is used to get docs for a node multiple times on the first initialization of the docs browser webview2 instance we can re-enter the initializeAsync function while we're still awaiting initialization. The previous logic would then go on to try to use the coreWebView object before it was initialized, now if we're not "done" we just bail. The original invocation that was still initializing will start executing and we'll show the docs browser.

a test is added.
 
### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB


