### PR TITLE
DYN-6449 Graph Loading Performance Improving

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
@@ -60,7 +62,10 @@ namespace Dynamo.Wpf
             publishCustomNodeItem.Command = nodeView.ViewModel.DynamoViewModel.PublishSelectedNodesCommand;
             publishCustomNodeItem.CommandParameter = functionNodeModel;
 
-            nodeView.UpdateLayout();
+            nodeView.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                nodeView.UpdateLayout();
+            }), DispatcherPriority.Background);
         }
 
         private void EditCustomNodeProperties()

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -551,6 +551,9 @@ namespace Dynamo.Controls
         {
             ViewModel.ZIndex = oldZIndex;
 
+            //Watch nodes doesn't have Preview so we should avoid to use any method/property in PreviewControl class due that Preview is created automatically
+            if (ViewModel.NodeModel != null && ViewModel.NodeModel is CoreNodeModels.Watch) return;
+
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
             if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen || IsMouseInsidePreview(e) ||
                 (Mouse.Captured is DragCanvas && IsMouseInsideNodeOrPreview(e.GetPosition(this)))) return;
@@ -730,6 +733,9 @@ namespace Dynamo.Controls
         internal void TogglePreviewControlAllowance()
         {
             previewEnabled = !previewEnabled;
+
+            //Watch nodes doesn't have Preview so we should avoid to use any method/property in PreviewControl class due that Preview is created automatically
+            if (ViewModel.NodeModel != null && ViewModel.NodeModel is CoreNodeModels.Watch) return;
 
             if (previewEnabled == false && !PreviewControl.StaysOpen)
             {

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Threading;
 using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
@@ -99,8 +100,11 @@ namespace PythonNodeModelsWpf
             PythonEngineManager.Instance.AvailableEngines.CollectionChanged += PythonEnginesChanged;
 
             nodeView.MainContextMenu.Items.Add(learnMoreItem);
-
-            nodeView.UpdateLayout();
+            nodeView.Dispatcher.BeginInvoke(new Action( () =>
+            {
+                nodeView.UpdateLayout();
+            }), DispatcherPriority.Background);
+            
 
             nodeView.MouseDown += View_MouseDown;
             nodeModel.DeletionStarted += NodeModel_DeletionStarted;


### PR DESCRIPTION
### Purpose

Improvements for loading a Graph in Dynamo
Using Jetbrains dotTrace I noticed that creating the NodeView for Watch nodes was taking too much time when loading the Graph (due that was creating the PreviewControl), then due that Watch nodes doesn't have Preview I've added code for preventing the creation of the PreviewControl, this improved the Graph loading time. Also I've noticed that the call nodeView.UpdateLayout() was consuming loading time so I've modified the code in a way that the method call will be executed asynchronous in background.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Improvements for loading a Graph in Dynamo

### Reviewers

@QilongTang 
@reddyashish 

### FYIs

@Amoursol 
