### PR TITLE
[WIP] with CustonBrowserControlDictionary

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -1808,6 +1808,9 @@
     <Resource Include="UI\Images\not-authenticated.png" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="UI\Themes\Modern\CustomBrowserControlDictionary.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
     <None Update="Views\HomePage\HomePage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </None>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4306,6 +4306,8 @@ static Dynamo.UI.SharedDictionaryManager.DynamoConvertersDictionary.get -> Syste
 static Dynamo.UI.SharedDictionaryManager.DynamoConvertersDictionaryUri.get -> System.Uri
 static Dynamo.UI.SharedDictionaryManager.DynamoModernDictionary.get -> System.Windows.ResourceDictionary
 static Dynamo.UI.SharedDictionaryManager.DynamoModernDictionaryUri.get -> System.Uri
+static Dynamo.UI.SharedDictionaryManager.CustomBrowserControlDictionary.get -> System.Windows.ResourceDictionary
+static Dynamo.UI.SharedDictionaryManager.CustomBrowserControlDictionaryUri.get -> System.Uri
 static Dynamo.UI.SharedDictionaryManager.DynamoTextDictionary.get -> System.Windows.ResourceDictionary
 static Dynamo.UI.SharedDictionaryManager.DynamoTextDictionaryUri.get -> System.Uri
 static Dynamo.UI.SharedDictionaryManager.InPortsDictionary.get -> System.Windows.ResourceDictionary

--- a/src/DynamoCoreWpf/UI/SharedResourceDictionary.cs
+++ b/src/DynamoCoreWpf/UI/SharedResourceDictionary.cs
@@ -67,7 +67,8 @@ namespace Dynamo.UI
         private static ResourceDictionary outPortsDictionary;
         private static ResourceDictionary inPortsDictionary;
         private static ResourceDictionary _liveChartDictionary;
-        
+        private static ResourceDictionary _customBrowserControlDictionary;
+
 
         public static string ThemesDirectory 
         {
@@ -91,6 +92,11 @@ namespace Dynamo.UI
         public static Uri DynamoColorsAndBrushesDictionaryUri
         {
             get { return new Uri(Path.Combine(ThemesDirectory, "DynamoColorsAndBrushes.xaml")); }
+        }
+
+        public static Uri CustomBrowserControlDictionaryUri
+        {
+            get { return new Uri(Path.Combine(ThemesDirectory, "CustomBrowserControlDictionary.xaml")); }
         }
 
         public static Uri DynamoConvertersDictionaryUri
@@ -173,6 +179,15 @@ namespace Dynamo.UI
             get {
                 return _dynamoColorsAndBrushesDictionary ??
                        (_dynamoColorsAndBrushesDictionary = new ResourceDictionary() { Source = DynamoColorsAndBrushesDictionaryUri });
+            }
+        }
+
+        public static ResourceDictionary CustomBrowserControlDictionary
+        {
+            get
+            {
+                return _customBrowserControlDictionary ??
+                       (_customBrowserControlDictionary = new ResourceDictionary() { Source = CustomBrowserControlDictionaryUri });
             }
         }
 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/CustomBrowserControlDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/CustomBrowserControlDictionary.xaml
