### PR TITLE
DYN-6603 decrease weight for tspline nodes

### DIFF
--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -231,6 +231,7 @@ namespace Dynamo.Utilities
         /// <param name="value">Field value</param>
         /// <param name="isTextField">This is used when the value need to be tokenized(broken down into pieces), whereas StringTextFields are tokenized.</param>
         /// <param name="isLast">This is used for the last value set in the document. It will fetch all the fields not set in the document and add them with an empty string.</param>
+        /// <param name="isTSpline">Indicate if the field being indexed belongs to a T-Spline node or not</param>
         internal void SetDocumentFieldValue(Document doc, string field, string value, bool isTextField = true, bool isLast = false, bool isTSpline = false)
         {
             string[] indexedFields = null;

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -231,7 +231,7 @@ namespace Dynamo.Utilities
         /// <param name="value">Field value</param>
         /// <param name="isTextField">This is used when the value need to be tokenized(broken down into pieces), whereas StringTextFields are tokenized.</param>
         /// <param name="isLast">This is used for the last value set in the document. It will fetch all the fields not set in the document and add them with an empty string.</param>
-        internal void SetDocumentFieldValue(Document doc, string field, string value, bool isTextField = true, bool isLast = false)
+        internal void SetDocumentFieldValue(Document doc, string field, string value, bool isTextField = true, bool isLast = false, bool isTSpline = false)
         {
             string[] indexedFields = null;
             if (startConfig.Directory.Equals(LuceneConfig.NodesIndexingDirectory))
@@ -247,6 +247,10 @@ namespace Dynamo.Utilities
             if (isTextField && !field.Equals("DocName"))
             {
                 ((TextField)doc.GetField(field)).SetStringValue(value);
+
+                //Index-time boost, setting the weight to 0 for TSpline nodes and 1 for the other nodes, this only apply for Description and SearchKeywords fields
+                ((TextField)doc.GetField(field)).SetStringValue(value);
+                ((TextField)doc.GetField(field)).Boost = isTSpline == true ? 0 : 1;
             }
             else
             {
@@ -559,6 +563,8 @@ namespace Dynamo.Utilities
             // If the index writer is still null, skip the indexing
             if (writer == null) return;
 
+            bool isTSplineNode = node.FullCategoryName.ToLower().Contains("tspline")? true: false;
+
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.FullCategoryName), node.FullCategoryName);
 
             var categoryParts = node.FullCategoryName.Split('.');
@@ -572,10 +578,10 @@ namespace Dynamo.Utilities
             string nameParsed = nameParts.Length > 1 ? nameParts[nameParts.Length - 1] : node.Name;
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.NameSplitted), nameParsed);
 
-            SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), node.Description);
+            SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), node.Description, true, false, isTSplineNode);
             if (node.SearchKeywords.Count > 0)
             {
-                SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true);
+                SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), node.SearchKeywords.Aggregate((x, y) => x + " " + y), true, true, isTSplineNode);
             }
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Parameters), node.Parameters ?? string.Empty);
 

--- a/test/DynamoCoreWpfTests/SearchSideEffects.cs
+++ b/test/DynamoCoreWpfTests/SearchSideEffects.cs
@@ -10,7 +10,9 @@ namespace Dynamo.Tests
     {
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
+            libraries.Add("VMDataBridge.dll");
             libraries.Add("DSCoreNodes.dll");
+            libraries.Add("ProtoGeometry.dll");
         }
 
         [SetUp]
@@ -213,6 +215,45 @@ namespace Dynamo.Tests
                 //Check that the result match the expected position
                 Assert.AreEqual(nodesNamesList.ElementAt(i), expectedSearchResults2.ElementAt(i));
             }
+        }
+
+        //This test will validate that resulting nodes have a specific order when having T-Spline nodes in the nodes list.
+        [Test]
+        [Category("UnitTests")]
+        public void LuceneSearchTSplineNodesOrderingValidation()
+        {
+            Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), ViewModel.Model.CurrentWorkspace);
+            string[] searchTerms = { "sphere", "cone" };
+
+            // Search for "sphere" and check that the results are correct based in the node name provided for the searchTerms
+            var nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(searchTerms[0]);
+
+            Assert.IsNotNull(nodesResult);
+            Assert.That(nodesResult.Count(), Is.GreaterThan(0));
+            var firstTSpline = nodesResult.Take(5).ToList().FindIndex(x => x.Class.ToLower().Contains("tspline"));
+
+            //Take the first 5 elements, get the ones that belong to the expected category and finally get the index in the list
+            var firstCatExpectedNode = nodesResult.Take(5).ToList().FindIndex(x => x.Class.ToLower().Contains(searchTerms[0]));
+
+            //Validate that the normal node (category Sphere) will be at index 0 (first place) and the TSpline node at index 3 (3 > 0)
+            Assert.That(firstTSpline > firstCatExpectedNode);
+
+            // Search for "cone "and check that the results are correct based in the node name provided for the searchTerms
+            nodesResult = ViewModel.CurrentSpaceViewModel.InCanvasSearchViewModel.Search(searchTerms[1]);
+
+            Assert.IsNotNull(nodesResult);
+            Assert.That(nodesResult.Count(), Is.GreaterThan(0));
+            firstTSpline = nodesResult.Take(5).ToList().FindIndex(x => x.Class.ToLower().Contains("tspline"));
+
+            //Take the first 5 elements, get the ones that belong to the expected category and finally get the index in the list
+            firstCatExpectedNode = nodesResult.Take(5).ToList().FindIndex(x => x.Class.ToLower().Contains(searchTerms[1]));
+
+            //Validate that T-Spline nodes are not found in the results
+            Assert.That(firstTSpline == -1);
+
+            //Validate that the normal node (category Cone) will be at index 0 (first place)
+            Assert.That(firstCatExpectedNode == 0);
+
         }
     }
 }


### PR DESCRIPTION
### Purpose

Decreasing t-spline nodes weight during search so we will see nodes under a specific category at the top and later t-spline nodes.
I've changed the weight of Spline nodes at indexing time so when using criteria like "sphere" will show first the nodes under the Sphere category and later the T-Spline nodes which has the text "sphere" in the name. For implementing  the expected behavior I've decreased the weight of the fields Description and SearchKeywords just for t-spline nodes.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Decreasing t-spline nodes weight during search so we will see nodes under a specific category at the top and later t-spline nodes.

### Reviewers

@QilongTang @reddyashish 

### FYIs

