### PR TITLE
DYN-6857 homepage settings refactor

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -397,19 +397,8 @@ namespace Dynamo.Configuration
 
         /// <summary>
         /// Persistence for Dynamo HomePage
-        /// </summary>
-        [XmlIgnore]
-        internal Dictionary<string, object> HomePageSettings { get; set; }
-
-        /// <summary>
-        /// A helper intermediary string to allow the serialization of the HomePageSettings dictionary
-        /// </summary>
-        public string HomePageSettingsSerialized
-        {
-            get => Newtonsoft.Json.JsonConvert.SerializeObject(HomePageSettings);   
-            set => HomePageSettings = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, object>>(value);
-        }
-
+        /// </summary>  
+        public List<string> HomePageSettings { get; set; }
         #endregion
 
         #region Dynamo application settings
@@ -997,6 +986,7 @@ namespace Dynamo.Configuration
             backupLocation = string.Empty;
             GraphChecksumItemsList = new List<GraphChecksumItem>();
             isMLAutocompleteTOUApproved = true;
+            HomePageSettings = new List<string>();
         }
 
         /// <summary>
@@ -1114,7 +1104,7 @@ namespace Dynamo.Configuration
                     return new PreferenceSettings() { isCreatedFromValidFile = false };
                 }
             }
-
+                
             settings.CustomPackageFolders = settings.CustomPackageFolders.Distinct().ToList();
             settings.GroupStyleItemsList = settings.GroupStyleItemsList.GroupBy(entry => entry.Name).Select(result => result.First()).ToList();
             MigrateStdLibTokenToBuiltInToken(settings);

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -171,8 +171,8 @@ Dynamo.Configuration.PreferenceSettings.HideAutocompleteMethodOptions.get -> boo
 Dynamo.Configuration.PreferenceSettings.HideAutocompleteMethodOptions.set -> void
 Dynamo.Configuration.PreferenceSettings.HideNodesBelowSpecificConfidenceLevel.get -> bool
 Dynamo.Configuration.PreferenceSettings.HideNodesBelowSpecificConfidenceLevel.set -> void
-Dynamo.Configuration.PreferenceSettings.HomePageSettingsSerialized.get -> string
-Dynamo.Configuration.PreferenceSettings.HomePageSettingsSerialized.set -> void
+Dynamo.Configuration.PreferenceSettings.HomePageSettings.get -> System.Collections.Generic.List<string>
+Dynamo.Configuration.PreferenceSettings.HomePageSettings.set -> void
 Dynamo.Configuration.PreferenceSettings.IronPythonResolveTargetVersion.get -> string
 Dynamo.Configuration.PreferenceSettings.IronPythonResolveTargetVersion.set -> void
 Dynamo.Configuration.PreferenceSettings.IsADPAnalyticsReportingApproved.get -> bool

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -490,16 +490,15 @@ namespace Dynamo.Tests.Configuration
             PreferenceSettings settings = new PreferenceSettings();
 
             // Assert defaults
-            Assert.AreEqual(settings.HomePageSettings, null);
-            Assert.AreEqual(settings.HomePageSettingsSerialized, "null");
+            Assert.IsEmpty(settings.HomePageSettings);
 
-            settings.HomePageSettings = new Dictionary<string, object> { { "greeting", "Hello World" } };
+            settings.HomePageSettings = new List<string> { { String.Concat("greeting", "Hello World") } };
 
             // Save
             settings.Save(tempPath);
             settings = PreferenceSettings.Load(tempPath);
 
-            Assert.AreEqual(settings.HomePageSettings["greeting"], "Hello World");
+            Assert.IsTrue(settings.HomePageSettings.Contains(String.Concat("greeting", "Hello World")));
         }
     }
 }

--- a/test/DynamoCoreWpfTests/HomePageTests.cs
+++ b/test/DynamoCoreWpfTests/HomePageTests.cs
@@ -65,7 +65,7 @@ namespace DynamoCoreWpfTests
 
             homePage.DataContext = startPage;
 
-            Assert.IsNull(preferences.HomePageSettings);
+            Assert.IsEmpty(preferences.HomePageSettings);
 
             // Act
             var pair1 = @"{""Name"": ""Alice""}";

--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -32,7 +32,10 @@
   <WindowW>1936</WindowW>
   <WindowH>1056</WindowH>
   <UseHardwareAcceleration>false</UseHardwareAcceleration>
-  <HomePageSettingsSerialized>{"recentPageViewMode":"grid","samplesViewMode":"list"}</HomePageSettingsSerialized>
+  <HomePageSettings>
+    <string>recentPageViewMode:list</string>
+    <string>samplesViewMode:list</string>
+  </HomePageSettings>
   <NumberFormat>f4</NumberFormat>
   <MaxNumRecentFiles>12</MaxNumRecentFiles>
   <RecentFiles>


### PR DESCRIPTION
### Purpose

Simplification of the way HomePage settings were serialized as part of the Dynamo Preferences. No longer maintains a `Dictionary<string, object>` but uses `List<string>` instead. 

Formerly, a workaround was created to serialize a json-serialized version of the Dictionary, as the limitation is that xaml cannot serialize Dictionary types.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- no longer serializes to Dictionary, but list<string> of ':' delimited key/value pairs
- adjusted all affected Tests and resources

### Reviewers

@QilongTang 
@reddyashish 

### FYIs


