### PR TITLE
Fix slider localization test

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
@@ -63,7 +63,8 @@ namespace CoreNodeModelsWpf
                 if (value.CompareTo(model.Min) == -1)
                     model.Min = value;
 
-                var stepValueString = model.Step.ToString();
+                double.TryParse(model.Step.ToString(), out double stepValue);
+                var stepValueString = stepValue.ToString(null, CultureInfo.InvariantCulture);
                 var decimalPoints = 0;
                 if (stepValueString.Contains('.'))
                 {
@@ -73,8 +74,8 @@ namespace CoreNodeModelsWpf
                 if (value is IFormattable formattableval)
                 {
                     var invariantString  = formattableval.ToString(null,CultureInfo.InvariantCulture);
-                    var sliderValue = Math.Round(decimal.Parse(invariantString), decimalPoints);
-                    model.UpdateValue(new Dynamo.Graph.UpdateValueParams(nameof(Value), sliderValue.ToString()));
+                    var sliderValue = Math.Round(decimal.Parse(invariantString, CultureInfo.InvariantCulture), decimalPoints);
+                    model.UpdateValue(new Dynamo.Graph.UpdateValueParams(nameof(Value), sliderValue.ToString(CultureInfo.InvariantCulture)));
                 }
                 else
                 {

--- a/test/DynamoCoreWpfTests/SliderViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SliderViewModelTests.cs
@@ -140,7 +140,6 @@ namespace DynamoCoreWpfTests
         /// modify the value.
         /// </summary>
         [Test]
-        [Category("Failure")]
         public void SliderViewModel_ValueTest_Localized()
         {
             //change current thread culture to German.


### PR DESCRIPTION
### Purpose

This is to fix the slider localization test SliderViewModel_ValueTest_Localized which was marked as failure [here](https://github.com/DynamoDS/Dynamo/pull/15101)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Fix slider localization test

### Reviewers
@QilongTang @mjkkirschner 

