### PR TITLE
DYN-5656-PackagesGuide-BugFix

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -262,20 +262,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
 
                 dynamoViewModel.OnEnableShortcutBarItems(true);
 
-                EnableDynamoUI();
-
                 //Hide guide background overlay
                 guideBackgroundElement.Visibility = Visibility.Hidden;
                 GuidesValidationMethods.CurrentExecutingGuide = null;
                 tourStarted = false;
             }
-        }
-
-        private void EnableDynamoUI()
-        {
-            var dynamoView = mainRootElement as DynamoView;
-            if (dynamoView != null)
-                dynamoView.EnableEnvironment(true);
         }
 
         /// <summary>
@@ -306,7 +297,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
         private void ExitTourButton_Click(object sender, RoutedEventArgs e)
         {
             exitGuideWindow.IsOpen = false;
-            EnableDynamoUI();
             GuideFlowEvents.OnGuidedTourExited(currentGuide.Name);
             ExitTour();
         }

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesValidationMethods.cs
@@ -392,13 +392,6 @@ namespace Dynamo.Wpf.UI.GuidedTour
             packageManager.PackageManagerViewModel.Width = PMDefaultWidth;
             packageManager.PackageManagerViewModel.Height = PMDefaultHeight;
             packageManagerViewModel.PropertyChanged -= searchPackagesPropertyChanged.Invoke;
-
-            //Enable the DynamoView.mainGrid so the user will be able to interact with Dynamo
-            var dynamoView = packageManager.Owner as DynamoView;
-            if (dynamoView != null)
-            {
-                dynamoView.EnableEnvironment(true);
-            }        
             packageManager.Close();
             
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2316,11 +2316,6 @@ namespace Dynamo.Controls
             cmd.Dispose();
         }
 
-        internal void EnableEnvironment(bool isEnabled)
-        {
-            this.mainGrid.IsEnabled = isEnabled;       
-        }
-
         /// <summary>
         /// Adds/Removes an overlay so the user won't be able to interact with the background (this behavior was implemented for Dynamo and for Library)
         /// </summary>
@@ -2329,6 +2324,7 @@ namespace Dynamo.Controls
         {
             object[] parametersInvokeScript = new object[] { "fullOverlayVisible", new object[] { isEnabled } };
             ResourceUtilities.ExecuteJSFunction(this, parametersInvokeScript);
+            var backgroundName = "BackgroundBlocker";
 
             if (isEnabled)
             {
@@ -2336,7 +2332,7 @@ namespace Dynamo.Controls
                 Panel.SetZIndex(shortcutsBarGrid, 0);
                 var backgroundElement = new GuideBackground(this)
                 {
-                    Name = "BackgroundBlocker",
+                    Name = backgroundName,
                     HorizontalAlignment = HorizontalAlignment.Left,
                     VerticalAlignment = VerticalAlignment.Top,
                     Visibility = Visibility.Visible
@@ -2351,7 +2347,7 @@ namespace Dynamo.Controls
             {
                 //Restoring the ZIndex value to the default one.
                 Panel.SetZIndex(shortcutsBarGrid, 1);
-                var backgroundElement = mainGrid.Children.OfType<GuideBackground>().FirstOrDefault();
+                var backgroundElement = mainGrid.Children.OfType<GuideBackground>().Where(element => element.Name == backgroundName).FirstOrDefault();
                 if (backgroundElement != null)
                 {
                     mainGrid.Children.Remove(backgroundElement);


### PR DESCRIPTION
### Purpose

Fixing bug when showing/hiding the dark overlay
When opening the Packages tour and later opening the PackageManager (during the tour) at closing was removing the wrong dark background, then I added some code for searching for the specific overlay added  (not the one added by the guided tour). Also deleted the code for using the EnableEnvironment function due that  is not used any more.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing bug when showing/hiding the dark overlay

### Reviewers

@QilongTang 

### FYIs

@avidit 
