### PR TITLE
DYN-6198 Show Node Details When Zoomed Out

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -181,6 +181,11 @@ namespace Dynamo.Configuration
         public bool ShowPreviewBubbles { get; set; }
 
         /// <summary>
+        /// Indicates if node details should be displayed when Zoomed Out
+        /// </summary>
+        public bool ShowNodeDetailsWhenZoomedOut { get; set; }
+
+        /// <summary>
         /// Indicates if Host units should be used for graphic helpers for Dynamo Revit
         /// </summary>
         public bool UseHostScaleUnits { get; set; }

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7373,6 +7373,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show Node Details When Zoomed Out.
+        /// </summary>
+        public static string PreferencesShowNodeDetailsWhenZoomedOut {
+            get {
+                return ResourceManager.GetString("PreferencesShowNodeDetailsWhenZoomedOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use Revit to scale background graphic helpers.
         /// </summary>
         public static string PreferencesUseHostScaleUnits {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3915,4 +3915,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="PublishPackageRetainFolderStructureToggleButtonText" xml:space="preserve">
     <value>Retain folder structure</value>
   </data>
+  <data name="PreferencesShowNodeDetailsWhenZoomedOut" xml:space="preserve">
+    <value>Show Node Details When Zoomed Out</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3902,4 +3902,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="PublishPackageRetainFolderStructureToggleButtonText" xml:space="preserve">
     <value>Retain folder structure</value>
   </data>
+  <data name="PreferencesShowNodeDetailsWhenZoomedOut" xml:space="preserve">
+    <value>Show Node Details When Zoomed Out</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1744,7 +1744,7 @@ namespace Dynamo.Controls
         {
             double number = (double)System.Convert.ChangeType(value, typeof(double));
 
-            if (number <= Configurations.ZoomThreshold)
+            if (number <= Configurations.ZoomThreshold && !PreferenceSettings.Instance.ShowNodeDetailsWhenZoomedOut)
                 return false;
 
             return true;
@@ -1762,7 +1762,7 @@ namespace Dynamo.Controls
         {
             double number = (double)System.Convert.ChangeType(value, typeof(double));
 
-            if (number <= Configurations.ZoomThreshold)
+            if (number <= Configurations.ZoomThreshold && !PreferenceSettings.Instance.ShowNodeDetailsWhenZoomedOut)
                 return 0.0;
 
             return 0.5;
@@ -1783,7 +1783,7 @@ namespace Dynamo.Controls
         {
             double number = (double)System.Convert.ChangeType(value, typeof(double));
 
-            if (number > Configurations.ZoomThreshold)
+            if (number > Configurations.ZoomThreshold && !PreferenceSettings.Instance.ShowNodeDetailsWhenZoomedOut)
                 return Visibility.Collapsed;
 
             return Visibility.Visible;    

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -771,6 +771,22 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Indicates if node details should be displayed when Zoomed Out
+        /// </summary>
+        public bool ShowNodeDetailsWhenZoomedOut
+        {
+            get
+            {
+                return preferenceSettings.ShowNodeDetailsWhenZoomedOut;
+            }
+            set
+            {
+                preferenceSettings.ShowNodeDetailsWhenZoomedOut = value;
+                RaisePropertyChanged(nameof(ShowNodeDetailsWhenZoomedOut));
+            }
+        }
+
+        /// <summary>
         /// Indicates if Host units should be used for graphic helpers for Dynamo Revit
         /// Also toggles between Host and Dynamo units 
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -334,12 +334,11 @@ namespace Dynamo.Controls
             var editWindow = new EditWindow(viewModel.DynamoViewModel, false, true)
             {
                 DataContext = ViewModel,
-                Title = Dynamo.Wpf.Properties.Resources.EditNodeWindowTitle
+                Title = Wpf.Properties.Resources.EditNodeWindowTitle,
+                Owner = Window.GetWindow(this)
             };
 
-            editWindow.Owner = Window.GetWindow(this);
-
-            editWindow.BindToProperty(null, new Binding("Name")
+            editWindow.BindToProperty(null, new Binding( nameof(ViewModel.Name))
             {
                 Mode = BindingMode.TwoWay,
                 NotifyOnValidationError = false,

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1261,7 +1261,8 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
 
                                     <StackPanel Orientation="Horizontal" 
                                                     Margin="0,12,0,0" 
@@ -1413,11 +1414,11 @@
                                                Margin="10,0,0,0"
                                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                         <Label HorizontalAlignment="Left"
-                                                   Name="ShowPreviewBubblesInfoLabel"
-                                                   VerticalAlignment="Center" 
-                                                   Height="26" 
-                                                   Width="53"
-                                                   Margin="0 3 0 0">
+                                               Name="ShowPreviewBubblesInfoLabel"
+                                               VerticalAlignment="Center" 
+                                               Height="26" 
+                                               Width="53"
+                                               Margin="0 3 0 0">
                                             <Image
                                                Margin="5,3,0,0"
                                                Width="14"
@@ -1432,10 +1433,44 @@
                                             </Image>
                                         </Label>
                                     </StackPanel>
-                                    
+
+                                    <StackPanel Orientation="Horizontal" 
+                                                Margin="0,12,0,0" 
+                                                Grid.Row="5">
+                                        <ToggleButton Name="ShowNodeDetailsWhenZoomedOutToggle"
+                                                      Width="{StaticResource ToggleButtonWidth}"
+                                                      Height="{StaticResource ToggleButtonHeight}"
+                                                      VerticalAlignment="Center"
+                                                      IsChecked="{Binding Path=ShowNodeDetailsWhenZoomedOut}"
+                                                      Style="{StaticResource EllipseToggleButton1}"/>
+                                        <Label Content="{x:Static p:Resources.PreferencesShowNodeDetailsWhenZoomedOut}" 
+                                               VerticalAlignment="Center"
+                                               Margin="10,0,0,0"
+                                               Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                        <Label HorizontalAlignment="Left"
+                                            Name="ShowNodeNamesWhenZoomOutLabel"
+                                            VerticalAlignment="Center" 
+                                            Height="26" 
+                                            Width="53"
+                                            Margin="0 3 0 0">
+                                            <Image
+                                                Margin="5,3,0,0"
+                                                Width="14"
+                                                Height="14"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Style="{StaticResource QuestionIcon}"
+                                                ToolTipService.ShowDuration="30000">
+                                                <Image.ToolTip>
+                                                    <ToolTip Content="{x:Static p:Resources.PreferencesWindowShowPreviewBubblesTooltip}" Style="{StaticResource GenericToolTipLight}"/>
+                                                </Image.ToolTip>
+                                            </Image>
+                                        </Label>
+                                    </StackPanel>
+
                                     <Grid x:Name="GraphicHelpersScale"
                                           Margin="0 12 0 5"
-                                          Grid.Row="5">
+                                          Grid.Row="6">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
### Purpose

Add a setting in Preferences to control if node details are hidden under a high zoom level.

Before:
![HideNodeDetailsWhenZoomedOut](https://github.com/DynamoDS/Dynamo/assets/3942418/566c0780-92fb-4f00-b7cb-f38f0b0ba956)

After:

With Setting:
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/dc8f708d-ae5f-420b-9435-42e98c33f35b)


![ShowNodeDetailsWhenZoomedOut](https://github.com/DynamoDS/Dynamo/assets/3942418/76948dd7-ecd8-4c00-bdca-06114fbeeed0)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
