### PR TITLE
DYN-6769 Improving Dynamo Load Graph II

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -93,6 +93,8 @@ namespace Dynamo.ViewModels
 
         internal DynamoMLDataPipelineExtension MLDataPipelineExtension { get; set; }
 
+        internal static Dictionary<string, NodeSearchElementViewModel> DefaultAutocompleteCandidates = new Dictionary<string, NodeSearchElementViewModel>();
+
         /// <summary>
         /// Collection of Right SideBar tab items: view extensions and docked windows.
         /// </summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -194,7 +194,12 @@ namespace Dynamo.ViewModels
             {
                 foreach (var query in queries)
                 {
-                    candidates.Add(foundNode);
+                    var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
+                    if (foundNode != null)
+                    {
+                        candidates.Add(foundNode);
+                        DynamoViewModel.DefaultAutocompleteCandidates.Add(foundNode.Name, foundNode);
+                    }
                 }
                 DefaultResults = candidates;
             }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -185,15 +185,19 @@ namespace Dynamo.ViewModels
             // TODO: These are basic input types in Dynamo
             // This should be only served as a temporary default case.
             var queries = new List<string>(){"String", "Number Slider", "Integer Slider", "Number", "Boolean", "Watch", "Watch 3D", "Python Script"};
-            foreach (var query in queries)
+            var nodeNamesList = DynamoViewModel.DefaultAutocompleteCandidates.Keys.ToList();
+            if (nodeNamesList.Where(queries.Contains).Any() == true)
             {
-                var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
-                if(foundNode != null)
+                DefaultResults = DynamoViewModel.DefaultAutocompleteCandidates.Values;
+            }
+            else
+            {
+                foreach (var query in queries)
                 {
                     candidates.Add(foundNode);
                 }
+                DefaultResults = candidates;
             }
-            DefaultResults = candidates;
         }
 
         internal MLNodeAutoCompletionRequest GenerateRequestForMLAutocomplete()


### PR DESCRIPTION
### Purpose

With this change only will be executing the DefaultAutocompleteCandidates functionality only once at Dynamo startup, then when a graph is loaded won't be executed.
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

With this change only will be executing the DefaultAutocompleteCandidates functionality only once at Dynamo startup, then when a graph is loaded won't be executed.

### Reviewers

@QilongTang 

### FYIs

