### PR TITLE
[DYN-6616] Restore the Not Authenticated message when an unauthenticated user triggers ML Nodeautocomplete

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -452,8 +452,12 @@ namespace Dynamo.ViewModels
                     var uri = DynamoUtilities.PathHelper.GetServiceBackendAddress(this, nodeAutocompleteMLEndpoint);
                     var client = new RestClient(uri);
                     var request = new RestRequest(string.Empty,Method.Post);
-
-                    request.AddHeader("Authorization",$"Bearer {tokenprovider?.GetAccessToken()}");
+                    var tkn = tokenprovider?.GetAccessToken();
+                    if (string.IsNullOrEmpty(tkn))
+                    {
+                        throw new Exception("Authentication required.");
+                    }
+                    request.AddHeader("Authorization",$"Bearer {tkn}");
                     request = request.AddJsonBody(requestJSON);
                     request.RequestFormat = DataFormat.Json;
                     RestResponse response = client.Execute(request);


### PR DESCRIPTION
### Purpose

The PR restores the not Authenticated message when an unauthenticated user triggers ML Nodeautocomplete suggestions.
(This will not trigger login, unlike 2.19)

![DynamoSandbox_wfUt8JjZ3T](https://github.com/DynamoDS/Dynamo/assets/32665108/d3636a5a-72a2-4ffa-bdf5-8517fd7be344)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Restore the Not Authenticated message when an unauthenticated user triggers ML Nodeautocomplete

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Amoursol 
