### PR TITLE
update ironPython2.7 target version to 3.2

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -856,7 +856,7 @@ namespace Dynamo.Configuration
         /// This property is not serialized and is assigned IronPythonResolveTargetVersion's value
         /// if found at deserialize time.
         /// </summary>
-        internal Version ironPythonResolveTargetVersion = new Version(3, 0, 0);
+        internal Version ironPythonResolveTargetVersion = new Version(3, 2, 0);
 
         /// <summary>
         /// The Version of the IronPython package that Dynamo will download when it is found as missing in graphs.

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -62,7 +62,7 @@ namespace Dynamo.PythonMigration
         {
             LoadedParams = p;
 
-            var ironPythonVersion = new Version(3, 0, 0);
+            var ironPythonVersion = new Version(3, 2, 0);
             if(LoadedParams.StartupParams.Preferences is PreferenceSettings prefs)
             {
                  Version.TryParse(prefs.IronPythonResolveTargetVersion,out ironPythonVersion);


### PR DESCRIPTION
So that users get the latest version of the IronPython2.7 package with the latest fixes for net8 we update the target version in the prefs.

