### PR TITLE
DYN-6775-Localizing-SplashScreen

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -489,9 +489,9 @@ namespace Dynamo.UI.Views
                    $"importSettingsTitle: \"{Wpf.Properties.Resources.ImportSettingsDialogTitle}\"," +
                    $"showScreenAgainLabel: \"{Wpf.Properties.Resources.SplashScreenShowScreenAgainLabel}\"," +
                    $"signInTitle: \"{Wpf.Properties.Resources.SplashScreenSignIn}\"," +
-                   $"signInToolTip: \"{Wpf.Properties.Resources.SignInButtonContentToolTip}\"," +
+                   $"signInTooltip: \"{Wpf.Properties.Resources.SignInButtonContentToolTip}\"," +
                    $"signOutTitle: \"{Wpf.Properties.Resources.SplashScreenSignOut}\"," +
-                   $"signOutToolTip: \"{Wpf.Properties.Resources.SignOutConfirmationDialogText}\"," +
+                   $"signOutTooltip: \"{Wpf.Properties.Resources.SignOutConfirmationDialogText}\"," +
                    $"signingInTitle: \"{Wpf.Properties.Resources.SplashScreenSigningIn}\"," +
                    $"importSettingsTooltipDescription: \"{Wpf.Properties.Resources.ImportPreferencesInfo}\"" + "})");
             }

--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -489,7 +489,9 @@ namespace Dynamo.UI.Views
                    $"importSettingsTitle: \"{Wpf.Properties.Resources.ImportSettingsDialogTitle}\"," +
                    $"showScreenAgainLabel: \"{Wpf.Properties.Resources.SplashScreenShowScreenAgainLabel}\"," +
                    $"signInTitle: \"{Wpf.Properties.Resources.SplashScreenSignIn}\"," +
+                   $"signInToolTip: \"{Wpf.Properties.Resources.SignInButtonContentToolTip}\"," +
                    $"signOutTitle: \"{Wpf.Properties.Resources.SplashScreenSignOut}\"," +
+                   $"signOutToolTip: \"{Wpf.Properties.Resources.SignOutConfirmationDialogText}\"," +
                    $"signingInTitle: \"{Wpf.Properties.Resources.SplashScreenSigningIn}\"," +
                    $"importSettingsTooltipDescription: \"{Wpf.Properties.Resources.ImportPreferencesInfo}\"" + "})");
             }


### PR DESCRIPTION
### Purpose

Localizing SplashScreen Tooltip
I've added some code for localizing the tooltip in the SignOut/SignIn buttons, but still won't be working until the React SplashScreen component is fixed.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Localizing SplashScreen Tooltip

### Reviewers

@QilongTang 

### FYIs

