### PR TITLE
[DYN-6361] Bugfix copy/paste operation conflict between library search and Workspace

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -237,6 +237,8 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// <param name="text">text to be added to clipboard</param>
         internal void OnCopyToClipboard(string text)
         {
+            dynamoViewModel.Model.ClipBoard.Clear();
+            Clipboard.Clear();
             Clipboard.SetText(text);
         }
 

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -238,7 +238,6 @@ namespace Dynamo.LibraryViewExtensionWebView2
         internal void OnCopyToClipboard(string text)
         {
             dynamoViewModel.Model.ClipBoard.Clear();
-            Clipboard.Clear();
             Clipboard.SetText(text);
         }
 


### PR DESCRIPTION
### Purpose
Fix Library search copy/paste operation misbehavior that affects Workspace.
Ref.: [DYN-6361](https://jira.autodesk.com/browse/DYN-6361)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Reviewers

@QilongTang 

### FYIs

@avidit 
