### PR TITLE
DYN-6908 string from object float precision

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -61,7 +61,7 @@ namespace ProtoCore.DSASM.Mirror
 
             if (val.IsDouble)
             {
-                return val.DoubleValue.ToString("F6");
+                return val.DoubleValue.ToString("F17");
             }
 
             if (val.IsNull)

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -61,7 +61,32 @@ namespace ProtoCore.DSASM.Mirror
 
             if (val.IsDouble)
             {
-                return val.DoubleValue.ToString("F17");
+                bool hasDecimals = false;
+                int counter = 0;
+                int precision;
+
+                double nextDoubleValue = val.DoubleValue;
+                var nexDoubleValueString = nextDoubleValue.ToString();
+                if (nexDoubleValueString.Contains(".") || nexDoubleValueString.Contains(","))
+                {
+                    while (!hasDecimals)
+                    {
+                        //This line behaves weird after more than 6 decimals
+                        nextDoubleValue = nextDoubleValue * 10;
+                        counter++;
+                        if (nextDoubleValue % 1 == 0)
+                            hasDecimals = true;
+                    }
+                    precision = counter;
+                }
+                else
+                {
+                    //Means that we don't have a double value with decimals
+                    precision = 0;
+                }
+
+                //I've noticed that when having more than 6 decimals after the point .NET (CLR) behaves weird so the counter will be 16
+                return val.DoubleValue.ToString("F"+precision.ToString());
             }
 
             if (val.IsNull)


### PR DESCRIPTION
### Purpose

Calculating the double precision dynamically based in the number of decimals provided in the double value.
When using a double value with more than 15 decimals and passing the value to the StringFromObject node was truncating the output to use only 6 decimals so I did a fix in a way that the precision will be calculated dynamically.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Calculating the double precision dynamically based in the number of decimals provided in the double value.

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner @jnealb 
