### PR TITLE
Fix crash when navigating from package details

### DIFF
--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.cs
@@ -67,13 +67,7 @@ namespace Dynamo.PackageDetails
             if (PackageDetailsView == null) PackageDetailsView = new PackageDetailsView();
             PackageDetailsView.DataContext = PackageDetailsViewModel;
 
-            if (packageManagerSearchElement.UIParent != null)
-            {
-                HostPackageDetailsExtension(packageManagerSearchElement);
-                return;
-            }
-
-            ViewLoadedParamsReference?.AddToExtensionsSideBar(this, PackageDetailsView);
+            HostPackageDetailsExtension(packageManagerSearchElement);
         }
 
         private void HostPackageDetailsExtension(PackageManagerSearchElement packageManagerSearchElement)


### PR DESCRIPTION
### Purpose

Dynamo crashed when navigating to another package details from the dependent package link.

![Screenshot 2024-03-21 at 4 21 38 PM](https://github.com/DynamoDS/Dynamo/assets/32665108/0feb18a0-4ad4-498f-8b40-70af0546c8a5)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

@QilongTang 
