### PR TITLE
DYN-7055 Library view initialization crash

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -354,6 +354,16 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
         private void Browser_CoreWebView2InitializationCompleted(object sender, CoreWebView2InitializationCompletedEventArgs e)
         {
+            if (!e.IsSuccess)
+            {
+                if (e.InitializationException != null)
+                {
+                    LogToDynamoConsole(e.InitializationException.Message);
+                }
+                LogToDynamoConsole("LibraryViewExtension CoreWebView2 initialization failed.");
+                return;
+            }
+
             LibraryViewModel model = new LibraryViewModel();
             LibraryView view = new LibraryView(model);
 
@@ -397,7 +407,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
             }
             catch (Exception ex)
             {
-                string msg = ex.Message;
+                LogToDynamoConsole("LibraryViewExtension CoreWebView2 initialization failed: " + ex.Message);
             }
         }
 
@@ -694,7 +704,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// <param name="meessage"></param>
         internal void LogToDynamoConsole(string message)
         {
-            this.dynamoViewModel.Model.Logger.Log(message);
+            this.dynamoViewModel?.Model?.Logger?.Log(message);
         }
 
         public void Dispose()

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Interop;
 using CoreNodeModels.Properties;
 using Dynamo.Extensions;
 using Dynamo.LibraryViewExtensionWebView2.Handlers;
@@ -704,7 +705,14 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// <param name="meessage"></param>
         internal void LogToDynamoConsole(string message)
         {
-            this.dynamoViewModel?.Model?.Logger?.Log(message);
+            if (DynamoModel.IsTestMode)
+            {
+                System.Console.WriteLine(message);
+            }
+            else
+            {
+                this.dynamoViewModel?.Model?.Logger?.Log(message);
+            }
         }
 
         public void Dispose()

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -384,26 +384,21 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
             try
             {
-                 this.browser.NavigateToString(libraryHTMLPage);
+                this.browser.NavigateToString(libraryHTMLPage);
+                SetLibraryFontSize();
+                SetTooltipText();
+                browser.ZoomFactor = (double)dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100d;
+                browser.ZoomFactorChanged += Browser_ZoomFactorChanged;
+                browser.KeyDown += Browser_KeyDown;
+
+                // Hosts an object that will expose the properties and methods to be called from the javascript side
+                browser.CoreWebView2.AddHostObjectToScript("scriptObject",
+                    new ScriptObject(OnCopyToClipboard, OnPasteFromClipboard));
             }
             catch (Exception ex)
             {
                 string msg = ex.Message;
             }
-
-            SetLibraryFontSize();
-            SetTooltipText();
-            //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent            
-            double zoomFactor = ((double)dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100d);
-
-            //The default value of the zoom factor is 1.0. The value that comes from the slider is in percentage, so we divide by 100 to be equivalent
-            browser.ZoomFactor = (double)dynamoViewModel.Model.PreferenceSettings.LibraryZoomScale / 100;
-            browser.ZoomFactorChanged += Browser_ZoomFactorChanged;
-            browser.KeyDown += Browser_KeyDown;
-
-            // Hosts an object that will expose the properties and methods to be called from the javascript side
-            browser.CoreWebView2.AddHostObjectToScript("scriptObject",
-                new ScriptObject(OnCopyToClipboard, OnPasteFromClipboard));
         }
 
         private void Browser_Loaded(object sender, RoutedEventArgs e)

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -233,9 +233,9 @@ namespace Dynamo.Notifications
             {
                 if (e.InitializationException != null)
                 {
-                    LogToDynamoConsole(e.InitializationException.Message);
+                    Log(e.InitializationException.Message);
                 }
-                LogToDynamoConsole("NotificationCenter CoreWebView2 initialization failed.");
+                Log("NotificationCenter CoreWebView2 initialization failed.");
                 return;
             }
 
@@ -274,7 +274,7 @@ namespace Dynamo.Notifications
                 }
                 catch (Exception ex)
                 {
-                    LogToDynamoConsole("NotificationCenter CoreWebView2 initialization failed: " + ex.Message);
+                    Log("NotificationCenter CoreWebView2 initialization failed: " + ex.Message);
                 }
             }
         }

--- a/src/Notifications/NotificationCenterController.cs
+++ b/src/Notifications/NotificationCenterController.cs
@@ -218,15 +218,6 @@ namespace Dynamo.Notifications
             e.Handled = true;
         }
 
-        /// <summary>
-        /// Convenience method for logging to Dynamo Console.
-        /// </summary>
-        /// <param name="meessage"></param>
-        internal void LogToDynamoConsole(string message)
-        {
-            this.dynamoViewModel?.Model?.Logger?.Log(message);
-        }
-
         private void WebView_CoreWebView2InitializationCompleted(object sender, Microsoft.Web.WebView2.Core.CoreWebView2InitializationCompletedEventArgs e)
         {
             if (!e.IsSuccess)


### PR DESCRIPTION
### Purpose

Per https://jira.autodesk.com/browse/DYN-7055, library view initialization could crash at the end of it by looking at the call stacks from v3.0.3, 
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/2558d092-5572-4cee-a943-cfd446a678db)

see https://github.com/DynamoDS/Dynamo/blob/RC3.0.3_master/src/LibraryViewExtensionWebView2/LibraryViewController.cs#L397C34-L397C51

According to the callstack, it would be worth to put more code into the try-catch in the function than just the navigate function

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix a potential Library view initialization crash on Dynamo 3.0.3

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
