### PR TITLE
[DYN-6666] Improvements to workspace checksum that is needed for Dynamo ML data pipeline.

### DIFF
--- a/src/DynamoCore/Configuration/GraphChecksumItem.cs
+++ b/src/DynamoCore/Configuration/GraphChecksumItem.cs
@@ -1,17 +1,26 @@
 using System;
-using System.Collections.ObjectModel;
-using Dynamo.Core;
-using Dynamo.Properties;
+using System.Collections.Generic;
 
 namespace Dynamo.Configuration
 {
     /// <summary>
     /// Represents the stringified version of the nodes connections from a graph
     /// </summary>
+    [Obsolete("This property is not needed anymore in the preference settings and can be removed in a future version of Dynamo.")]
     public class GraphChecksumItem
     {
         public string GraphId { get; set; }
 
         public string Checksum { get; set; }   
+    }
+
+    /// <summary>
+    /// Represents the stringified version of the nodes connections from a graph
+    /// </summary>
+    public class GraphChecksumPair
+    {
+        public string GraphId { get; set; }
+
+        public List<string> Checksum { get; set; }
     }
 }

--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -148,6 +148,7 @@ namespace Dynamo.Interfaces
         /// <param name="value">Active state to set</param>
         void SetIsBackgroundPreviewActive(string name, bool value);
 
+        [Obsolete("This property is not needed anymore in the preference settings and can be removed in a future version of Dynamo.")]
         /// <summary>
         /// Return a list of GraphChecksumItems
         /// </summary>

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -472,6 +472,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Return a list of GraphChecksumItems
         /// </summary>
+        [Obsolete("This property is not needed anymore in the preference settings and can be removed in a future version of Dynamo.")]
         public List<GraphChecksumItem> GraphChecksumItemsList { get; set; }
 
         // This function is used to deserialize the trusted locations manually

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -148,6 +148,16 @@ namespace Dynamo.Models
             }
         }
 
+        /// <summary>
+        /// Return a dictionary of GraphChecksumItems
+        /// </summary>
+        internal Dictionary<string, List<string>> GraphChecksumDictionary { get; set; }
+
+        /// <summary>
+        /// Return a list of GraphChecksumItems
+        /// </summary>
+        public List<GraphChecksumPair> GraphChecksumList { get; set; }
+
         #endregion
 
         #region static properties
@@ -979,6 +989,10 @@ namespace Dynamo.Models
             {
                 LuceneUtility.DisposeWriter();
             }
+
+            GraphChecksumList = new List<GraphChecksumPair>();
+            GraphChecksumDictionary = new Dictionary<string, List<string>>();
+                 
             // This event should only be raised at the end of this method.
             DynamoReady(new ReadyParams(this));
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -149,7 +149,8 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// Return a dictionary of GraphChecksumItems
+        /// Return a dictionary of GraphChecksumItems.
+        /// Key will be the workspace guid and its value will be a list of saved checksums(sha256 hash) for that workspace.
         /// </summary>
         internal Dictionary<string, List<string>> GraphChecksumDictionary { get; set; }
 

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -107,6 +107,12 @@ Dynamo.Configuration.GraphChecksumItem.Checksum.set -> void
 Dynamo.Configuration.GraphChecksumItem.GraphChecksumItem() -> void
 Dynamo.Configuration.GraphChecksumItem.GraphId.get -> string
 Dynamo.Configuration.GraphChecksumItem.GraphId.set -> void
+Dynamo.Configuration.GraphChecksumPair
+Dynamo.Configuration.GraphChecksumPair.Checksum.get -> System.Collections.Generic.List<string>
+Dynamo.Configuration.GraphChecksumPair.Checksum.set -> void
+Dynamo.Configuration.GraphChecksumPair.GraphChecksumPair() -> void
+Dynamo.Configuration.GraphChecksumPair.GraphId.get -> string
+Dynamo.Configuration.GraphChecksumPair.GraphId.set -> void
 Dynamo.Configuration.GroupStyleItem
 Dynamo.Configuration.GroupStyleItem.GroupStyleItem() -> void
 Dynamo.Configuration.PreferenceSettings

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1864,6 +1864,8 @@ Dynamo.Models.DynamoModel.ExtensionManager.get -> Dynamo.Extensions.IExtensionMa
 Dynamo.Models.DynamoModel.ForceRun() -> void
 Dynamo.Models.DynamoModel.ForceRunCancelCommand
 Dynamo.Models.DynamoModel.ForceRunCancelCommand.ForceRunCancelCommand(bool showErrors, bool cancelRun) -> void
