### PR TITLE
Correct versions for UPI

### DIFF
--- a/src/Config/upiconfig.xml
+++ b/src/Config/upiconfig.xml
@@ -14,7 +14,7 @@
             <upi_attribute name='id' value='Win64'/>
             <upi_element name='level'>
               <upi_attribute name='name' value='build'/>
-              <upi_attribute name='id' value='3.0.0' />
+              <upi_attribute name='id' value='3.0.1' />
             </upi_element>
           </upi_element>
         </upi_element>

--- a/tools/autobuild/build.json
+++ b/tools/autobuild/build.json
@@ -1,9 +1,9 @@
 {
     "product_id": "DYN",
-    "release_id": "3.0.1",
+    "release_id": "3.0.0",
     "master_id": "Win64",
     "build_id": "3.0.1",
     "name": "3.0.1",
-    "build_milestone": "FCS",
+    "build_milestone": "Update 1",
     "description":"Build"
 }

--- a/tools/autobuild/master.json
+++ b/tools/autobuild/master.json
@@ -1,11 +1,11 @@
 {
   "product_id": "DYN",
-  "release_id": "3.0.1",
-  "name": "DynamoCore3.0.1 Win64",
+  "release_id": "3.0.0",
+  "name": "DynamoCore3.0.0 Win64",
   "master_id": "Win64",
   "language_pk": 1,
   "language_code_pk": 3,
   "master_platform_pk": 2,
   "master_type_pk": 1,
-  "description":"DynamoCore3.0.1"
+  "description":"DynamoCore3.0.0"
 }

--- a/tools/autobuild/release.json
+++ b/tools/autobuild/release.json
@@ -1,8 +1,8 @@
 {
   "product_id": "DYN",
-  "release_id": "3.0.1",
-  "name": "DynamoCore3.0.1",
-  "marketing_release_name": "DynamoCore3.0.1",
-  "description":"DynamoCore3.0.1",
-  "code_name": "DynamoCore3.0.1"
+  "release_id": "3.0.0",
+  "name": "DynamoCore3.0.0",
+  "marketing_release_name": "DynamoCore3.0.0",
+  "description":"DynamoCore3.0.0",
+  "code_name": "DynamoCore3.0.0"
 }


### PR DESCRIPTION
### Purpose

Some of the versions especially release and master versions on the config files mean different things v.s. our understanding of release, so there is no need to touch them for a hotfix release to be registered on UPI. In fact, all the hotfixes are registered on the same release with different builds as `Update 1`, `Update 2`, etc.

Previous examples can be found at https://github.com/DynamoDS/Dynamo/pull/14432/files

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
