### PR TITLE
Revert "DYN-6769 Improving Dynamo Load Graph II (#15108)"

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -93,8 +93,6 @@ namespace Dynamo.ViewModels
 
         internal DynamoMLDataPipelineExtension MLDataPipelineExtension { get; set; }
 
-        internal static Dictionary<string, NodeSearchElementViewModel> DefaultAutocompleteCandidates = new Dictionary<string, NodeSearchElementViewModel>();
-
         /// <summary>
         /// Collection of Right SideBar tab items: view extensions and docked windows.
         /// </summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -185,24 +185,15 @@ namespace Dynamo.ViewModels
             // TODO: These are basic input types in Dynamo
             // This should be only served as a temporary default case.
             var queries = new List<string>(){"String", "Number Slider", "Integer Slider", "Number", "Boolean", "Watch", "Watch 3D", "Python Script"};
-            var nodeNamesList = DynamoViewModel.DefaultAutocompleteCandidates.Keys.ToList();
-            if (nodeNamesList.Where(queries.Contains).Any() == true)
+            foreach (var query in queries)
             {
-                DefaultResults = DynamoViewModel.DefaultAutocompleteCandidates.Values;
-            }
-            else
-            {
-                foreach (var query in queries)
+                var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
+                if(foundNode != null)
                 {
-                    var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
-                    if (foundNode != null)
-                    {
-                        candidates.Add(foundNode);
-                        DynamoViewModel.DefaultAutocompleteCandidates.Add(foundNode.Name, foundNode);
-                    }
+                    candidates.Add(foundNode);
                 }
-                DefaultResults = candidates;
             }
+            DefaultResults = candidates;
         }
 
         internal MLNodeAutoCompletionRequest GenerateRequestForMLAutocomplete()


### PR DESCRIPTION
### Purpose

This reverts commit 30e7c0d28ee863f56775940e08e91a0603f923e6.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

This reverts commit 30e7c0d28ee863f56775940e08e91a0603f923e6.

### Reviewers

@QilongTang 

### FYIs

