### PR TITLE
upgrade fflags

### DIFF
--- a/src/Tools/DynamoFeatureFlags/DynamoFeatureFlags.csproj
+++ b/src/Tools/DynamoFeatureFlags/DynamoFeatureFlags.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)Config/CS_SDK.props" />
   </ImportGroup>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.1">
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="5.1.0">
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Tools/DynamoFeatureFlags/FeatureFlagsClient.cs
+++ b/src/Tools/DynamoFeatureFlags/FeatureFlagsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -107,7 +107,7 @@ namespace DynamoFeatureFlags
         internal void Init(string mobileKey)
         {
             //start up client.
-            ldClient =  LaunchDarkly.Sdk.Client.LdClient.Init(mobileKey, user,TimeSpan.FromSeconds(5));
+            ldClient =  LaunchDarkly.Sdk.Client.LdClient.Init(mobileKey, LaunchDarkly.Sdk.Client.ConfigurationBuilder.AutoEnvAttributes.Disabled, user, TimeSpan.FromSeconds(5));
             if (ldClient.Initialized)
             {
                 MessageLogged?.Invoke($"launch darkly initalized");


### PR DESCRIPTION
This PR upgrades feature flags in order to fix a reported security issue
DYN-6777

There was a change in on of the APIs we used. The change is relatively safe because DynamoFeatureFlags is part of a separate process