### PR TITLE
Fix crash/freeze on systems with no AdskIdentityManager or any adsk product

### DIFF
--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using Autodesk.IDSDK;
 using Dynamo.Configuration;
+using DynamoServices;
 using Greg;
 using Greg.AuthProviders;
 using RestSharp;
@@ -239,10 +240,12 @@ namespace Dynamo.Core
                         }
                     }
                 }
+                DynamoConsoleLogger.OnLogMessageToDynamoConsole("Auth Service (IDSDK) could not be initialized!");
                 return false;
             }
             catch (Exception)
             {
+                DynamoConsoleLogger.OnLogMessageToDynamoConsole("An error occurred while initializing Auth Service (IDSDK).");
                 return false;
             }
         }

--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -213,38 +213,38 @@ namespace Dynamo.Core
 
         private bool Initialize()
         {
-            if (Client.IsInitialized()) return true;
-            idsdk_status_code bRet = Client.Init();
-
-            if (Client.IsSuccess(bRet))
+            try
             {
-                if (Client.IsInitialized())
-                {
-                    try
-                    {
-                        IntPtr hWnd = Process.GetCurrentProcess().MainWindowHandle;
-                        if (hWnd != null)
-                        {
-                            Client.SetHost(hWnd);
-                        }
+                if (Client.IsInitialized()) return true;
+                idsdk_status_code bRet = Client.Init();
 
-                        bool ret = GetClientIDAndServer(out idsdk_server server, out string client_id);
-                        if (ret)
-                        {
-                            Client.LogoutCompleteEvent += AuthCompleteEventHandler;
-                            Client.LoginCompleteEvent += AuthCompleteEventHandler;
-                            ret = SetProductConfigs(Configurations.DynamoAsString, server, client_id);
-                            Client.SetServer(server);
-                            return ret;
-                        }
-                    }
-                    catch (Exception)
+                if (Client.IsSuccess(bRet))
+                {
+                    if (Client.IsInitialized())
                     {
-                        return false;
+                            IntPtr hWnd = Process.GetCurrentProcess().MainWindowHandle;
+                            if (hWnd != null)
+                            {
+                                Client.SetHost(hWnd);
+                            }
+
+                            bool ret = GetClientIDAndServer(out idsdk_server server, out string client_id);
+                            if (ret)
+                            {
+                                Client.LogoutCompleteEvent += AuthCompleteEventHandler;
+                                Client.LoginCompleteEvent += AuthCompleteEventHandler;
+                                ret = SetProductConfigs(Configurations.DynamoAsString, server, client_id);
+                                Client.SetServer(server);
+                                return ret;
+                            }
                     }
                 }
+                return false;
             }
-            return false;
+            catch (Exception)
+            {
+                return false;
+            }
         }
         private bool Deinitialize()
         {

--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -222,21 +222,21 @@ namespace Dynamo.Core
                 {
                     if (Client.IsInitialized())
                     {
-                            IntPtr hWnd = Process.GetCurrentProcess().MainWindowHandle;
-                            if (hWnd != null)
-                            {
-                                Client.SetHost(hWnd);
-                            }
+                        IntPtr hWnd = Process.GetCurrentProcess().MainWindowHandle;
+                        if (hWnd != null)
+                        {
+                            Client.SetHost(hWnd);
+                        }
 
-                            bool ret = GetClientIDAndServer(out idsdk_server server, out string client_id);
-                            if (ret)
-                            {
-                                Client.LogoutCompleteEvent += AuthCompleteEventHandler;
-                                Client.LoginCompleteEvent += AuthCompleteEventHandler;
-                                ret = SetProductConfigs(Configurations.DynamoAsString, server, client_id);
-                                Client.SetServer(server);
-                                return ret;
-                            }
+                        bool ret = GetClientIDAndServer(out idsdk_server server, out string client_id);
+                        if (ret)
+                        {
+                            Client.LogoutCompleteEvent += AuthCompleteEventHandler;
+                            Client.LoginCompleteEvent += AuthCompleteEventHandler;
+                            ret = SetProductConfigs(Configurations.DynamoAsString, server, client_id);
+                            Client.SetServer(server);
+                            return ret;
+                        }
                     }
                 }
                 return false;


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-6799
Expanded the region of try-catch to include init API that throws an exception when Dynamo is launched on clean machine with no autodesk product or no Adsk Identity Manager. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

@DynamoDS/dynamo 