+Dynamo.Models.DynamoModel.GraphChecksumList.get -> System.Collections.Generic.List<Dynamo.Configuration.GraphChecksumPair>
+Dynamo.Models.DynamoModel.GraphChecksumList.set -> void
 Dynamo.Models.DynamoModel.HostVersion.get -> string
 Dynamo.Models.DynamoModel.HostVersion.set -> void
 Dynamo.Models.DynamoModel.InsertFileCommand

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -14,6 +14,8 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Threading;
+using System.Xml;
+using System.Xml.Serialization;
 using Dynamo.Configuration;
 using Dynamo.Core;
 using Dynamo.Engine;
@@ -67,6 +69,7 @@ namespace Dynamo.ViewModels
         private Point transformOrigin;
         private bool showStartPage = false;
         private PreferencesViewModel preferencesViewModel;
+        private string dynamoMLDataPath = string.Empty;
 
         // Can the user run the graph
         private bool CanRunGraph => HomeSpace.RunSettings.RunEnabled && !HomeSpace.GraphRunInProgress;
@@ -768,11 +771,26 @@ namespace Dynamo.ViewModels
             model.ComputeModelDeserialized += model_ComputeModelDeserialized;
             model.RequestNotification += model_RequestNotification;
 
-            preferencesViewModel = new PreferencesViewModel(this);            
+            preferencesViewModel = new PreferencesViewModel(this);
+
+            dynamoMLDataPath = Path.Combine(Model.PathManager.UserDataDirectory, "DynamoMLDataPipeline.xml");
 
             if (!DynamoModel.IsTestMode && !DynamoModel.IsHeadless)
             {
                 model.State = DynamoModel.DynamoModelState.StartedUI;
+
+                // deserialize workspace checksum hashes that is used for Dynamo ML data pipeline.
+                var checksums = new List<GraphChecksumPair>();
+                var serializer = new XmlSerializer(Model.GraphChecksumList.GetType());
+
+                if (File.Exists(dynamoMLDataPath))
+                {
+                    using (var reader = XmlReader.Create(dynamoMLDataPath))
+                    {
+                        checksums = (List<GraphChecksumPair>)serializer.Deserialize(reader);
+                    }
+                    Model.GraphChecksumDictionary = checksums.ToDictionary(x => x.GraphId, x => x.Checksum);
+                }
             }
 
             FileTrustViewModel = new FileTrustWarningViewModel();
@@ -2192,30 +2210,58 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Indicates if the graph has been changed substantially bearing in mind the connections of its nodes and store the checksum value of the graph in the preferences to later comparison
+        /// Indicates if the workspace has been changed based on node connections and store the checksum value of the graph.
         /// </summary>
         /// <returns></returns>
