### PR TITLE
DYN-6967 Crash when placing List selector archi-lab Dynamo nodes in canvas

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5027,6 +5027,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to create node: .
+        /// </summary>
+        public static string NodeInCanvasSearchCreationError {
+            get {
+                return ResourceManager.GetString("NodeInCanvasSearchCreationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dismisses the info messages on this node. Utilize when you want to design in graph failures, or the info message will not be relevant during graph execution..
         /// </summary>
         public static string NodeInfoDismissButtonToolTip {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -582,7 +582,7 @@ Don't worry, you'll have the option to save your work.</value>
     <value>_Select All</value>
     <comment>Edit menu | Select all nodes</comment>
   </data>
-    <data name="DynamoViewEditMenuUnpinAllPreviewBubbles" xml:space="preserve">
+  <data name="DynamoViewEditMenuUnpinAllPreviewBubbles" xml:space="preserve">
     <value>_Unpin All Preview Bubbles</value>
     <comment>Edit menu | Unpin preview bubbles</comment>
   </data>
@@ -3982,5 +3982,8 @@ To make this file into a new template, save it to a different folder, then move 
   </data>
   <data name="MessagePackOlderDynamoLink" xml:space="preserve">
     <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>
+  </data>
+  <data name="NodeInCanvasSearchCreationError" xml:space="preserve">
+    <value>Failed to create node: </value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -330,7 +330,7 @@
     <value>_Select All</value>
     <comment>Edit menu | Select all nodes</comment>
   </data>
-    <data name="DynamoViewEditMenuUnpinAllPreviewBubbles" xml:space="preserve">
+  <data name="DynamoViewEditMenuUnpinAllPreviewBubbles" xml:space="preserve">
     <value>_Unpin All Preview Bubbles</value>
     <comment>Edit menu | Unpin preview bubbles</comment>
   </data>
@@ -3969,5 +3969,8 @@ To make this file into a new template, save it to a different folder, then move 
   </data>
   <data name="MessagePackOlderDynamoLink" xml:space="preserve">
     <value>#Learn more=https://primer2.dynamobim.org/1_developer_primer_intro/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-net8</value>
+  </data>
+  <data name="NodeInCanvasSearchCreationError" xml:space="preserve">
+    <value>Failed to create node: </value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4878,6 +4878,7 @@ static Dynamo.Wpf.Properties.Resources.NodeHelpWindowNodeDescription.get -> stri
 static Dynamo.Wpf.Properties.Resources.NodeHelpWindowNodeInput.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeHelpWindowNodeOutput.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeHelpWindowNodeType.get -> string
+static Dynamo.Wpf.Properties.Resources.NodeInCanvasSearchCreationError.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeInfoDismissButtonToolTip.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeInformationalStateDismiss.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeInformationalStateDismissAll.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -362,8 +362,19 @@ namespace Dynamo.Wpf.ViewModels
         {
             if (Clicked != null)
             {
-                var nodeModel = Model.CreateNode();
-                Clicked(nodeModel, Position);
+                // Try to create the node based on the search element (in-Canvas search or library)
+                // The node creation can fail if the node constructor dependencies are not found or other reasons.
+                // This is a best effort to create the node and log the error both in console and toast notification if it fails.
+                try
+                {
+                    var nodeModel = Model.CreateNode();
+                    Clicked(nodeModel, Position);
+                }
+                catch (Exception)
+                {
+                    searchViewModel.dynamoViewModel.Model.Logger.Log("Failed to create node from search element: " + Model.Name);
+                    searchViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow("Failed to create node: " + Model.Name, true);
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -370,9 +370,9 @@ namespace Dynamo.Wpf.ViewModels
                     var nodeModel = Model.CreateNode();
                     Clicked(nodeModel, Position);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    searchViewModel.dynamoViewModel.Model.Logger.Log("Failed to create node from search element: " + Model.Name);
+                    searchViewModel.dynamoViewModel.Model.Logger.Log("Failed to create node from search element: " + Model.Name + "\n" + ex.Message);
                     searchViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Wpf.Properties.Resources.NodeInCanvasSearchCreationError + Model.Name, true);
                 }
             }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -362,7 +362,7 @@ namespace Dynamo.Wpf.ViewModels
         {
             if (Clicked != null)
             {
-                // Try to create the node based on the search element (in-Canvas search or library)
+                // Try to create the node based on the search element from in-Canvas search
                 // The node creation can fail if the node constructor dependencies are not found or other reasons.
                 // This is a best effort to create the node and log the error both in console and toast notification if it fails.
                 try

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -373,7 +373,7 @@ namespace Dynamo.Wpf.ViewModels
                 catch (Exception)
                 {
                     searchViewModel.dynamoViewModel.Model.Logger.Log("Failed to create node from search element: " + Model.Name);
-                    searchViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow("Failed to create node: " + Model.Name, true);
+                    searchViewModel.dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Wpf.Properties.Resources.NodeInCanvasSearchCreationError + Model.Name, true);
                 }
             }
         }


### PR DESCRIPTION
### Purpose

per [DYN-6967](https://jira.autodesk.com/browse/DYN-6967) Crash when placing List selector archi-lab Dynamo nodes in canvas. This could happen when nodes from 3rd party in package crash at node constructor.

Example crash stacktrace
```
Could not load file or assembly 'Microsoft.Practices.Prism, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.

   at archilabUI.ListSelector.ListSelector..ctor()
   at lambda_method661(Closure)
   at Dynamo.Search.SearchElements.NodeModelSearchElement.ConstructNewNodeModel()
   at Dynamo.Search.SearchElements.NodeSearchElement.CreateNode()
   at Dynamo.Wpf.ViewModels.NodeSearchElementViewModel.OnClicked()
   at Prism.Commands.DelegateCommand.Execute()
   at Prism.Commands.DelegateCommand.Execute(Object parameter)
   at Prism.Commands.DelegateCommandBase.System.Windows.Input.ICommand.Execute(Object parameter)
   at Dynamo.UI.Controls.InCanvasSearchControl.ExecuteSearchElement(ListBoxItem listBoxItem)
   at Dynamo.UI.Controls.InCanvasSearchControl.OnMouseLeftButtonUp(Object sender, MouseButtonEventArgs e)
```

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix a crash when placing List selector archi-lab Dynamo nodes in canvas, Dynamo would crash and show crash report dialog. This crash currently can only be fixed by package author.

### Reviewers

@DynamoDS/dynamo

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
