### PR TITLE
Update Directory.Build.props in the test folder

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
     <TestProject>true</TestProject>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\src\</SolutionDir>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update the Directory.Build.props in the test folder to add the SolutionDir property. It seems that if a Directory.Build.props is found in a subfolder, msbuild does not look in parent folders for other props files.

Issue:
Dotnet list packages command from the root folder does not work for test projects.