### PR TITLE
DYN-6440 Custom Selection Overlapped

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1988,7 +1988,7 @@
                                  Focusable="True"
                                  TextWrapping="Wrap"
                                  TextTrimming="CharacterEllipsis"
-                                 Visibility="Collapsed" /> 
+                                 Visibility="{Binding IsVisibleDropDownTextBlock, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" /> 
                         <Popup Name="Popup"
                                AllowsTransparency="True"
                                Focusable="False"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1982,13 +1982,10 @@
                                  IsReadOnly="{TemplateBinding IsReadOnly}"
                                  Visibility="Hidden" />
                         <TextBlock x:Name="PART_ReadOnlyTextBlock"
-                                 Margin="0,0,25,4"
+                                 Margin="10,0,20,0"
                                  HorizontalAlignment="Left"
                                  VerticalAlignment="Center"
                                  Focusable="True"
-                                 FontFamily="{StaticResource ArtifaktElementRegular}"
-                                 FontSize="18px"
-                                 Foreground="#F5F5F5"
                                  TextWrapping="Wrap"
                                  TextTrimming="CharacterEllipsis"
                                  Visibility="Collapsed" /> 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1981,6 +1981,17 @@
                                  Foreground="#F5F5F5"
                                  IsReadOnly="{TemplateBinding IsReadOnly}"
                                  Visibility="Hidden" />
+                        <TextBlock x:Name="PART_ReadOnlyTextBlock"
+                                 Margin="0,0,25,4"
+                                 HorizontalAlignment="Left"
+                                 VerticalAlignment="Center"
+                                 Focusable="True"
+                                 FontFamily="{StaticResource ArtifaktElementRegular}"
+                                 FontSize="18px"
+                                 Foreground="#F5F5F5"
+                                 TextWrapping="Wrap"
+                                 TextTrimming="CharacterEllipsis"
+                                 Visibility="Collapsed" /> 
                         <Popup Name="Popup"
                                AllowsTransparency="True"
                                Focusable="False"

