### PR TITLE
DYN-6135: Use new feature flag for ML data ingestion pipeline

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -206,18 +206,6 @@ namespace Dynamo.ViewModels
             get { return model.CurrentWorkspace; }
         }
 
-        [Obsolete("This flag is not needed anymore and can be removed.")]
-        /// <summary>
-        /// Controls if the the ML data ingestion pipeline is beta from feature flag
-        /// </summary>
-        internal bool IsMLDataIngestionPipelineinBeta
-        {
-            get
-            {
-                return DynamoModel.FeatureFlags?.CheckFeatureFlag("IsMLDataIngestionPipelineinBeta", true) ?? true;
-            }
-        }
-
         /// <summary>
         /// Controls if the the ML data ingestion pipeline is beta from feature flag
         /// </summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -207,6 +206,7 @@ namespace Dynamo.ViewModels
             get { return model.CurrentWorkspace; }
         }
 
+        [Obsolete("This flag is not needed anymore and can be removed.")]
         /// <summary>
         /// Controls if the the ML data ingestion pipeline is beta from feature flag
         /// </summary>
@@ -215,6 +215,17 @@ namespace Dynamo.ViewModels
             get
             {
                 return DynamoModel.FeatureFlags?.CheckFeatureFlag("IsMLDataIngestionPipelineinBeta", true) ?? true;
+            }
+        }
+
+        /// <summary>
+        /// Controls if the the ML data ingestion pipeline is beta from feature flag
+        /// </summary>
+        internal bool IsDNADataIngestionPipelineinBeta
+        {
+            get
+            {
+                return DynamoModel.FeatureFlags?.CheckFeatureFlag("IsDNADataIngestionPipelineinBeta", true) ?? true;
             }
         }
 
@@ -3005,7 +3016,7 @@ namespace Dynamo.ViewModels
             // Upon closing a workspace, validate if the workspace is valid to be sent to the ML datapipeline and then send it.
             if (!DynamoModel.IsTestMode && !HomeSpace.HasUnsavedChanges && (currentWorkspaceViewModel?.IsHomeSpace ?? true) && HomeSpace.HasRunWithoutCrash)
             {
-                if (!IsMLDataIngestionPipelineinBeta && Model.CurrentWorkspace.IsValidForFDX && currentWorkspaceViewModel.Checksum != string.Empty)
+                if (!IsDNADataIngestionPipelineinBeta && Model.CurrentWorkspace.IsValidForFDX && currentWorkspaceViewModel.Checksum != string.Empty)
                 {
                     if (HasDifferentialCheckSum())
                     {


### PR DESCRIPTION
### Purpose

Use new feature flag for ML data ingestion pipeline so that it won't affect the 3.1 version and starts sending data only from 3.2 version.
Epic link:  https://jira.autodesk.com/browse/DYN-6135

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Use new feature flag for ML data ingestion pipeline

### Reviewers
@QilongTang 

