### PR TITLE
Fix typo

### DIFF
--- a/doc/distrib/NodeHelpFiles/6ICXLN4V6DNK5KMYTY5LPCJBE27IRW5VOBKCCVFQGO3HST752ZNQ.md
+++ b/doc/distrib/NodeHelpFiles/6ICXLN4V6DNK5KMYTY5LPCJBE27IRW5VOBKCCVFQGO3HST752ZNQ.md
@@ -5,7 +5,7 @@ In the example below, a T-Spline surface is matched with a NURBS curve using
 node is the base `tSplineSurface`, a set of edges of the surface, provided in `tsEdges` input, and a curve or
 list of curves.
 The following inputs control the parameters of the match:
-- `continuity` allows to set the continuity type for the match. The input expects values 0, 1, or 2, corresponding to G0 Positional, G1 Tangent, and G2 Curvature continuity. However, for matching a surface with a curve, only the GO (input value 0) is available.
+- `continuity` allows to set the continuity type for the match. The input expects values 0, 1, or 2, corresponding to G0 Positional, G1 Tangent, and G2 Curvature continuity. However, for matching a surface with a curve, only the G0 (input value 0) is available.
 - `useArcLength` controls the alignment type options. If set to True, the alignment type used is Arc
 Length. This alignment minimizes the physical distance between each point of the T-Spline surface and
 the corresponding point on the curve. When False input is provided, the alignment type is Parametric -


### PR DESCRIPTION
### Purpose

Fix a typo proposed by localization team, `GO` should be `G0` per https://jira.autodesk.com/browse/LOCDYN-1207

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

@DynamoDS/dynamo 