### PR TITLE
DYN-6993 Add crash protection for window Owner setting

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
@@ -236,26 +236,6 @@ namespace Dynamo.UI.Prompts
         }
 
         /// <summary>
-        /// Set the owner window of the message box and prevent any exceptions that may occur
-        /// </summary>
-        /// <param name="owner">Owner Window</param>
-        /// <param name="dynamoMessageBox">New message box</param>
-        internal static void SetOwnerWindow(Window owner, DynamoMessageBox dynamoMessageBox)
-        {
-            if (owner != null && owner.IsLoaded)
-            {
-                try
-                {
-                    dynamoMessageBox.Owner = owner;
-                }
-                catch (Exception)
-                {
-                    // In this case, we will not set the owner window
-                }
-            }
-        }
-
-        /// <summary>
         /// Displays a dialog to the user and returns their choice as a MessageBoxResult.
         /// </summary>
         /// <param name="owner">owning window of the messagebox</param>
@@ -372,6 +352,26 @@ namespace Dynamo.UI.Prompts
             dynamoMessageBox.ConfigureButtons(button, buttonNames);
             dynamoMessageBox.ShowDialog();
             return dynamoMessageBox.CustomDialogResult;
+        }
+
+        /// <summary>
+        /// Set the owner window of the message box and prevent any exceptions that may occur
+        /// </summary>
+        /// <param name="owner">Owner Window</param>
+        /// <param name="dynamoMessageBox">New message box</param>
+        internal static void SetOwnerWindow(Window owner, DynamoMessageBox dynamoMessageBox)
+        {
+            if (owner != null && owner.IsLoaded)
+            {
+                try
+                {
+                    dynamoMessageBox.Owner = owner;
+                }
+                catch (Exception)
+                {
+                    // In this case, we will not set the owner window
+                }
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/DynamoMessageBox.xaml.cs
@@ -199,11 +199,7 @@ namespace Dynamo.UI.Prompts
                 MessageBoxButton = button,
                 MessageBoxImage = icon
             };
-            if (owner != null && owner.IsLoaded)
-            {
-                dynamoMessageBox.Owner = owner;
-            }
-
+            SetOwnerWindow(owner, dynamoMessageBox);
             if (showRichTextBox)
             {
                 dynamoMessageBox.BodyTextBlock.Visibility = Visibility.Collapsed;
@@ -233,15 +229,30 @@ namespace Dynamo.UI.Prompts
                 MessageBoxButton = button,
                 MessageBoxImage = icon
             };
-
-            if (owner != null && owner.IsLoaded)
-            {
-                dynamoMessageBox.Owner = owner;
-            }
-
+            SetOwnerWindow(owner, dynamoMessageBox);
             dynamoMessageBox.ConfigureButtons(button);
             dynamoMessageBox.ShowDialog();
             return dynamoMessageBox.CustomDialogResult;
+        }
+
+        /// <summary>
+        /// Set the owner window of the message box and prevent any exceptions that may occur
+        /// </summary>
+        /// <param name="owner">Owner Window</param>
+        /// <param name="dynamoMessageBox">New message box</param>
+        internal static void SetOwnerWindow(Window owner, DynamoMessageBox dynamoMessageBox)
+        {
+            if (owner != null && owner.IsLoaded)
+            {
+                try
+                {
+                    dynamoMessageBox.Owner = owner;
+                }
+                catch (Exception)
+                {
+                    // In this case, we will not set the owner window
+                }
+            }
         }
 
         /// <summary>
@@ -264,11 +275,7 @@ namespace Dynamo.UI.Prompts
                 MessageBoxButton = button,
                 MessageBoxImage = icon
             };
-            if (owner != null && owner.IsLoaded)
-            {
-                dynamoMessageBox.Owner = owner;
-            }
-
+            SetOwnerWindow(owner, dynamoMessageBox);
             if (flags.TryGetValue(DialogFlags.Scrollable, out bool scrollable) && scrollable)
             {
                 dynamoMessageBox.BodyTextBlock.Visibility = Visibility.Collapsed;
@@ -361,12 +368,7 @@ namespace Dynamo.UI.Prompts
                 MessageBoxButton = button,
                 MessageBoxImage = icon
             };
-
-            if (owner != null && owner.IsLoaded)
-            {
-                dynamoMessageBox.Owner = owner;
-            }
-
+            SetOwnerWindow(owner, dynamoMessageBox);
             dynamoMessageBox.ConfigureButtons(button, buttonNames);
             dynamoMessageBox.ShowDialog();
             return dynamoMessageBox.CustomDialogResult;


### PR DESCRIPTION
### Purpose

Per https://jira.autodesk.com/browse/DYN-6993, add crash protection to DynamoMessageBox display code during window owner assignment.

Here is the crash callstack

```
presentationframework!_NA_::System.Windows.Window.set_Owner(System.Windows.Window)
dynamocorewpf!_NA_::Dynamo.UI.Prompts.DynamoMessageBox.Show(System.Windows.Window, System.String, System.String, System.Windows.MessageBoxButton, System.Windows.MessageBoxImage)
dynamocorewpf!_NA_::Dynamo.Wpf.Utilities.MessageBoxService+DefaultMessageBox.Show(System.Windows.Window, System.String, System.String, System.Windows.MessageBoxButton, System.Windows.MessageBoxImage)
dynamocorewpf!_NA_::Dynamo.Wpf.Utilities.MessageBoxService.Show(System.Windows.Window, System.String, System.String, System.Windows.MessageBoxButton, System.Windows.MessageBoxImage)
dynamocorewpf!_NA_::Dynamo.Controls.DynamoView.DynamoViewModelRequestUserSaveWorkflow(System.Object, Dynamo.ViewModels.WorkspaceSaveEventArgs)
dynamocorewpf!_NA_::Dynamo.ViewModels.DynamoViewModel.OnRequestUserSaveWorkflow(System.Object, Dynamo.ViewModels.WorkspaceSaveEventArgs)
dynamocorewpf!_NA_::Dynamo.ViewModels.DynamoViewModel.AskUserToSaveWorkspacesOrCancel(Boolean)
dynamocorewpf!_NA_::Dynamo.ViewModels.DynamoViewModel.PerformShutdownSequence(ShutdownParams)
dynamocorewpf!_NA_::Dynamo.Controls.DynamoView.PerformShutdownSequenceOnViewModel()
dynamocorewpf!_NA_::Dynamo.Controls.DynamoView.WindowClosed(System.Object, System.EventArgs)
presentationframework!_NA_::System.Windows.Window.WmDestroy()
```

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add crash protection to DynamoMessageBox display code during window owner assignment.

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
