### PR TITLE
DYN-6619-Localizing-StreamWriter-Exception

### DIFF
--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -55,6 +55,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ExportSampleImagesViewExtension")]
 [assembly: InternalsVisibleTo("DocumentationBrowserViewExtension")]
 [assembly: InternalsVisibleTo("Notifications")]
+[assembly: InternalsVisibleTo("DSOffice")]
 
 // Disable PublicAPIAnalyzer errors for this type as they're already added to the public API text file
 #pragma warning disable RS0016 

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1952,6 +1952,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file or directory cannot be found.
+        /// </summary>
+        public static string StreamWriterNotFoundException {
+            get {
+                return ResourceManager.GetString("StreamWriterNotFoundException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Creates a string..
         /// </summary>
         public static string StringNodeDescription {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -911,4 +911,7 @@ This package likely contains an assembly that is blocked. You will need to load 
   <data name="LegacyTraceDataWarning" xml:space="preserve">
     <value>This workspace contains element binding data in a legacy format that is no longer supported in Dynamo 3.0 and higher versions. Element binding data will be saved in the new format the next time you run and save this workspace.</value>
   </data>
+  <data name="StreamWriterNotFoundException" xml:space="preserve">
+    <value>The file or directory cannot be found</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -914,4 +914,7 @@ This package likely contains an assembly that is blocked. You will need to load 
   <data name="LegacyTraceDataWarning" xml:space="preserve">
     <value>This workspace contains element binding data in a legacy format that is no longer supported in Dynamo 3.0 and higher versions. Element binding data will be saved in the new format the next time you run and save this workspace.</value>
   </data>
+  <data name="StreamWriterNotFoundException" xml:space="preserve">
+    <value>The file or directory cannot be found</value>
+  </data>
 </root>

--- a/src/DynamoCore/Utilities/LocalizedExceptionHelper.cs
+++ b/src/DynamoCore/Utilities/LocalizedExceptionHelper.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using Dynamo.Properties;
+
+namespace Dynamo.Utilities
+{
+    internal static class LocalizedExceptionHelper
+    {
+        /// <summary>
+        /// This method will throw the exception with the translated string according to the selected Language in Dynamo
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <exception cref="Exception"></exception>
+        internal static void ThrowLocalizedException(Exception ex)
+        {
+            if (ex is DirectoryNotFoundException)
+                throw new Exception(Resources.StreamWriterNotFoundException);
+            else
+                throw ex;
+        }
+    }
+}

--- a/src/Libraries/DSOffice/CSVNodes.cs
+++ b/src/Libraries/DSOffice/CSVNodes.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Dynamo.Utilities;
 
 namespace DSOffice
 {
@@ -20,19 +21,26 @@ namespace DSOffice
         /// <search>write,text,file</search>
         public static void ExportCSV(string filePath, object[][] data)
         {
-            using (var writer = new StreamWriter(DSCore.IO.FileSystem.AbsolutePath(filePath)))
+            try
             {
-                foreach (var line in data)
+                using (var writer = new StreamWriter(DSCore.IO.FileSystem.AbsolutePath(filePath)))
                 {
-                    int count = 0;
-                    foreach (var entry in line)
+                    foreach (var line in data)
                     {
-                        writer.Write(entry);
-                        if (++count < line.Length)
-                            writer.Write(",");
+                        int count = 0;
+                        foreach (var entry in line)
+                        {
+                            writer.Write(entry);
+                            if (++count < line.Length)
+                                writer.Write(",");
+                        }
+                        writer.WriteLine();
                     }
-                    writer.WriteLine();
                 }
+            }
+            catch (Exception ex)
+            {
+                LocalizedExceptionHelper.ThrowLocalizedException(ex);
             }
         }
 


### PR DESCRIPTION
### Purpose

Localizing System StreamWriter exception
I added a static class and a static method that will throw a DirectoryNotFoundException with the translated string (added in Resources.resx). If we want to add more exceptions we will need to modify the LocalizedExceptionHelper to include the new one.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Localizing System StreamWriter exception

### Reviewers

@QilongTang 

### FYIs

