### PR TITLE
[DYN-6491] Consume latest librarie js package

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -19,7 +19,7 @@
         <!--This command updates the npm registry configuration if necessary-->
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
         <!--This command gets a specific build of the notifcation center from npm-->
-        <Exec Command="npm pack @dynamods/librariejs@1.0.4" />
+        <Exec Command="npm pack @dynamods/librariejs@1.0.5" />
     </Target>
 
     <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild">


### PR DESCRIPTION
### Purpose

Consume the latest librarie js package after this revert change: https://github.com/DynamoDS/librarie.js/pull/234 

https://jira.autodesk.com/browse/DYN-6491

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Consume latest librarie js package 1.0.5 version

### Reviewers
@QilongTang 

