### PR TITLE
Fix Test Failure for AggregateRenderPackagesDoesntMutateRenderPackage

### DIFF
--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -1251,7 +1251,10 @@ namespace WpfVisualizationTests
 
             output.RenderPackagesUpdated += TestRenderPackageUpdate;
 
-            output.RequestVisualUpdateAsync(ViewModel.Model.Scheduler, ViewModel.Model.EngineController, new HelixRenderPackageFactory(), true);
+            var factory = new HelixRenderPackageFactory();
+            factory.TessellationParameters.UseRenderInstancing = true;
+
+            output.RequestVisualUpdateAsync(ViewModel.Model.Scheduler, ViewModel.Model.EngineController, factory, true);
         }
 
         private void TestRenderPackageUpdate(NodeModel nodeModel, RenderPackageCache renderPackages) {


### PR DESCRIPTION
### Purpose

The original test had instancing on due to a quirk of the feature flag implementation.  This restores the behavior by setting the tessellation parameters to have instancing enabled. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Not applicable.  Tests 

### Reviewers

@reddyashish 

### FYIs

@QilongTang 