### PR TITLE
Update DynamoVisualProgramming.ZeroTouchLibrary.nuspec to support multitarget

### DIFF
--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.ZeroTouchLibrary.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.ZeroTouchLibrary.nuspec
@@ -16,6 +16,9 @@
             <group targetFramework="$TargetFramework$">
                 <dependency id="DynamoVisualProgramming.DynamoServices" version="$Version$"/>
             </group>
+            <group targetFramework="netstandard2.0">
+                <dependency id="DynamoVisualProgramming.DynamoServices" version="$Version$"/>
+            </group>
         </dependencies>
     </metadata>
     <!--for now we assume that that the working directory root is dynamo/bin/AnyCPU/Release-->
@@ -25,6 +28,9 @@
         <file src="ProtoGeometry.dll" target="lib\$TargetFramework$" />
         <file src="ProtoGeometry.xml" target="lib\$TargetFramework$" />
         
+        <file src="ProtoGeometry.dll" target="lib\netstandard2.0" />
+        <file src="ProtoGeometry.xml" target="lib\netstandard2.0" />
+
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
     </files>
 </package>


### PR DESCRIPTION
Add netstandard2.0 target for ZeroTouchLibrary 
ZeroTouchLibrary could be used for libraries that need to support both 2.19 and 3.0 versions of Dynamo