### PR TITLE
Pm publish experience rework

### DIFF
--- a/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Controls/InstalledPackagesControl.xaml
@@ -204,12 +204,28 @@
                                                                     <ToolTip Content="{x:Static p:Resources.InstalledPackageViewContextMenuPublishTooltip}" Style="{StaticResource GenericToolTipLight}"/>
                                                                 </MenuItem.ToolTip>
                                                             </MenuItem>
+                                                            <MenuItem Name="MakePackageRetainButton"
+                                                                      Visibility="{Binding Path=CanPublish, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                                                                      Command="{Binding Path=PublishNewPackageRetainCommand}"
+                                                                      Header="{x:Static p:Resources.InstalledPackageViewContextMenuPublishRetain}">
+                                                                <MenuItem.ToolTip>
+                                                                    <ToolTip Content="{x:Static p:Resources.InstalledPackageViewContextMenuPublishRetainTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                                                                </MenuItem.ToolTip>
+                                                            </MenuItem>
                                                             <MenuItem Name="MakeNewVersionButton"
                                                                               Visibility="{Binding Path=CanPublishNewVersion, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
                                                                               Command="{Binding Path=PublishNewPackageVersionCommand}"
                                                                               Header="{x:Static p:Resources.InstalledPackageViewContextMenuPublishVersion}">
                                                                 <MenuItem.ToolTip>
                                                                     <ToolTip Content="{x:Static p:Resources.InstalledPackageViewContextMenuPublishVersionTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                                                                </MenuItem.ToolTip>
