### PR TITLE
Revert "homepage preferences (#15139)"

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -395,21 +395,6 @@ namespace Dynamo.Configuration
         /// </summary>
         public bool UseHardwareAcceleration { get; set; }
 
-        /// <summary>
-        /// Persistence for Dynamo HomePage
-        /// </summary>
-        [XmlIgnore]
-        internal Dictionary<string, object> HomePageSettings { get; set; }
-
-        /// <summary>
-        /// A helper intermediary string to allow the serialization of the HomePageSettings dictionary
-        /// </summary>
-        public string HomePageSettingsSerialized
-        {
-            get => Newtonsoft.Json.JsonConvert.SerializeObject(HomePageSettings);   
-            set => HomePageSettings = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, object>>(value);
-        }
-
         #endregion
 
         #region Dynamo application settings

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-abstract Dynamo.Extensions.LinterExtensionBase.Name.get -> string
+﻿abstract Dynamo.Extensions.LinterExtensionBase.Name.get -> string
 abstract Dynamo.Extensions.LinterExtensionBase.Shutdown() -> void
 abstract Dynamo.Extensions.LinterExtensionBase.UniqueId.get -> string
 abstract Dynamo.Graph.ModelBase.DeserializeCore(System.Xml.XmlElement nodeElement, Dynamo.Graph.SaveContext context) -> void
@@ -177,8 +177,6 @@ Dynamo.Configuration.PreferenceSettings.HideAutocompleteMethodOptions.get -> boo
 Dynamo.Configuration.PreferenceSettings.HideAutocompleteMethodOptions.set -> void
 Dynamo.Configuration.PreferenceSettings.HideNodesBelowSpecificConfidenceLevel.get -> bool
 Dynamo.Configuration.PreferenceSettings.HideNodesBelowSpecificConfidenceLevel.set -> void
-Dynamo.Configuration.PreferenceSettings.HomePageSettingsSerialized.get -> string
-Dynamo.Configuration.PreferenceSettings.HomePageSettingsSerialized.set -> void
 Dynamo.Configuration.PreferenceSettings.IronPythonResolveTargetVersion.get -> string
 Dynamo.Configuration.PreferenceSettings.IronPythonResolveTargetVersion.set -> void
 Dynamo.Configuration.PreferenceSettings.IsADPAnalyticsReportingApproved.get -> bool

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1576,8 +1576,7 @@ Dynamo.UI.Views.ScriptHomeObject.NewCustomNodeWorkspace() -> void
 Dynamo.UI.Views.ScriptHomeObject.NewWorkspace() -> void
 Dynamo.UI.Views.ScriptHomeObject.OpenFile(string path) -> void
 Dynamo.UI.Views.ScriptHomeObject.OpenWorkspace() -> void
-Dynamo.UI.Views.ScriptHomeObject.SaveSettings(string settings) -> void
-Dynamo.UI.Views.ScriptHomeObject.ScriptHomeObject(System.Action<string> requestOpenFile, System.Action requestNewWorkspace, System.Action requestOpenWorkspace, System.Action requestNewCustomNodeWorkspace, System.Action requestApplicationLoaded, System.Action<string> requestShowGuidedTour, System.Action requestShowSampleFilesInFolder, System.Action requestShowBackupFilesInFolder, System.Action requestShowTemplate, System.Action<string> requestSaveSettings) -> void
+Dynamo.UI.Views.ScriptHomeObject.ScriptHomeObject(System.Action<string> requestOpenFile, System.Action requestNewWorkspace, System.Action requestOpenWorkspace, System.Action requestNewCustomNodeWorkspace, System.Action requestApplicationLoaded, System.Action<string> requestShowGuidedTour, System.Action requestShowSampleFilesInFolder, System.Action requestShowBackupFilesInFolder, System.Action requestShowTemplate) -> void
 Dynamo.UI.Views.ScriptHomeObject.ShowBackupFilesInFolder() -> void
 Dynamo.UI.Views.ScriptHomeObject.ShowSampleFilesInFolder() -> void
 Dynamo.UI.Views.ScriptHomeObject.ShowTempalte() -> void

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -479,27 +479,5 @@ namespace Dynamo.Tests.Configuration
 
             Assert.IsTrue(allTheGroupStylesHaveAValidFontSize, $"All the GroupStyles have a valid Font size : {allTheGroupStylesHaveAValidFontSize}");
         }
-
-        [Test]
-        [Category("UnitTests")]
-        public void TestSerializingHomePageSettings()
-        {
-            string tempPath = System.IO.Path.GetTempPath();
-            tempPath = Path.Combine(tempPath, "homePagePreference.xml");
-
-            PreferenceSettings settings = new PreferenceSettings();
-
-            // Assert defaults
-            Assert.AreEqual(settings.HomePageSettings, null);
-            Assert.AreEqual(settings.HomePageSettingsSerialized, "null");
-
-            settings.HomePageSettings = new Dictionary<string, object> { { "greeting", "Hello World" } };
-
-            // Save
-            settings.Save(tempPath);
-            settings = PreferenceSettings.Load(tempPath);
-
-            Assert.AreEqual(settings.HomePageSettings["greeting"], "Hello World");
-        }
     }
 }

--- a/test/DynamoCoreWpfTests/HomePageTests.cs
+++ b/test/DynamoCoreWpfTests/HomePageTests.cs
@@ -53,36 +53,6 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(homePage.RequestShowBackupFilesInFolder);
             Assert.IsNotNull(homePage.RequestShowTemplate);
         }
-
-        [Test]
-        public void HomePage_NewSettingsAreAddedCorrectly()
-        {
-            // Arrange
-            var vm = View.DataContext as DynamoViewModel;
-            var startPage = new StartPageViewModel(vm, true);
-            var preferences = startPage.DynamoViewModel.PreferenceSettings;
-            var homePage = new HomePage();
-
-            homePage.DataContext = startPage;
-
-            Assert.IsNull(preferences.HomePageSettings);
-
-            // Act
-            var pair1 = @"{""Name"": ""Alice""}";
-            homePage.SaveSettings(pair1);
-
-            // Assert 
-            Assert.IsNotNull(preferences.HomePageSettings);
-            Assert.AreEqual(preferences.HomePageSettings.Count, 1);
-
-            // Act
-            var pair2 = @"{""Number"": 12 }";
-            homePage.SaveSettings(pair2);
-
-            // Assert
-            Assert.AreEqual(preferences.HomePageSettings.Count, 2);
-        }
-
         #endregion
 
         #region integration tests


### PR DESCRIPTION
### Purpose

Reverting https://github.com/DynamoDS/Dynamo/pull/15139 for now as it has caused a regression. The test failing is [Dynamo.Tests.Configuration.PreferenceSettingsTests.TestImportCopySettings](https://master-5.jenkins.autodesk.com/job/Dynamo/job/DynamoSelfServe/job/pullRequestValidation/15846/testReport/Dynamo.Tests.Configuration/PreferenceSettingsTests/TestImportCopySettings/)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Revert "homepage preferences (#15139)"

### Reviewers
@QilongTang 

