### PR TITLE
DYN-6187: Dash in the middle of a sentence should not be converted to bullet point

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -290,7 +290,7 @@ namespace Dynamo.Nodes
             // dont convert it to bullet
             bool lineContainsBullet = BULLETS_CHARS.Where(b => line.Contains(b)).Any();
             var textBeforeCaret = line.Substring(0, caretAtLine);
-            if (!StringUtils.IsStringSpacesWithTabs(textBeforeCaret)|| lineContainsBullet)
+            if (!StringUtils.IsStringSpacesWithTabs(textBeforeCaret) || lineContainsBullet)
             {
                 line = line.Insert(caretAtLine, "-");
                 return StringUtils.ReplaceLineOfText(text, lineNumber, line);

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -290,7 +290,7 @@ namespace Dynamo.Nodes
             // dont convert it to bullet
             bool lineContainsBullet = BULLETS_CHARS.Where(b => line.Contains(b)).Any();
             var textBeforeCaret = line.Substring(0, caretAtLine);
-            if (!StringUtils.IsStringSpacesWithTabs(textBeforeCaret)&& !lineContainsBullet)
+            if (!StringUtils.IsStringSpacesWithTabs(textBeforeCaret) || lineContainsBullet)
             {
                 line = line.Insert(caretAtLine, "-");
                 return StringUtils.ReplaceLineOfText(text, lineNumber, line);

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -290,7 +290,7 @@ namespace Dynamo.Nodes
             // dont convert it to bullet
             bool lineContainsBullet = BULLETS_CHARS.Where(b => line.Contains(b)).Any();
             var textBeforeCaret = line.Substring(0, caretAtLine);
-            if (!StringUtils.IsStringSpacesWithTabs(textBeforeCaret) || lineContainsBullet)
+            if (!StringUtils.IsStringSpacesWithTabs(textBeforeCaret)|| lineContainsBullet)
             {
                 line = line.Insert(caretAtLine, "-");
                 return StringUtils.ReplaceLineOfText(text, lineNumber, line);


### PR DESCRIPTION
### Purpose

Small PR that fixes a bug which converts dash to bullet point in the middle of a Note line if a bullet point has been used previously in the text of the Note.

The PR addresses the following Jira issue: https://jira.autodesk.com/browse/DYN-6187

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/75697a0a-d70d-4aa9-ad31-aa661b54e46d)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Dash in the middle of a sentence should not be converted to bullet

### Reviewers

@dnenov
@reddyashish

### FYIs

@Amoursol
