### PR TITLE
ensures connectorPins are included in SelectNeighbors

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1760,16 +1760,31 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
+        /// <summary>
+        /// Selects all neighboring nodes ans connector pins to this node
+        /// </summary>
         public void SelectNeighbors()
         {
             IEnumerable<ConnectorModel> outConnectors = outPorts.SelectMany(x => x.Connectors);
             IEnumerable<ConnectorModel> inConnectors = inPorts.SelectMany(x => x.Connectors);
 
             foreach (var c in outConnectors.Where(c => !DynamoSelection.Instance.Selection.Contains(c.End.Owner)))
+            {
                 DynamoSelection.Instance.Selection.Add(c.End.Owner);
+                foreach (var p in c.ConnectorPinModels)
+                {
+                    DynamoSelection.Instance.Selection.Add(p);
+                }
+            }                
 
             foreach (var c in inConnectors.Where(c => !DynamoSelection.Instance.Selection.Contains(c.Start.Owner)))
+            {
                 DynamoSelection.Instance.Selection.Add(c.Start.Owner);
+                foreach (var p in c.ConnectorPinModels)
+                {
+                    DynamoSelection.Instance.Selection.Add(p);
+                }
+            }
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Windows.Input;
 using System.Windows.Media;
 using Dynamo.Controls;
+using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
@@ -637,6 +638,39 @@ namespace DynamoCoreWpfTests
 
             Assert.AreEqual(outPort_With_Function.ValueMarkerWidth, outPort_With_Function.ValueMarkerWidthWithFunction);
             Assert.AreEqual(outPort_Without_Function.ValueMarkerWidth, outPort_Without_Function.ValueMarkerWidthWithoutFunction);
+        }
+
+        [Test]
+        public void TestSelectNeighborPins()
+        {
+            // Open and run the workspace
+            Open(@"core\ConnectorPinSelectionTest.dyn");
+
+            // Clear selection to ensure a clean state
+            DynamoSelection.Instance.Selection.Clear();
+
+            // Select the node
+            var nodeView = NodeViewWithGuid("80eca4d6-45bf-4c54-9412-d7d175c9a9b5");
+
+            NodeViewModel nodeVM = (nodeView.DataContext as NodeViewModel);
+            WorkspaceModel ws = nodeVM.DynamoViewModel.CurrentSpace;
+
+            // Check if connectors are in the model
+            var allConnectors = ws.Connectors;
+
+            DynamoSelection.Instance.Selection.Add(nodeVM.NodeModel);
+
+            var countBefore = DynamoSelection.Instance.Selection.Count;
+            Assert.AreEqual(1, countBefore);
+
+            // Run method ans assert whether more nodes were selected
+            nodeVM.NodeModel.SelectNeighbors();
+
+            var modelsSelected = DynamoSelection.Instance.Selection.Select(s => s as ModelBase);
+            var countAfter = modelsSelected.Count();
+
+            Assert.AreEqual(5, countAfter);
+
         }
     }
 }

--- a/test/core/ConnectorPinSelectionTest.dyn
+++ b/test/core/ConnectorPinSelectionTest.dyn
@@ -1,0 +1,217 @@
+{
+  "Uuid": "c484caa8-858d-4a32-92db-f17e7197d804",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "ConnectorPinSelectionTest",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "a0d7d02adf09455ebd04c38def8f3e07",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "c2b90a87544c4c1796b0452a94b93948",
+          "Name": "x",
+          "Description": "Integer or double value\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f97306cf803e409cb395c6a2a61f4e18",
+          "Name": "y",
+          "Description": "Integer or double value\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "13fee9dc55894984929a7bdeeb44611d",
+          "Name": "number",
+          "Description": "The product of the two input numbers",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "*@var[]..[],var[]..[]",
+      "Replication": "Auto",
+      "Description": "Returns multiplication of x times y\n\n* (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NumberType": "Double",
+      "Id": "41b2aa88001c4b3991e6b05c52dfeff6",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5da9bf8a700c409bb37ec5b15f93f509",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number",
+      "InputValue": 0.0
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 28.0,
+      "WatchHeight": 38.0,
+      "Id": "7cdc095c2d41415b9935b44c990ee782",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "965d08cf73744b8189d21214ab0cc6c4",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a995cd9966414d10879bdec9e009d872",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "13fee9dc55894984929a7bdeeb44611d",
+      "End": "965d08cf73744b8189d21214ab0cc6c4",
+      "Id": "dd11a60aae71472e9b5c3613e9095574",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5da9bf8a700c409bb37ec5b15f93f509",
+      "End": "c2b90a87544c4c1796b0452a94b93948",
+      "Id": "59214901d88d4940bd97c323d5dd1835",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5da9bf8a700c409bb37ec5b15f93f509",
+      "End": "f97306cf803e409cb395c6a2a61f4e18",
+      "Id": "70a4abb9e07c4e80b7797c28bceedb43",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": null,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.1",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.1.0.3411",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [
+      {
+        "Left": 570.0,
+        "Top": 94.0001,
+        "IsHidden": false,
+        "ConnectorGuid": "66f58071-534f-4710-96e0-68d5aa11987d"
+      },
+      {
+        "Left": 268.0,
+        "Top": 44.0001,
+        "IsHidden": false,
+        "ConnectorGuid": "aef055ee-0f7a-4e99-993e-9947275ca71b"
+      }
+    ],
+    "NodeViews": [
+      {
+        "Id": "a0d7d02adf09455ebd04c38def8f3e07",
+        "Name": "*",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 363.5,
+        "Y": 164.0
+      },
+      {
+        "Id": "41b2aa88001c4b3991e6b05c52dfeff6",
+        "Name": "Number",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 96.5,
+        "Y": 198.0
+      },
+      {
+        "Id": "7cdc095c2d41415b9935b44c990ee782",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 658.5,
+        "Y": 179.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Small PR that adds related Connector Pins to selection when user uses Tab key to select neighboring nodes. Includes unit test thanks to @dnenov.
Supersedes https://github.com/DynamoDS/Dynamo/pull/15007 (build keeps failing)

![DYN-5149-fix](https://github.com/DynamoDS/Dynamo/assets/48355182/e6ee9f7e-5283-4fdf-af6d-5e841521c51f)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

When selecting a node and hitting "tab" it automatically adds the connected nodes to the selection. This is super handy for moving groups of nodes around.  The selection will now include not only the next connected node, but all pins of the connectors at the same time. 

### Reviewers

@dnenov
@reddyashish

### FYIs

@Amoursol
