### PR TITLE
DYN-6602 Make Dynamo TSpline nodes OOTB and hide experiment toggle under feature flag

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1141,8 +1141,16 @@ namespace Dynamo.Configuration
             return defaultPythonEngine;
         }
 
-        internal void InitializeNamespacesToExcludeFromLibrary()
+        internal void InitializeNamespacesToExcludeFromLibrary(bool isTSplineNodesExperimentToggleVisible)
         {
+            // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.
+            if (!isTSplineNodesExperimentToggleVisible)
+            {
+                NamespacesToExcludeFromLibrary.Remove(
+                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
+                );
+                return;
+            }
             if (!NamespacesToExcludeFromLibrarySpecified)
             {
                 NamespacesToExcludeFromLibrary.Add(

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1141,6 +1141,10 @@ namespace Dynamo.Configuration
             return defaultPythonEngine;
         }
 
+        /// <summary>
+        /// Initialize namespaces to exclude from Library based on conditions
+        /// </summary>
+        /// <param name="isTSplineNodesExperimentToggleVisible">indicates if the experiment toggle is visible under feature flag</param>
         internal void InitializeNamespacesToExcludeFromLibrary(bool isTSplineNodesExperimentToggleVisible)
         {
             // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1146,20 +1146,27 @@ namespace Dynamo.Configuration
         /// </summary>
         internal void InitializeNamespacesToExcludeFromLibrary()
         {
-            // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.
-            if (!DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? true)
-            {
-                NamespacesToExcludeFromLibrary.Remove(
-                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
-                );
-                return;
-            }
             if (!NamespacesToExcludeFromLibrarySpecified)
             {
                 NamespacesToExcludeFromLibrary.Add(
                     "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
                 );
                 NamespacesToExcludeFromLibrarySpecified = true;
+            }
+        }
+
+        /// <summary>
+        /// Update namespaces to exclude from Library based on feature flags
+        /// </summary>
+        internal void UpdateNamespacesToExcludeFromLibrary()
+        {
+            // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.
+            if (!DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false)
+            {
+                NamespacesToExcludeFromLibrary.Remove(
+                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
+                );
+                return;
             }
         }
 

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1147,7 +1147,7 @@ namespace Dynamo.Configuration
         internal void InitializeNamespacesToExcludeFromLibrary()
         {
             // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.
-            if (!DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false)
+            if (!DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? true)
             {
                 NamespacesToExcludeFromLibrary.Remove(
                     "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1144,11 +1144,10 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Initialize namespaces to exclude from Library based on conditions
         /// </summary>
-        /// <param name="isTSplineNodesExperimentToggleVisible">indicates if the experiment toggle is visible under feature flag</param>
-        internal void InitializeNamespacesToExcludeFromLibrary(bool isTSplineNodesExperimentToggleVisible)
+        internal void InitializeNamespacesToExcludeFromLibrary()
         {
             // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.
-            if (!isTSplineNodesExperimentToggleVisible)
+            if (!DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false)
             {
                 NamespacesToExcludeFromLibrary.Remove(
                     "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -36,6 +36,7 @@ using Dynamo.Search.SearchElements;
 using Dynamo.Selection;
 using Dynamo.Utilities;
 using DynamoServices;
+using DynamoUtilities;
 using Greg;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
@@ -716,7 +717,7 @@ namespace Dynamo.Models
                     {
                         //this will kill the CLI process after cacheing the flags in Dynamo process.
                         using (FeatureFlags =
-                                new DynamoUtilities.DynamoFeatureFlagsManager(
+                                new DynamoFeatureFlagsManager(
                                 AnalyticsService.GetUserIDForSession(),
                                 mainThreadSyncContext,
                                 IsTestMode))
@@ -728,6 +729,7 @@ namespace Dynamo.Models
                     }
                     catch (Exception e) { Logger.LogError($"could not start feature flags manager {e}"); };
                 });
+                DynamoFeatureFlagsManager.FlagsRetrieved += HandleFeatureFlags;
             }
 
             // TBD: Do we need settings migrator for service mode? If we config the docker correctly, this could be skipped I think
@@ -973,6 +975,15 @@ namespace Dynamo.Models
             }
             // This event should only be raised at the end of this method.
             DynamoReady(new ReadyParams(this));
+        }
+
+        /// <summary>
+        /// When feature flags received, handle them and make changes 
+        /// </summary>
+        private void HandleFeatureFlags()
+        {
+            PreferenceSettings.UpdateNamespacesToExcludeFromLibrary();
+            return;
         }
 
         private void HandleAnalytics()
@@ -1367,6 +1378,7 @@ namespace Dynamo.Models
             LibraryServices.LibraryLoaded -= LibraryLoaded;
 
             EngineController.VMLibrariesReset -= ReloadDummyNodes;
+            DynamoFeatureFlagsManager.FlagsRetrieved -= HandleFeatureFlags;
 
             Logger.Dispose();
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1719,7 +1719,7 @@ namespace Dynamo.Models
             if (PreferenceSettings != null)
             {
                 ProtoCore.Mirror.MirrorData.PrecisionFormat = DynamoUnits.Display.PrecisionFormat = PreferenceSettings.NumberFormat;
-                // PreferenceSettings.InitializeNamespacesToExcludeFromLibrary();
+                PreferenceSettings.InitializeNamespacesToExcludeFromLibrary(DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false);
 
                 if (string.IsNullOrEmpty(PreferenceSettings.BackupLocation))
                 {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1719,7 +1719,7 @@ namespace Dynamo.Models
             if (PreferenceSettings != null)
             {
                 ProtoCore.Mirror.MirrorData.PrecisionFormat = DynamoUnits.Display.PrecisionFormat = PreferenceSettings.NumberFormat;
-                PreferenceSettings.InitializeNamespacesToExcludeFromLibrary(DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false);
+                PreferenceSettings.InitializeNamespacesToExcludeFromLibrary();
 
                 if (string.IsNullOrEmpty(PreferenceSettings.BackupLocation))
                 {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1719,7 +1719,7 @@ namespace Dynamo.Models
             if (PreferenceSettings != null)
             {
                 ProtoCore.Mirror.MirrorData.PrecisionFormat = DynamoUnits.Display.PrecisionFormat = PreferenceSettings.NumberFormat;
-                PreferenceSettings.InitializeNamespacesToExcludeFromLibrary();
+                // PreferenceSettings.InitializeNamespacesToExcludeFromLibrary();
 
                 if (string.IsNullOrEmpty(PreferenceSettings.BackupLocation))
                 {

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1122,7 +1122,7 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Controls if the the Node autocomplete Machine Learning option is beta from feature flag
+        /// Controls if the TSpline nodes experiment toggle is visible from feature flag
         /// </summary>
         public bool IsTSplineNodesExperimentToggleVisible
         {

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1122,6 +1122,17 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Controls if the the Node autocomplete Machine Learning option is beta from feature flag
+        /// </summary>
+        public bool IsTSplineNodesExperimentToggleVisible
+        {
+            get
+            {
+                return DynamoModel.FeatureFlags?.CheckFeatureFlag("NodeAutocompleteMachineLearningIsBeta", true) ?? false;
+            }
+        }
+
+        /// <summary>
         /// Contains the numbers of result of the ML recommendation
         /// </summary>
         public int MLRecommendationNumberOfResults

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1128,7 +1128,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return DynamoModel.FeatureFlags?.CheckFeatureFlag("NodeAutocompleteMachineLearningIsBeta", true) ?? false;
+                return DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1023,7 +1023,10 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
-                                    <StackPanel Orientation="Horizontal" Margin="0,12,0,0" Grid.Row="0">
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="0,12,0,0"
+                                                Grid.Row="0"
+                                                Visibility="{Binding IsTSplineNodesExperimentToggleVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <ToggleButton Name="EnableTSplineToggle"
                                                       Width="{StaticResource ToggleButtonWidth}"
                                                       Height="{StaticResource ToggleButtonHeight}"

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -166,7 +166,7 @@ namespace DynamoCoreWpfTests
 
             // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(44, searchViewModel.FilteredResults.Count());
+            Assert.AreEqual(58, searchViewModel.FilteredResults.Count());
         }
         [Test]
         public void NodeSuggestions_CanAutoCompleteOnCustomNodesOutPort_WithWhiteSpaceStartingPortName()
@@ -186,7 +186,7 @@ namespace DynamoCoreWpfTests
 
             // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(44, searchViewModel.FilteredResults.Count());
+            Assert.AreEqual(58, searchViewModel.FilteredResults.Count());
         }
 
         [Test]
@@ -316,7 +316,7 @@ namespace DynamoCoreWpfTests
 
             // Get the output port type for the node. 
             var outPorts = nodeView.ViewModel.OutPorts;
-            Assert.AreEqual(1, outPorts.Count());
+            Assert.AreEqual(1, outPorts.Count);
 
             var port = outPorts[0].PortModel;
             var type = port.GetOutPortType();
@@ -326,7 +326,7 @@ namespace DynamoCoreWpfTests
             var searchViewModel = ViewModel.CurrentSpaceViewModel.NodeAutoCompleteSearchViewModel;
             searchViewModel.PortViewModel = outPorts[0];
             var suggestions = searchViewModel.GetMatchingSearchElements();
-            Assert.AreEqual(44, suggestions.Count());
+            Assert.AreEqual(58, suggestions.Count());
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

DYN-6602 Make Dynamo TSpline nodes OOTB and hide experiment toggle under feature flag.
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/2e0f1b32-74d4-47ad-bb8a-fcac0edd1aac)

Tested cases covering:

- Feature flag off - TSpline nodes available OOTB
- Feature flag on - Toggle visible and use able to control show/hide TSpline nodes based on toggle value


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Make Dynamo TSpline nodes OOTB and hide experiment toggle under feature flag

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
