### PR TITLE
DYN-7071: better hierarchy of Graph Elements Scale settings

### DIFF
--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1562,7 +1562,6 @@
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
                                         </Grid.RowDefinitions>
 
                                         <StackPanel Margin="0,0,0,5"
@@ -1616,7 +1615,7 @@
 
                                         <!-- Use Revit scale toggle (only visible in DynamoRevit) -->
                                         <StackPanel Orientation="Horizontal" 
-                                            Margin="0,6,0,8" 
+                                            Margin="0,8,0,8" 
                                             Grid.Row="2"
                                             Visibility="{Binding IsDynamoRevit, Converter={StaticResource BooleanToVisibilityConverter}}">
                                                 <ToggleButton Name="UseHostScaleUnitsToggle"

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1591,11 +1591,33 @@
                                                     </Image.ToolTip>
                                                 </Image>
                                             </Label>
-                                        </StackPanel>                           
-                                        
+                                        </StackPanel>                                                            
+
+                                        <ComboBox Grid.Row="1" 
+                                              Width="213"
+                                              HorizontalAlignment="Left"
+                                              ItemsSource="{Binding Path=UnitList}"
+                                              SelectedItem="{Binding Path=SelectedUnits}"
+                                              Style="{StaticResource NoBordersComboBoxStyle}"
+                                              IsEnabled="{Binding EnableManualScaleOverrides}">
+                                        </ComboBox>
+                                        <TextBlock Grid.Row="1"
+                                                    x:Name="HostUnitsTextBlock"
+                                                    Padding="2"
+                                                    Margin="0 2"
+                                                    Width="190"
+                                                    FontWeight="Regular"
+                                                    HorizontalAlignment="Left"
+                                                    Text="{Binding HostGenericScaleUnits}"
+                                                    Foreground="#888888"
+                                                    Background="{StaticResource PreferencesWindowBackgroundColor}"
+                                                    Visibility="{Binding EnableManualScaleOverrides, Converter={StaticResource InverseBoolToVisibilityConverter}}">
+                                        </TextBlock>
+
+                                        <!-- Use Revit scale toggle (only visible in DynamoRevit) -->
                                         <StackPanel Orientation="Horizontal" 
                                             Margin="0,6,0,8" 
-                                            Grid.Row="1"
+                                            Grid.Row="2"
                                             Visibility="{Binding IsDynamoRevit, Converter={StaticResource BooleanToVisibilityConverter}}">
                                                 <ToggleButton Name="UseHostScaleUnitsToggle"
                                                     Width="{StaticResource ToggleButtonWidth}"
@@ -1626,28 +1648,7 @@
                                                     </Image.ToolTip>
                                                 </Image>
                                             </Label>
-                                        </StackPanel>                                        
-
-                                        <ComboBox Grid.Row="3" 
-                                              Width="213"
-                                              HorizontalAlignment="Left"
-                                              ItemsSource="{Binding Path=UnitList}"
-                                              SelectedItem="{Binding Path=SelectedUnits}"
-                                              Style="{StaticResource NoBordersComboBoxStyle}"
-                                              IsEnabled="{Binding EnableManualScaleOverrides}">
-                                        </ComboBox>
-                                        <TextBlock Grid.Row="3"
-                                                    x:Name="HostUnitsTextBlock"
-                                                    Padding="2"
-                                                    Margin="0 2"
-                                                    Width="190"
-                                                    FontWeight="Regular"
-                                                    HorizontalAlignment="Left"
-                                                    Text="{Binding HostGenericScaleUnits}"
-                                                    Foreground="#888888"
-                                                    Background="{StaticResource PreferencesWindowBackgroundColor}"
-                                                    Visibility="{Binding EnableManualScaleOverrides, Converter={StaticResource InverseBoolToVisibilityConverter}}">
-                                        </TextBlock>
+                                        </StackPanel>   
 
                                     </Grid>
 


### PR DESCRIPTION
### Purpose

This PR addresses the following concern raised by this ticket https://forum.dynamobim.com/t/dynamo-setting-graphic-elements-scale/101595/2?u=jacob.small. The issue is tracked here https://jira.autodesk.com/browse/DYN-7071 `As a Dynamo user, I want a better hierarchy of Graph Elements Scale settings`

### UI Changes

<img src="https://github.com/DynamoDS/Dynamo/assets/5354594/e59a29c0-0ca6-4e94-8a18-5377799df318" alt="image description" width="500"/>

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- change location of the toggle for better user experience

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
