### PR TITLE
[DYN-5194] feature (NotificationsCenter): disable link reference tooltip

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -239,6 +239,7 @@ namespace Dynamo.Notifications
                     new ScriptObject(OnMarkAllAsRead, OnNotificationPopupUpdated));
 
                 notificationUIPopup.webView.CoreWebView2.Settings.IsZoomControlEnabled = false;
+                notificationUIPopup.webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
             }
         }
 


### PR DESCRIPTION
### Purp
![4BC75EB8-BD1B-4E19-AD34-19225D81C365](https://github.com/DynamoDS/Dynamo/assets/111511512/5fa375e4-ba1b-4f7d-a18b-92dcc64c6adb)
ose

Ref.: [DYN-5194](https://jira.autodesk.com/browse/DYN-5194)
This PR disable link reference tooltip for notificationsCenter webview component.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Set NotificationsCenter's Webview.IsStatusBarEnabled property to false.

### Reviewers
@avidit 