+                                                            </MenuItem>
+                                                            <MenuItem Name="MakeNewVersionRetainButton"
+                                                                              Visibility="{Binding Path=CanPublishNewVersion, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                                                                              Command="{Binding Path=PublishNewPackageVersionRetainCommand}"
+                                                                              Header="{x:Static p:Resources.InstalledPackageViewContextMenuPublishVersionRetain}">
+                                                                <MenuItem.ToolTip>
+                                                                    <ToolTip Content="{x:Static p:Resources.InstalledPackageViewContextMenuPublishVersionRetainTooltip}" Style="{StaticResource GenericToolTipLight}"/>
                                                                 </MenuItem.ToolTip>
                                                             </MenuItem>
                                                             <MenuItem Name="DeprecateButton"

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3858,6 +3858,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Publish Retain....
+        /// </summary>
+        public static string InstalledPackageViewContextMenuPublishRetain {
+            get {
+                return ResourceManager.GetString("InstalledPackageViewContextMenuPublishRetain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Publish this package retaining its folder structure, if it has yet to be published..
+        /// </summary>
+        public static string InstalledPackageViewContextMenuPublishRetainTooltip {
+            get {
+                return ResourceManager.GetString("InstalledPackageViewContextMenuPublishRetainTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Publish this package, if it has yet to be published..
         /// </summary>
         public static string InstalledPackageViewContextMenuPublishTooltip {
@@ -3872,6 +3890,24 @@ namespace Dynamo.Wpf.Properties {
         public static string InstalledPackageViewContextMenuPublishVersion {
             get {
                 return ResourceManager.GetString("InstalledPackageViewContextMenuPublishVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Publish Version Retain....
+        /// </summary>
+        public static string InstalledPackageViewContextMenuPublishVersionRetain {
+            get {
+                return ResourceManager.GetString("InstalledPackageViewContextMenuPublishVersionRetain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Publish a new version of this package retaining its folder structure, assuming it has already been published. Only allowed if you&apos;re a current maintainer of the package..
+        /// </summary>
+        public static string InstalledPackageViewContextMenuPublishVersionRetainTooltip {
+            get {
+                return ResourceManager.GetString("InstalledPackageViewContextMenuPublishVersionRetainTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1146,11 +1146,23 @@ Failed to publish file(s):
   <data name="InstalledPackageViewContextMenuPublishTooltip" xml:space="preserve">
     <value>Publish this package, if it has yet to be published.</value>
   </data>
+  <data name="InstalledPackageViewContextMenuPublishRetain" xml:space="preserve">
+    <value>Publish Retain...</value>
+  </data>
+  <data name="InstalledPackageViewContextMenuPublishRetainTooltip" xml:space="preserve">
+    <value>Publish this package retaining its folder structure, if it has yet to be published.</value>
+  </data>
   <data name="InstalledPackageViewContextMenuPublishVersion" xml:space="preserve">
     <value>Publish Version...</value>
   </data>
   <data name="InstalledPackageViewContextMenuPublishVersionTooltip" xml:space="preserve">
     <value>Publish a new version of this package, assuming it has already been published. Only allowed if you're a current maintainer of the package.</value>
+  </data>
+  <data name="InstalledPackageViewContextMenuPublishVersionRetain" xml:space="preserve">
+    <value>Publish Version Retain...</value>
+  </data>
+  <data name="InstalledPackageViewContextMenuPublishVersionRetainTooltip" xml:space="preserve">
+    <value>Publish a new version of this package retaining its folder structure, assuming it has already been published. Only allowed if you're a current maintainer of the package.</value>
   </data>
   <data name="InstalledPackageViewContextMenuRemoveDeprecation" xml:space="preserve">
     <value>Remove deprecation</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1193,11 +1193,23 @@ Don't worry, you'll have the option to save your work.</value>
   <data name="InstalledPackageViewContextMenuPublishTooltip" xml:space="preserve">
     <value>Publish this package, if it has yet to be published.</value>
   </data>
+  <data name="InstalledPackageViewContextMenuPublishRetain" xml:space="preserve">
+    <value>Publish Retain...</value>
+  </data>
+  <data name="InstalledPackageViewContextMenuPublishRetainTooltip" xml:space="preserve">
+    <value>Publish this package retaining its folder structure, if it has yet to be published.</value>
+  </data>
   <data name="InstalledPackageViewContextMenuPublishVersion" xml:space="preserve">
     <value>Publish Version...</value>
   </data>
   <data name="InstalledPackageViewContextMenuPublishVersionTooltip" xml:space="preserve">
     <value>Publish a new version of this package, assuming it has already been published. Only allowed if you're a current maintainer of the package.</value>
+  </data>
+  <data name="InstalledPackageViewContextMenuPublishVersionRetain" xml:space="preserve">
+    <value>Publish Version Retain...</value>
+  </data>
+  <data name="InstalledPackageViewContextMenuPublishVersionRetainTooltip" xml:space="preserve">
+    <value>Publish a new version of this package retaining its folder structure, assuming it has already been published. Only allowed if you're a current maintainer of the package.</value>
   </data>
   <data name="InstalledPackageViewContextMenuRemoveDeprecation" xml:space="preserve">
     <value>Remove deprecation</value>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageItemRootViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageItemRootViewModel.cs
@@ -71,7 +71,7 @@ namespace Dynamo.PackageManager.UI
             this.DependencyType = DependencyType.Assembly;
             this.Assembly = assembly;
             this.DisplayName = assembly.Name;
-            this.FilePath = assembly.LocalFilePath;
+            this.FilePath = assembly.LocalFilePath != null ? assembly.LocalFilePath : assembly.Assembly.Location;
             this.DirectoryName = Path.GetDirectoryName(this.FilePath);
             this.BuildDependencies(new HashSet<object>());
             this.isChild = true;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -164,10 +164,12 @@ namespace Dynamo.ViewModels
         [Obsolete("Do not use. This command will be removed. It does nothing.")]
         public DelegateCommand GetLatestVersionCommand { get; set; }
         public DelegateCommand PublishNewPackageVersionCommand { get; set; }
+        public DelegateCommand PublishNewPackageVersionRetainCommand { get; set; }
         public DelegateCommand UninstallCommand { get; set; }
         public DelegateCommand UnmarkForUninstallationCommand { get; set; }
         public DelegateCommand LoadCommand { get; set; }
         public DelegateCommand PublishNewPackageCommand { get; set; }
+        public DelegateCommand PublishNewPackageRetainCommand { get; set; }
         public DelegateCommand DeprecateCommand { get; set; }
         public DelegateCommand UndeprecateCommand { get; set; }
         public DelegateCommand GoToRootDirectoryCommand { get; set; }
@@ -185,6 +187,10 @@ namespace Dynamo.ViewModels
             GetLatestVersionCommand = new DelegateCommand(() => { }, () => false);
             PublishNewPackageVersionCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackageVersion), IsOwner);
             PublishNewPackageCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackage), () => CanPublish);
+
+            PublishNewPackageVersionRetainCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackageVersionRetainFolderStructure), IsOwner);
+            PublishNewPackageRetainCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackageRetainFolderStructure), () => CanPublish);
+
             UninstallCommand = new DelegateCommand(Uninstall, CanUninstall);
             UnmarkForUninstallationCommand = new DelegateCommand(UnmarkForUninstallation, CanUnmarkForUninstallation);
             LoadCommand = new DelegateCommand(Load, CanLoad);
@@ -442,6 +448,24 @@ namespace Dynamo.ViewModels
         {
             Model.RefreshCustomNodesFromDirectory(dynamoModel.CustomNodeManager, DynamoModel.IsTestMode);
             var vm = PublishPackageViewModel.FromLocalPackage(dynamoViewModel, Model);
+            vm.IsNewVersion = false;
+
+            dynamoViewModel.OnRequestPackagePublishDialog(vm);
+        }
+
+        private void PublishNewPackageVersionRetainFolderStructure()
+        {
+            Model.RefreshCustomNodesFromDirectory(dynamoModel.CustomNodeManager, DynamoModel.IsTestMode);
+            var vm = PublishPackageViewModel.FromLocalPackageRetainFolderStructure(dynamoViewModel, Model);
+            vm.IsNewVersion = true;
+
+            dynamoViewModel.OnRequestPackagePublishDialog(vm);
+        }
+
+        private void PublishNewPackageRetainFolderStructure()
+        {
+            Model.RefreshCustomNodesFromDirectory(dynamoModel.CustomNodeManager, DynamoModel.IsTestMode);
+            var vm = PublishPackageViewModel.FromLocalPackageRetainFolderStructure(dynamoViewModel, Model);
             vm.IsNewVersion = false;
 
             dynamoViewModel.OnRequestPackagePublishDialog(vm);


### PR DESCRIPTION
### Purpose

The new `RetainFolder` functionality of the Package Manager is still not providing the desired functionality. This PR tries to fix some of the logic behind it. 

#### Changes
![Dynamo_PublishVersion](https://github.com/DynamoDS/Dynamo/assets/5354594/f2ebd781-ff9b-4c8a-9fff-68b27164eb52)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- changes the way Publish and Publish Version load assembly files when retaining folder structure toggle is on
- stopped the `ErrorString` from being overridden when a specific condition is met leading to `Resources.OneAssemblyWasLoadedSeveralTimesErrorMessage` - this has not been tested fully, if it leads to some strange behavior later on
- also removed the limitation to loading multiple binaries with the same name, but located in different folders when **creating a new package**. This will allow, when retaining folder toggle is on, to create custom packages if necessary. If the toggle is off and the default folder structure is used, the duplicate binaries will be pruned in a different part of the code

### Reviewers

@mjkkirschner 

### FYIs

@reddyashish 
