### PR TITLE
DYN-6603 TSplines Lucene Search

### DIFF
--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -234,6 +234,8 @@ namespace Dynamo.Utilities
         internal void SetDocumentFieldValue(Document doc, string field, string value, bool isTextField = true, bool isLast = false)
         {
             string[] indexedFields = null;
+            const string tsplinesNodesCategory = "tspline";
+
             if (startConfig.Directory.Equals(LuceneConfig.NodesIndexingDirectory))
             {
                 indexedFields = LuceneConfig.NodeIndexFields;
@@ -247,6 +249,10 @@ namespace Dynamo.Utilities
             if (isTextField && !field.Equals("DocName"))
             {
                 ((TextField)doc.GetField(field)).SetStringValue(value);
+
+                //Index-time boost, incremeting the weight for TSpline nodes
+                if (!string.IsNullOrEmpty(value) && value.ToLower().Contains(tsplinesNodesCategory))
+                    ((TextField)doc.GetField(field)).Boost += 1;
             }
             else
             {


### PR DESCRIPTION
### Purpose

Changing weight for TSpline nodes.
Changing the Weight for TSpline nodes at indexing time, so when we are searching terms like "cone", "sphere", "plane" the tsplines nodes will be shown at the top (before the Dynamo out-of-box nodes).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Changing weight for TSpline nodes.

### Reviewers

@QilongTang @reddyashish 

### FYIs

