### PR TITLE
DYN-5149 Update the TestSelectNeighborPins unit test

### DIFF
--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -650,7 +650,7 @@ namespace DynamoCoreWpfTests
             DynamoSelection.Instance.Selection.Clear();
 
             // Select the node
-            var nodeView = NodeViewWithGuid("80eca4d6-45bf-4c54-9412-d7d175c9a9b5");
+            var nodeView = NodeViewWithGuid("a0d7d02a-df09-455e-bd04-c38def8f3e07");
 
             NodeViewModel nodeVM = (nodeView.DataContext as NodeViewModel);
             WorkspaceModel ws = nodeVM.DynamoViewModel.CurrentSpace;
@@ -663,14 +663,13 @@ namespace DynamoCoreWpfTests
             var countBefore = DynamoSelection.Instance.Selection.Count;
             Assert.AreEqual(1, countBefore);
 
-            // Run method ans assert whether more nodes were selected
+            // Run method and assert whether more nodes were selected
             nodeVM.NodeModel.SelectNeighbors();
 
             var modelsSelected = DynamoSelection.Instance.Selection.Select(s => s as ModelBase);
             var countAfter = modelsSelected.Count();
 
             Assert.AreEqual(5, countAfter);
-
         }
     }
 }

--- a/test/core/ConnectorPinSelectionTest.dyn
+++ b/test/core/ConnectorPinSelectionTest.dyn
@@ -110,20 +110,20 @@
     },
     {
       "Start": "5da9bf8a700c409bb37ec5b15f93f509",
-      "End": "c2b90a87544c4c1796b0452a94b93948",
-      "Id": "59214901d88d4940bd97c323d5dd1835",
+      "End": "f97306cf803e409cb395c6a2a61f4e18",
+      "Id": "70a4abb9e07c4e80b7797c28bceedb43",
       "IsHidden": "False"
     },
     {
       "Start": "5da9bf8a700c409bb37ec5b15f93f509",
-      "End": "f97306cf803e409cb395c6a2a61f4e18",
-      "Id": "70a4abb9e07c4e80b7797c28bceedb43",
+      "End": "c2b90a87544c4c1796b0452a94b93948",
+      "Id": "a622ae3642ed462696f7ca4c05394344",
       "IsHidden": "False"
     }
   ],
   "Dependencies": [],
   "NodeLibraryDependencies": [],
-  "EnableLegacyPolyCurveBehavior": null,
+  "EnableLegacyPolyCurveBehavior": true,
   "Thumbnail": "",
   "GraphDocumentationURL": null,
   "ExtensionWorkspaceData": [
@@ -165,16 +165,22 @@
     },
     "ConnectorPins": [
       {
-        "Left": 570.0,
-        "Top": 94.0001,
+        "Left": 264.09530143377094,
+        "Top": 257.73218770417003,
         "IsHidden": false,
-        "ConnectorGuid": "66f58071-534f-4710-96e0-68d5aa11987d"
+        "ConnectorGuid": "70a4abb9-e07c-4e80-b779-7c28bceedb43"
       },
       {
-        "Left": 268.0,
-        "Top": 44.0001,
+        "Left": 281.3766210423312,
+        "Top": 210.6627915786814,
         "IsHidden": false,
-        "ConnectorGuid": "aef055ee-0f7a-4e99-993e-9947275ca71b"
+        "ConnectorGuid": "a622ae36-42ed-4626-96f7-ca4c05394344"
+      },
+      {
+        "Left": 561.3765041866548,
+        "Top": 205.37993194560642,
+        "IsHidden": false,
+        "ConnectorGuid": "dd11a60a-ae71-472e-9b5c-3613e9095574"
       }
     ],
     "NodeViews": [
@@ -196,7 +202,7 @@
         "Excluded": false,
         "ShowGeometry": true,
         "X": 96.5,
-        "Y": 198.0
+        "Y": 199.07317839436
       },
       {
         "Id": "7cdc095c2d41415b9935b44c990ee782",
@@ -210,8 +216,8 @@
       }
     ],
     "Annotations": [],
-    "X": 0.0,
-    "Y": 0.0,
-    "Zoom": 1.0
+    "X": -65.75259710831733,
+    "Y": 92.39817788510285,
+    "Zoom": 1.0987122290256521
   }
 }


### PR DESCRIPTION
### Purpose

Update `TestSelectNeighborPins` test to reflect the selection behavior for pins as a follow up of https://github.com/DynamoDS/Dynamo/pull/15091. It looks like the PR checks on master-5 machine no longer report failures, this regression is reported on master-15 while the original PR checks all passed.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers



### FYIs

@DynamoDS/dynamo 