### PR TITLE
Fix preference setting test after a new setting has been added.

### DIFF
--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -25,6 +25,7 @@
   <DefaultScaleFactor>-2</DefaultScaleFactor>
   <RenderPrecision>8</RenderPrecision>
   <ShowEdges>true</ShowEdges>
+  <UseRenderInstancing>false</UseRenderInstancing>
   <ShowDetailedLayout>false</ShowDetailedLayout>
   <WindowX>-8</WindowX>
   <WindowY>-8</WindowY>


### PR DESCRIPTION
### Purpose

Fixing the preference setting test after Helix instancing flag is added to the preference setting here: https://github.com/DynamoDS/Dynamo/pull/14675

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Fix preference setting test after a new setting has been added.

### Reviewers
@QilongTang @saintentropy 
