### PR TITLE
DYN-6934 Address edge case where placing custom node would send Guid instead of node name as analytics

### DIFF
--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1003,10 +1003,16 @@ namespace Dynamo.Models
 
             internal override void TrackAnalytics()
             {
-                Dynamo.Logging.Analytics.TrackEvent(
-                    Logging.Actions.Create,
-                    Logging.Categories.NodeOperations,
-                    (Node != null) ? Node.GetOriginalName() : Name ?? "");
+                // For custom nodes, Node is null until the node has been created
+                // Including the custom node cases should not be encouraged since
+                // GetOriginalName() will return the Guid of custom node
+                if (Node != null)
+                {
+                    Logging.Analytics.TrackEvent(
+                        Logging.Actions.Create,
+                        Logging.Categories.NodeOperations,
+                        Node.GetOriginalName() ?? string.Empty);
+                }
             }
 
             #endregion


### PR DESCRIPTION
### Purpose

DYN-6934 Address edge case where placing custom node would send Guid instead of node name as analytics

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Address edge case where placing custom node would send Guid instead of node name as analytics

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
