### PR TITLE
Add nonetworkmode guard in PM client viewmodel initialization

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -283,9 +283,9 @@ namespace Dynamo.ViewModels
                 };
             }
 
-            if (AuthenticationManager.LoginState.Equals(LoginState.LoggedIn))
+            if (AuthenticationManager.LoginState.Equals(LoginState.LoggedIn) && !dynamoViewModel.Model.NoNetworkMode)
             {
-                this.Uservotes = this.Model.UserVotes();
+                Uservotes = Model.UserVotes();
             }
         }
 


### PR DESCRIPTION
### Purpose

Add no-network mode check to prevent network calls for user votes on PM client viewmodel initialization. 
This, however, is not a complete fix as the synchronous call to `uservotes` can still pose issues.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**


