### PR TITLE
DYN-6990 Crash when selecting node with view extension

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -293,8 +293,15 @@ namespace Dynamo.Models
 
         private void AddSelectionAndRecordUndo(ModelBase model)
         {
-            WorkspaceModel.RecordModelsForModification(new List<ModelBase>() { model }, CurrentWorkspace.UndoRecorder);
-            DynamoSelection.Instance.Selection.AddUnique(model);
+            try
+            {
+                WorkspaceModel.RecordModelsForModification(new List<ModelBase>() { model }, CurrentWorkspace.UndoRecorder);
+                DynamoSelection.Instance.Selection.AddUnique(model);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to add model(s) to selection." + "\n" + ex.Message);
+            }
         }
 
         private void ClearSelectionAndRecordUndo()


### PR DESCRIPTION
### Purpose

This PR handles the crash described in https://jira.autodesk.com/browse/DYN-6990,
the crash seems to occur when the user tried make a selection of node(s), the main issue could be related an action performed with monocle extension. I was not able to re-produce the crash in Dynamo 3.0.3, the version of monocle used is not provided but I tried with 2024.5.1.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Fix crash when selecting node with view extension

### Reviewers

@DynamoDS/dynamo 