-        private bool HasSubstantialCheckSum()
+        private bool HasDifferentialCheckSum()
         {
-            bool substantialChecksum = false;
+            bool differentialChecksum = false;
             string graphId = Model.CurrentWorkspace.Guid.ToString();
 
-            GraphChecksumItem checksumItem = PreferenceSettings.GraphChecksumItemsList.Where(i => i.GraphId == graphId).FirstOrDefault();
-            if (checksumItem != null)
+
+            Model.GraphChecksumDictionary.TryGetValue(graphId, out List<string> checksums);
+
+            // compare the current checksum with previous hash values.
+            if (checksums != null)
             {
-                if (checksumItem.Checksum != currentWorkspaceViewModel.Checksum)
+                if (!checksums.Contains(currentWorkspaceViewModel.CurrentCheckSum))
                 {
-                    PreferenceSettings.GraphChecksumItemsList.Remove(checksumItem);
-                    PreferenceSettings.GraphChecksumItemsList.Add(new GraphChecksumItem() { GraphId = graphId, Checksum = currentWorkspaceViewModel.Checksum });
-                    substantialChecksum = true;
+                    checksums.Add(currentWorkspaceViewModel.CurrentCheckSum);
+                    Model.GraphChecksumDictionary.Remove(graphId);
+                    Model.GraphChecksumDictionary.Add(graphId, checksums);
+                    differentialChecksum = true;
                 }
             }
             else
             {
-                PreferenceSettings.GraphChecksumItemsList.Add(new GraphChecksumItem() { GraphId = graphId, Checksum = currentWorkspaceViewModel.Checksum });
-                substantialChecksum = true;
+                Model.GraphChecksumDictionary.Add(graphId, new List<string>() { currentWorkspaceViewModel.CurrentCheckSum });
+                differentialChecksum = true;
             }
-            return substantialChecksum;
+
+            // if the checksum is different from previous hashes, serialize this new info. 
+            if (differentialChecksum)
+            {
+                var graphChecksums = new List<GraphChecksumPair>();
+                foreach (KeyValuePair<string, List<string>> entry in Model.GraphChecksumDictionary)
+                {
+                    var item = new GraphChecksumPair
+                    {
+                        GraphId = entry.Key,
+                        Checksum = entry.Value
+                    };
+
+                    graphChecksums.Add(item);
+                }
+
+                var serializer = new XmlSerializer(Model.GraphChecksumList.GetType());
+                using (var writer = XmlWriter.Create(dynamoMLDataPath))
+                {
+                    Model.GraphChecksumList = graphChecksums;
+                    serializer.Serialize(writer, Model.GraphChecksumList);
+                }
+            }
+
+            return differentialChecksum;
         }
 
         private void InternalSaveAs(string path, SaveContext saveContext, bool isBackup = false)
@@ -2239,13 +2285,14 @@ namespace Dynamo.ViewModels
                 {
                     AddToRecentFiles(path);
 
-                    if ((currentWorkspaceViewModel?.IsHomeSpace ?? true) && HomeSpace.HasRunWithoutCrash && Model.CurrentWorkspace.IsValidForFDX && IsMLDataIngestionPipelineinBeta && currentWorkspaceViewModel.Checksum != string.Empty)
+                    if ((currentWorkspaceViewModel?.IsHomeSpace ?? true) && HomeSpace.HasRunWithoutCrash &&
+                         Model.CurrentWorkspace.IsValidForFDX && !IsMLDataIngestionPipelineinBeta && currentWorkspaceViewModel.Checksum != string.Empty)
                     {
-                        Model.Logger.Log("The Workspace is valid for FDX");
-                        Model.Logger.Log("The Workspace id is : " + currentWorkspaceViewModel.Model.Guid.ToString());
-                        Model.Logger.Log("The Workspace checksum is : " + currentWorkspaceViewModel.Checksum);
-                        Model.Logger.Log("The Workspace has Substantial checksum, so is ready to send to FDX : " + HasSubstantialCheckSum().ToString());
-                        MLDataPipelineExtension.DynamoMLDataPipeline.DataExchange(path);
+                        if (HasDifferentialCheckSum())
+                        {
+                            Model.Logger.Log("This Workspace is shared to train the Dynamo Machine Learning model.");
+                            MLDataPipelineExtension.DynamoMLDataPipeline.DataExchange(path);
+                        }
                     }
                 }                           
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -6,8 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -391,7 +389,7 @@ namespace Dynamo.ViewModels
 
                 if (nodeInfoConnections.Count > 0)
                 {
-                    var checksumhash = ConvertToSha256(String.Join(",", nodeInfoConnections));
+                    var checksumhash = Hash.ToSha256String(String.Join(",", nodeInfoConnections));
                     CurrentCheckSum = checksumhash;
                     return checksumhash;
                 }
