### PR TITLE
DYN-6769 improving dynamo load graph ii 2

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -93,6 +93,8 @@ namespace Dynamo.ViewModels
 
         internal DynamoMLDataPipelineExtension MLDataPipelineExtension { get; set; }
 
+        internal static Dictionary<string, NodeSearchElementViewModel> DefaultAutocompleteCandidates = new Dictionary<string, NodeSearchElementViewModel>();
+
         /// <summary>
         /// Collection of Right SideBar tab items: view extensions and docked windows.
         /// </summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -93,7 +93,7 @@ namespace Dynamo.ViewModels
 
         internal DynamoMLDataPipelineExtension MLDataPipelineExtension { get; set; }
 
-        internal static Dictionary<string, NodeSearchElementViewModel> DefaultAutocompleteCandidates = new Dictionary<string, NodeSearchElementViewModel>();
+        internal Dictionary<string, NodeSearchElementViewModel> DefaultAutocompleteCandidates;
 
         /// <summary>
         /// Collection of Right SideBar tab items: view extensions and docked windows.
@@ -697,6 +697,28 @@ namespace Dynamo.ViewModels
             return new DynamoViewModel(startConfiguration);
         }
 
+        private void SearchDefaultNodeAutocompleteCandidates()
+        {
+            var tempSearchViewModel = new SearchViewModel(this)
+            {
+                Visible = true
+            };
+            DefaultAutocompleteCandidates = new Dictionary<string, NodeSearchElementViewModel>();
+
+            // TODO: These are basic input types in Dynamo
+            // This should be only served as a temporary default case.
+            var queries = new List<string>() { "String", "Number Slider", "Integer Slider", "Number", "Boolean", "Watch", "Watch 3D", "Python Script" };
+            foreach (var query in queries)
+            {
+                var foundNode = tempSearchViewModel.Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
+                if (foundNode != null)
+                {
+                    DefaultAutocompleteCandidates.Add(foundNode.Name, foundNode);
+                }
+            }
+            tempSearchViewModel.Dispose();
+        }
+
         protected DynamoViewModel(StartConfiguration startConfiguration)
         {
             // CurrentDomain_UnhandledException - catches unhandled exceptions that are fatal to the current process. These exceptions cannot be handled and process termination is guaranteed
@@ -736,6 +758,7 @@ namespace Dynamo.ViewModels
 
             //add the initial workspace and register for future 
             //updates to the workspaces collection
+            SearchDefaultNodeAutocompleteCandidates();
             var homespaceViewModel = new HomeWorkspaceViewModel(model.CurrentWorkspace as HomeWorkspaceModel, this);
             workspaces.Add(homespaceViewModel);
             currentWorkspaceViewModel = homespaceViewModel;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -758,7 +758,11 @@ namespace Dynamo.ViewModels
 
             //add the initial workspace and register for future 
             //updates to the workspaces collection
-            SearchDefaultNodeAutocompleteCandidates();
+            if(!Model.IsServiceMode)
+            {
+                SearchDefaultNodeAutocompleteCandidates();
+            }
+            
             var homespaceViewModel = new HomeWorkspaceViewModel(model.CurrentWorkspace as HomeWorkspaceModel, this);
             workspaces.Add(homespaceViewModel);
             currentWorkspaceViewModel = homespaceViewModel;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -185,15 +185,24 @@ namespace Dynamo.ViewModels
             // TODO: These are basic input types in Dynamo
             // This should be only served as a temporary default case.
             var queries = new List<string>(){"String", "Number Slider", "Integer Slider", "Number", "Boolean", "Watch", "Watch 3D", "Python Script"};
-            foreach (var query in queries)
+            var nodeNamesList = DynamoViewModel.DefaultAutocompleteCandidates.Keys.ToList();
+            if (nodeNamesList.Where(queries.Contains).Any() == true)
             {
-                var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
-                if(foundNode != null)
-                {
-                    candidates.Add(foundNode);
-                }
+                DefaultResults = DynamoViewModel.DefaultAutocompleteCandidates.Values;
             }
-            DefaultResults = candidates;
+            else
+            {
+                foreach (var query in queries)
+                {
+                    var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
+                    if (foundNode != null)
+                    {
+                        candidates.Add(foundNode);
+                        DynamoViewModel.DefaultAutocompleteCandidates.Add(foundNode.Name, foundNode);
+                    }
+                }
+                DefaultResults = candidates;
+            }
         }
 
         internal MLNodeAutoCompletionRequest GenerateRequestForMLAutocomplete()

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -160,7 +160,7 @@ namespace Dynamo.ViewModels
         internal NodeAutoCompleteSearchViewModel(DynamoViewModel dynamoViewModel) : base(dynamoViewModel)
         {
             // Off load some time consuming operation here
-            InitializeDefaultAutoCompleteCandidates();
+            DefaultResults = dynamoViewModel.DefaultAutocompleteCandidates.Values;
             ServiceVersion = string.Empty;
         }
 
@@ -177,32 +177,6 @@ namespace Dynamo.ViewModels
             FilteredHighConfidenceResults = new List<NodeSearchElementViewModel>();
             FilteredLowConfidenceResults = new List<NodeSearchElementViewModel>();
             searchElementsCache = new List<NodeSearchElementViewModel>();
-        }
-
-        private void InitializeDefaultAutoCompleteCandidates()
-        {
-            var candidates = new List<NodeSearchElementViewModel>();
-            // TODO: These are basic input types in Dynamo
-            // This should be only served as a temporary default case.
-            var queries = new List<string>(){"String", "Number Slider", "Integer Slider", "Number", "Boolean", "Watch", "Watch 3D", "Python Script"};
-            var nodeNamesList = DynamoViewModel.DefaultAutocompleteCandidates.Keys.ToList();
-            if (nodeNamesList.Where(queries.Contains).Any() == true)
-            {
-                DefaultResults = DynamoViewModel.DefaultAutocompleteCandidates.Values;
-            }
-            else
-            {
-                foreach (var query in queries)
-                {
-                    var foundNode = Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
-                    if (foundNode != null)
-                    {
-                        candidates.Add(foundNode);
-                        DynamoViewModel.DefaultAutocompleteCandidates.Add(foundNode.Name, foundNode);
-                    }
-                }
-                DefaultResults = candidates;
-            }
         }
 
         internal MLNodeAutoCompletionRequest GenerateRequestForMLAutocomplete()

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -670,7 +670,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("UnitTests")]
+        [Category("Failure")]
         public void RemovePIIDataFromWorkspace()
         {
             string graphWithPIIDataPath = Path.Combine(TestDirectory, (@"UI\GraphWithPIIData.dyn"));


### PR DESCRIPTION
### Purpose

Modifying the DefaultNodeAutocompleteCandidates functionality so is only executed once.
Instead of using a static Dictionary now I will be using a normal instance that will be initialized in DynamoViewModel and pass it to NodeAutoCompleteSearchViewModel, in this case we are also confirming that only be executed once.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Modifying the DefaultNodeAutocompleteCandidates functionality so is only executed once.

### Reviewers

@QilongTang 

### FYIs

