### PR TITLE
fix extension assembly paths for linux

### DIFF
--- a/src/DynamoCore/Extensions/ExtensionLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLoader.cs
@@ -75,7 +75,8 @@ namespace Dynamo.Extensions
                 if (item.Name == "AssemblyPath")
                 {
                     // Usually the extension configs are written on a Windows system, so we only need to make them compatible with linux
-                    path = Path.Combine(path, item.InnerText.Replace('\\', Path.DirectorySeparatorChar));
+                    string assemblyRelativePath = OSHelper.IsWindows() ? item.InnerText : item.InnerText.Replace('\\', Path.DirectorySeparatorChar);
+                    path = Path.Combine(path, assemblyRelativePath);
                     definition.AssemblyPath = path;
                 }
                 else if (item.Name == "TypeName")

--- a/src/DynamoCore/Extensions/ExtensionLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLoader.cs
@@ -74,7 +74,8 @@ namespace Dynamo.Extensions
             {
                 if (item.Name == "AssemblyPath")
                 {
-                    path = Path.Combine(path, item.InnerText);
+                    // Usually the extension configs are written on a Windows system, so we only need to make them compatible with linux
+                    path = Path.Combine(path, item.InnerText.Replace('\\', Path.DirectorySeparatorChar));
                     definition.AssemblyPath = path;
                 }
                 else if (item.Name == "TypeName")


### PR DESCRIPTION
Issue:
Extensions assembly paths contain windows style dir separators. This is causing load issues on linux.

### Purpose

Fix extension assembly paths when running on linux

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
