### PR TITLE
specify versions for javascript dependencies

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -22,9 +22,10 @@
   </PropertyGroup>
 
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
-      <!--This command gets the latest build from the splash screen-->
+      <!--This command updates the npm registry configuration if necessary-->
       <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
-      <Exec Command="npm pack @dynamods/splash-screen@latest" />
+      <!--This command gets a specific splash screen build from npm-->
+      <Exec Command="npm pack @dynamods/splash-screen@1.0.18" />
   </Target>
 
     <Target Name="ExtractTGZFile" DependsOnTargets="NpmRunBuild" BeforeTargets="BeforeBuild">      
@@ -33,11 +34,6 @@
             <TGZFiles Include="./dynamods-splash-screen-*.tgz" />
         </ItemGroup>
 
-        <!--Reverse the order of the files to get the higher version-->
-        <ItemGroup>
-            <Reversed Include="@(TGZFiles-&gt;Reverse())" />
-        </ItemGroup>
-        
         <PropertyGroup>
             <Last>%(TGZFiles.Filename)</Last>
         </PropertyGroup>
@@ -56,19 +52,14 @@
     <Target Name="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
         <!--This command updates the npm registry configuration if necessary-->
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
-        <!--Download the latest build of the Dynamo Home package-->
-        <Exec Command="npm pack @dynamods/dynamo-home@latest" />
+        <!--Download a specific build of the Dynamo Home package from npm-->
+        <Exec Command="npm pack @dynamods/dynamo-home@1.0.5" />
     </Target>
 
     <Target Name="ExtractTGZFileDynamoHome" DependsOnTargets="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
         <!--Locate the .tgz files for the Dynamo Home package-->
         <ItemGroup>
             <TGZFilesDynamoHome Include="./dynamods-dynamo-home-*.tgz" />
-        </ItemGroup>
-
-        <!--Reverse the order of the files to get the higher version-->
-        <ItemGroup>
-            <ReversedDynamoHome Include="@(TGZFilesDynamoHome-&gt;Reverse())" />
         </ItemGroup>
 
         <PropertyGroup>

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Xml.Serialization;
+using Autodesk.DesignScript.Runtime;
 using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Core;
@@ -218,8 +219,8 @@ namespace Dynamo.UI.Views
         private void SplashScreenRequestClose(object sender, EventArgs e)
         {
             //This is only called when shutdownparams.closeDynamoView = true
-            //which is during tests or an exist command
-            //which is used rarely, during but we it is used when the Revit document is lost and Dynamo is open.
+            //which is during tests or an exit command
+            //which is used rarely, but it is used when the Revit document is lost and Dynamo is open.
             CloseWindow();
             viewModel.RequestClose -= SplashScreenRequestClose;
         }
@@ -657,29 +658,34 @@ namespace Dynamo.UI.Views
             RequestSignOut = requestSignOut;
             RequestCloseWindowPreserve = requestCloseWindow;
         }
-
+        [DynamoJSInvokable]
         public void LaunchDynamo(bool showScreenAgain)
         {
             RequestLaunchDynamo(showScreenAgain);
             Analytics.TrackEvent(Actions.Start, Categories.SplashScreenOperations);
         }
-
+        [DynamoJSInvokable]
         public void ImportSettings(string file)
         {
             RequestImportSettings(file);
         }
+        [DynamoJSInvokable]
         public bool SignIn()
         {
             return RequestSignIn();
         }
+        [DynamoJSInvokable]
         public bool SignOut()
         {
             return RequestSignOut();
         }
+        [Obsolete]
+        [DynamoJSInvokable]
         public void CloseWindow()
         {
             RequestCloseWindow();
         }
