### PR TITLE
DYN-6965 Do not show No Documentation message when In Depth documentation is not available for a node

### DIFF
--- a/src/DocumentationBrowserViewExtension/Docs/NodeAnnotationNotFound.md
+++ b/src/DocumentationBrowserViewExtension/Docs/NodeAnnotationNotFound.md
@@ -1,3 +1,0 @@
-## No further documentation provided for this node.
- 
-For more information on how to add extended documentation to your custom nodes, have a look [here](https://github.com/DynamoDS/Dynamo/wiki/Create-and-Add-Custom-Documentation-to-Nodes).

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
@@ -97,9 +97,6 @@
     <EmbeddedResource Include="Docs\MarkdownStyling.html" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Docs\NodeAnnotationNotFound.md" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Docs\syntaxHighlight.html" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DocumentationBrowserViewExtension/MarkdownHandler.cs
+++ b/src/DocumentationBrowserViewExtension/MarkdownHandler.cs
@@ -10,7 +10,6 @@ namespace Dynamo.DocumentationBrowser
     /// </summary>
     internal class MarkdownHandler : IDisposable
     {
-        private const string NODE_ANNOTATION_NOT_FOUND = "Dynamo.DocumentationBrowser.Docs.NodeAnnotationNotFound.md";
         private readonly Md2Html converter = new Md2Html();
 
         /// <summary>
@@ -36,51 +35,6 @@ namespace Dynamo.DocumentationBrowser
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Converts a markdown string into Html.
-        /// </summary>
-        /// <param name="writer"></param>
-        /// <param name="nodeNamespace"></param>
-        internal void ParseToHtml(ref StringWriter writer, string nodeNamespace, string packageName)
-        {
-            if (writer is null)
-                throw new ArgumentNullException(nameof(writer));
-
-            var mdFilePath = PackageDocumentationManager.Instance.GetAnnotationDoc(nodeNamespace, packageName);
-
-            string mdString;
-
-            if (string.IsNullOrWhiteSpace(mdFilePath) ||
-                !File.Exists(mdFilePath))
-                mdString = DocumentationBrowserUtils.GetContentFromEmbeddedResource(NODE_ANNOTATION_NOT_FOUND);
-
-            else
-            {
-                // Doing this to avoid 'System.ObjectDisposedException'
-                // https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2202?view=vs-2019
-                Stream stream = null;
-                try
-                {
-                    stream = File.Open(mdFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    using (StreamReader reader = new StreamReader(stream))
-                    {
-                        stream = null;
-                        mdString = reader.ReadToEnd();
-                    }
-                }
-                finally
-                {
-                    stream?.Dispose();
-                }
-
-                if (string.IsNullOrWhiteSpace(mdString))
-                    return;
-            }
-
-            var html = converter.ParseMd2Html(mdString, mdFilePath);
-            writer.WriteLine(html);
         }
 
         /// <summary>

--- a/src/DocumentationBrowserViewExtension/MarkdownHandler.cs
+++ b/src/DocumentationBrowserViewExtension/MarkdownHandler.cs
@@ -91,13 +91,9 @@ namespace Dynamo.DocumentationBrowser
         {
             var mdFilePath = PackageDocumentationManager.Instance.GetAnnotationDoc(nodeNamespace, packageName);
 
-            string mdString;
+            string mdString = string.Empty;
 
-            if (string.IsNullOrWhiteSpace(mdFilePath) ||
-                !File.Exists(mdFilePath))
-                mdString = ResourceUtilities.LoadContentFromResources(NODE_ANNOTATION_NOT_FOUND, GetType().Assembly);
-
-            else
+            if (!string.IsNullOrWhiteSpace(mdFilePath) && File.Exists(mdFilePath))
             {
                 // Doing this to avoid 'System.ObjectDisposedException'
                 // https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2202?view=vs-2019


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-6965

The PR removes the `No documentation provided` message, when no In Depth documentation is found.

Without documentation:
![Screenshot 2024-05-29 at 7 05 42 PM](https://github.com/DynamoDS/Dynamo/assets/32665108/adb83d32-b12c-479d-96e6-58175b80a790)

With documentation:
![Screenshot 2024-05-29 at 7 06 08 PM](https://github.com/DynamoDS/Dynamo/assets/32665108/23d6f2a5-0a0a-40fd-90c1-b1001f77c5e3)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Do not show No Documentation message when In Depth documentation is not available for a node

### Reviewers

@DynamoDS/dynamo 
