### PR TITLE
Unify const string usage of Dynamo and Autodesk in Dynamo code base

### DIFF
--- a/src/DynamoApplications/PathResolvers.cs
+++ b/src/DynamoApplications/PathResolvers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Dynamo.Configuration;
 using Dynamo.Interfaces;
 
 namespace Dynamo.Applications
@@ -62,7 +63,7 @@ namespace Dynamo.Applications
         {
             get { return Path.Combine(Environment.GetFolderPath(
                 Environment.SpecialFolder.ApplicationData),
-                "Dynamo", "Dynamo Core").ToString(); }
+                Configurations.DynamoAsString, "Dynamo Core").ToString(); }
         }
 
         public string CommonDataRootFolder
@@ -80,7 +81,7 @@ namespace Dynamo.Applications
         public IEnumerable<string> GetDynamoUserDataLocations()
         {
             var appDatafolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var dynamoFolder = Path.Combine(appDatafolder, "Dynamo");
+            var dynamoFolder = Path.Combine(appDatafolder, Configurations.DynamoAsString);
             if (!Directory.Exists(dynamoFolder)) return Enumerable.Empty<string>();
 
             var paths = new List<string>();

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -38,6 +38,16 @@ namespace Dynamo.Configuration
         /// </summary>
         public static readonly double IntegerSliderTextBoxWidth = 30.0;
 
+        /// <summary>
+        /// Const string of Autodesk
+        /// </summary>
+        public static readonly string AutodeskAsString = "Autodesk";
+
+        /// <summary>
+        /// Const string of Dynamo
+        /// </summary>
+        public static readonly string DynamoAsString = "Dynamo";
+
         #endregion
 
         #region Usage Reporting Error Message

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -638,7 +638,7 @@ namespace Dynamo.Core
                 return userDataDir; //Return the cached userDataDir if we have one.
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            return GetDynamoDataFolder(Path.Combine(folder, "Dynamo", "Dynamo Core"));
+            return GetDynamoDataFolder(Path.Combine(folder, Configurations.DynamoAsString, "Dynamo Core"));
         }
 
         /// <summary>
@@ -659,7 +659,7 @@ namespace Dynamo.Core
                 return GetDynamoDataFolder(pathResolver.CommonDataRootFolder);
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            return GetDynamoDataFolder(Path.Combine(folder, "Dynamo", "Dynamo Core"));
+            return GetDynamoDataFolder(Path.Combine(folder, Configurations.DynamoAsString, "Dynamo Core"));
         }
 
         private string GetDynamoDataFolder(string folder)

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1238,13 +1238,11 @@ namespace Dynamo.Configuration
         internal void AddDefaultTrustedLocations()
         {
             if (!IsFirstRun) return;
-
-            const string Autodesk = "Autodesk";
             string ProgramData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-            AddTrustedLocation(Path.Combine(ProgramData, Autodesk));
+            AddTrustedLocation(Path.Combine(ProgramData, Configurations.AutodeskAsString));
 
             string ProgramFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-            AddTrustedLocation(Path.Combine(ProgramFiles, Autodesk));
+            AddTrustedLocation(Path.Combine(ProgramFiles, Configurations.AutodeskAsString));
         }
 
         /// <summary>

