### PR TITLE
[cherry-pick] Re-work watch node display logic (#14841)

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -186,8 +186,11 @@ namespace Dynamo.ViewModels
             get { return isCollection; }
             set
             {
-                isCollection = value;
-                RaisePropertyChanged("IsCollection");
+                if (isCollection != value)
+                {
+                    isCollection = value;
+                    RaisePropertyChanged(nameof(IsCollection));
+                }
             }
         }
 
@@ -199,8 +202,11 @@ namespace Dynamo.ViewModels
             get { return levels; }
             set
             {
-                levels = value;
-                RaisePropertyChanged("Levels");
+                if (levels != value)
+                {
+                    levels = value;
+                    RaisePropertyChanged(nameof(Levels));
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -389,24 +389,17 @@
                 BorderBrush="#D3D3D3"
                 CornerRadius="0,0,2,2"
                 BorderThickness="0">
+            <Grid Name="ListLevelsGrid">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-            <DockPanel Name="ListLevelsDisplay" Height="27px" Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-
-                <!--  A draggable control to resize the Watch window  -->
-                <Thumb Name="resizeThumb"
-                       DockPanel.Dock="Right"
-                       Margin="1,3,5,3"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center"
-                       Cursor="SizeNWSE"
-                       DragDelta="ThumbResizeThumbOnDragDeltaHandler"
-                       Visibility="Hidden">
-                    <Thumb.Template>
-                        <ControlTemplate>
-                            <Polygon Fill="#AFAFAF" Points="0,8 8,8 8,0" />
-                        </ControlTemplate>
-                    </Thumb.Template>
-                </Thumb>
+                <!--  Left Column display List Levels  -->
+                <DockPanel Name="ListLevelsDisplay"
+                       Height="27px"
+                       Grid.Column="0"
+                       Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
 
                 <!--  Shows counts of all items in List  -->
                 <TextBlock Name="ListItems"
@@ -466,7 +459,25 @@
                     </ListView.ItemTemplate>
                 </ListView>
 
-            </DockPanel>
+                </DockPanel>
+
+                <!--  Left Column display a draggable control to resize the Watch window  -->
+                <Thumb Name="resizeThumb"
+                       Grid.Column="1"
+                       DockPanel.Dock="Right"
+                       Margin="1,3,5,3"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       Cursor="SizeNWSE"
+                       DragDelta="ThumbResizeThumbOnDragDeltaHandler"
+                       Visibility="Collapsed">
+                    <Thumb.Template>
+                        <ControlTemplate>
+                            <Polygon Fill="#AFAFAF" Points="0,8 8,8 8,0" />
+                        </ControlTemplate>
+                    </Thumb.Template>
+                </Thumb>
+            </Grid>
         </Border>
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls.Primitives;
 using Dynamo.ViewModels;
 using System;
 using CoreNodeModels;
+using System.Linq;
 
 namespace Dynamo.Controls
 {
@@ -68,7 +69,7 @@ namespace Dynamo.Controls
 
             if (e.PropertyName == nameof(WatchViewModel.IsCollection))
             {
-                // // The WatchTree controll will resize only if its role is a WatchNode (starts with an specific height), otherwise it won't resize (Bubble role).
+                // The WatchTree controll will resize only if its role is a WatchNode (starts with an specific height), otherwise it won't resize (Bubble role).
                 if (!Double.IsNaN(this.Height))
                 {
                     if (_vm.IsCollection)
@@ -100,10 +101,13 @@ namespace Dynamo.Controls
                 {
                     if (!_vm.Children[0].IsCollection)
                     {
-                        // We will use 7.5 as width factor for each character.
+                        // if multiline string
+                        if (NodeLabel.Contains(Environment.NewLine) || NodeLabel.Contains("\n"))
+                            this.Height = defaultHeightSize;
 
-                        double requiredWidth = (NodeLabel.Length * widthPerCharacter);
-                        if (requiredWidth > (MaxWidthSize))
+                        // We will use 7.5 as width factor for each character.
+                        double requiredWidth = NodeLabel.Length * widthPerCharacter;
+                        if (requiredWidth > MaxWidthSize)
                         {
                             requiredWidth = MaxWidthSize;
                         }
@@ -123,6 +127,8 @@ namespace Dynamo.Controls
                     // Forcing not to display the Levels content when is being used for display info from another node like the Color Range
                     this.ListLevelsDisplay.Visibility = Visibility.Hidden;
                     this.ListLevelsDisplay.Height = 0;
+                    // Hide resize grip
+                    resizeThumb.Visibility = Visibility.Collapsed;
                 }
             }
         }


### PR DESCRIPTION
### Purpose

[cherry-pick] Re-work watch node display logic (#14841)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers



### FYIs

@DynamoDS/dynamo 
