### PR TITLE
DYN-6606: Make ShowCrashErrorReportWindow more robust

### DIFF
--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -199,30 +199,59 @@ namespace Dynamo.Wpf.Utilities
                 {
                     string logFile = Path.Combine(cerDir.FullName, "DynamoLog.log");
 
-                    File.Copy(model.Logger.LogPath, logFile);
-                    // might be usefull to dump all loaded Packages into
-                    // the log at this point.
-                    filesToSend.Add(logFile);
+                    try
+                    {
+                        File.Copy(model.Logger.LogPath, logFile);
+                        // might be useful to dump all loaded Packages into
+                        // the log at this point.
+                        filesToSend.Add(logFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        model?.Logger?.LogError($"Failed to add DynamoLog.log to CER with the following error : {ex.Message}");
+                    }
                 }
 
                 if (args.SendSettingsFile && model != null)
                 {
                     string settingsFile = Path.Combine(cerDir.FullName, "DynamoSettings.xml");
-                    File.Copy(model.PathManager.PreferenceFilePath, settingsFile);
 
-                    filesToSend.Add(settingsFile);
+                    try
+                    {
+                        File.Copy(model.PathManager.PreferenceFilePath, settingsFile);
+
+                        filesToSend.Add(settingsFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        model?.Logger?.LogError($"Failed to add DynamoSettings.xml to CER with the following error : {ex.Message}");
+                    }
                 }
 
                 if (args.HasDetails())
                 {
                     var stackTracePath = Path.Combine(cerDir.FullName, "StackTrace.log");
-                    File.WriteAllText(stackTracePath, args.Details);
-                    filesToSend.Add(stackTracePath);
+                    try
+                    {
+                        File.WriteAllText(stackTracePath, args.Details);
+                        filesToSend.Add(stackTracePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        model?.Logger?.LogError($"Failed to add StackTrace.log to CER with the following error : {ex.Message}");
+                    }
                 }
 
                 if (args.SendRecordedCommands && viewModel != null)
                 {
-                    filesToSend.Add(viewModel.DumpRecordedCommands());
+                    try
+                    {
+                        filesToSend.Add(viewModel.DumpRecordedCommands());
+                    }
+                    catch (Exception ex)
+                    {
+                        model?.Logger?.LogError($"Failed to add recorded commands to CER with the following error : {ex.Message}");
+                    }
                 }
 
                 string appConfig = "";

--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -200,14 +200,14 @@ namespace Dynamo.Wpf.Utilities
                 {
                     string logFile = Path.Combine(cerDir.FullName, "DynamoLog.log");
 
-                    if(File.Exists(logFile))
+                    if(File.Exists(model.Logger.LogPath))
                     {
                         File.Copy(model.Logger.LogPath, logFile);
                         filesToSend.Add(logFile);
                     }
                     else
                     {
-                        model?.Logger?.LogError($"Failed to add DynamoLog.log to CER with the following error : {logFile} Not Found");
+                        model?.Logger?.LogError($"Failed to add DynamoLog.log to CER with the following error : {model.Logger.LogPath} Not Found");
                     }
                 }
 
@@ -215,7 +215,7 @@ namespace Dynamo.Wpf.Utilities
                 {
                     string settingsFile = Path.Combine(cerDir.FullName, "DynamoSettings.xml");
 
-                    if (File.Exists(settingsFile))
+                    if (File.Exists(model.PathManager.PreferenceFilePath))
                     {
                         File.Copy(model.PathManager.PreferenceFilePath, settingsFile);
 
@@ -223,21 +223,21 @@ namespace Dynamo.Wpf.Utilities
                     }
                     else
                     {
-                        model?.Logger?.LogError($"Failed to add DynamoSettings.xml to CER with the following error : {settingsFile} Not Found");
+                        model?.Logger?.LogError($"Failed to add DynamoSettings.xml to CER with the following error : {model.PathManager.PreferenceFilePath} Not Found");
                     }
                 }
 
                 if (args.HasDetails())
                 {
                     var stackTracePath = Path.Combine(cerDir.FullName, "StackTrace.log");
-                    if(File.Exists(stackTracePath))
+                    try
                     {
                         File.WriteAllText(stackTracePath, args.Details);
                         filesToSend.Add(stackTracePath);
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        model?.Logger?.LogError($"Failed to add StackTrace.log to CER with the following error : {stackTracePath} Not Found ");
+                        model?.Logger?.LogError($"Failed to add StackTrace.log to CER with the following error : {ex.Message}");
                     }
                 }
 


### PR DESCRIPTION

### Purpose

DYN-6606:  Update D4R OnRequestsCrashPrompt API to reflect lated dyn changes

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
