### PR TITLE
DYN-6856 Import settings from splash screen should handle empty file content.

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1087,7 +1087,7 @@ namespace Dynamo.Configuration
             PreferenceSettings settings = null;
 
             if(string.IsNullOrEmpty(content))
-                return new PreferenceSettings();
+                return new PreferenceSettings() { isCreatedFromValidFile = false };
 
             try
             {


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-6856

Preferences settings Import from splash screen should show an error when an empty xml file is imported.

<img width="621" alt="Screenshot 2024-06-04 at 10 20 34 AM" src="https://github.com/DynamoDS/Dynamo/assets/43763136/0dd423be-4801-4992-b769-cefb602ae452">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
DYN-6856 Import settings from splash screen should handle empty file content.

### Reviewers
@QilongTang @avidit 

