### PR TITLE
Ucs turn off with grid

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -3948,6 +3948,7 @@ Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.Grid.get -> HelixToolkit.Sha
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.Grid.set -> void
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.HasRenderedGeometry.get -> bool
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.HelixWatch3DViewModel(Dynamo.Graph.Nodes.NodeModel model, Dynamo.Wpf.ViewModels.Watch3D.Watch3DViewModelStartupParams parameters) -> void
+Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.IsAxesVisible.get -> bool
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.IsResizable.get -> bool
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.IsResizable.set -> void
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.LeftClickCommand.get -> System.Windows.Input.RoutedCommand

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -3948,7 +3948,6 @@ Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.Grid.get -> HelixToolkit.Sha
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.Grid.set -> void
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.HasRenderedGeometry.get -> bool
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.HelixWatch3DViewModel(Dynamo.Graph.Nodes.NodeModel model, Dynamo.Wpf.ViewModels.Watch3D.Watch3DViewModelStartupParams parameters) -> void
-Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.IsAxesVisible.get -> bool
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.IsResizable.get -> bool
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.IsResizable.set -> void
 Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.LeftClickCommand.get -> System.Windows.Input.RoutedCommand

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -168,6 +168,21 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private static readonly float defaultDeadAlphaScale = 0.2f;
         private const float defaultLabelOffset = 0.025f;
 
+
+        private static readonly Color4Collection DefaultAxesColors = new Color4Collection
+        {
+            Color.Red, Color.Red,
+            Color.Blue, Color.Blue,
+            Color.Green, Color.Green
+        };
+
+        private static readonly Color4Collection TransparentAxesColors = new Color4Collection
+        {
+            Color.Transparent, Color.Transparent,
+            Color.Transparent, Color.Transparent,
+            Color.Transparent, Color.Transparent
+        };
+
         internal const string DefaultGridName = "Grid";
         internal const string DefaultAxesName = "Axes";
         internal const string DefaultLightName = "DirectionalLight";
@@ -1418,7 +1433,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
 
             // Create the headlight singleton and add it to the dictionary
-
             headLight = new DirectionalLight3D
             {
                 Color = System.Windows.Media.Color.FromRgb(230, 230, 230),
@@ -1441,7 +1455,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
 
             // Create the grid singleton and add it to the dictionary
-
             gridModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Grid,
@@ -1461,7 +1474,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
 
             // Create the axes singleton and add it to the dictionary
-
             var axesModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Axes,
@@ -1508,33 +1520,26 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             Axes = new LineGeometry3D();
             var axesPositions = new Vector3Collection();
             var axesIndices = new IntCollection();
-            var axesColors = new Color4Collection();
 
             // Draw the coordinate axes
             axesPositions.Add(new Vector3());
             axesIndices.Add(axesPositions.Count - 1);
             axesPositions.Add(new Vector3(50 * scale, 0, 0));
             axesIndices.Add(axesPositions.Count - 1);
-            axesColors.Add(Color.Red);
-            axesColors.Add(Color.Red);
 
             axesPositions.Add(new Vector3());
             axesIndices.Add(axesPositions.Count - 1);
             axesPositions.Add(new Vector3(0, 5 * scale, 0));
             axesIndices.Add(axesPositions.Count - 1);
-            axesColors.Add(Color.Blue);
-            axesColors.Add(Color.Blue);
 
             axesPositions.Add(new Vector3());
             axesIndices.Add(axesPositions.Count - 1);
             axesPositions.Add(new Vector3(0, 0, -50 * scale));
             axesIndices.Add(axesPositions.Count - 1);
-            axesColors.Add(Color.Green);
-            axesColors.Add(Color.Green);
 
             Axes.Positions = axesPositions;
             Axes.Indices = axesIndices;
-            Axes.Colors = axesColors;
+            Axes.Colors = DefaultAxesColors;            
         }
 
         private void SetGridVisibility()
@@ -1542,8 +1547,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var visibility = isGridVisible ? Visibility.Visible : Visibility.Hidden;
             //return if there is nothing to change
             if (gridModel3D.Visibility == visibility) return;
-            
+
+            // set axes colors and grid visibility based on grid visibility
+            Axes.Colors = isGridVisible ? DefaultAxesColors : TransparentAxesColors;
             gridModel3D.Visibility = visibility;
+
             OnRequestViewRefresh();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -168,15 +168,16 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private static readonly float defaultDeadAlphaScale = 0.2f;
         private const float defaultLabelOffset = 0.025f;
 
-
-        private static readonly Color4Collection DefaultAxesColors = new Color4Collection
+        /// <summary>
+        /// Color4Collections to represent the axes in drawn and hidden states
+        /// </summary>
+        private readonly Color4Collection DefaultAxesColors = new Color4Collection
         {
             Color.Red, Color.Red,
             Color.Blue, Color.Blue,
             Color.Green, Color.Green
         };
-
-        private static readonly Color4Collection TransparentAxesColors = new Color4Collection
+        private readonly Color4Collection TransparentAxesColors = new Color4Collection
         {
             Color.Transparent, Color.Transparent,
             Color.Transparent, Color.Transparent,
@@ -370,7 +371,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             set
             {
                 worldAxes = value;
-                RaisePropertyChanged("Axes");
+                RaisePropertyChanged(DefaultAxesName);
             }
         }
 
@@ -453,6 +454,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
+        public bool IsAxesVisible
+        {
+            get { return Axes.Colors == TransparentAxesColors ? false : true;  }
+        }
 
         /// <summary>
         /// Sets the scale of the Grid helper

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -169,7 +169,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private const float defaultLabelOffset = 0.025f;
 
         /// <summary>
