### PR TITLE
DYN-7103, DYN-7127 Fix crash error in Instancing Rendering logic, Fix issue with code block rendering

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4083,15 +4083,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo has had an issue displaying some geometry to the background preview.
-        /// </summary>
-        public static string InstancingRenderFailureSummary {
-            get {
-                return ResourceManager.GetString("InstancingRenderFailureSummary", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _Interactive Guides.
         /// </summary>
         public static string InteractiveGuides {
@@ -7292,7 +7283,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 3D Preview had an issue.
+        ///   Looks up a localized string similar to Background Preview had an issue.
         /// </summary>
         public static string PartialRenderFailureTitle {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4074,6 +4074,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please disable Use Instancing in the Display Settings section of Visual Settings..
+        /// </summary>
+        public static string InstancingRenderFailureDescription {
+            get {
+                return ResourceManager.GetString("InstancingRenderFailureDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamo has had an issue displaying some geometry to the background preview.
+        /// </summary>
+        public static string InstancingRenderFailureSummary {
+            get {
+                return ResourceManager.GetString("InstancingRenderFailureSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Interactive Guides.
         /// </summary>
         public static string InteractiveGuides {
@@ -7270,6 +7288,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PackageWebsiteLabel {
             get {
                 return ResourceManager.GetString("PackageWebsiteLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 3D Preview had an issue.
+        /// </summary>
+        public static string PartialRenderFailureTitle {
+            get {
+                return ResourceManager.GetString("PartialRenderFailureTitle", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4007,10 +4007,7 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="InstancingRenderFailureDescription" xml:space="preserve">
     <value>Please disable Use Instancing in the Display Settings section of Visual Settings.</value>
   </data>
-  <data name="InstancingRenderFailureSummary" xml:space="preserve">
-    <value>Dynamo has had an issue displaying some geometry to the background preview</value>
-  </data>
   <data name="PartialRenderFailureTitle" xml:space="preserve">
-    <value>3D Preview had an issue</value>
+    <value>Background Preview had an issue</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4004,4 +4004,13 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="NodeInCanvasSearchCreationError" xml:space="preserve">
     <value>Failed to create node: </value>
   </data>
+  <data name="InstancingRenderFailureDescription" xml:space="preserve">
+    <value>Please disable Use Instancing in the Display Settings section of Visual Settings.</value>
+  </data>
+  <data name="InstancingRenderFailureSummary" xml:space="preserve">
+    <value>Dynamo has had an issue displaying some geometry to the background preview</value>
+  </data>
+  <data name="PartialRenderFailureTitle" xml:space="preserve">
+    <value>3D Preview had an issue</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3994,10 +3994,7 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="InstancingRenderFailureDescription" xml:space="preserve">
     <value>Please disable Use Instancing in the Display Settings section of Visual Settings.</value>
   </data>
-  <data name="InstancingRenderFailureSummary" xml:space="preserve">
-    <value>Dynamo has had an issue displaying some geometry to the background preview</value>
-  </data>
   <data name="PartialRenderFailureTitle" xml:space="preserve">
-    <value>3D Preview had an issue</value>
+    <value>Background Preview had an issue</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -3991,4 +3991,13 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="NodeInCanvasSearchCreationError" xml:space="preserve">
     <value>Failed to create node: </value>
   </data>
+  <data name="InstancingRenderFailureDescription" xml:space="preserve">
+    <value>Please disable Use Instancing in the Display Settings section of Visual Settings.</value>
+  </data>
+  <data name="InstancingRenderFailureSummary" xml:space="preserve">
+    <value>Dynamo has had an issue displaying some geometry to the background preview</value>
+  </data>
+  <data name="PartialRenderFailureTitle" xml:space="preserve">
+    <value>3D Preview had an issue</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4784,6 +4784,7 @@ static Dynamo.Wpf.Properties.Resources.InstalledPackageViewNodeLibrariesLabel.ge
 static Dynamo.Wpf.Properties.Resources.InstalledPackageViewPendingInstallButton.get -> string
 static Dynamo.Wpf.Properties.Resources.InstalledPackageViewTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.InstallMessageCaption.get -> string
+static Dynamo.Wpf.Properties.Resources.InstancingRenderFailureDescription.get -> string
 static Dynamo.Wpf.Properties.Resources.InteractiveGuides.get -> string
 static Dynamo.Wpf.Properties.Resources.InvalidDraggingOperationMessgae.get -> string
 static Dynamo.Wpf.Properties.Resources.InvalidLoginUrl.get -> string
@@ -5133,6 +5134,7 @@ static Dynamo.Wpf.Properties.Resources.PackageViewContextMenuLoadText.get -> str
 static Dynamo.Wpf.Properties.Resources.PackageViewContextMenuLoadTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageWarningMessageBoxTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageWebsiteLabel.get -> string
+static Dynamo.Wpf.Properties.Resources.PartialRenderFailureTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.Periodic.get -> string
 static Dynamo.Wpf.Properties.Resources.PersistentVisualStatusOfLinterIssues.get -> string
 static Dynamo.Wpf.Properties.Resources.PortPropertiesPromptDescriptionTooltip.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -44,6 +44,7 @@ using MeshBuilder = HelixToolkit.SharpDX.Core.MeshBuilder;
 using MeshGeometry3D = HelixToolkit.SharpDX.Core.MeshGeometry3D;
 using TextInfo = HelixToolkit.SharpDX.Core.TextInfo;
 using Dynamo.Configuration;
+using Dynamo.UI.Prompts;
 
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
@@ -950,17 +951,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             catch (InstancingRenderFailureException)
             {
                 //Notify the user of an issue impacting the background preview but do not disable the background preview.
-                string title = Resources.PartialRenderFailureTitle;
-                string summary = Resources.InstancingRenderFailureSummary;
+                var title = Resources.PartialRenderFailureTitle;
                 var description = Resources.InstancingRenderFailureDescription;
 
-                const string imageUri = "/DynamoCoreWpf;component/UI/Images/task_dialog_future_file.png";
-                var args = new TaskDialogEventArgs(
-                   new Uri(imageUri, UriKind.Relative),
-                   title, summary, description);
-
-                //Show the dialog to inform the user
-                (dynamoModel as DynamoModel).OnRequestTaskDialog(null, args);
+                var result = DynamoMessageBox.Show(description, title, MessageBoxButton.OK, MessageBoxImage.Warning);
             }
 #if DEBUG
             // Defer stopping the timer until after the rendering has occurred

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1917,9 +1917,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         //
                         //Example: One Render package with a line, a rectangle (via instance transform) and another line
                         //
-                        //Positions [P0,P1,P3,P3,P4,P5,P6,P7,P8] (line 1 (2 Positions), rectangle (5 Positions), line 2 (2 Positions))
+                        //Positions [P0,P1,P2,P3,P4,P5,P6,P7,P8] (line 1 (2 Positions), rectangle (5 Positions), line 2 (2 Positions))
                         //Colors    [C0,C1,C2,C3,C4,C5,C6,C7,C8] (line 1 (2 Colors), rectangle (5 Colors), line 2 (2 Colors))
-                        //Indices [0,1,2,3,3,4,4,5,5,5,6,7,8] -> [(line 1) 1,2, (rectangle) 2,3,3,4,4,5,5,5,6 (line 2) 7,8]
+                        //Indices [0,1,2,3,3,4,4,5,5,6,7,8] -> [(line 1) 1,2, (rectangle) 2,3,3,4,4,5,5,6 (line 2) 7,8]
                         //
                         //Note, the Indices array is always bound by the number of Positions. Values in Indices[] should not be less than 0 and should be less than count of Positions.
                         //
@@ -1933,7 +1933,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                             //For each range of line vertices associated with an instance we will add the line data and instances to the scene
                             //From the example above we would want to gather the data for the rectangle.
                             //
-                            //For Positions [P0,P1,P3,P3,P4,P5,P6,P7,P8]
+                            //For Positions [P0,P1,P2,P3,P4,P5,P6,P7,P8]
                             //we know from LineVertexRangesAssociatedWithInstancing that the rectangle is associated with vertices 2-6
                             //We get the startIndex which is 2 and the count which is 6-2+1 = 5
                             var j = 0;
@@ -1971,12 +1971,12 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                             //From the example above we would want to gather the data for the two lines. RemoveLineGeometryByRange will remove the rectangle data.
                             //
                             //Start Point:
-                            //Positions [P0,P1,P3,P3,P4,P5,P6,P7,P8] (line 1 (2 Positions), rectangle (5 Positions), line 2 (2 Positions))
+                            //Positions [P0,P1,P2,P3,P4,P5,P6,P7,P8] (line 1 (2 Positions), rectangle (5 Positions), line 2 (2 Positions))
                             //Colors    [C0,C1,C2,C3,C4,C5,C6,C7,C8] (line 1 (2 Colors), rectangle (5 Colors), line 2 (2 Colors))
                             //Indices [0,1,2,3,3,4,4,5,5,6,7,8] -> [(line 1) 1,2, (rectangle) 2,3,3,4,4,5,5,6 (line 2) 7,8]
                             //
                             //End State to pass to AddLineData
-                            //Positions [P0,P1,P3,P3] (line 1 (2 Positions), line 2 (2 Positions))
+                            //Positions [P0,P1,P2,P3] (line 1 (2 Positions), line 2 (2 Positions))
                             //Colors    [C0,C1,C2,C3] (line 1 (2 Colors), line 2 (2 Colors))
                             //Indices [0,1,2,3] -> [(line 1) 1,2, (line 2) 3,4]
                             if (lineVertexRangesToRemove.Any())
@@ -2205,14 +2205,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             //Example with data from a line, a rectangle, and another line.  In this case the data would look like this:
             //
-            //Positions [P0,P1,P3,P3,P4,P5,P6,P7,P8] (line 1 (2 Positions), rectangle (5 Positions), line 2 (2 Positions))
+            //Positions [P0,P1,P2,P3,P4,P5,P6,P7,P8] (line 1 (2 Positions), rectangle (5 Positions), line 2 (2 Positions))
             //Colors    [C0,C1,C2,C3,C4,C5,C6,C7,C8] (line 1 (2 Colors), rectangle (5 Colors), line 2 (2 Colors))
             //Indices [0,1,2,3,3,4,4,5,5,6,7,8] -> [(line 1) 1,2, (rectangle) 2,3,3,4,4,5,5,6 (line 2) 7,8]
             //
             //In this example we want to remove the rectangle so the verticeRange would be [(2,6)]
             //
             //End State to pass to AddLineData
-            //Positions [P0,P1,P3,P3] (line 1 (2 Positions), line 2 (2 Positions))
+            //Positions [P0,P1,P2,P3] (line 1 (2 Positions), line 2 (2 Positions))
             //Colors    [C0,C1,C2,C3] (line 1 (2 Colors), line 2 (2 Colors))
             //Indices [0,1,2,3] -> [(line 1) 1,2, (line 2) 3,4]
             //
@@ -2237,7 +2237,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
                 //Now we need determine the first index and count of the range to remove in indices
                 //This is found via lookup by value associated with Position indexes.
-                //In the example, for Indices [0,1,2,3,3,4,4,5,5,5,6,7,8] we would find the firstIndicesIndex = 2 (ie first time we see 2)
+                //In the example, for Indices [0,1,2,3,3,4,4,5,5,6,7,8] we would find the firstIndicesIndex = 2 (ie first time we see 2)
                 //For indicesCount = 8 -> first time we see 6 is the 10 index -> 10-2+1 = 8
                 var firstIndicesIndex = l.Indices.IndexOf(range.start);
                 var indicesCount = l.Indices.IndexOf(range.end) - firstIndicesIndex + 1;
@@ -2247,7 +2247,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 //Last step is to normalize the indices array so that it is correct for the remaining data.
                 //from the example above the data now looks like this:
                 //
-                //Positions [P0,P1,P3,P3] (line 1 (2 Positions), line 2 (2 Positions))
+                //Positions [P0,P1,P2,P3] (line 1 (2 Positions), line 2 (2 Positions))
                 //Colors    [C0,C1,C2,C3] (line 1 (2 Colors), line 2 (2 Colors))
                 //Indices [0,1,7,8] -> [(line 1) 1,2, (line 2) 7,8]
                 //

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -2117,34 +2117,24 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             verticesRange.Sort();
             verticesRange.Reverse();
 
-            //track removed vertices to renumber indices index
-            var totalRemoved = 0;
-
-            //Determine first removed indice index within the range of indices.
-            var lowestVerticeInRanges = verticesRange.Min(x => x.start);
-            var lowestRemovedIndicesIndex = l.Indices.IndexOf(lowestVerticeInRanges);
-
             //Remove already generated line geometry from render package
 
             foreach (var range in verticesRange)
             {
                 var i = range.start;
-                var c = range.end - range.start + 1;
-                l.Positions.RemoveRange(i, c);
-                l.Colors.RemoveRange(i, c);
-                totalRemoved += c;
+                var count = range.end - range.start + 1;
+                l.Positions.RemoveRange(i, count);
+                l.Colors.RemoveRange(i, count);
 
                 var firstIndicesIndex = l.Indices.IndexOf(range.start);
                 var indicesCount = l.Indices.IndexOf(range.end) - firstIndicesIndex + 1;
                 l.Indices.RemoveRange(firstIndicesIndex, indicesCount);
-            }
 
-            //Reset the Indices values for the indices that were after the removed region
-
-            var lowestRemovedIndice = verticesRange.Min(x => x.start);
-            for (int i = lowestRemovedIndicesIndex; i < l.Indices.Count; i++)
-            {
-                l.Indices[i] -= totalRemoved;
+                //Reset the Indices values for the indices that were after the removed region
+                for (int j = firstIndicesIndex; j < l.Indices.Count; j++)
+                {
+                    l.Indices[j] -= count;
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -958,6 +958,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                    new Uri(imageUri, UriKind.Relative),
                    title, summary, description);
 
+                //Show the dialog to inform the user
                 (dynamoModel as DynamoModel).OnRequestTaskDialog(null, args);
             }
 #if DEBUG

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1977,8 +1977,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                             //Indices [0,1,2,3,3,4,4,5,5,6,7,8] -> [(line 1) 1,2, (rectangle) 2,3,3,4,4,5,5,6 (line 2) 7,8]
                             //
                             //End State to pass to AddLineData
-                            //Positions [P0,P1,P2,P3] (line 1 (2 Positions), line 2 (2 Positions))
-                            //Colors    [C0,C1,C2,C3] (line 1 (2 Colors), line 2 (2 Colors))
+                            //Positions [P0,P1,P7,P8] (line 1 (2 Positions), line 2 (2 Positions))
+                            //Colors    [C0,C1,C7,C8] (line 1 (2 Colors), line 2 (2 Colors))
                             //Indices [0,1,2,3] -> [(line 1) 1,2, (line 2) 3,4]
                             if (lineVertexRangesToRemove.Any())
                             {
@@ -2213,8 +2213,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             //In this example we want to remove the rectangle so the verticeRange would be [(2,6)]
             //
             //End State to pass to AddLineData
-            //Positions [P0,P1,P2,P3] (line 1 (2 Positions), line 2 (2 Positions))
-            //Colors    [C0,C1,C2,C3] (line 1 (2 Colors), line 2 (2 Colors))
+            //Positions [P0,P1,P7,P8] (line 1 (2 Positions), line 2 (2 Positions))
+            //Colors    [C0,C1,C7,C8] (line 1 (2 Colors), line 2 (2 Colors))
             //Indices [0,1,2,3] -> [(line 1) 1,2, (line 2) 3,4]
             //
             //Note that while the Position and Color arrays are simple range remove operations, The Indices require both a remove and a normalization operation.
@@ -2248,8 +2248,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 //Last step is to normalize the indices array so that it is correct for the remaining data.
                 //from the example above the data now looks like this:
                 //
-                //Positions [P0,P1,P2,P3] (line 1 (2 Positions), line 2 (2 Positions))
-                //Colors    [C0,C1,C2,C3] (line 1 (2 Colors), line 2 (2 Colors))
+                //Positions [P0,P1,P7,P8] (line 1 (2 Positions), line 2 (2 Positions))
+                //Colors    [C0,C1,C7,C8] (line 1 (2 Colors), line 2 (2 Colors))
                 //Indices [0,1,7,8] -> [(line 1) 1,2, (line 2) 7,8]
                 //
                 //The Indices array values are incorrect as they point to vertices that no longer exist in the Position Array.

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -946,6 +946,20 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 var description = Resources.RenderingMemoryOutageDescription;
                 (dynamoModel as DynamoModel).Report3DPreviewOutage(summary, description);
             }
+            catch (InstancingRenderFailureException)
+            {
+                //Notify the user of an issue impacting the background preview but do not disable the background preview.
+                string title = Resources.PartialRenderFailureTitle;
+                string summary = Resources.InstancingRenderFailureSummary;
+                var description = Resources.InstancingRenderFailureDescription;
+
+                const string imageUri = "/DynamoCoreWpf;component/UI/Images/task_dialog_future_file.png";
+                var args = new TaskDialogEventArgs(
+                   new Uri(imageUri, UriKind.Relative),
+                   title, summary, description);
+
+                (dynamoModel as DynamoModel).OnRequestTaskDialog(null, args);
+            }
 #if DEBUG
             // Defer stopping the timer until after the rendering has occurred
             Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() =>
@@ -2088,6 +2102,29 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                             rp.Transform, rp.RequiresPerVertexColoration);
                     }
                 }
+
+                //Pass failure to the calling function try catch.
+                if (instancingRenderFailure)
+                {
+                    throw new InstancingRenderFailureException();
+                }
+            }
+        }
+
+        internal class InstancingRenderFailureException : Exception
+        {
+            public InstancingRenderFailureException()
+            {
+            }
+
+            public InstancingRenderFailureException(string message)
+                : base(message)
+            {
+            }
+
+            public InstancingRenderFailureException(string message, Exception inner)
+                : base(message, inner)
+            {
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -2113,14 +2113,19 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <param name="l">line object</param>
         private static void RemoveLineGeometryByRange(List<(int start, int end)> verticesRange, LineGeometry3D l)
         {
-            //First sort the range data
+            //First sort the range data so that we remove the range from the end to the start.
             verticesRange.Sort();
             verticesRange.Reverse();
 
             //track removed vertices to renumber indices index
             var totalRemoved = 0;
-            
+
+            //Determine first removed indice index within the range of indices.
+            var lowestVerticeInRanges = verticesRange.Min(x => x.start);
+            var lowestRemovedIndicesIndex = l.Indices.IndexOf(lowestVerticeInRanges);
+
             //Remove already generated line geometry from render package
+
             foreach (var range in verticesRange)
             {
                 var i = range.start;
@@ -2134,7 +2139,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 l.Indices.RemoveRange(firstIndicesIndex, indicesCount);
             }
 
-            for (int i = 0; i < l.Indices.Count; i++)
+            //Reset the Indices values for the indices that were after the removed region
+
+            var lowestRemovedIndice = verticesRange.Min(x => x.start);
+            for (int i = lowestRemovedIndicesIndex; i < l.Indices.Count; i++)
             {
                 l.Indices[i] -= totalRemoved;
             }

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -1474,6 +1474,27 @@ X: 0.5 Y: -0.5 Z: -0.5".Replace(" ",string.Empty),
         }
 
         [Test]
+        public void StandardCurvesAndInstancedCurvesAndAreAddedToBackGroundPreviewForWhenTesselatedFromOneNodeExample1()
+        {
+            ViewModel.RenderPackageFactoryViewModel.UseRenderInstancing = true;
+
+            Model.LibraryServices.ImportLibrary("FFITarget.dll");
+            OpenVisualizationTest("MixedListOfInstancedAndStandardCurves.dyn");
+            RunCurrentModel();
+            DispatcherUtil.DoEvents();
+
+            //this graph displays a 3 lines.
+            Assert.AreEqual(3, BackgroundPreviewGeometry.TotalCurvesMinusInstances());
+
+            //this graph displays 2 rectangle instances.
+            Assert.AreEqual(2, BackgroundPreviewGeometry.TotalLineInstancesToRender());
+
+            Assert.AreEqual(false, BackgroundPreviewGeometry.AnyLargerIndicesThanVertexCount());
+
+            Assert.AreEqual(false, BackgroundPreviewGeometry.AnyNegativeIndices());
+        }
+
+        [Test]
         public void Watch3dNodeDisposal_DoesNotBreakBackGroundPreview()
         {
            OpenVisualizationTest("FirstRunWatch3D.dyn");
@@ -1596,6 +1617,45 @@ X: 0.5 Y: -0.5 Z: -0.5".Replace(" ",string.Empty),
             return lines.Any()
                 ? lines.SelectMany(g => ((LineGeometryModel3D)g).Geometry.Positions).Count()/2
                 : 0;
+        }
+
+        public static int TotalCurvesMinusInstances(this IEnumerable<Element3D> dictionary)
+        {
+            var lines = dictionary.Where(g => g is LineGeometryModel3D && !keyList.Contains(g.Name) && ((LineGeometryModel3D)g).Instances == null).ToArray();
+
+            return lines.Any()
+                ? lines.SelectMany(g => ((LineGeometryModel3D)g).Geometry.Positions).Count() / 2
+                : 0;
+        }
+
+        public static bool AnyNegativeIndices(this IEnumerable<Element3D> dictionary)
+        {
+            var lines = dictionary.Where(g => g is LineGeometryModel3D && !keyList.Contains(g.Name) && ((LineGeometryModel3D)g).Instances == null).ToArray();
+
+            foreach(var line in lines)
+            {
+                var indices = ((LineGeometryModel3D)line).Geometry.Indices;
+                if (indices.Any(i => i < 0))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool AnyLargerIndicesThanVertexCount(this IEnumerable<Element3D> dictionary)
+        {
+            var lines = dictionary.Where(g => g is LineGeometryModel3D && !keyList.Contains(g.Name) && ((LineGeometryModel3D)g).Instances == null).ToArray();
+
+            foreach (var line in lines)
+            {
+                var max = ((LineGeometryModel3D)line).Geometry.Positions.Count();
+
+                var indices = ((LineGeometryModel3D)line).Geometry.Indices;
+                if (indices.Any(i => i > max))
+                    return true;
+            }
+
+            return false;
         }
 
         public static int TotalText(this IEnumerable<Element3D> dictionary)

--- a/test/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/test/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -1495,6 +1495,20 @@ X: 0.5 Y: -0.5 Z: -0.5".Replace(" ",string.Empty),
         }
 
         [Test]
+        public void InstanceGeometryWithinCodeBlock()
+        {
+            ViewModel.RenderPackageFactoryViewModel.UseRenderInstancing = true;
+
+            Model.LibraryServices.ImportLibrary("FFITarget.dll");
+            OpenVisualizationTest("InstancingWithinCodeBlock.dyn");
+            RunCurrentModel();
+            DispatcherUtil.DoEvents();
+
+            //this graph displays 2 rectangle instances.
+            Assert.AreEqual(2, BackgroundPreviewGeometry.TotalLineInstancesToRender());
+        }
+
+        [Test]
         public void Watch3dNodeDisposal_DoesNotBreakBackGroundPreview()
         {
            OpenVisualizationTest("FirstRunWatch3D.dyn");

--- a/test/core/visualization/InstancingWithinCodeBlock.dyn
+++ b/test/core/visualization/InstancingWithinCodeBlock.dyn
@@ -1,0 +1,128 @@
+{
+  "Uuid": "db6f1cd5-06d1-47c7-83a2-9865a281864a",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "InstancingWithinCodeBlock",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Cuboid": {
+        "Key": "Autodesk.DesignScript.Geometry.Cuboid",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Circle": {
+        "Key": "Autodesk.DesignScript.Geometry.Circle",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Sphere": {
+        "Key": "Autodesk.DesignScript.Geometry.Sphere",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Line": {
+        "Key": "Autodesk.DesignScript.Geometry.Line",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Rectangle": {
+        "Key": "Autodesk.DesignScript.Geometry.Rectangle",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "c0a1361e543f46858c92564816649e7d",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cda3b41512bc427c8c0829cb70650ebe",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9195bd7048384b09b1477631d0a9f135",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "Rectangle.ByWidthLength(2,4);\nRectangle.ByWidthLength(1,2);"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": true,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.3",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.3.0.5237",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -18.08238983154297,
+      "EyeY": 25.974166870117188,
+      "EyeZ": 2.616847038269043,
+      "LookX": 13.082389831542969,
+      "LookY": -14.974166870117188,
+      "LookZ": -10.616847038269043,
+      "UpX": 0.3794049024581909,
+      "UpY": 0.872495710849762,
+      "UpZ": -0.3079013228416443
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "c0a1361e543f46858c92564816649e7d",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 2097.06910448662,
+        "Y": 724.121483527379
+      }
+    ],
+    "Annotations": [],
+    "X": -2146.757813379982,
+    "Y": -478.75882791579454,
+    "Zoom": 1.1129446513066208
+  }
+}

--- a/test/core/visualization/MixedListOfInstancedAndStandardCurves.dyn
+++ b/test/core/visualization/MixedListOfInstancedAndStandardCurves.dyn
@@ -1,0 +1,762 @@
+{
+  "Uuid": "94fd0076-8a21-4ebc-b511-3fc2ca5cf6d5",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "MixedListOfInstancedAndStandardCurvesExample1",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "a939340ad3924041bc9cfc9a8eb3a654",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "ca4f8570ee8b4a0fa13e2f28dc1a4190",
+          "Name": "startPoint",
+          "Description": "Line start point\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "23870adadbaa459fbd32fe89aafe7a1b",
+          "Name": "endPoint",
+          "Description": "Line end point\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0a58654d584841a3b09f1d0eb27ed2fa",
+          "Name": "Line",
+          "Description": "Line from start and end point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "Replication": "Auto",
+      "Description": "Creates a straight Line between two input Points.\n\nLine.ByStartPointEndPoint (startPoint: Point, endPoint: Point): Line"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "4509fc4f52044806959453de3f4bf379",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "b7c4afef8d7f4b0e97b4aeb6f3bf57dd",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0948a955126c49ce81410855596e37cf",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c1b00303b7d144c586b382a8fd5330b5",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "22d41f1acb4f4d56a89d390039c09080",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "4c730f1c39034771bfc7b3a928bca148",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "c63a3443d6984ac8ae75cc2bb5569d0c",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a7837251d01747c6865e06980947cb83",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1466fcbdc31d405db1c687834288e8ec",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b2452eb90e28424e92ef7735974d2888",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "e934e12ee950421a9cd0da902a6e18b3",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "4e30df2bab254b02a2e37304edec2389",
+          "Name": "startPoint",
+          "Description": "Line start point\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9e0f291b5f1e454aa5c27968f3932cbb",
+          "Name": "endPoint",
+          "Description": "Line end point\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e15f2a7075314555b8bb4aff5d0137e3",
+          "Name": "Line",
+          "Description": "Line from start and end point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "Replication": "Auto",
+      "Description": "Creates a straight Line between two input Points.\n\nLine.ByStartPointEndPoint (startPoint: Point, endPoint: Point): Line"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "2168390b0cf24d9086b71ca01e6105f4",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "e64a1af67dcb4fc39e90e18c92ffd959",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dadad763bfda4252839d9c4ee4aad59a",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6b09e203f5ba44d19feda4d218e2461d",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4805d87d34674793b41ceb464fc02b12",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "0b1d72d34270481faf2e73b0b43733af",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "528c98513c3c46e687c3c5fbeb620d6d",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a8ee97f17ff245ada24fd4519c239594",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e9b061f93fef42749b8c593667689f46",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e9d17e87a2084df892b7eecb760d96c4",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "9b7984fb7a104accb8fb04b4483aa0e6",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "5710363291ec4d4db3f84dcbdabfe7b3",
+          "Name": "centerPoint",
+          "Description": "Center point of circle\n\nPoint\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1789c0fe022a4c36aba5dd514dee3ea5",
+          "Name": "radius",
+          "Description": "Radius\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3d14edfd1b3a45939be098311ec8e91f",
+          "Name": "Circle",
+          "Description": "Circle created with center point and radius",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
+      "Replication": "Auto",
+      "Description": "Creates a Circle with input center Point and radius in the world XY plane, with world Z as normal.\n\nCircle.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Circle"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.CreateList, CoreNodeModels",
+      "VariableInputPorts": true,
+      "Id": "5fafc4cf09f54f99a2f4f4c5c87e47db",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "59b668e2efe947d3a175a1ef4d2c53f6",
+          "Name": "item0",
+          "Description": "Item Index #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f4f6f92f39474e92901321cadf458586",
+          "Name": "item1",
+          "Description": "Item Index #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "65dd7636ce0c46b1bd203439903187cb",
+          "Name": "item2",
+          "Description": "Item Index #2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f3254e7e6f0f4b8e8859a1578d8f1711",
+          "Name": "item3",
+          "Description": "Item Index #3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "214be1346afe47e8aab1f3a820e08f9d",
+          "Name": "item4",
+          "Description": "Item Index #4",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cb29cfe04ce240f4bc9c6922cd051d7a",
+          "Name": "list",
+          "Description": "A list (type: var[]..[])",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Makes a new list from the given inputs"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "517fb5f5a46742b4a737f00b3d3afc28",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "000e85f53de44504a0963c52cae01ff6",
+          "Name": "width",
+          "Description": "Width of rectangle\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cb2274143dee4eddad95013f9274dfb8",
+          "Name": "length",
+          "Description": "Length of rectangle\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "df84eee0bcbf4d4bac5eaae009ae4e7a",
+          "Name": "Rectangle",
+          "Description": "Rectangle created by width and length",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@double,double",
+      "Replication": "Auto",
+      "Description": "Create a Rectangle centered at the WCS origin in the WCS XY Plane, with specified width (X Axis length), and length (Y Axis length).\n\nRectangle.ByWidthLength (width: double = 1, length: double = 1): Rectangle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "10df6f92394c4b2e9af08ee5c485e28d",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "0101c227912a4a81a81dc0f2d5c90a3e",
+          "Name": "circle",
+          "Description": "Circle",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9b9e03049de441e6b37f5fbd96df58f2",
+          "Name": "numberSides",
+          "Description": "int\nDefault value : 5",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4e8e7816422a41a19a279eb983bfe2c1",
+          "Name": "Polygon",
+          "Description": "Polygon",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Polygon.RegularPolygon@Autodesk.DesignScript.Geometry.Circle,int",
+      "Replication": "Auto",
+      "Description": "Construct an inscribed Polygon Curve within a circle.\n\nPolygon.RegularPolygon (circle: Circle, numberSides: int = 5): Polygon"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "f96016639285444492e2daa77fb4aded",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a2041c8d436b47e39fcba310dac6ed04",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a0de099470eb4de8bf78452d95397cdb",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6c5b33339db04958905f60a99ee8652e",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "5;\n10;\n15;"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "0a58654d584841a3b09f1d0eb27ed2fa",
+      "End": "59b668e2efe947d3a175a1ef4d2c53f6",
+      "Id": "35d76de6c75240c39f887cb056581c92",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "22d41f1acb4f4d56a89d390039c09080",
+      "End": "ca4f8570ee8b4a0fa13e2f28dc1a4190",
+      "Id": "683fe9d80af04f4e99e0628f49d3f487",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "b2452eb90e28424e92ef7735974d2888",
+      "End": "23870adadbaa459fbd32fe89aafe7a1b",
+      "Id": "cde38f67750c4d43908d531da8efe93f",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e15f2a7075314555b8bb4aff5d0137e3",
+      "End": "214be1346afe47e8aab1f3a820e08f9d",
+      "Id": "8666f2ca1e2c49fa980eb1d317dc1306",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e15f2a7075314555b8bb4aff5d0137e3",
+      "End": "65dd7636ce0c46b1bd203439903187cb",
+      "Id": "af521c4a12424b27a14f5021bee5a77c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "4805d87d34674793b41ceb464fc02b12",
+      "End": "9e0f291b5f1e454aa5c27968f3932cbb",
+      "Id": "50b09ed017ad48ce9267729fe2025a8b",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e9d17e87a2084df892b7eecb760d96c4",
+      "End": "4e30df2bab254b02a2e37304edec2389",
+      "Id": "e74eb97bde394c4e984bcc7cc4dd7655",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "3d14edfd1b3a45939be098311ec8e91f",
+      "End": "0101c227912a4a81a81dc0f2d5c90a3e",
+      "Id": "516e184b667a4627933e6825df5da7b2",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "df84eee0bcbf4d4bac5eaae009ae4e7a",
+      "End": "f3254e7e6f0f4b8e8859a1578d8f1711",
+      "Id": "a2001a60da85400ca28f8d5892b539f4",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "df84eee0bcbf4d4bac5eaae009ae4e7a",
+      "End": "f4f6f92f39474e92901321cadf458586",
+      "Id": "90da52dda828419da6f33ba0ca903cb6",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "a2041c8d436b47e39fcba310dac6ed04",
+      "End": "e64a1af67dcb4fc39e90e18c92ffd959",
+      "Id": "bddc5bd57c8f45eba5fa01eb678c8c81",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "a2041c8d436b47e39fcba310dac6ed04",
+      "End": "cb2274143dee4eddad95013f9274dfb8",
+      "Id": "09279f864317446289ec84613a40cc8d",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "a0de099470eb4de8bf78452d95397cdb",
+      "End": "b7c4afef8d7f4b0e97b4aeb6f3bf57dd",
+      "Id": "21895c705051433bb9486e710109af87",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "6c5b33339db04958905f60a99ee8652e",
+      "End": "0948a955126c49ce81410855596e37cf",
+      "Id": "80417bdfe0c340129b7c6f473a39d43b",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "6c5b33339db04958905f60a99ee8652e",
+      "End": "c63a3443d6984ac8ae75cc2bb5569d0c",
+      "Id": "6c934fd67cde438288041257a263395f",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": true,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.1",
+      "Data": {}
+    },
+    {
+      "ExtensionGuid": "DFBD9CC0-DB40-457A-939E-8C8555555A9D",
+      "Name": "Generative Design",
+      "Version": "8.1",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.3.0.5237",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -6.20245885848999,
+      "EyeY": 9.908356666564941,
+      "EyeZ": 11.395869255065918,
+      "LookX": 6.316849231719971,
+      "LookY": -9.985294342041016,
+      "LookZ": -11.307574272155762,
+      "UpX": 0.2977660000324249,
+      "UpY": 0.7919747829437256,
+      "UpZ": -0.5330210328102112
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "a939340ad3924041bc9cfc9a8eb3a654",
+        "Name": "Line.ByStartPointEndPoint",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 909.6100968399442,
+        "Y": 376.7056460921775
+      },
+      {
+        "Id": "4509fc4f52044806959453de3f4bf379",
+        "Name": "Point.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 414.52915289042176,
+        "Y": 242.13865401567614
+      },
+      {
+        "Id": "4c730f1c39034771bfc7b3a928bca148",
+        "Name": "Point.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 406.75,
+        "Y": 509.5
+      },
+      {
+        "Id": "e934e12ee950421a9cd0da902a6e18b3",
+        "Name": "Line.ByStartPointEndPoint",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 880.4814731252401,
+        "Y": -204.2868307058916
+      },
+      {
+        "Id": "2168390b0cf24d9086b71ca01e6105f4",
+        "Name": "Point.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 418.0970447962202,
+        "Y": -30.69921043855618
+      },
+      {
+        "Id": "0b1d72d34270481faf2e73b0b43733af",
+        "Name": "Point.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 418.0923038180292,
+        "Y": -310.68431022138395
+      },
+      {
+        "Id": "9b7984fb7a104accb8fb04b4483aa0e6",
+        "Name": "Circle.ByCenterPointRadius",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 908.6193796802797,
+        "Y": 85.19584696848915
+      },
+      {
+        "Id": "5fafc4cf09f54f99a2f4f4c5c87e47db",
+        "Name": "List Create",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 1928.0069379375384,
+        "Y": -332.766179847473
+      },
+      {
+        "Id": "517fb5f5a46742b4a737f00b3d3afc28",
+        "Name": "Rectangle.ByWidthLength",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 868.9614632641276,
+        "Y": -497.971884611467
+      },
+      {
+        "Id": "10df6f92394c4b2e9af08ee5c485e28d",
+        "Name": "Polygon.RegularPolygon",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": false,
+        "X": 1469.1119589045527,
+        "Y": 236.94109494540123
+      },
+      {
+        "Id": "f96016639285444492e2daa77fb4aded",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 23.727069375110432,
+        "Y": -462.8420014416303
+      }
+    ],
+    "Annotations": [],
+    "X": -243.32284942016759,
+    "Y": 532.762701137783,
+    "Zoom": 0.6884351367313164
+  }
+}


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

This PR corrects an error in the instancing render logic that can cause a crash.  Specifically the fix adjusts the logic that is used when the `HelixWatch3DViewModel` is extracting regions of line vertices, colors, and indices associated with goemetry that will be rendered with instancing mechanism.  The logic error occurred when the remaining indices are reset.  Previous every indices was reset vs only those after the removed regions.

sudo example 

Indices List before remove [1,2,3,4,5,6,7,8] 

Indices List after remove [1,2,7,8]

Indices List after reset of values old way [-3,-2,3,4] WRONG

Indices List after reset of values: new way [1,2,3,4] CORRECT

The PR also add additional asserts to validate that the logic does keep the indices with the correct bounds.  If the asserts fail then the render skips on completing the render of the geometry and passes a message to the user

![image](https://github.com/DynamoDS/Dynamo/assets/2145751/6e988ee2-c82d-4ae9-917a-580cec643abf)
 
### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixed an issue where Dynamo would crash when rendering the background preview with the instancing turned on.

### Reviewers

@BogdanZavu @mjkkirschner 

### FYIs

@jnealb @aparajit-pratap @pinzart @QilongTang 
