### PR TITLE
feat: localized no-notifications message

### DIFF
--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -140,6 +140,9 @@ namespace Dynamo.Notifications
 
             string setBottomButtonText = String.Format("window.setBottomButtonText('{0}');", Properties.Resources.NotificationsCenterBottomButtonText);
             InvokeJS(setBottomButtonText);
+
+            string setNoNotificationsTexts = String.Format("window.setNoNotificationsTexts('{{\"title\":\"{0}\", \"msg\":\"{1}\"}}');", Properties.Resources.NoNotificationsTitle, Properties.Resources.NoNotificationsMsg);
+            InvokeJS(setNoNotificationsTexts);
         }
 
         private void AddNotifications(List<NotificationItemModel> notifications)

--- a/src/Notifications/Properties/Resources.Designer.cs
+++ b/src/Notifications/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Notifications.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -111,6 +111,24 @@ namespace Dynamo.Notifications.Properties {
         public static string ExtensionName {
             get {
                 return ResourceManager.GetString("ExtensionName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You currently have no notifications. New notifications will appear above.
+        /// </summary>
+        public static string NoNotificationsMsg {
+            get {
+                return ResourceManager.GetString("NoNotificationsMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No notifications.
+        /// </summary>
+        public static string NoNotificationsTitle {
+            get {
+                return ResourceManager.GetString("NoNotificationsTitle", resourceCulture);
             }
         }
         

--- a/src/Notifications/Properties/Resources.en-US.resx
+++ b/src/Notifications/Properties/Resources.en-US.resx
@@ -135,6 +135,12 @@
   <data name="ExtensionName" xml:space="preserve">
     <value>Notifications</value>
   </data>
+  <data name="NoNotificationsMsg" xml:space="preserve">
+    <value>You currently have no notifications. New notifications will appear above</value>
+  </data>
+  <data name="NoNotificationsTitle" xml:space="preserve">
+    <value>No notifications</value>
+  </data>
   <data name="NotificationCenterDisabledMsg" xml:space="preserve">
     <value>Notification Center feature is disabled. Enable it in preference panel to see latest news.</value>
   </data>


### PR DESCRIPTION

### Purpose

This PR add the implementation for localized message when there's no notifications to show
Ref.: [DYN-6484](https://jira.autodesk.com/browse/DYN-6484)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Implement message in resources `NoNotificationsTitle` and `NoNotificationsMsg` with respective text associated and expose setNoNotificationsTexts() through Windows object to make it accessible from NotificationCenter react component.

### Reviewers
@QilongTang 

