### PR TITLE
DYN-7033: distinct recent files

### DIFF
--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -259,7 +259,7 @@ namespace Dynamo.UI.Views
 
         private void RecentFiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            var recentFiles = startPage.RecentFiles.DistinctBy(x => x.ContextData).ToList();
+            var recentFiles = startPage.RecentFiles?.DistinctBy(x => x.ContextData).ToList();
             LoadGraphs(recentFiles);  
         }
 
@@ -270,6 +270,7 @@ namespace Dynamo.UI.Views
         /// <param name="data"></param>
         private async void LoadGraphs(List<StartPageListItem> data)
         {
+            if (data == null) { return; }
             string jsonData = JsonSerializer.Serialize(data);
 
             if (dynWebView?.CoreWebView2 != null)
@@ -309,7 +310,7 @@ namespace Dynamo.UI.Views
             }
 
             // Load recent files
-            var recentFiles = startPage.RecentFiles.DistinctBy(x => x.ContextData).ToList();
+            var recentFiles = startPage.RecentFiles?.DistinctBy(x => x.ContextData).ToList();
             if (recentFiles != null && recentFiles.Any())
             {
                 LoadGraphs(recentFiles);

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -260,7 +259,8 @@ namespace Dynamo.UI.Views
 
         private void RecentFiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            LoadGraphs(startPage.RecentFiles);  
+            var recentFiles = startPage.RecentFiles.DistinctBy(x => x.ContextData).ToList();
+            LoadGraphs(recentFiles);  
         }
 
         #region FrontEnd Initialization Calls
@@ -268,7 +268,7 @@ namespace Dynamo.UI.Views
         /// Sends graph data to react app
         /// </summary>
         /// <param name="data"></param>
-        private async void LoadGraphs(ObservableCollection<StartPageListItem> data)
+        private async void LoadGraphs(List<StartPageListItem> data)
         {
             string jsonData = JsonSerializer.Serialize(data);
 
@@ -309,7 +309,7 @@ namespace Dynamo.UI.Views
             }
 
             // Load recent files
-            var recentFiles = startPage.RecentFiles;
+            var recentFiles = startPage.RecentFiles.DistinctBy(x => x.ContextData).ToList();
             if (recentFiles != null && recentFiles.Any())
             {
                 LoadGraphs(recentFiles);


### PR DESCRIPTION
### Purpose

References https://jira.autodesk.com/browse/DYN-7033 `Same graphs opened twice appear twice on AppHome`.

Note: it is still possible to show the same graph name saved in **multiple file locations**. For details, user can utilize the `List` view in the HomePage.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/1982a038-eb14-45a4-8789-7040469d7b76)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now explicitly filters out duplicate recent graphs based on location (cannot add the same graph twice to the list of recent graphs)
- note: still possible to have the same graph saved in multiple locations

### Reviewers

@avidit 
@reddyashish 

### FYIs

@Amoursol 