@@ -401,21 +399,6 @@ namespace Dynamo.ViewModels
                     return string.Empty;
                 }
             }            
-        }
-
-        // converts the checksum string into a sha 256 hash.
-        private string ConvertToSha256(string s)
-        {
-            using var mySHA256 = SHA256.Create();
-
-            byte[] bytes = mySHA256.ComputeHash(Encoding.UTF8.GetBytes(s));
-            var sb = new StringBuilder();
-
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                sb.Append(bytes[i].ToString("x2"));
-            }
-            return sb.ToString();
         }
 
         Tuple<string,int> GetNodeByInputId(string inputId, JObject jsonWorkspace)

--- a/src/DynamoUtilities/Hash.cs
+++ b/src/DynamoUtilities/Hash.cs
@@ -91,6 +91,22 @@ namespace Dynamo.Utilities
 
             return result;
         }
+
+
+        // converts the string into a sha 256 hash.
+        internal static string ToSha256String(string s)
+        {
+            using var mySHA256 = SHA256.Create();
+
+            byte[] bytes = mySHA256.ComputeHash(Encoding.UTF8.GetBytes(s));
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                sb.Append(bytes[i].ToString("x2"));
+            }
+            return sb.ToString();
+        }
     }
 }
 

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -1,13 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
-using Dynamo.Configuration;
-using Dynamo.Models;
-using NUnit.Framework;
 using System.Linq;
-using System;
-using Dynamo.Interfaces;
 using System.Reflection;
+using Dynamo.Configuration;
+using Dynamo.Interfaces;
+using Dynamo.Models;
 using Dynamo.Utilities;
+using NUnit.Framework;
 
 namespace Dynamo.Tests.Configuration
 {
@@ -350,18 +350,6 @@ namespace Dynamo.Tests.Configuration
                     {
                         if (((List<DynamoPlayerFolderGroup>)sourcePi.GetValue(newGeneralSettings, null)).Count ==
                             ((List<DynamoPlayerFolderGroup>)destinationPi.GetValue(defaultSettings, null)).Count)
-                        {
-                            propertiesWithSameValue.Add(destinationPi.Name);
-                        }
-                        else
-                        {
-                            propertiesWithDifferentValue.Add(destinationPi.Name);
-                        }
-                    }
-                    else if (destinationPi.PropertyType == typeof(List<GraphChecksumItem>))
-                    {
-                        if (((List<GraphChecksumItem>)sourcePi.GetValue(newGeneralSettings, null)).Count ==
-                            ((List<GraphChecksumItem>)destinationPi.GetValue(defaultSettings, null)).Count)
                         {
                             propertiesWithSameValue.Add(destinationPi.Name);
                         }

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -1541,6 +1541,21 @@ namespace Dynamo.Tests
             Assert.True(initialNodeName == customNodeInstance.Name);
             Assert.False(Path.GetFileNameWithoutExtension(savePath) == customNodeInstance.Name);
         }
+
+        /// <summary>
+        /// Workspace checksum test.
+        /// </summary>
+        [Test]
+        public void WorkapceChecksumTest()
+        {
+            var model = ViewModel.Model;
+            var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            var checksumString = ViewModel.CurrentSpaceViewModel.Checksum;
+
+            Assert.AreEqual("65b395b9874b9d82e088093f30234c496704006030ecf35471404f62b62a6442", checksumString);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
### Purpose

Improvements are done to the checksum computation. that is used to determine if the current workspace should be sent to ML data service. 
1) The checksum now uses node connections and converts it into sha256 hash value to determine if it is unique.
2) This info is serialized in a different file under dynamo user directory: AppData\Dynamo\Dynamo Core\3.1\DynamoMLDataPipeline.xml.
3) The serialized data format is converted from a list to dictionary so as to store all unique checksum hashes for that particular workspace. This is to avoid sending any duplicate workspaces that have been sent before.
4) Avoid reading the node connections from the json again and use the in memory data to calculate the checksum string.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

### Reviewers
@QilongTang @mjkkirschner 

