### PR TITLE
DYN-5656 Preferences Blocking Action Bug

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -130,8 +130,7 @@ namespace Dynamo.PackageManager.UI
         /// <param name="e"></param>
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
-            Analytics.TrackEvent(Actions.Close, Categories.PackageManager);
-            (this.Owner as DynamoView).EnableOverlayBlocker(false);
+            Analytics.TrackEvent(Actions.Close, Categories.PackageManager);           
 
             Close();
         }
@@ -143,6 +142,7 @@ namespace Dynamo.PackageManager.UI
         {
             this.packageManagerPublish?.Dispose();
             this.packageManagerSearch?.Dispose();
+            (this.Owner as DynamoView).EnableOverlayBlocker(false);
 
             if (PackageManagerViewModel == null) return;
             this.PackageManagerViewModel.PackageSearchViewModel.RequestShowFileDialog -= OnRequestShowFileDialog;


### PR DESCRIPTION
### Purpose

Fixing bug reported when closing the Preferences panel was still showing the dark background.
If we open the PackageManager from Preferences panel and then back to Preferences panel using the link then after closing preferences the background was still present. So with this fix is removing the background under the described specfic case.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing bug when closing the Preferences panel was still showing the dark background following a specifc flow.

### Reviewers

@QilongTang 

### FYIs

@avidit 
