### PR TITLE
DYN-6991 crash report groups change

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1251,10 +1251,21 @@ namespace Dynamo.ViewModels
         {
             using (NestedGroupsGeometries.DeferCollectionReset())
             {
-                ViewModelBases
-                    .OfType<AnnotationViewModel>()
-                    .ToList()
-                    .ForEach(x => UpdateGroupCutGeometry(x));
+                ViewModelBases = null;
+
+                if (ViewModelBases != null)
+                {        
+                    ViewModelBases
+                        .OfType<AnnotationViewModel>()
+                        .ToList()
+                        .ForEach(x => UpdateGroupCutGeometry(x));
+                }
+                else
+                {
+                    var selectNothing = new DynamoModel.SelectModelCommand(Guid.Empty, System.Windows.Input.ModifierKeys.None.AsDynamoType());
+                    WorkspaceViewModel.DynamoViewModel.ExecuteCommand(selectNothing);               
+                }
+
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1251,8 +1251,6 @@ namespace Dynamo.ViewModels
         {
             using (NestedGroupsGeometries.DeferCollectionReset())
             {
-                ViewModelBases = null;
-
                 if (ViewModelBases != null)
                 {        
                     ViewModelBases
@@ -1260,12 +1258,6 @@ namespace Dynamo.ViewModels
                         .ToList()
                         .ForEach(x => UpdateGroupCutGeometry(x));
                 }
-                else
-                {
-                    var selectNothing = new DynamoModel.SelectModelCommand(Guid.Empty, System.Windows.Input.ModifierKeys.None.AsDynamoType());
-                    WorkspaceViewModel.DynamoViewModel.ExecuteCommand(selectNothing);               
-                }
-
             }
         }
 


### PR DESCRIPTION

### Purpose

Dynamo Crash when the ViewModelBases is null
By checking the StackTrace of this report the System.Linq.ThrowHelper.ThrowArgumentNullException is send when trying to execute the next Linq instruction:
`ViewModelBases.OfType<AnnotationViewModel>().ToList().ForEach(x => UpdateGroupCutGeometry(x));`
So when ViewModelBases is null the exception is thrown. 
I was trying to reproduce the behavior adding groups, group inside groups, moving the groups and nodes inside it but the crash was not generated then by checking the code the only way that ViewModelBases could be null is if the AnnotationModel doesn't contain the nodes/connectors in WorkspaceViewModel but this scenario was not reproducible.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Dynamo Crash when the ViewModelBases is null

### Reviewers

@QilongTang 

### FYIs

@pinzart90 @avidit 