@@ -1,0 +1,391 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
+                    xmlns:local="clr-namespace:Dynamo.PackageManager.UI"
+                    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf">
+    <ResourceDictionary.MergedDictionaries>
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+        <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!--#region Brushes-->
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Stroke" Color="Transparent"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Fill" Color="#DCDCDC"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Stroke" Color="Transparent"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Fill" Color="#FFCCEEFB"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Checked.Stroke" Color="Transparent"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.Static.Checked.Fill" Color="#DCDCDC"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Checked.Stroke" Color="Transparent"/>
+    <SolidColorBrush x:Key="TreeViewItem.TreeArrow.MouseOver.Checked.Fill" Color="#FF82DFFB"/>
+    <SolidColorBrush x:Key="StrokeBrush" Color="#696969" />
+    <SolidColorBrush x:Key="ListBorder" Color="#828790"/>
+    <PathGeometry x:Key="TreeArrow" Figures="M 0 0 L 0 7.2 L 4.8 3.6 Z"/>
+    <!--#endregion -->
+
+    <!--#region Converters-->
+    <!--https://stackoverflow.com/questions/61217523/wpf-treeview-how-to-make-controls-align-relative-to-every-treeviewitem-yet-sti-->
+    <local:IndentConverter x:Key="IndentConverter" />
+    <local:HasChildrenToVisibilityConverter x:Key="HasChildrenToVisibilityConverter" />
+    <local:DependencyTypeToVisibilityConverter x:Key="DependencyTypeToVisibilityConverter" />
+    <local:SortingConverter x:Key="SortingConverter" />
+    <local:ChildrenItemsContainsFolderToVisibilityConverter x:Key="ChildrenItemsContainsFolderToVisibilityConverter" />
+    <!--#endregion-->
+
+    <!--ToggleButton Style-->
+    <Style x:Key="FolderToggleStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Width" Value="16"/>
+        <Setter Property="Height" Value="16"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Background="Transparent" Height="16" Padding="7 5 0 0" Width="16">
+                        <Canvas>
+                            <Path x:Name="ExpandPath" Data="{StaticResource TreeArrow}" Fill="{StaticResource TreeViewItem.TreeArrow.Static.Fill}" Stroke="{StaticResource TreeViewItem.TreeArrow.Static.Stroke}">
+                                <Path.RenderTransform>
+                                    <RotateTransform Angle="0" CenterY="3" CenterX="3"/>
+                                </Path.RenderTransform>
+                            </Path>
+                        </Canvas>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="RenderTransform" TargetName="ExpandPath">
+                                <Setter.Value>
+                                    <RotateTransform Angle="90" CenterY="4" CenterX="2"/>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Fill" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.Static.Checked.Fill}"/>
+                            <Setter Property="Stroke" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.Static.Checked.Stroke}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Stroke" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Stroke}"/>
+                            <Setter Property="Fill" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Fill}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True"/>
+                                <Condition Property="IsChecked" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Stroke" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Checked.Stroke}"/>
+                            <Setter Property="Fill" TargetName="ExpandPath" Value="{StaticResource TreeViewItem.TreeArrow.MouseOver.Checked.Fill}"/>
+                        </MultiTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--TreeView Style-->
+    <Style x:Key="TreeViewStyle" TargetType="{x:Type TreeView}">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ListBorder}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="1"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TreeView}">
+                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" SnapsToDevicePixels="true">
+                        <ScrollViewer x:Name="_tv_scrollviewer_" Background="{TemplateBinding Background}" CanContentScroll="false" Focusable="false" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                            <ItemsPresenter/>
+                        </ScrollViewer>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Background" TargetName="Bd" Value="#343434"/>
+                        </Trigger>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
+                            <Setter Property="CanContentScroll" TargetName="_tv_scrollviewer_" Value="true"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Background" Value="#343434"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!--TreeViewItem Style-->
+    <Style TargetType="TreeViewItem" x:Key="CustomTreeViewItem">
+        <Setter Property="Template" Value="{DynamicResource TreeViewItemControlTemplate1}" />
+        <Setter Property="IsExpanded" Value="True" />
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="Foreground" Value="#F5F5F5"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding DependencyType, Converter={StaticResource DependencyTypeToVisibilityConverter}, ConverterParameter=Folder}"
+                     Value="Collapsed">
+                <Setter Property="Visibility" Value="Collapsed" />
+            </DataTrigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="#F5F5F5"/>
+                <Setter Property="IsSelected" Value="False"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!--TreeViewItem Template-->
+    <ControlTemplate x:Key="TreeViewItemControlTemplate1" TargetType="{x:Type TreeViewItem}">
+        <Grid x:Name="tvGrid">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition MinWidth="19" Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="24"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30"/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+
+            <!-- Selection border -->
+            <Border Grid.ColumnSpan="5" Grid.Column="0" x:Name="SelectionBorder" Background="Transparent" Opacity="0.1"/>
+
+            <!-- Vertical dash line and sets the indent -->
+            <Border Grid.Column="0" Grid.RowSpan="2" VerticalAlignment="Stretch"
+                 Width="{Binding Path=(local:TreeViewItemHelper.Indent).Value, Mode=OneWay, RelativeSource={RelativeSource AncestorType=ItemsPresenter}}">
+                <Rectangle Width="1" Height="Auto" Stroke="{StaticResource StrokeBrush}"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Stretch"
+                        StrokeDashArray="1,2.3"
+                        StrokeThickness="3"
+                        UseLayoutRounding="True"
+                        SnapsToDevicePixels="True"
+                        Margin="0 -8 0 14"
+                        x:Name="VerticalMarker">
+                </Rectangle>
+            </Border>
+
+            <!-- Horizontal dash line -->
+            <Border Grid.Column="1">
+                <Rectangle Width="18" Height="1"                                        
+                        StrokeDashArray="1,3,1,2"
+                        StrokeThickness="3" Stroke="{StaticResource StrokeBrush}" HorizontalAlignment="Left" VerticalAlignment="Center" 
+                        Margin="-1 3 0 0"
+                        Visibility="Visible"
+                        x:Name="HorizontalMarker"/>
+            </Border>
+
+            <!-- Arrow expander -->
+            <ToggleButton x:Name="Expander"
+                       Grid.Column="2"
+                       Margin="-15 0 0 0"
+                       ClickMode="Press"
+                       IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}"
+                       Style="{StaticResource FolderToggleStyle}"
+                       Visibility="{Binding ChildItems,
+                                            Converter={StaticResource ChildrenItemsContainsFolderToVisibilityConverter}}" />
+            <!-- Content presenter -->
+            <Border x:Name="Bd" 
+                 Grid.Column="3"
+                 BorderBrush="{TemplateBinding BorderBrush}"
+                 BorderThickness="{TemplateBinding BorderThickness}"
+                 Background="{TemplateBinding Background}"
+                 Padding="{TemplateBinding Padding}"
+                 SnapsToDevicePixels="True">
+
+                <Grid>
+                    <ContentPresenter x:Name="PART_Header"
+                                   ContentTemplate="{TemplateBinding HeaderTemplate}" 
+                                   Content="{TemplateBinding Header}" 
+                                   ContentStringFormat="{TemplateBinding HeaderStringFormat}" 
+                                   ContentSource="Header" 
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                   VerticalAlignment="Center"
+                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+
+                </Grid>
+            </Border>
+
+            <!-- Garbage icon remove item button -->
+            <Grid Grid.Column="4" HorizontalAlignment="Right" Margin="0 0 8 0">
+                <Button Margin="2"
+                     x:Name="RemoveButton"
+                     BorderThickness="0"
+                     HorizontalAlignment="Right"
+                     VerticalAlignment="Center"
+                     Visibility="Hidden"
+                     Click="RemoveButton_Click"
+                     Cursor="Hand">
+                    <Button.ToolTip>
+                        <ToolTip Content="{x:Static p:Resources.PublishPackageRemoveFromPacakgeTooltip}"
+                              Style="{StaticResource GenericToolTipLight}" />
+                    </Button.ToolTip>
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent">
+                                <Viewbox Width="14"
+                                         Height="14"
+                                         VerticalAlignment="Center">
+                                    <Path x:Name="Folder"
+                                         Fill="#999999"
+                                         Data="M5 2H2V4H14V2H11V0H5V2ZM10 2H6V1.5C6 1.22386 6.22386 1 6.5 1H9.5C9.77614 1 10 1.22386 10 1.5V2ZM13 5H3V16H13V5Z"
+                                         StrokeThickness="0">
+                                    </Path>
+                                </Viewbox>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver"
+                                         Value="True">
+                                    <Setter TargetName="Folder"
+                                         Property="Fill"
+                                         Value="#6AC0E7" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Button.Template>
+                </Button>
+
+            </Grid>
+
+            <ItemsPresenter x:Name="ItemsHost" Grid.ColumnSpan="5" Grid.Column="0" Grid.Row="1"
+                         local:TreeViewItemHelper.Indent="{Binding Path=(local:TreeViewItemHelper.Indent), Mode=OneWay, RelativeSource={RelativeSource AncestorType=ItemsPresenter}, Converter={StaticResource IndentConverter}}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsExpanded" Value="False">
+                <Setter Property="Visibility" TargetName="ItemsHost" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" TargetName="Bd" Value="Transparent"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+                <Setter Property="Visibility" TargetName="RemoveButton" Value="Visible"/>
+                <Setter Property="Background" TargetName="SelectionBorder" Value="#F5F5F5"/>
+            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="local:MyTreeViewHelper.IsMouseDirectlyOverItem" Value="True"/>
+                </MultiTrigger.Conditions>
+                <Setter Property="Visibility" TargetName="RemoveButton" Value="Visible"/>
+                <Setter Property="Background" TargetName="SelectionBorder" Value="#F5F5F5"/>
+            </MultiTrigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                <Setter Property="Visibility" TargetName="RemoveButton" Value="Hidden"/>
+                <Setter Property="Background" TargetName="Bd" Value="#343434"/>
+                <Setter Property="Background" TargetName="SelectionBorder" Value="#343434"/>
+            </Trigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=DisableRemove}" Value="True">
+                <Setter Property="Visibility" TargetName="RemoveButton" Value="Hidden"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Tag}" Value="True">
+                <Setter Property="Visibility" TargetName="RemoveButton" Value="Hidden"/>
+            </DataTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!--#region CheckBox -->
+    <Style x:Key="FocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="2" StrokeDashArray="1 2" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" SnapsToDevicePixels="true" StrokeThickness="1"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="OptionMarkFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="14,0,0,0" StrokeDashArray="1 2" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" SnapsToDevicePixels="true" StrokeThickness="1"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <SolidColorBrush x:Key="OptionMark.Static.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Border" Color="#FF707070"/>
+    <SolidColorBrush x:Key="OptionMark.Static.Glyph" Color="#FF212121"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Background" Color="#FFF3F9FF"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Border" Color="#FF5593FF"/>
+    <SolidColorBrush x:Key="OptionMark.MouseOver.Glyph" Color="#FF212121"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Background" Color="#FFD9ECFF"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Border" Color="#FF3C77DD"/>
+    <SolidColorBrush x:Key="OptionMark.Pressed.Glyph" Color="#FF212121"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Background" Color="#FFE6E6E6"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Border" Color="#FFBCBCBC"/>
+    <SolidColorBrush x:Key="OptionMark.Disabled.Glyph" Color="#FF707070"/>
+    <Style x:Key="CheckBoxStyle" TargetType="{x:Type CheckBox}">
+        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="Background" Value="{StaticResource OptionMark.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource OptionMark.Static.Border}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CheckBox}">
+                    <Grid x:Name="templateRoot" Background="Transparent" SnapsToDevicePixels="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Border x:Name="checkBoxBorder" Width="12" Height="12" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="0" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            <Grid x:Name="markGrid">
+                                <Path x:Name="optionMark" Data="M 0.387 4.6521 L 1.6793 3.3598 L 3.2327 4.6984 L 6.5682 1.0353 L 7.9158 2.2623 L 3.3863 7.2367 L 0.387 4.6521 Z" Fill="{StaticResource OptionMark.Static.Glyph}" Margin="1" Opacity="0" Stretch="None"/>
+                                <Rectangle x:Name="indeterminateMark" Fill="{StaticResource OptionMark.Static.Glyph}" Margin="2" Opacity="0"/>
+                            </Grid>
+                        </Border>
+                        <ContentPresenter x:Name="contentPresenter" Grid.Column="1" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="HasContent" Value="true">
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource OptionMarkFocusVisual}"/>
+                            <Setter Property="Padding" Value="4,-1,0,0"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Background" TargetName="checkBoxBorder" Value="{StaticResource OptionMark.MouseOver.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="checkBoxBorder" Value="{StaticResource OptionMark.MouseOver.Border}"/>
+                            <Setter Property="Fill" TargetName="optionMark" Value="{StaticResource OptionMark.MouseOver.Glyph}"/>
+                            <Setter Property="Fill" TargetName="indeterminateMark" Value="{StaticResource OptionMark.MouseOver.Glyph}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Background" TargetName="checkBoxBorder" Value="{StaticResource OptionMark.Disabled.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="checkBoxBorder" Value="{StaticResource OptionMark.Disabled.Border}"/>
+                            <Setter Property="Fill" TargetName="optionMark" Value="{StaticResource OptionMark.Disabled.Glyph}"/>
+                            <Setter Property="Fill" TargetName="indeterminateMark" Value="{StaticResource OptionMark.Disabled.Glyph}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="true">
+                            <Setter Property="Background" TargetName="checkBoxBorder" Value="{StaticResource OptionMark.Pressed.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="checkBoxBorder" Value="{StaticResource OptionMark.Pressed.Border}"/>
+                            <Setter Property="Fill" TargetName="optionMark" Value="{StaticResource OptionMark.Pressed.Glyph}"/>
+                            <Setter Property="Fill" TargetName="indeterminateMark" Value="{StaticResource OptionMark.Pressed.Glyph}"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="true">
+                            <Setter Property="Opacity" TargetName="optionMark" Value="1"/>
+                            <Setter Property="Opacity" TargetName="indeterminateMark" Value="0"/>
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="{x:Null}">
+                            <Setter Property="Opacity" TargetName="optionMark" Value="0"/>
+                            <Setter Property="Opacity" TargetName="indeterminateMark" Value="1"/>
+                            <Setter Property="Visibility" Value="Hidden"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="False">
+                            <Setter Property="Visibility" Value="Hidden"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!--#endregion -->
+
+</ResourceDictionary>


### PR DESCRIPTION
### Purpose

Just a DRAFT for review following https://autodesk.slack.com/archives/CPJ5UQW0Z/p1717491645738229
Potential use of separate ResourceDictionary to hold styled and templates of CustomBrowserControl. Aim is to use them in DynamoATF

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Just for review if the dictionary is setup correctly and can be used in DynamoATF.

### Reviewers

@BogdanZavu 

