### PR TITLE
[Cherry-pick for 3.0.2][DYN-6455] Add warning text to selection node's initial warning (#14833) 

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -374,7 +374,7 @@ namespace Dynamo.ViewModels
 
                         if (viewModelElement != null)
                         {
-                            viewModelElement.AutoCompletionNodeMachineLearningInfo = new AutoCompletionNodeMachineLearningInfo(true, true, result.Score * 100);
+                            viewModelElement.AutoCompletionNodeMachineLearningInfo = new AutoCompletionNodeMachineLearningInfo(true, true, Math.Round(result.Score * 100));
                             results.Add(viewModelElement);
                         }
                     }
@@ -407,7 +407,7 @@ namespace Dynamo.ViewModels
 
                         if (viewModelElement != null)
                         {
-                            viewModelElement.AutoCompletionNodeMachineLearningInfo = new AutoCompletionNodeMachineLearningInfo(true, true, result.Score * 100);
+                            viewModelElement.AutoCompletionNodeMachineLearningInfo = new AutoCompletionNodeMachineLearningInfo(true, true, Math.Round(result.Score * 100));
                             results.Add(viewModelElement);
                         }
                     }

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -161,8 +161,8 @@ namespace CoreNodeModels
 
             Prefix = prefix;
 
-            State = ElementState.Warning; 
-            
+            Warning(Resources.SelectionNodeNothingSelected, true);
+
             ShouldDisplayPreviewCore = true;
         }
 
@@ -183,7 +183,7 @@ namespace CoreNodeModels
 
             Prefix = prefix;
 
-            State = ElementState.Warning;
+            Warning(Resources.SelectionNodeNothingSelected);
 
             ShouldDisplayPreviewCore = true;
 
@@ -220,9 +220,13 @@ namespace CoreNodeModels
         private void SetSelectionNodeState()
         {
             if (null == selectionResults || selectionResults.Count == 0)
+            {
                 State = ElementState.Warning;
-            else if (State == ElementState.Warning)
-                State = ElementState.Active;
+            }
+            else if (State == ElementState.Warning || State == ElementState.PersistentWarning)
+            {
+                base.ClearErrorsAndWarnings();
+            }
         }
 
         public bool CanBeginSelect()


### PR DESCRIPTION
### Purpose

Cherrypick for [DYN-6455] Add warning text to selection node's initial warning (#14833)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

@DynamoDS/dynamo 
