### PR TITLE
DYN-6874 Logging Packages Tour

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/Guide.cs
@@ -143,7 +143,9 @@ namespace Dynamo.Wpf.UI.GuidedTour
         /// </summary>
         internal void Initialize()
         {
-            TotalSteps = GuideSteps.Count;
+            //There are guided tours containing repeated Sequences due that we can have different Steps flow (conditional flows)
+            var differentSteps = GuideSteps.Select(step => step.Sequence).Distinct().ToList();
+            TotalSteps = differentSteps.Count;
 
             SetLibraryViewVisible(false);
 

--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -240,7 +240,11 @@ namespace Dynamo.Wpf.UI.GuidedTour
                 }
 
                 string guidName = Resources.ResourceManager.GetString(currentGuide.GuideNameResource, System.Globalization.CultureInfo.InvariantCulture).Replace("_", "");
-                if (currentGuide.TotalSteps - 1 == currentGuide.CurrentStep.Sequence)
+                int offSet = 1;
+                //Due that the Packages guide doesn't have a Welcome popup (like the other guides) then the Guide.Sequence starts at 1 (instead of 0) when we need to use a offSet = 0
+                if (currentGuide.Name == PackagesGuideName)
+                    offSet = 0;
+                if (currentGuide.TotalSteps - offSet == currentGuide.CurrentStep.Sequence)
                 {
                     Logging.Analytics.TrackEvent(Logging.Actions.Completed, Logging.Categories.GuidedTourOperations, guidName, currentGuide.CurrentStep.Sequence);
                 }


### PR DESCRIPTION
### Purpose

Fixing Packages guide logging when is completed by user.
Due that the Packages guide doesn't have a Welcome popup (like the other guides)  the Guide.Sequence starts at 1 (instead of 0) also the sequences are repeated (this allow to have conditional guide flow) so I had to do a fix for calculating the number of steps correctly and modify the validation which is logging information when packages tour is completed.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Packages guide logging when is completed by user.

### Reviewers

@QilongTang 
@zeusongit 

### FYIs

