### PR TITLE
[Cherry-pick for 3.0.2] DYN-6606: Make ShowCrashErrorReportWindow more robust

### DIFF
--- a/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashReportTool.cs
@@ -177,10 +177,11 @@ namespace Dynamo.Wpf.Utilities
 
             DynamoModel model = viewModel?.Model;
 
-            string cerToolDir = !string.IsNullOrEmpty(model.CERLocation) ?
-                model.CERLocation : FindCERToolInInstallLocations();
+            string cerToolDir = !string.IsNullOrEmpty(model?.CERLocation) ?
+                model?.CERLocation : FindCERToolInInstallLocations();
 
-            var cerToolPath = Path.Combine(cerToolDir, CERDllName);
+            var cerToolPath = !string.IsNullOrEmpty(cerToolDir) ? Path.Combine(cerToolDir, CERDllName) : string.Empty;
+
             if (string.IsNullOrEmpty(cerToolPath) || !File.Exists(cerToolPath))
             {
                 model?.Logger?.LogError($"The CER tool was not found at location {cerToolPath}");
@@ -199,30 +200,57 @@ namespace Dynamo.Wpf.Utilities
                 {
                     string logFile = Path.Combine(cerDir.FullName, "DynamoLog.log");
 
-                    File.Copy(model.Logger.LogPath, logFile);
-                    // might be usefull to dump all loaded Packages into
-                    // the log at this point.
-                    filesToSend.Add(logFile);
+                    if(File.Exists(model.Logger.LogPath))
+                    {
+                        File.Copy(model.Logger.LogPath, logFile);
+                        filesToSend.Add(logFile);
+                    }
+                    else
+                    {
+                        model?.Logger?.LogError($"Failed to add DynamoLog.log to CER with the following error : {model.Logger.LogPath} Not Found");
+                    }
                 }
 
                 if (args.SendSettingsFile && model != null)
                 {
                     string settingsFile = Path.Combine(cerDir.FullName, "DynamoSettings.xml");
-                    File.Copy(model.PathManager.PreferenceFilePath, settingsFile);
 
-                    filesToSend.Add(settingsFile);
+                    if (File.Exists(model.PathManager.PreferenceFilePath))
+                    {
+                        File.Copy(model.PathManager.PreferenceFilePath, settingsFile);
+
+                        filesToSend.Add(settingsFile);
+                    }
+                    else
+                    {
+                        model?.Logger?.LogError($"Failed to add DynamoSettings.xml to CER with the following error : {model.PathManager.PreferenceFilePath} Not Found");
+                    }
                 }
 
                 if (args.HasDetails())
                 {
                     var stackTracePath = Path.Combine(cerDir.FullName, "StackTrace.log");
-                    File.WriteAllText(stackTracePath, args.Details);
-                    filesToSend.Add(stackTracePath);
+                    try
+                    {
+                        File.WriteAllText(stackTracePath, args.Details);
+                        filesToSend.Add(stackTracePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        model?.Logger?.LogError($"Failed to add StackTrace.log to CER with the following error : {ex.Message}");
+                    }
                 }
 
                 if (args.SendRecordedCommands && viewModel != null)
                 {
-                    filesToSend.Add(viewModel.DumpRecordedCommands());
+                    try
+                    {
+                        filesToSend.Add(viewModel.DumpRecordedCommands());
+                    }
+                    catch (Exception ex)
+                    {
+                        model?.Logger?.LogError($"Failed to add recorded commands to CER with the following error : {ex.Message}");
+                    }
                 }
 
                 string appConfig = "";
@@ -234,9 +262,23 @@ namespace Dynamo.Wpf.Utilities
                                 $"session_start_count=\"0\" session_clean_close_count=\"0\" current_session_length=\"0\" />";
                 }
 
-                string dynName = viewModel?.Model.CurrentWorkspace.Name;
+                string dynName = model?.CurrentWorkspace.Name;
 
-                var miniDumpFilePath = CreateMiniDumpFile(cerDir.FullName);
+                var miniDumpFilePath = string.Empty;
+                try
+                {
+                    miniDumpFilePath = CreateMiniDumpFile(cerDir.FullName);
+                }
+                catch (Exception ex)
+                {
+                    model?.Logger?.LogError($"Failed to generate minidump file for CER due to the following error : {ex.Message}");
+                }
+
+                if (string.IsNullOrEmpty(miniDumpFilePath))
+                {
+                    return false;
+                }
+
                 var upiConfigFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "upiconfig.xml");
 
                 using (var cerDLL = new CerDLL(cerToolPath)) 


### PR DESCRIPTION
### Purpose

* [Cherry pick for 3.0.2] DYN-6606: Make ShowCrashErrorReportWindow more robust

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
