### PR TITLE
Cherry-Pick DYN-6995 Crash When Changing Language (#15254)

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.cs
@@ -251,7 +251,14 @@ namespace Dynamo.DocumentationBrowser
                 var annotationViewModel = DynamoViewModel.CurrentSpaceViewModel.Annotations
                         .First(x => x.AnnotationModel == annotation);
 
-                var styleItem = annotationViewModel.GroupStyleList.First(x => x.Name.Equals(DynamoProperties.Resources.GroupStyleDefaultReview));
+                GroupStyleItem styleItem = null;
+                //This will try to find the GroupStyle review 
+                styleItem =  annotationViewModel.GroupStyleList.OfType<GroupStyleItem>().FirstOrDefault(x => x.Name.Equals(DynamoProperties.Resources.GroupStyleDefaultReview));
+                if(styleItem == null)
+                {
+                    //If no GroupStyle is found matching the specific criteria we will use the first one
+                    styleItem = annotationViewModel.GroupStyleList.OfType<GroupStyleItem>().First();
+                }
                 var groupStyleItem = new GroupStyleItem {Name = styleItem.Name, HexColorString = styleItem.HexColorString};
                 annotationViewModel.UpdateGroupStyle(groupStyleItem);
 


### PR DESCRIPTION
### Purpose

Cherry-Pick DYN-6995 Crash When Changing Language (#15254) 
https://github.com/DynamoDS/Dynamo/pull/15254

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Cherry-Pick DYN-6995 Crash When Changing Language (#15254)

### Reviewers

@QilongTang 

### FYIs

