### PR TITLE
DYN-6719 - show warning when installing, and log when loading a package from 2.x in Dynamo 3.x

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3546,17 +3546,14 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// Displays file open error dialog if the file is of a future version than the currently installed version
+        /// Displays file open error dialog if the file is of a future version than the currently installed version.
         /// </summary>
         /// <param name="fullFilePath"></param>
         /// <param name="fileVersion"></param>
         /// <param name="currVersion"></param>
-        /// <returns> true if the file must be opened and false otherwise </returns>
+        /// <returns> true if the file must be opened and false otherwise. </returns>
         private bool DisplayFutureFileMessage(string fullFilePath, Version fileVersion, Version currVersion)
         {
-            var fileVer = ((fileVersion != null) ? fileVersion.ToString() : Resources.UnknownVersion);
-            var currVer = ((currVersion != null) ? currVersion.ToString() : Resources.UnknownVersion);
-
             string summary = Resources.FutureFileSummary;
             var description = string.Format(Resources.FutureFileDescription, fullFilePath, fileVersion, currVersion);
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -7139,7 +7139,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package may not work in this version of Dynamo {0}!.
+        ///   Looks up a localized string similar to Package may not work in this version of {0}!.
         /// </summary>
         public static string PackageUseOlderDynamoMessageBoxTitle {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4652,6 +4652,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to #Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8.
+        /// </summary>
+        public static string MessagePackOlderDynamoLink {
+            get {
+                return ResourceManager.GetString("MessagePackOlderDynamoLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot contain special characters (# % * ? \ : [ ]).
         /// </summary>
         public static string MessagePortNameInvalid {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4607,6 +4607,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package or one of its dependencies use an older version of {0} than you are currently using. Do you want to continue?.
+        /// </summary>
+        public static string MessagePackageOlderDynamo {
+            get {
+                return ResourceManager.GetString("MessagePackageOlderDynamo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package or one of its dependencies targets a different environment, such as Revit, Civil 3D, Advance Steel, Alias or FormIt. This can cause instability and unexpected problems. Do you want to continue?.
         /// </summary>
         public static string MessagePackageTargetOtherHosts {
@@ -7117,6 +7126,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PackageUseNewerDynamoMessageBoxTitle {
             get {
                 return ResourceManager.GetString("PackageUseNewerDynamoMessageBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package Uses OlderVersion of {0}!.
+        /// </summary>
+        public static string PackageUseOlderDynamoMessageBoxTitle {
+            get {
+                return ResourceManager.GetString("PackageUseOlderDynamoMessageBoxTitle", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4589,7 +4589,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package or one of its dependencies use a newer version of {0} than you are currently using. Do you want to continue?.
+        ///   Looks up a localized string similar to This package or one of its dependencies were created for a newer version of Dynamo. It may not work in this version. Do you want to continue?.
         /// </summary>
         public static string MessagePackageNewerDynamo {
             get {
@@ -4607,7 +4607,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package or one of its dependencies use an older version of {0} than you are currently using. Do you want to continue?.
+        ///   Looks up a localized string similar to This package or one of its dependencies were created for a previous version of Dynamo. It may not work in this version. Do you want to continue?.
         /// </summary>
         public static string MessagePackageOlderDynamo {
             get {
@@ -7130,7 +7130,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package Uses Newer Version of {0}!.
+        ///   Looks up a localized string similar to Package may not work in this version of {0}!.
         /// </summary>
         public static string PackageUseNewerDynamoMessageBoxTitle {
             get {
@@ -7139,7 +7139,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package Uses OlderVersion of {0}!.
+        ///   Looks up a localized string similar to Package may not work in this version of Dynamo {0}!.
         /// </summary>
         public static string PackageUseOlderDynamoMessageBoxTitle {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3961,4 +3961,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
     <value>Package Uses OlderVersion of {0}!</value>
   </data>
+  <data name="MessagePackOlderDynamoLink" xml:space="preserve">
+    <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3955,4 +3955,10 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="DynamoXmlFileFormat" xml:space="preserve">
     <value>Dynamo 1.x file format</value>
   </data>
+  <data name="MessagePackageOlderDynamo" xml:space="preserve">
+    <value>The package or one of its dependencies use an older version of {0} than you are currently using. Do you want to continue?</value>
+  </data>
+  <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
+    <value>Package Uses OlderVersion of {0}!</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1783,7 +1783,7 @@ Next assemblies were loaded several times:
     <value>Has no dependecies</value>
   </data>
   <data name="PackageUseNewerDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package Uses Newer Version of {0}!</value>
+    <value>Package may not work in this version of {0}!</value>
   </data>
   <data name="PackageWarningMessageBoxTitle" xml:space="preserve">
     <value>Package Warning</value>
@@ -3959,7 +3959,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>The package or one of its dependencies use an older version of {0} than you are currently using. Do you want to continue?</value>
   </data>
   <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package Uses OlderVersion of {0}!</value>
+    <value>Package may not work in this version of Dynamo {0}!</value>
   </data>
   <data name="MessagePackOlderDynamoLink" xml:space="preserve">
     <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3942,4 +3942,10 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="DynamoXmlFileFormat" xml:space="preserve">
     <value>Dynamo 1.x file format</value>
   </data>
+  <data name="MessagePackageOlderDynamo" xml:space="preserve">
+    <value>The package or one of its dependencies use an older version of {0} than you are currently using. Do you want to continue?</value>
+  </data>
+  <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
+    <value>Package Uses OlderVersion of {0}!</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3946,7 +3946,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>This package or one of its dependencies were created for a previous version of Dynamo. It may not work in this version. Do you want to continue?</value>
   </data>
   <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package may not work in this version of Dynamo {0}!</value>
+    <value>Package may not work in this version of {0}!</value>
   </data>
   <data name="MessagePackOlderDynamoLink" xml:space="preserve">
     <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3948,4 +3948,7 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
   <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
     <value>Package Uses OlderVersion of {0}!</value>
   </data>
+  <data name="MessagePackOlderDynamoLink" xml:space="preserve">
+    <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -985,7 +985,7 @@ You can always redownload the package.</value>
     <value>The package or one of its dependencies contains Python scripts or binaries. Do you want to continue?</value>
   </data>
   <data name="MessagePackageNewerDynamo" xml:space="preserve">
-    <value>The package or one of its dependencies use a newer version of {0} than you are currently using. Do you want to continue?</value>
+    <value>This package or one of its dependencies were created for a newer version of Dynamo. It may not work in this version. Do you want to continue?</value>
   </data>
   <data name="MessageSelectAtLeastOneNode" xml:space="preserve">
     <value>You must select at least one custom node.</value>
@@ -1048,7 +1048,7 @@ To avoid unintended behavior, uninstall the conflicting loaded package(s), resta
     <value>Package Download</value>
   </data>
   <data name="PackageUseNewerDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package Uses Newer Version of {0}!</value>
+    <value>Package may not work in this version of {0}!</value>
   </data>
   <data name="PackageWarningMessageBoxTitle" xml:space="preserve">
     <value>Package Warning</value>
@@ -3943,10 +3943,10 @@ In certain complex graphs or host program scenarios, Automatic mode may cause in
     <value>Dynamo 1.x file format</value>
   </data>
   <data name="MessagePackageOlderDynamo" xml:space="preserve">
-    <value>The package or one of its dependencies use an older version of {0} than you are currently using. Do you want to continue?</value>
+    <value>This package or one of its dependencies were created for a previous version of Dynamo. It may not work in this version. Do you want to continue?</value>
   </data>
   <data name="PackageUseOlderDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package Uses OlderVersion of {0}!</value>
+    <value>Package may not work in this version of Dynamo {0}!</value>
   </data>
   <data name="MessagePackOlderDynamoLink" xml:space="preserve">
     <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4825,6 +4825,7 @@ static Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHosts.get -> str
 static Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHosts2.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHostShort.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageVersionNotFound.get -> string
+static Dynamo.Wpf.Properties.Resources.MessagePackOlderDynamoLink.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePortNameInvalid.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageRemovePythonPort.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageSamePackageDiffVersInBuiltinPackages.get -> string

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -5481,6 +5481,7 @@ static Dynamo.Wpf.Utilities.CompactBubbleHandler.Process(ProtoCore.Mirror.Mirror
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Collections.Generic.IEnumerable<string> buttonNames, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
+static Dynamo.Wpf.Utilities.MessageBoxService.Show(System.Windows.Window owner, string msg, string title, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(System.Windows.Window owner, string msg, string title, System.Windows.MessageBoxButton button, System.Collections.Generic.IEnumerable<string> buttonNames, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(System.Windows.Window owner, string msg, string title, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.WebView2Utilities.ValidateWebView2RuntimeInstalled() -> bool

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4274,6 +4274,7 @@ static Dynamo.UI.Prompts.DynamoMessageBox.Show(string messageBoxText, string cap
 static Dynamo.UI.Prompts.DynamoMessageBox.Show(string messageBoxText, string caption, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon) -> System.Windows.MessageBoxResult
 static Dynamo.UI.Prompts.DynamoMessageBox.Show(string messageBoxText, string caption, System.Windows.MessageBoxButton button) -> System.Windows.MessageBoxResult
 static Dynamo.UI.Prompts.DynamoMessageBox.Show(string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, string tooltip = "") -> System.Windows.MessageBoxResult
+static Dynamo.UI.Prompts.DynamoMessageBox.Show(System.Windows.Window owner, string messageBoxText, string caption, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon) -> System.Windows.MessageBoxResult
 static Dynamo.UI.Prompts.DynamoMessageBox.Show(System.Windows.Window owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon) -> System.Windows.MessageBoxResult
 static Dynamo.UI.SharedDictionaryManager.ConnectorsDictionary.get -> System.Windows.ResourceDictionary
 static Dynamo.UI.SharedDictionaryManager.ConnectorsDictionaryUri.get -> System.Uri

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4819,6 +4819,7 @@ static Dynamo.Wpf.Properties.Resources.MessagePackageContainPythonScript.get -> 
 static Dynamo.Wpf.Properties.Resources.MessagePackageDepsInBuiltinPackages.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageNewerDynamo.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageNotFound.get -> string
+static Dynamo.Wpf.Properties.Resources.MessagePackageOlderDynamo.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHosts.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHosts2.get -> string
 static Dynamo.Wpf.Properties.Resources.MessagePackageTargetOtherHostShort.get -> string
@@ -5095,6 +5096,7 @@ static Dynamo.Wpf.Properties.Resources.PackageUploadStateReady.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageUploadStateUploaded.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageUploadStateUploading.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageUseNewerDynamoMessageBoxTitle.get -> string
+static Dynamo.Wpf.Properties.Resources.PackageUseOlderDynamoMessageBoxTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageViewContextMenuLoadText.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageViewContextMenuLoadTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageWarningMessageBoxTitle.get -> string

--- a/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml
@@ -4,7 +4,6 @@
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:localui="clr-namespace:Dynamo.Wpf.UI.GuidedTour"
-        xmlns:w="clr-namespace:System.Windows;assembly=PresentationCore"
         xmlns:fa5="http://schemas.fontawesome.com/icons/"
         Title="{x:Static p:Resources.GenericTaskDialogTitle}"
         MinWidth="400"
@@ -14,7 +13,8 @@
         SizeToContent="WidthAndHeight"
         Style="{DynamicResource DynamoWindowStyle}"
         WindowStartupLocation="CenterOwner"
-        WindowStyle="None">
+        WindowStyle="None"
+        ToolTipService.IsEnabled="false">
     <Window.Background>
         <SolidColorBrush Opacity="0" />
     </Window.Background>
@@ -34,7 +34,9 @@
         <KeyBinding Command="Close" Key="Esc"/>
     </Window.InputBindings>
 
-    <Grid Background="Transparent" MouseDown="UIElement_OnMouseDown">
+    <Grid Background="Transparent"
+          MouseDown="UIElement_OnMouseDown">
+        
         <Border Name="MainBorder"
                 Background="White"
                 CornerRadius="4 "

--- a/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
@@ -173,6 +173,40 @@ namespace Dynamo.UI.Prompts
         /// <summary>
         /// Displays a dialog to the user and returns their choice as a MessageBoxResult.
         /// </summary>
+        /// <param name="owner">owning window of the messagebox</param>
+        /// <param name="messageBoxText">Content of the message</param>
+        /// <param name="caption">MessageBox title</param>
+        /// <param name="showRichTextBox">True if we will be using the RichTextBox instead of the usual one</param>
+        /// <param name="button">OK button shown in the MessageBox</param>
+        /// <param name="icon">Type of message: Warning, Error</param>
+        /// <returns></returns>
+        public static MessageBoxResult Show(Window owner, string messageBoxText, string caption, bool showRichTextBox, MessageBoxButton button,
+           MessageBoxImage icon)
+        {
+            var dynamoMessageBox = new DynamoMessageBox
+            {
+                BodyText = messageBoxText,
+                TitleText = caption,
+                MessageBoxButton = button,
+                MessageBoxImage = icon
+            };
+            if (owner != null && owner.IsLoaded)
+            {
+                dynamoMessageBox.Owner = owner;
+            }
+
+            if (showRichTextBox)
+            {
+                dynamoMessageBox.BodyTextBlock.Visibility = Visibility.Collapsed;
+                dynamoMessageBox.ContentRichTextBox.Visibility = Visibility.Visible;
+            }
+            dynamoMessageBox.ConfigureButtons(button);
+            dynamoMessageBox.ShowDialog();
+            return dynamoMessageBox.CustomDialogResult;
+        }
+        /// <summary>
+        /// Displays a dialog to the user and returns their choice as a MessageBoxResult.
+        /// </summary>
         /// <param name="owner">owner window</param>
         /// <param name="messageBoxText"></param>
         /// <param name="caption"></param>

--- a/src/DynamoCoreWpf/Utilities/MessageBoxUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/MessageBoxUtilities.cs
@@ -11,6 +11,7 @@ namespace Dynamo.Wpf.Utilities
         {
             MessageBoxResult Show(string msg, string title, MessageBoxButton button, MessageBoxImage img);
             MessageBoxResult Show(string msg, string title, bool showRichTextBox, MessageBoxButton button, MessageBoxImage img);
+            MessageBoxResult Show(Window owner, string msg, string title, bool showRichTextBox, MessageBoxButton button, MessageBoxImage img);
             MessageBoxResult Show(Window owner,string msg, string title, MessageBoxButton button, MessageBoxImage img);
             MessageBoxResult Show(Window owner, string msg, string title, MessageBoxButton button, IEnumerable<string> buttonNames, MessageBoxImage img);
             MessageBoxResult Show(string msg, string title, MessageBoxButton button, IEnumerable<string> buttonNames, MessageBoxImage img);
@@ -28,6 +29,10 @@ namespace Dynamo.Wpf.Utilities
             MessageBoxResult IMessageBox.Show(string msg, string title, bool showRichTextBox, MessageBoxButton button, MessageBoxImage img)
             {
                 return DynamoMessageBox.Show(msg, title, showRichTextBox, button, img);
+            }
+            MessageBoxResult IMessageBox.Show(Window owner, string msg, string title, bool showRichTextBox, MessageBoxButton button, MessageBoxImage img)
+            {
+                return DynamoMessageBox.Show(owner,msg, title, showRichTextBox, button, img);
             }
 
             public MessageBoxResult Show(Window owner, string msg, string title, MessageBoxButton button, MessageBoxImage img)
@@ -58,6 +63,10 @@ namespace Dynamo.Wpf.Utilities
         public static MessageBoxResult Show(string msg, string title, bool showRichTextBox, MessageBoxButton button, MessageBoxImage img)
         {
             return (msg_box ?? (msg_box = new DefaultMessageBox())).Show(msg, title, showRichTextBox, button, img);
+        }
+        public static MessageBoxResult Show(Window owner, string msg, string title, bool showRichTextBox, MessageBoxButton button, MessageBoxImage img)
+        {
+            return (msg_box ?? (msg_box = new DefaultMessageBox())).Show(owner,msg, title, showRichTextBox, button, img);
         }
         public static MessageBoxResult Show(Window owner,string msg, string title, MessageBoxButton button, MessageBoxImage img)
         {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -892,7 +892,7 @@ namespace Dynamo.ViewModels
 
                 // If any of the required packages use a newer version of Dynamo, show a dialog to the user
                 // allowing them to cancel the package download
-                if (true)
+                if (futureDeps.Any())
                 {
                     var res = MessageBoxService.Show(ViewModelOwner,
                         $"{string.Format(Resources.MessagePackageNewerDynamo, DynamoViewModel.BrandingResourceProvider.ProductName)} {Resources.MessagePackOlderDynamoLink}",

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -880,10 +880,15 @@ namespace Dynamo.ViewModels
                     if (res == MessageBoxResult.Cancel || res == MessageBoxResult.None) return;
                 }
 
-                // Determine if there are any dependencies that are made with a newer version
-                // of Dynamo (this includes the root package)
+                // Determine if there are any dependencies that have a newer dynamo version, (this includes the root package).
+                // We assume this means this package is compatibile with that dynamo version, but we should warn the user it
+                // may not work with the current version of Dynamo.
                 var dynamoVersion = VersionUtilities.PartialParse(DynamoModel.Version);
                 var futureDeps = newPackageHeaders.Where(dep => VersionUtilities.PartialParse(dep.engine_version) > dynamoVersion);
+                // also identify packages that have a dynamo engine version than 3.x as a special case,
+                // as Dynamo 3.x uses .net8 and older versions used .net framework - these packages may not be compatible.
+                // This check will return empty if the current major version is not 3.
+                var preDYN3Deps = newPackageHeaders.Where(dep => dynamoVersion.Major == 3 && VersionUtilities.PartialParse(dep.engine_version).Major < dynamoVersion.Major);
 
                 // If any of the required packages use a newer version of Dynamo, show a dialog to the user
                 // allowing them to cancel the package download
@@ -894,6 +899,21 @@ namespace Dynamo.ViewModels
                         string.Format(Resources.PackageUseNewerDynamoMessageBoxTitle, DynamoViewModel.BrandingResourceProvider.ProductName),
                         MessageBoxButton.OKCancel,
                         MessageBoxImage.Warning);
+                    if (res == MessageBoxResult.Cancel || res == MessageBoxResult.None)
+                    {
+                        return;
+                    }
+                }
+
+                //if any of the required packages use a pre 3.x version of Dynamo, show a dialog to the user
+                //allowing them to cancel the package download
+                if (preDYN3Deps.Any())
+                {
+                    var res = MessageBoxService.Show(ViewModelOwner,
+                    string.Format(Resources.MessagePackageOlderDynamo, DynamoViewModel.BrandingResourceProvider.ProductName),
+                    string.Format(Resources.PackageUseOlderDynamoMessageBoxTitle, DynamoViewModel.BrandingResourceProvider.ProductName),
+                    MessageBoxButton.OKCancel,
+                    MessageBoxImage.Warning);
                     if (res == MessageBoxResult.Cancel || res == MessageBoxResult.None)
                     {
                         return;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -892,11 +892,13 @@ namespace Dynamo.ViewModels
 
                 // If any of the required packages use a newer version of Dynamo, show a dialog to the user
                 // allowing them to cancel the package download
-                if (futureDeps.Any())
+                if (true)
                 {
                     var res = MessageBoxService.Show(ViewModelOwner,
-                        string.Format(Resources.MessagePackageNewerDynamo, DynamoViewModel.BrandingResourceProvider.ProductName),
+                        $"{string.Format(Resources.MessagePackageNewerDynamo, DynamoViewModel.BrandingResourceProvider.ProductName)} {Resources.MessagePackOlderDynamoLink}",
                         string.Format(Resources.PackageUseNewerDynamoMessageBoxTitle, DynamoViewModel.BrandingResourceProvider.ProductName),
+                        //this message has a url link so we use the rich text box version of the message box.
+                        showRichTextBox: true,
                         MessageBoxButton.OKCancel,
                         MessageBoxImage.Warning);
                     if (res == MessageBoxResult.Cancel || res == MessageBoxResult.None)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -885,7 +885,7 @@ namespace Dynamo.ViewModels
                 // may not work with the current version of Dynamo.
                 var dynamoVersion = VersionUtilities.PartialParse(DynamoModel.Version);
                 var futureDeps = newPackageHeaders.Where(dep => VersionUtilities.PartialParse(dep.engine_version) > dynamoVersion);
-                // also identify packages that have a dynamo engine version than 3.x as a special case,
+                // also identify packages that have a dynamo engine version less than 3.x as a special case,
                 // as Dynamo 3.x uses .net8 and older versions used .net framework - these packages may not be compatible.
                 // This check will return empty if the current major version is not 3.
                 var preDYN3Deps = newPackageHeaders.Where(dep => dynamoVersion.Major == 3 && VersionUtilities.PartialParse(dep.engine_version).Major < dynamoVersion.Major);
@@ -910,13 +910,15 @@ namespace Dynamo.ViewModels
                 if (preDYN3Deps.Any())
                 {
                     var res = MessageBoxService.Show(ViewModelOwner,
-                    string.Format(Resources.MessagePackageOlderDynamo, DynamoViewModel.BrandingResourceProvider.ProductName),
+                    $"{string.Format(Resources.MessagePackageOlderDynamo, DynamoViewModel.BrandingResourceProvider.ProductName)} {Resources.MessagePackOlderDynamoLink}",
                     string.Format(Resources.PackageUseOlderDynamoMessageBoxTitle, DynamoViewModel.BrandingResourceProvider.ProductName),
+                    //this message has a url link so we use the rich text box version of the message box.
+                    showRichTextBox:true,
                     MessageBoxButton.OKCancel,
                     MessageBoxImage.Warning);
                     if (res == MessageBoxResult.Cancel || res == MessageBoxResult.None)
                     {
-                        return;
+                        return; 
                     }
                 }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -198,6 +198,8 @@ namespace Dynamo.PackageManager
             List<Assembly> failedNodeLibs = new List<Assembly>();
             try
             {
+                var dynamoVersion = VersionUtilities.PartialParse(DynamoModel.Version);
+
                 List<Assembly> blockedAssemblies = new List<Assembly>();
                 // Try to load node libraries from all assemblies
                 foreach (var assem in package.EnumerateAndLoadAssembliesInBinDirectory())
@@ -270,6 +272,11 @@ namespace Dynamo.PackageManager
                     LoadPythonEngine(package.LoadedAssemblies.Select(x => x.Assembly));
 
                 Log($"Loaded Package {package.Name} {package.VersionName} from {package.RootDirectory}");
+                if(dynamoVersion.Major == 3 && VersionUtilities.PartialParse(package.EngineVersion).Major < 3)
+                {
+                    Log($@"{package.Name} {package.VersionName} has has an engine version of {package.EngineVersion},
+                        it may not be compatible with this version of Dynamo due to .NET runtime changes. ");
+                }
                 PackgeLoaded?.Invoke(package);
             }
             catch (CustomNodePackageLoadException e)

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -272,10 +272,17 @@ namespace Dynamo.PackageManager
                     LoadPythonEngine(package.LoadedAssemblies.Select(x => x.Assembly));
 
                 Log($"Loaded Package {package.Name} {package.VersionName} from {package.RootDirectory}");
-                if(dynamoVersion.Major == 3 && VersionUtilities.PartialParse(package.EngineVersion).Major < 3)
+                try
                 {
-                    Log($@"{package.Name} {package.VersionName} has an engine version of {package.EngineVersion},
+                    if (dynamoVersion.Major == 3 && Version.Parse(package.EngineVersion).Major < 3)
+                    {
+                        Log($@"{package.Name} {package.VersionName} has an engine version of {package.EngineVersion},
                         it may not be compatible with this version of Dynamo due to .NET runtime changes. ");
+                    }
+                }
+                catch(Exception ex)
+                {
+                    Log($"exception while trying to compare version info between package and dynamo {ex}");
                 }
                 PackgeLoaded?.Invoke(package);
             }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -274,7 +274,7 @@ namespace Dynamo.PackageManager
                 Log($"Loaded Package {package.Name} {package.VersionName} from {package.RootDirectory}");
                 if(dynamoVersion.Major == 3 && VersionUtilities.PartialParse(package.EngineVersion).Major < 3)
                 {
-                    Log($@"{package.Name} {package.VersionName} has has an engine version of {package.EngineVersion},
+                    Log($@"{package.Name} {package.VersionName} has an engine version of {package.EngineVersion},
                         it may not be compatible with this version of Dynamo due to .NET runtime changes. ");
                 }
                 PackgeLoaded?.Invoke(package);

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerUITests.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Dynamo.Core;
 using Dynamo.Extensions;
+using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.PackageManager.Interfaces;
 using Dynamo.PackageManager.Tests;
@@ -1188,6 +1189,7 @@ namespace DynamoCoreWpfTests.PackageManager
 
             var clientmock = new Mock<Dynamo.PackageManager.PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
             var pmVmMock = new Mock<PackageManagerClientViewModel>(ViewModel, clientmock.Object) { CallBase = true };
+            var sharedEngineVersion = DynamoModel.Version;
 
 
             //when we attempt a download - it returns a valid download path, also record order
@@ -1221,7 +1223,7 @@ namespace DynamoCoreWpfTests.PackageManager
             var dep_pkgVer = new PackageVersion()
             {
                 version = dep_version,
-                engine_version = "2.1.1",
+                engine_version = sharedEngineVersion,
                 name = dep_name,
                 id = dep_id,
                 full_dependency_ids = dep_deps,
@@ -1237,7 +1239,7 @@ namespace DynamoCoreWpfTests.PackageManager
             var pkgVer = new PackageVersion()
             {
                 version = version,
-                engine_version = "2.1.1",
+                engine_version = sharedEngineVersion,
                 name = name,
                 id = id,
                 full_dependency_ids = deps,
@@ -1591,7 +1593,8 @@ namespace DynamoCoreWpfTests.PackageManager
                 });
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
-            dlgMock.Setup(m => m.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(), It.Is<MessageBoxButton>(x => x == MessageBoxButton.OKCancel || x == MessageBoxButton.OK), It.IsAny<MessageBoxImage>()))
+            dlgMock.Setup(m => m.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.Is<MessageBoxButton>(x => x == MessageBoxButton.OKCancel || x == MessageBoxButton.OK), It.IsAny<MessageBoxImage>()))
                 .Returns(MessageBoxResult.OK);
             MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
             pmVm.ExecutePackageDownload(id, pkgVersionObject, "");
@@ -1599,9 +1602,11 @@ namespace DynamoCoreWpfTests.PackageManager
             // Users should get 2 warnings :
             // 1. To confirm that they want to download the specified package.
             // 2. That this package is a legacy package.
-            dlgMock.Verify(x => x.Show(It.IsAny<Window>(), string.Format(Dynamo.Wpf.Properties.Resources.MessagePackageOlderDynamo, ViewModel.BrandingResourceProvider.ProductName),
+            dlgMock.Verify(x => x.Show(null,
+                       $"{string.Format(Dynamo.Wpf.Properties.Resources.MessagePackageOlderDynamo, ViewModel.BrandingResourceProvider.ProductName)} {Dynamo.Wpf.Properties.Resources.MessagePackOlderDynamoLink}",
                        string.Format(Dynamo.Wpf.Properties.Resources.PackageUseOlderDynamoMessageBoxTitle, ViewModel.BrandingResourceProvider.ProductName),
-                        MessageBoxButton.OKCancel,MessageBoxImage.Warning), Times.Exactly(1));
+                       true,
+                        MessageBoxButton.OKCancel,MessageBoxImage.Exclamation), Times.Exactly(1));
 
         }
         #endregion


### PR DESCRIPTION
### Purpose

Since packages that were published from Dynamo 1.x or 2.x likely target net framework instead of .NET8 - we'll raise a warning if versions of those packages are installed. At load time, we'll just log some information without alerting the user, this will be useful for devs when inspecting logs - it's possible that a package may load successfully but have strange behavior later.



~~- [ ] One improvement we could make here is to not raise these warnings for packages that do not contain any .Net binaries. (ie those that only contain dyf files) I was not sure about this, what do reviewers think?~~

![Screenshot 2024-04-12 at 1 34 04 PM](https://github.com/DynamoDS/Dynamo/assets/508936/f71287c6-7854-4ea8-8723-e8b4b7a44178)


This PR also fixes a really annoying bug where Dynamo's custom message box type had a tooltip show up with no content.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

show warnings when installing packages into Dynamo 3.x that were published from Dynamo < 3.x

### Reviewers
