### PR TITLE
HomePage: loading screen stuck fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1842,6 +1842,8 @@ namespace Dynamo.ViewModels
                         commandString,
                         MessageBoxButton.OK,
                         MessageBoxImage.Error);
+
+                    this.ShowStartPage = true;  // Triggers start page change to notify the frontend
                 }
                 else
                 {


### PR DESCRIPTION
### Purpose

A small bug-fix to handle the edge-case where opening a file generates an error causing the front-end to get stuck on the loading screen.

The current implementation relies on starting the `loading screen` is as follows:
- the user clicks on a recent file in the front-end, immediately enabling the `loading screen`
- the front-end makes a call to the back-end to open the file, providing the file details
- the back-end opens the file, and if successful, marks the `ShowStartPage` as **false**, which in turn makes a call to the front-end to disable the `loading screen`

If opening the file, an error has been thrown, the `ShowSartPage` would not change, hance no call to the front-end was made to disable the `loading screen`. This PR explicitly makes such change in order to force an update.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- small change to force update of the front end after a corrupt file is being opened
- in case of an error, re-setting the `ShowStartPage` will trigger the update to the front end and remove the loading screen

### Reviewers

@QilongTang 

### FYIs


