### PR TITLE
Open File crash fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1928,7 +1928,7 @@ namespace Dynamo.ViewModels
                     return;
             }
 
-            bool isTemplate = (parameter as string).Equals("Template");
+            bool isTemplate = parameter != null && (parameter as string).Equals("Template");
 
             DynamoOpenFileDialog _fileDialog = new DynamoOpenFileDialog(this)
             {


### PR DESCRIPTION
### Purpose

 This PR fixes a crash that the open file would crash because of missing a param null check.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers



### FYIs

@DynamoDS/dynamo 