--- a/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModels/Input/CustomSelection.cs
@@ -29,6 +29,23 @@ namespace CoreNodeModels.Input
     public class CustomSelection : DSDropDownBase
     {
         private List<DynamoDropDownItem> serializedItems;
+        private bool isVisibleDropDownTextBlock = false;
+
+        /// <summary>
+        /// This property will Collapse or make Visible the TextBlock for the ComboBox template "RefreshComboBox" (by default will be Collapsed)
+        /// </summary>
+        public bool IsVisibleDropDownTextBlock
+        {
+            get
+            {
+                return isVisibleDropDownTextBlock;
+            }
+            set
+            {
+                isVisibleDropDownTextBlock = value;
+                RaisePropertyChanged(nameof(IsVisibleDropDownTextBlock));
+            }
+        }
 
         /// <summary>
         /// Copy of <see cref="DSDropDownBase.Items"/> to be serialized./>

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
@@ -6,7 +6,6 @@ using System.Windows;
 using Dynamo.Wpf;
 using CoreNodeModels;
 using System.Windows.Data;
-using System.Runtime.InteropServices;
 
 namespace CoreNodeModelsWpf.Nodes
 {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
@@ -4,6 +4,8 @@ using CoreNodeModelsWpf.Controls;
 using System.Windows.Controls;
 using System.Windows;
 using Dynamo.Wpf;
+using CoreNodeModels;
+using System.Windows.Data;
 
 namespace CoreNodeModelsWpf.Nodes
 {
@@ -36,6 +38,27 @@ namespace CoreNodeModelsWpf.Nodes
             // Add margin to the dropdown to show the expander.
             dropdown.Margin = new Thickness(leftMargin, 0, 0, 0);
             dropdown.VerticalAlignment = VerticalAlignment.Top;
+            dropdown.ApplyTemplate();
+
+            var dropDownTextBlock = dropdown.Template.FindName("PART_ReadOnlyTextBlock", dropdown) as TextBlock;
+            if (dropDownTextBlock != null)
+            {
+                dropDownTextBlock.Visibility = Visibility.Visible;
+            }
+
+            var dropDownContent = dropdown.Template.FindName("ContentSite", dropdown) as ContentPresenter;
+            if (dropDownContent != null)
+            {
+                dropDownContent.Visibility = Visibility.Collapsed;
+            }
+
+            // Bind the TextBlock to the selected item hash.
+            var bindingVal = new Binding(nameof(DSDropDownBase.SelectedString))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = model
+            };
+            dropDownTextBlock.SetBinding(TextBlock.TextProperty, bindingVal);
         }
 
         private void BaseComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
@@ -6,6 +6,8 @@ using System.Windows;
 using Dynamo.Wpf;
 using CoreNodeModels;
 using System.Windows.Data;
+using System.Data.Common;
+using System;
 
 namespace CoreNodeModelsWpf.Nodes
 {
@@ -14,6 +16,7 @@ namespace CoreNodeModelsWpf.Nodes
     /// </summary>
     public class CustomSelectionNodeViewCustomization : DropDownNodeViewCustomization, INodeViewCustomization<CustomSelection>
     {
+        private CustomSelectionControl formControl;
         /// <summary>
         /// Customize the visual appearance of the custom dropdown node.
         /// </summary>
@@ -22,7 +25,7 @@ namespace CoreNodeModelsWpf.Nodes
         public void CustomizeView(CustomSelection model, NodeView nodeView)
         {
             const double leftMargin = 40;
-            var formControl = new CustomSelectionControl(new CustomSelectionViewModel(model));
+            formControl = new CustomSelectionControl(new CustomSelectionViewModel(model));
 
             nodeView.inputGrid.Children.Add(formControl);
 
@@ -43,6 +46,8 @@ namespace CoreNodeModelsWpf.Nodes
             var dropDownTextBlock = dropdown.Template.FindName("PART_ReadOnlyTextBlock", dropdown) as TextBlock;
             if (dropDownTextBlock != null)
             {
+                //IsVisibleDropDownTextBlock will be false by default so the TextBlock (located in the ComboBox template) will be Collapsed then just when is a Custom Selection node we set the value to true and the TextBlock will be visible
+                //We used a TextBlock because the normal TextBox doesn't have the TextTrimming property and the requirement was asking for setting TextTrimming="CharacterEllipsis"
                 model.IsVisibleDropDownTextBlock = true;
             }
 
@@ -68,6 +73,20 @@ namespace CoreNodeModelsWpf.Nodes
             {
                 comboSender.ToolTip = comboSender.SelectedItem?.ToString();
             }           
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                formControl.BaseComboBox.SelectionChanged -= BaseComboBox_SelectionChanged;
+            }
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
@@ -19,6 +19,7 @@ namespace CoreNodeModelsWpf.Nodes
         /// <param name="nodeView"></param>
         public void CustomizeView(CustomSelection model, NodeView nodeView)
         {
+            const double leftMargin = 40;
             var formControl = new CustomSelectionControl(new CustomSelectionViewModel(model));
 
             nodeView.inputGrid.Children.Add(formControl);
@@ -27,12 +28,23 @@ namespace CoreNodeModelsWpf.Nodes
             base.CustomizeView(model, nodeView);
 
             var dropdown = (ComboBox)nodeView.inputGrid.Children[1];
+            dropdown.MaxWidth = formControl.Width - leftMargin;
 
             formControl.BaseComboBox = dropdown;
+            formControl.BaseComboBox.SelectionChanged += BaseComboBox_SelectionChanged;
 
             // Add margin to the dropdown to show the expander.
-            dropdown.Margin = new Thickness(40, 0, 0, 0);
+            dropdown.Margin = new Thickness(leftMargin, 0, 0, 0);
             dropdown.VerticalAlignment = VerticalAlignment.Top;
+        }
+
+        private void BaseComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var comboSender = sender as ComboBox;
+            if (comboSender != null)
+            {
+                comboSender.ToolTip = comboSender.SelectedItem?.ToString();
+            }           
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CustomSelection.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using Dynamo.Wpf;
 using CoreNodeModels;
 using System.Windows.Data;
+using System.Runtime.InteropServices;
 
 namespace CoreNodeModelsWpf.Nodes
 {
@@ -43,7 +44,7 @@ namespace CoreNodeModelsWpf.Nodes
             var dropDownTextBlock = dropdown.Template.FindName("PART_ReadOnlyTextBlock", dropdown) as TextBlock;
             if (dropDownTextBlock != null)
             {
-                dropDownTextBlock.Visibility = Visibility.Visible;
+                model.IsVisibleDropDownTextBlock = true;
             }
 
             var dropDownContent = dropdown.Template.FindName("ContentSite", dropdown) as ContentPresenter;


### PR DESCRIPTION
### Purpose

Fixing problem with large text in the Custom Selection nodes.
When choosing a large string text from the ComboBox was overlapping other controls at left side then for fixing this bug I've added a new TextBlock that will hidden for all the nodes but will be shown just for Custom Selection nodes.
This new TextBlock will show "..." at the end of the string when trying to display a very large text.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing problem with large text in the Custom Selection nodes.

### Reviewers

@QilongTang 

### FYIs

@avidit 
