### PR TITLE
PR checker and updater for Jira missing stuff

### DIFF
--- a/.github/workflows/pr_jira_check.yml
+++ b/.github/workflows/pr_jira_check.yml
@@ -1,0 +1,24 @@
+name: PR checker and updater for Jira missing stuff
+
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  title:
+    name: Missing Jira ticket check
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check for ticket
+        uses: neofinancial/ticket-check-action@v1
+
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://jira.autodesk.com/browse/DYN-%ticketNumber%'
+          ticketPrefix: 'DYN-'
+          titleRegex: '^DYN-(?<ticketNumber>\d+)'
+          branchRegex: '^DYN-(?<ticketNumber>\d+)'
+          bodyRegex: 'DYN-(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(jira.autodesk.com)(\/browse)\/(DYN\-)(?<ticketNumber>\d+)'

--- a/.github/workflows/pr_jira_check.yml
+++ b/.github/workflows/pr_jira_check.yml
@@ -1,4 +1,4 @@
-name: PR checker and updater for Jira missing stuff
+name: Jira ticket check
 
 on:
   pull_request:

--- a/.github/workflows/pr_jira_check.yml
+++ b/.github/workflows/pr_jira_check.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Check for ticket
-        uses: neofinancial/ticket-check-action@v1
+        uses: neofinancial/ticket-check-action@v2
 
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Purpose

Sometimes authors forget to add the ticket number to the title or/and add a Jira link to the description. So I'm adding the GitHub Action to check if the Jira ticket number is missing in the title or in the description. This updates the title with the ticket number and adds a comment with the link redirecting to the Jira ticket.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

GitHub Action to check if the Jira ticket number is missing in the title or in the description. This updates the title with the ticket number and adds a comment with the link redirecting to the Jira ticket.


### Reviewers

@sm6srw 


### FYIs


