### PR TITLE
DYN-: Dyn 6808 node icons p4 p5 errors manual

### DIFF
--- a/src/DynamoCoreWpf/Views/Debug/UpdateNodeIconsWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Debug/UpdateNodeIconsWindow.xaml.cs
@@ -374,7 +374,27 @@ namespace Dynamo.Wpf.Views.Debug
             var oldElement = resxItems.Where(x => x.Attribute("name").Value.ToLower().Equals((iconName + "." + iconSuffix).ToLower())).FirstOrDefault();
             if (oldElement != null)
             {
-                data = oldElement.Descendants("value").FirstOrDefault().Value;
+                string resXValue = oldElement.Descendants("value").FirstOrDefault().Value;
+                //This validation is for an edge case in which the resource contains a path to the image instead of the base64 value
+                if (resXValue.ToLower().Contains(".png") || resXValue.ToLower().Contains(".jpg"))
+                {
+                    var imageName = resXValue.Split(";")[0];
+                    var imageFullPath = Path.Combine(Path.GetDirectoryName(path), imageName);
+                    if(File.Exists(imageFullPath))
+                    {
+                        byte[] imageBytes = File.ReadAllBytes(imageFullPath);
+                        data = Convert.ToBase64String(imageBytes);
+                    }
+                    else
+                    {
+                        data = null;
+                        return false;
+                    }                  
+                }
+                else
+                {
+                    data = resXValue;
+                }             
                 return true;
             }
             data = null;


### PR DESCRIPTION
### Purpose

Fix that includes changes in the Update Node Icon tool and also changes done manually in icons with errors reported by the tool.
Includes a fix for an edge case in the Update Node Icon tool in which the resource contains a path to the image instead of the base64 value, so we will be reading the image content and get the base64 value.
Also includes a change for some of the icons reported with errors by the Update Node Icon tool for P4 and P5 folder (P6 didn't have errors), this changes were done completely manually because the tool was not able to process them.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix that includes changes in the Update Node Icon tool and also changes done manually in icons with errors reported by the tool

### Reviewers

@QilongTang @zeusongit 

### FYIs

