### PR TITLE
Update WatchNodeTests.cs in 2.16.3

### DIFF
--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -270,7 +270,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(3, watchVM.Children.Count);
 
             Assert.AreEqual("1", watchVM.Children.ElementAt(0).NodeLabel);
-            Assert.AreEqual("Int64", watchVM.Children.ElementAt(0).ValueType);
+            Assert.AreEqual("Int", watchVM.Children.ElementAt(0).ValueType);
 
             Assert.AreEqual("null", watchVM.Children.ElementAt(1).NodeLabel);
             Assert.AreEqual("null", watchVM.Children.ElementAt(1).ValueType);


### PR DESCRIPTION
### Purpose

Fix regression due to `Int` type of data was displayed differently between 2.16.3 and later versions.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

@DynamoDS/dynamo 