### PR TITLE
Re-enable graph node manager tests

### DIFF
--- a/test/DynamoCoreWpfTests/ViewExtensions/GraphNodeManagerViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/GraphNodeManagerViewExtensionTests.cs
@@ -103,7 +103,7 @@ namespace DynamoCoreWpfTests
         /// <summary>
         /// Test if the number of nodes displayed in the extension is equal to current number of nodes
         /// </summary>
-        [Test, Category("Failure")]
+        [Test]
         public void CorrectNumberNodeItemsTest()
         {
             var extensionManager = View.viewExtensionManager;
@@ -147,7 +147,7 @@ namespace DynamoCoreWpfTests
         /// <summary>
         /// Test if using the IsFrozen filter yields correct results
         /// </summary>
-        [Test, Category("Failure")]
+        [Test]
         public void FilterFrozenItemsTest()
         {
             var extensionManager = View.viewExtensionManager;
@@ -193,7 +193,7 @@ namespace DynamoCoreWpfTests
         /// Test if the number of Nodes containing Null or Empty List matches what is shown on the UI
         /// Marked as Failure until we can fix flakyness
         /// </summary>
-        [Test, Category("Failure")]
+        [Test]
         public void ContainsEmptyListOrNullTest()
         {
             var extensionManager = View.viewExtensionManager;


### PR DESCRIPTION
### Purpose

Given master-5 can now run tests, try to re-enable these tests to see if they pass

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
