### PR TITLE
DYN-6749: update recent files metadata

### DIFF
--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -252,6 +252,10 @@ namespace Dynamo.UI.Views
             var recentFiles = startPage.RecentFiles;
             if (recentFiles == null || !recentFiles.Any()) { return; }
 
+            // Subscribe to the DynamoViewModel refresh file changed event in order to refresh the Recent File metadata
+            // There is no way to track if the metadata has changed specifically, so we refresh in any change to the recent files 
+            startPage.DynamoViewModel.RecentFiles.CollectionChanged += RecentFiles_CollectionChanged;
+
             LoadGraphs(recentFiles);
                 
             var userLocale = CultureInfo.CurrentCulture.Name;
@@ -260,6 +264,11 @@ namespace Dynamo.UI.Views
             {
                 await dynWebView.CoreWebView2.ExecuteScriptAsync(@$"window.setLocale('{userLocale}');");
             }
+        }
+
+        private void RecentFiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            LoadGraphs(startPage.RecentFiles);  
         }
 
         #region FrontEnd Initialization Calls
@@ -482,7 +491,11 @@ namespace Dynamo.UI.Views
         public void Dispose()
         {
             DataContextChanged -= OnDataContextChanged;
-            if(startPage != null) startPage.DynamoViewModel.PropertyChanged -= DynamoViewModel_PropertyChanged;
+            if (startPage != null)
+            {
+                startPage.DynamoViewModel.PropertyChanged -= DynamoViewModel_PropertyChanged;
+                startPage.DynamoViewModel.RecentFiles.CollectionChanged -= RecentFiles_CollectionChanged;
+            }
 
             this.dynWebView.CoreWebView2.NewWindowRequested -= CoreWebView2_NewWindowRequested;
 


### PR DESCRIPTION
### Purpose

This PR answers the request filed in https://jira.autodesk.com/browse/DYN-6749 - `As a Dynamo user, I would like to see graph metadata updates reflected in Dynamo App Home`

- Open a graph
- Add/Edit graph properties
- Save and close the graph
- See the change in the HomePage screen

## UI Changes
![DynamoSandbox_u3wSUItKbD](https://github.com/DynamoDS/Dynamo/assets/5354594/ddccdce7-9996-471f-84ea-cc8cce778744)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- refreshes the recent files list to HomePage

### Reviewers

@reddyashish 
@QilongTang 

### FYIs

@Amoursol 