-        /// Color4Collections to represent the axes in drawn and hidden states
+        /// Color4Collection to represent axes when drawn
         /// </summary>
         private readonly Color4Collection DefaultAxesColors = new Color4Collection
         {
@@ -177,6 +177,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             Color.Blue, Color.Blue,
             Color.Green, Color.Green
         };
+
+        /// <summary>
+        /// Color4Collection to represent axes when hidden
+        /// </summary>
         private readonly Color4Collection TransparentAxesColors = new Color4Collection
         {
             Color.Transparent, Color.Transparent,
@@ -454,7 +458,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
-        public bool IsAxesVisible
+        internal bool IsAxesVisible
         {
             get { return Axes.Colors == TransparentAxesColors ? false : true;  }
         }

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -762,9 +762,10 @@ namespace WpfVisualizationTests
             var bPreviewVm = ViewModel.BackgroundPreviewViewModel as HelixWatch3DViewModel;
             var grid = bPreviewVm.Element3DDictionary[HelixWatch3DViewModel.DefaultGridName];
 
-            Assert.IsNotNull(bPreviewVm, "HelixWatch3D has not been loaded");            
+            Assert.IsNotNull(bPreviewVm, "HelixWatch3D has not been loaded");
 
-            // Assert that grid and axes are drawn
+            // Ensure background grid and axes are enabled and check effects
+            bPreviewVm.IsGridVisible = true;
             Assert.IsTrue(grid.Visibility == Visibility.Visible, "Background grid has not been drawn");
             Assert.IsTrue(bPreviewVm.IsAxesVisible, "Axes have not been drawn");
 

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -17,7 +17,6 @@ using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
-using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Scheduler;
@@ -758,6 +757,29 @@ namespace WpfVisualizationTests
         }
 
         [Test]
+        public void HelixWatch3DViewModel_DisableGrid_AxesNotVisible()
+        {
+            var bPreviewVm = ViewModel.BackgroundPreviewViewModel as HelixWatch3DViewModel;
+            var grid = bPreviewVm.Element3DDictionary[HelixWatch3DViewModel.DefaultGridName];
+
+            Assert.IsNotNull(bPreviewVm, "HelixWatch3D has not been loaded");            
+
+            // Assert that grid and axes are drawn
+            Assert.IsTrue(grid.Visibility == Visibility.Visible, "Background grid has not been drawn");
+            Assert.IsTrue(bPreviewVm.IsAxesVisible, "Axes have not been drawn");
+
+            // Disable background grid and axes and check effects
+            bPreviewVm.IsGridVisible = false;          
+            Assert.IsTrue(grid.Visibility == Visibility.Hidden, "Background grid has not been hidden");
+            Assert.IsFalse(bPreviewVm.IsAxesVisible, "Axes have not been hidden");
+
+            // Re-enable background grid and axes and check effects
+            bPreviewVm.IsGridVisible = true;
+            Assert.IsTrue(grid.Visibility == Visibility.Visible, "Background grid has not been re-drawn");
+            Assert.IsTrue(bPreviewVm.IsAxesVisible, "Axes have not been re-drawn");
+        }
+
+        [Test]
         public void HelixWatch3DViewModel_ChangeBackgroundVisibility_CanNavigateButtonsAreCorrect()
         {
             var bPreviewVm = ViewModel.BackgroundPreviewViewModel as HelixWatch3DViewModel;
@@ -953,7 +975,7 @@ namespace WpfVisualizationTests
             var nodeView = View.ChildrenOfType<NodeView>().First(nv => nv.ViewModel.Name == "Watch");
             var parentTreeViewItem = nodeView.ChildOfType<TreeViewItem>();
 
-            // Selcting a sphere object 70 different times to render new labels again.
+            // Selecting a sphere object 70 different times to render new labels again.
             for (int i = 0; i < 30; i++)
             {
 
@@ -1119,7 +1141,7 @@ namespace WpfVisualizationTests
             var nodes = nodeIds.Select(workspace.NodeFromWorkspace).ToList();
             Assert.IsFalse(nodes.Any(n => n == null)); // Nothing should be null.
 
-            // Ensure that visulations match our expectations
+            // Ensure that visualizations match our expectations
             // Initially, all nodes has shortest lacing strategy
             // 5 points for point0 node, 2 points for point1 and point2 node
             Assert.AreEqual(9, BackgroundPreviewGeometry.TotalPoints());
@@ -1291,7 +1313,7 @@ namespace WpfVisualizationTests
             }
 
             var treeViewItem = nodeView.ChildOfType<TreeViewItem>();
-            // find TreeViewItem by given index in multi-dimentional array
+            // find TreeViewItem by given index in multi-dimensional array
             foreach (var index in indexes)
             {
                 treeViewItem = treeViewItem.ChildrenOfType<TreeViewItem>().ElementAt(index);


### PR DESCRIPTION
### Purpose

Small PR to hide/show Axes from HelixWatch3D when the Grid is hidden/shown as well.
Including test.

Before

![Dynamo UCS - Before](https://github.com/DynamoDS/Dynamo/assets/48355182/254782ba-9583-49ed-8a27-9cb0b614bff7)

After

![Dynamo UCS](https://github.com/DynamoDS/Dynamo/assets/48355182/0393abf9-1518-4cb5-a1bc-c65639bec07f)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Hide/show Axes from HelixWatch3D when the Grid is hidden/shown.
Including test.

### Reviewers

@dnenov
@reddyashish


### FYIs

@Amoursol
