### PR TITLE
DYN-6728 feature flags should be controlled by no network mode when creating a dynamo model directly.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -702,6 +702,10 @@ namespace Dynamo.Models
                     // Do nothing for now
                 }
             }
+            //align disable analytics with nonetwork mode, this is done in other entry points(CLI,Sandbox etc) - but
+            //not all integrators will use those entry points, some may just create a DynamoModel directly.
+            //TODO write test that checks these are equal.
+            Analytics.DisableAnalytics = NoNetworkMode;
 
             // If user skipped analytics from assembly config, do not try to launch the analytics client
             // or the feature flags client for web traffic reason.

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -702,9 +702,10 @@ namespace Dynamo.Models
                     // Do nothing for now
                 }
             }
-            //align disable analytics with nonetwork mode, this is done in other entry points(CLI,Sandbox etc) - but
+            //If network traffic is disabled, analytics should also be disabled - this is already done in
+            //our other entry points(CLI,Sandbox etc) - but
             //not all integrators will use those entry points, some may just create a DynamoModel directly.
-            Analytics.DisableAnalytics = NoNetworkMode;
+            Analytics.DisableAnalytics = NoNetworkMode || Analytics.DisableAnalytics;
 
             // If user skipped analytics from assembly config, do not try to launch the analytics client
             // or the feature flags client for web traffic reason.

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -704,7 +704,6 @@ namespace Dynamo.Models
             }
             //align disable analytics with nonetwork mode, this is done in other entry points(CLI,Sandbox etc) - but
             //not all integrators will use those entry points, some may just create a DynamoModel directly.
-            //TODO write test that checks these are equal.
             Analytics.DisableAnalytics = NoNetworkMode;
 
             // If user skipped analytics from assembly config, do not try to launch the analytics client

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -705,7 +705,7 @@ namespace Dynamo.Models
 
             // If user skipped analytics from assembly config, do not try to launch the analytics client
             // or the feature flags client for web traffic reason.
-            if (!IsServiceMode && !areAnalyticsDisabledFromConfig && !Analytics.DisableAnalytics)
+            if (!IsServiceMode && !areAnalyticsDisabledFromConfig && !Analytics.DisableAnalytics && !NoNetworkMode)
             {
                 HandleAnalytics();
 

--- a/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
+++ b/test/DynamoCoreTests/Logging/AnalyticsServiceTest.cs
@@ -80,5 +80,72 @@ namespace Dynamo.Tests.Loggings
                 dynamoCLI?.Kill();
             }
         }
+
+        [Test]
+        [Platform("win")]//nunit attribute for now only run on windows until we know it's useful on linux.
+        public void DisableAnalyticsViaNoNetWorkMode()
+        {
+            var versions = new List<Version>(){
+
+                    new Version(230, 0,0),
+            };
+
+            var directory = new DirectoryInfo(Assembly.GetExecutingAssembly().Location);
+            var testDirectory = Path.Combine(directory.Parent.Parent.Parent.FullName, "test");
+            string openPath = Path.Combine(testDirectory, @"core\Angle.dyn");
+            //go get a valid asm path.
+            var locatedPath = string.Empty;
+            var coreDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            Process dynamoCLI = null;
+            //TODO an approach we could take to get this running on linux.
+            //unclear if this needs to be compiled with an ifdef or runtime is ok.
+            //related to https://jira.autodesk.com/browse/DYN-5705
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                DynamoShapeManager.Utilities.SearchForASMInLibGFallback(versions, ref locatedPath, coreDirectory, out _);
+            }
+            else
+            {
+                DynamoShapeManager.Utilities.GetInstalledAsmVersion2(versions, ref locatedPath, coreDirectory);
+            }
+            try
+            {
+                Assert.DoesNotThrow(() =>
+                {
+
+                    dynamoCLI = Process.Start(new ProcessStartInfo(Path.Combine(coreDirectory, "DynamoCLI.exe"), $"--GeometryPath \"{locatedPath}\" -k --NoNetworkMode -o \"{openPath}\" ") { UseShellExecute = true });
+
+                    Thread.Sleep(5000);// Wait 5 seconds to open the dyn
+                    Assert.IsFalse(dynamoCLI.HasExited);
+                    var dt = DataTarget.AttachToProcess(dynamoCLI.Id, false);
+                    var assemblies = dt
+                          .ClrVersions
+                          .Select(dtClrVersion => dtClrVersion.CreateRuntime())
+                          .SelectMany(runtime => runtime.AppDomains.SelectMany(runtimeAppDomain => runtimeAppDomain.Modules))
+                          .Select(clrModule => clrModule.AssemblyName)
+                          .Distinct()
+                          .Where(x => x != null)
+                          .ToList();
+
+                    var firstASMmodulePath = string.Empty;
+                    foreach (string module in assemblies)
+                    {
+                        if (module.IndexOf("Analytics", StringComparison.OrdinalIgnoreCase) != -1)
+                        {
+                            Assert.Fail("Analytics module was loaded");
+                        }
+                        if (module.IndexOf("AdpSDKCSharpWrapper", StringComparison.OrdinalIgnoreCase) != -1)
+                        {
+                            Assert.Fail("ADP module was loaded");
+                        }
+                    }
+                });
+            }
+            finally
+            {
+
+                dynamoCLI?.Kill();
+            }
+        }
     }
 }

--- a/test/System/IntegrationTests/DynamoApplicationTests.cs
+++ b/test/System/IntegrationTests/DynamoApplicationTests.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Dynamo.Applications;
+using Dynamo.Logging;
 using Dynamo.Models;
 using NUnit.Framework;
+using static Dynamo.Models.DynamoModel;
 
 namespace IntegrationTests
 {
@@ -63,6 +65,14 @@ namespace IntegrationTests
         {
             var model = Dynamo.Applications.StartupUtils.MakeModel(false, string.Empty, "DynamoFormIt");
             Assert.AreEqual(DynamoModel.HostAnalyticsInfo.HostName, "DynamoFormIt");
+        }
+        [Test]
+        public void DynamoModelStartedWithNoNetworkMode_AlsoDisablesAnalytics()
+        {
+            var startConfig = new DefaultStartConfiguration() { NoNetworkMode = true };
+            var model = DynamoModel.Start(startConfig);
+            Assert.AreEqual(true, Analytics.DisableAnalytics);
+            model.ShutDown(false);
         }
 
         [Test]

--- a/test/System/IntegrationTests/DynamoApplicationTests.cs
+++ b/test/System/IntegrationTests/DynamoApplicationTests.cs
@@ -74,6 +74,15 @@ namespace IntegrationTests
             Assert.AreEqual(true, Analytics.DisableAnalytics);
             model.ShutDown(false);
         }
+        [Test]
+        public void DynamoModelStartedWithNoNetworkModeFalse_DisablesAnalyticsCanBeTrue()
+        {
+            var startConfig = new DefaultStartConfiguration() { NoNetworkMode = false };
+            Analytics.DisableAnalytics = true;
+            var model = DynamoModel.Start(startConfig);
+            Assert.AreEqual(true, Analytics.DisableAnalytics);
+            model.ShutDown(false);
+        }
 
         [Test]
         public void IfASMPathInvalidExceptionNotThrown()


### PR DESCRIPTION
### Purpose

[DYN-6728](https://jira.autodesk.com/browse/DYN-6728)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

fixed a bug where no network mode might not control feature flags retrieval for some dynamo integrations.
### Reviewers

