### PR TITLE
DYN-6492 add unhandled exception handler to viewmodel

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Threading;
 using Dynamo.Configuration;
+using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Exceptions;
 using Dynamo.Graph;
@@ -775,7 +776,7 @@ namespace Dynamo.ViewModels
 
                 DynamoModel.IsCrashing = true;
                 Analytics.TrackException(ex, true);
-                CrashReportTool.ShowCrashErrorReportWindow(this, new Dynamo.Core.CrashErrorReportArgs(ex));
+                Model?.OnRequestsCrashPrompt(new CrashErrorReportArgs(ex));
             }
             catch
             { }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -777,10 +777,11 @@ namespace Dynamo.ViewModels
                 DynamoModel.IsCrashing = true;
                 Analytics.TrackException(ex, true);
                 Model?.OnRequestsCrashPrompt(new CrashErrorReportArgs(ex));
+
+                Exit(false); // don't allow cancellation
             }
             catch
             { }
-            Exit(false); // don't allow cancellation
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -31,7 +31,6 @@ using Dynamo.Selection;
 using Dynamo.Services;
 using Dynamo.UI;
 using Dynamo.UI.Prompts;
-using Dynamo.Updates;
 using Dynamo.Utilities;
 using Dynamo.Visualization;
 using Dynamo.Wpf.Interfaces;
@@ -47,7 +46,6 @@ using Dynamo.Wpf.ViewModels.Watch3D;
 using DynamoUtilities;
 using ICSharpCode.AvalonEdit;
 using PythonNodeModels;
-using static Dynamo.ViewModels.SearchViewModel;
 using ISelectable = Dynamo.Selection.ISelectable;
 using WpfResources = Dynamo.Wpf.Properties.Resources;
 


### PR DESCRIPTION
### Purpose

Subscribe to `Application.DispatcherUnhandledException` event to handle unhandled exceptions coming from external code like extensions. This PR basically takes the work done in #14826 by @pinzart90 and moves it to the `ViewModel` so it isn't specific to sandbox.

WIP for some initial feedback.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