+        [DynamoJSInvokable]
         public void CloseWindowPreserve(bool isCheckboxChecked)
         {
             RequestCloseWindowPreserve(isCheckboxChecked);

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -15,20 +15,16 @@
 	</PropertyGroup>
 
     <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
-        <!--This command gets the latest build from the notifcation center-->
+        <!--This command updates the npm registry configuration if necessary-->
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
-        <Exec Command="npm pack @dynamods/notifications-center@latest" />
+        <!--This command gets a specific build of the notifcation center from npm-->
+        <Exec Command="npm pack @dynamods/notifications-center@0.0.29" />
     </Target>
 
     <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild">
         <!--Locates the .tgz files-->
         <ItemGroup>
             <TGZFiles Include="./dynamods-notifications-center-*.tgz" />
-        </ItemGroup>
-
-        <!--Reverse the order of the files to get the higher version-->
-        <ItemGroup>
-            <Reversed Include="@(TGZFiles-&gt;Reverse())" />
         </ItemGroup>
 
         <!--Gets the last one-->

--- a/test/DynamoCoreWpfTests/SplashScreenTests.cs
+++ b/test/DynamoCoreWpfTests/SplashScreenTests.cs
@@ -1,5 +1,7 @@
 
 
+using Dynamo.Configuration;
+using Dynamo.Models;
 using DynamoCoreWpfTests.Utility;
 using DynamoUtilities;
 using NUnit.Framework;
@@ -11,6 +13,26 @@ using System.Threading.Tasks;
 
 namespace DynamoCoreWpfTests
 {
+
+    [TestFixture]
+    class SplashScreenViewTests: DynamoTestUIBase
+    {
+        [Test]
+        public void SplashScreen_ClosePersistSetsPrefs()
+        {
+            var ss = new Dynamo.UI.Views.SplashScreen();
+            ss.DynamoView = View;
+            var oldPref = ViewModel.PreferenceSettings.EnableStaticSplashScreen;
+            Assert.IsTrue(oldPref);
+
+            ss.CloseWindow(true);
+            var newPref = ViewModel.PreferenceSettings.EnableStaticSplashScreen;
+            Assert.False(newPref);
+
+            Assert.IsTrue(ss.CloseWasExplicit);
+        }
+    }
+
     [TestFixture]
     internal class SplashScreenTests
     {
@@ -67,8 +89,9 @@ namespace DynamoCoreWpfTests
             ss.CloseWindow();
             Assert.IsTrue(ss.CloseWasExplicit);
         }
-
         [Test]
+        //note that this test sends a windows close message directly to the window
+        //but skips the JS interop that users rely on to close the window - so that is not tested by this test.
         public void SplashScreen_MultipleCloseMessages()
         {
             var ss = new Dynamo.UI.Views.SplashScreen();
@@ -97,10 +120,10 @@ namespace DynamoCoreWpfTests
             }
             ss.webView.NavigationCompleted += WebView_NavigationCompleted;
 
-            bool windoClosed = false;
+            bool windowClosed = false;
             void WindowClosed(object sender, EventArgs e)
             {
-                windoClosed = true;
+                windowClosed = true;
                 ss.Closed -= WindowClosed;
             }
 
@@ -108,10 +131,10 @@ namespace DynamoCoreWpfTests
 
             ss.Show();
 
-            DispatcherUtil.DoEventsLoop(() => windoClosed);
+            DispatcherUtil.DoEventsLoop(() => windowClosed);
 
             Assert.IsNull(ss.webView);// Make sure webview2 was disposed
-            Assert.IsTrue(windoClosed);// Make sure the window was closed
+            Assert.IsTrue(windowClosed);// Make sure the window was closed
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR exists because in release 3.0.4 the splash screen close button does not work. The button is a javascript button that calls a c# method on the `ScriptObject` which we provide via `WebView2`. 

The 3.0.4 release does not include the latest changes made to Dynamo master - (3.1) but did pull the latest javascript component because our build steps use `nom pack dynamods/splash-screen@latest`.

The c# method that the JS tries to call simply does not exist.

This should fix the issue going forward if developers update JS dependencies in sync like any other dependency - BUT in my opinion we're still in a brittle state - here are some thoughts.

1. We are not versioning the javascript dependencies with any semantic versioning scheme.
2. We are not leveraging typescript or any kind of contract between the `WebView2 ScriptObject` and the c# methods that the JS calls.
3. We do not have tests that end to end integration test the javascript once it's integrated into Dynamo so that we can prove all functionality is integrated correctly. It appears that @dnenov has added interaction testing via JS which I think is a step in the right direction - I think we should generalize this, make it robust enough to support all the components we integrate with JS and use it for all our js dependencies: https://github.com/DynamoDS/Dynamo/blob/c90f1052a3cd9f3af26b20531668d8c53a7da225/test/DynamoCoreWpfTests/HomePageTests.cs#L638
4. We do not have sufficient unit testing in the javascript components themselves - this should be the first order of business to address.
5. librarieJS should be integrated like all the others using npm if that is the pattern we are happy with.

I am going to file follow tasks for each of these in a new epic, if we truly aim to move to a javascript based UI system leveraging components we need to increase the quality and robustness of their integration.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