--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -414,7 +414,7 @@ namespace Dynamo.Core
         public IEnumerable<string> GetDynamoUserDataLocations()
         {
             var appDatafolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var dynamoFolder = Path.Combine(appDatafolder, "Dynamo");
+            var dynamoFolder = Path.Combine(appDatafolder, Configurations.DynamoAsString);
             if (!Directory.Exists(dynamoFolder)) return Enumerable.Empty<string>();
 
             var paths = new List<string>();

--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using Autodesk.IDSDK;
+using Dynamo.Configuration;
 using Greg;
 using Greg.AuthProviders;
 using RestSharp;
@@ -232,7 +233,7 @@ namespace Dynamo.Core
                         {
                             Client.LogoutCompleteEvent += AuthCompleteEventHandler;
                             Client.LoginCompleteEvent += AuthCompleteEventHandler;
-                            ret = SetProductConfigs("Dynamo", server, client_id);
+                            ret = SetProductConfigs(Configurations.DynamoAsString, server, client_id);
                             Client.SetServer(server);
                             return ret;
                         }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Xml;
+using Dynamo.Configuration;
 using Dynamo.Logging;
 using Dynamo.Models;
 using Dynamo.Utilities;
@@ -202,7 +203,7 @@ namespace Dynamo.Graph.Workspaces
                     Double.TryParse((viewObject.TryGetValue("Zoom", out value) ? value.ToString() : "1.0"), out zoom);
 
                     // Parse the following info when "View" block contains a "Dynamo" block
-                    if (viewObject.TryGetValue("Dynamo", out value))
+                    if (viewObject.TryGetValue(Configurations.DynamoAsString, out value))
                     {
                         JObject dynamoObject = value.ToObject<JObject>();
                         Double.TryParse((dynamoObject.TryGetValue("ScaleFactor", out value) ? value.ToString(): "1.0"), out scaleFactor);

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Autodesk.Analytics.ADP;
 using Autodesk.Analytics.Core;
 using Autodesk.Analytics.Events;
+using Dynamo.Configuration;
 using Dynamo.Models;
 using Microsoft.Win32;
 
@@ -122,7 +123,7 @@ namespace Dynamo.Logging
             //Setup Analytics service, and StabilityCookie.
             Session.Start();
 
-            var hostName = string.IsNullOrEmpty(hostAnalyticsInfo.HostName) ? "Dynamo" : hostAnalyticsInfo.HostName;
+            var hostName = string.IsNullOrEmpty(hostAnalyticsInfo.HostName) ? Configurations.DynamoAsString : hostAnalyticsInfo.HostName;
 
             hostInfo = new HostContextInfo() { ParentId = hostAnalyticsInfo.ParentId, SessionId = hostAnalyticsInfo.SessionId };
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2024,7 +2024,7 @@ namespace Dynamo.Models
             JsonReader reader = new JsonTextReader(new StringReader(json));
             var obj = JObject.Load(reader);
             var viewBlock = obj["View"];
-            var dynamoBlock = viewBlock == null ? null : viewBlock["Dynamo"];
+            var dynamoBlock = viewBlock == null ? null : viewBlock[Configurations.DynamoAsString];
             if (dynamoBlock == null)
                 return DynamoPreferencesData.Default();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Dynamo.Configuration;
 using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
@@ -32,7 +33,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
 
             writer.WriteStartObject();
 
-            writer.WritePropertyName("Dynamo");
+            writer.WritePropertyName(Configurations.DynamoAsString);
             serializer.Serialize(writer, workspaceView.DynamoPreferences);
 
             writer.WritePropertyName("Camera");

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1663,7 +1663,7 @@ namespace Dynamo.ViewModels
                     {
                         errorMsgString = String.Format(Resources.MessageUnkownErrorOpeningFile, "Json file content");
                     }
-                    model.Logger.LogNotification("Dynamo", commandString, errorMsgString, e.ToString());
+                    model.Logger.LogNotification(Configurations.DynamoAsString, commandString, errorMsgString, e.ToString());
                     MessageBoxService.Show(
                         Owner,
                         errorMsgString, 
@@ -1757,7 +1757,7 @@ namespace Dynamo.ViewModels
                     {
                         errorMsgString = String.Format(Resources.MessageUnkownErrorOpeningFile, filePath);
                     }
-                    model.Logger.LogNotification("Dynamo", commandString, errorMsgString, e.ToString());
+                    model.Logger.LogNotification(Configurations.DynamoAsString, commandString, errorMsgString, e.ToString());
                     MessageBoxService.Show(
                         Owner,
                         errorMsgString,
@@ -1846,7 +1846,7 @@ namespace Dynamo.ViewModels
                     {
                         errorMsgString = String.Format(Resources.MessageUnkownErrorOpeningFile, filePath);
                     }
-                    model.Logger.LogNotification("Dynamo", commandString, errorMsgString, e.ToString());
+                    model.Logger.LogNotification(Configurations.DynamoAsString, commandString, errorMsgString, e.ToString());
                     MessageBoxService.Show(errorMsgString, commandString, MessageBoxButton.OK, MessageBoxImage.Error);
                 }
                 else

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -286,7 +286,7 @@ namespace Dynamo.UI.Views
             var version = AssemblyHelper.GetDynamoVersion();
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            return Path.Combine(Path.Combine(folder, "Dynamo", "Dynamo Core"),
+            return Path.Combine(Path.Combine(folder, Configurations.DynamoAsString, "Dynamo Core"),
                             String.Format("{0}.{1}", version.Major, version.Minor));
         }
 

--- a/src/Libraries/CoreNodes/Web.cs
+++ b/src/Libraries/CoreNodes/Web.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using Autodesk.DesignScript.Runtime;
+using Dynamo.Configuration;
 
 namespace DSCore
 {
@@ -30,7 +31,7 @@ namespace DSCore
 
             // Set the User-Agent header required by some APIs
             if (myRequest is System.Net.HttpWebRequest httpRequest)
-                httpRequest.UserAgent = "Dynamo";
+                httpRequest.UserAgent = Configurations.DynamoAsString;
 
             string responseFromServer;
 


### PR DESCRIPTION
### Purpose

While reviewing trusted path related changes, I noticed there were a bunch of const string in Dynamo code base referencing "Dynamo" so this PR is to unify const string usage of Dynamo and Autodesk in Dynamo code base

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
