### PR TITLE
Graph properties should be displayed for Templates

### DIFF
--- a/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
+++ b/src/GraphMetadataViewExtension/GraphMetadataViewModel.cs
@@ -136,14 +136,13 @@ namespace Dynamo.GraphMetadata
                 return;
             }
 
-            if (string.IsNullOrEmpty(hwm.FileName))
+            if (!hwm.IsTemplate && string.IsNullOrEmpty(hwm.FileName) )
             {
                 GraphDescription = string.Empty;
                 GraphAuthor = string.Empty;
                 HelpLink = null;
                 Thumbnail = null;
             }
-
             else
             {
                 currentWorkspace = hwm;


### PR DESCRIPTION
### Purpose

Since template files do not have a filename, graph properties were being emptied, added a condition to check if the workspace is a template then skip clearing graph metadata.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Graph properties should be displayed for Templates

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
