### PR TITLE
DYN-6985 Get item from list with negative index (Wishlist #187)

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -630,6 +630,7 @@ namespace DSCore
                 index = list.Count + index;
             }
 
+            // When calculated index is more than list count or still negative, throw exception
             if (index >= list.Count || index < 0)
             {
                 throw new IndexOutOfRangeException();

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -625,6 +625,15 @@ namespace DSCore
         [IsVisibleInDynamoLibrary(true)]
         public static object GetItemAtIndex(IList list, int index)
         {
+            if (index<0)
+            {
+                index = list.Count + index;
+            }
+
+            if (index >= list.Count || index < 0)
+            {
+                throw new IndexOutOfRangeException();
+            }
             return list[index];
         }
 

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Dynamo.Graph.Nodes;
 using NUnit.Framework;
 using List = DSCore.List;
 
@@ -498,6 +499,35 @@ namespace DSCoreNodesTests
         public static void GetFromList()
         {
             Assert.AreEqual(2, List.GetItemAtIndex(new List<int> { 0, 1, 2, 3 }, 2));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void GetNegtiveIndexItemFromList()
+        {
+            Assert.AreEqual(3, List.GetItemAtIndex(new List<int> { 0, 1, 2, 3 }, -1));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void GetNegtiveIndexItemFromListCouldThrow()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() =>
+            {
+                // -7 as index argument will cause exception.
+                List.GetItemAtIndex(new List<int> { 0, 1, 2, 3 }, -7);
+            });
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void GetPositiveIndexItemFromListCouldThrow()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() =>
+            {
+                // 7 as index argument will cause exception.
+                List.GetItemAtIndex(new List<int> { 0, 1, 2, 3 }, 7);
+            });
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Update to List.GetItemAtIndex to allow negative index (get from right to left) retrieval
https://github.com/DynamoDS/DynamoWishlist/issues/187

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
