### PR TITLE
DYN-6927: Improvements to RemovePIIData API 

### DIFF
--- a/src/DynamoMLDataPipeline/DynamoMLDataPipeline.cs
+++ b/src/DynamoMLDataPipeline/DynamoMLDataPipeline.cs
@@ -162,11 +162,15 @@ namespace DynamoMLDataPipeline
             // Read .dyn file as a string
             string sourceFileContent = File.ReadAllText(filePath);
 
+            //Parsing the workspace info into a JSON object.
             JObject jsonObject = JObject.Parse(sourceFileContent);
 
+            // RemovePIIData will remove the sensitive data from specific parts of JSON structure(like the Views, Annotiations and code block info)
             Tuple<JObject, bool> jsonResult = PIIDetector.RemovePIIData(jsonObject);
 
             string formattedSourceContent = jsonObject.ToString();
+
+            // If the PII data is succesfully removed from the original JSON object, we use the formatted JSON result(without the PII data).
             if (jsonResult.Item2)
             {
                 formattedSourceContent = jsonResult.Item1.ToString();

--- a/src/DynamoMLDataPipeline/DynamoMLDataPipeline.cs
+++ b/src/DynamoMLDataPipeline/DynamoMLDataPipeline.cs
@@ -161,7 +161,16 @@ namespace DynamoMLDataPipeline
         {
             // Read .dyn file as a string
             string sourceFileContent = File.ReadAllText(filePath);
-            string formattedSourceContent = PIIDetector.RemovePIIData(sourceFileContent);
+
+            JObject jsonObject = JObject.Parse(sourceFileContent);
+
+            Tuple<JObject, bool> jsonResult = PIIDetector.RemovePIIData(jsonObject);
+
+            string formattedSourceContent = jsonObject.ToString();
+            if (jsonResult.Item2)
+            {
+                formattedSourceContent = jsonResult.Item1.ToString();
+            }
 
             // Convert the string to a byte array (buffer)
             byte[] stringBuffer = Encoding.UTF8.GetBytes(formattedSourceContent);

--- a/src/DynamoMLDataPipeline/DynamoMLDataPipeline.cs
+++ b/src/DynamoMLDataPipeline/DynamoMLDataPipeline.cs
@@ -165,7 +165,7 @@ namespace DynamoMLDataPipeline
             //Parsing the workspace info into a JSON object.
             JObject jsonObject = JObject.Parse(sourceFileContent);
 
-            // RemovePIIData will remove the sensitive data from specific parts of JSON structure(like the Views, Annotiations and code block info)
+            // RemovePIIData will remove the sensitive data from specific parts of JSON structure(like the Views, Annotiations, string nodes and code block info)
             Tuple<JObject, bool> jsonResult = PIIDetector.RemovePIIData(jsonObject);
 
             string formattedSourceContent = jsonObject.ToString();

--- a/src/DynamoUtilities/PIIDetector.cs
+++ b/src/DynamoUtilities/PIIDetector.cs
@@ -125,9 +125,8 @@ namespace Dynamo.Utilities
             result = Regex.Replace(result, directoryPattern, "");
             result = Regex.Replace(result, ssnPattern, "");
             result = Regex.Replace(result, datePattern, "");
-            //result = Regex.Replace(result, websitePattern, "");
-            //result = Regex.Replace(result, creditCardPattern, "");
-            //result = Regex.Replace(result, ipPattern, "");
+            result = Regex.Replace(result, ipPattern, "");
+            result = Regex.Replace(result, creditCardPattern, "");
 
             return result;
         }

--- a/src/DynamoUtilities/PIIDetector.cs
+++ b/src/DynamoUtilities/PIIDetector.cs
@@ -119,8 +119,6 @@ namespace Dynamo.Utilities
         {
             string result;
 
-            // ToDo: some of the regex patterns are interfering with other data in the json,
-            // so commenting them for now and will address those patterns later.
             result = Regex.Replace(data, emailPattern, "");
             result = Regex.Replace(result, directoryPattern, "");
             result = Regex.Replace(result, ssnPattern, "");

--- a/src/DynamoUtilities/PIIDetector.cs
+++ b/src/DynamoUtilities/PIIDetector.cs
@@ -125,6 +125,7 @@ namespace Dynamo.Utilities
             result = Regex.Replace(result, datePattern, "");
             result = Regex.Replace(result, ipPattern, "");
             result = Regex.Replace(result, creditCardPattern, "");
+            result = Regex.Replace(result, websitePattern, "");
 
             return result;
         }

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -670,7 +670,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failure")]
         public void RemovePIIDataFromWorkspace()
         {
             string graphWithPIIDataPath = Path.Combine(TestDirectory, (@"UI\GraphWithPIIData.dyn"));


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-6927

Using the RemovePIIData(JObject jsonObject), we check for the regex patterns in specific parts like the VIew or Annotations section of the JSON to remove the personal sensitive data.

It should remove email pattern, SSN number pattern, credit card pattern, user directory pattern, IP address pattern, date patterns and website patterns.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
DYN-6927: Improvements to RemovePIIData API to accurately remove only the sensitive personal info.

### Reviewers
@QilongTang @zeusongit 

### FYIs
@DynamoDS/dynamo 
