### PR TITLE
DYN-6893 input symbol nodes should have default names - pt 1

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using Dynamo.Engine;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Library;
+using Dynamo.Properties;
 using Newtonsoft.Json;
 using ProtoCore;
 using ProtoCore.AST.AssociativeAST;
@@ -388,8 +389,13 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             RegisterAllPorts();
 
             ArgumentLacing = LacingStrategy.Disabled;
-            //TODO localize
-            InputSymbol = new TypedParameter($"DefaultInputName", "var",-1,null).ToCommentNameString();
+            InputSymbol = new TypedParameter(
+                Resources.InputPortAlternativeName,
+                "var",
+                -1,
+                null,
+                Resources.InputNodeRenameHint)
+                .ToCommentNameString();
 
             ElementResolver = new ElementResolver();
         }

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -388,8 +388,8 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             RegisterAllPorts();
 
             ArgumentLacing = LacingStrategy.Disabled;
-
-            InputSymbol = String.Empty;
+            //TODO localize
+            InputSymbol = new TypedParameter($"DefaultInputName", "var",-1,null).ToCommentNameString();
 
             ElementResolver = new ElementResolver();
         }
@@ -463,7 +463,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
                 }
 
                 OnNodeModified();
-                RaisePropertyChanged("InputSymbol");
+                RaisePropertyChanged(nameof(InputSymbol));
             }
         }
 

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -993,6 +993,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to default input name, rename me!.
+        /// </summary>
+        public static string InputNodeRenameHint {
+            get {
+                return ResourceManager.GetString("InputNodeRenameHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to variable;argument;parameter.
         /// </summary>
         public static string InputNodeSearchTags {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -911,4 +911,7 @@ This package likely contains an assembly that is blocked. You will need to load 
   <data name="LegacyTraceDataWarning" xml:space="preserve">
     <value>This workspace contains element binding data in a legacy format that is no longer supported in Dynamo 3.0 and higher versions. Element binding data will be saved in the new format the next time you run and save this workspace.</value>
   </data>
+  <data name="InputNodeRenameHint" xml:space="preserve">
+    <value>default input name, rename me!</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -914,4 +914,7 @@ This package likely contains an assembly that is blocked. You will need to load 
   <data name="LegacyTraceDataWarning" xml:space="preserve">
     <value>This workspace contains element binding data in a legacy format that is no longer supported in Dynamo 3.0 and higher versions. Element binding data will be saved in the new format the next time you run and save this workspace.</value>
   </data>
+  <data name="InputNodeRenameHint" xml:space="preserve">
+    <value>default input name, rename me!</value>
+  </data>
 </root>

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -2834,6 +2834,7 @@ static Dynamo.Properties.Resources.IncorrectlyFormattedNodeLibraryWarning.get ->
 static Dynamo.Properties.Resources.IncorrectVersionToOpenFile.get -> string
 static Dynamo.Properties.Resources.InputLabel.get -> string
 static Dynamo.Properties.Resources.InputNodeDescription.get -> string
+static Dynamo.Properties.Resources.InputNodeRenameHint.get -> string
 static Dynamo.Properties.Resources.InputNodeSearchTags.get -> string
 static Dynamo.Properties.Resources.InputPortAlternativeName.get -> string
 static Dynamo.Properties.Resources.InsertDialogBoxText.get -> string

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -1428,6 +1428,8 @@ namespace Dynamo.Tests
         {
             var input = new Symbol();
             Assert.NotNull(input.Parameter.Name);
+            Assert.IsNotEmpty(input.Parameter.Name);
+            Assert.AreEqual("input",input.Parameter.Name);
         }
     }
 }

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -1423,5 +1423,11 @@ namespace Dynamo.Tests
             Assert.IsFalse(nodeInfo.Value.IsPackageMember);
             Assert.IsNull(nodeInfo.Value.PackageInfo);
         }
+        [Test]
+        public void InputNodeShouldHaveNameByDefault()
+        {
+            var input = new Symbol();
+            Assert.NotNull(input.Parameter.Name);
+        }
     }
 }


### PR DESCRIPTION
### Purpose

When a user creates a `input node` (also known as a symbol node) in a custom node workspace previously the input node was empty. If left in this state and saved, the input symbol would be invalid as it did not have a default name, and would raise a warning and disallow save when next opened.

Just for the curious the input does have a default type though `(var[]..[])`.

To address this issue - now when an `Input node` is constructed now we set the name to a default (I'm just using `input` for now, which is what we use as a display name when the name is empty)
 We now also show the type hint in default string to make the syntax more discoverable, as well as a comment -  we could also show the default value syntax easily enough but I thought that might be info overload, as well as potentially having unintended consequences.

before:
![Screenshot 2024-05-06 at 10 58 46 AM](https://github.com/DynamoDS/Dynamo/assets/508936/8e947f65-b36c-4994-aec1-0189a0b369c6)

after:
<img width="583" alt="Screenshot 2024-05-07 at 1 20 46 PM" src="https://github.com/DynamoDS/Dynamo/assets/508936/8252456d-0db1-49c1-8fd5-ef4b98f509af">
<img width="753" alt="Screenshot 2024-05-07 at 1 20 40 PM" src="https://github.com/DynamoDS/Dynamo/assets/508936/72b520e7-5076-46b2-ada2-631d48a22c2c">



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

By default creating inputs in a custom node will not put the custom node into an invalid state.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

@Jingyi-Wen thoughts on this approach or what the default name / default string should be?