### PR TITLE
add logging to std out in service mode

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -209,17 +209,11 @@ namespace Dynamo.Logging
         {
             lock (this.guardMutex)
             {
-                // In test mode, write the logs only to std out. 
-                if (testMode && !cliMode)
+                // In test mode or service mode, write the logs only to std out. 
+                if ((testMode && !cliMode) || serviceMode)
                 {
                     Console.WriteLine(string.Format("{0} : {1}", DateTime.UtcNow.ToString("u"), message));
                     return;
-                }
-
-                if (serviceMode && (level == LogLevel.Console || level == LogLevel.File))
-                {
-                    Console.WriteLine("LogLevel switched to ConsoleOnly in service mode");
-                    level = LogLevel.ConsoleOnly;
                 }
 
                 switch (level)


### PR DESCRIPTION
### Purpose

Add logging to std out in service mode
logs for Daas should be here : https://pp-autodesk.splunkcloud.com/en-GB/app/search/search?earliest=-30d%40d&latest=now&q=search%20source%3D%22dynaas-dynaas%40dynaas-c-uw2%22 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add logging to std out in service mode

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
