### PR TITLE
DYN-7015 ExecuteScriptFunctionAsync Crash Guard

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -786,22 +786,8 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// <param name="type"></param>
         internal void UpdateContext(string type)
         {
-            try
-            {
-                ExecuteScriptFunctionAsync(browser, "libController.setHostContext", type);
-            }
-            catch (Exception ex)
-            {
-                LogToDynamoConsole("Error setting the host context: " + ex.Message);
-            }
-            try
-            {
-                ExecuteScriptFunctionAsync(browser, "replaceImages");
-            }
-            catch (Exception ex)
-            {
-                LogToDynamoConsole("Error replacing images: " + ex.Message);
-            }
+            ExecuteScriptFunctionAsync(browser, "libController.setHostContext", type);
+            ExecuteScriptFunctionAsync(browser, "replaceImages");
         }
     }
 }

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -485,9 +485,16 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
             if(fontSize != libraryFontSize)
             {
-                var result = await ExecuteScriptFunctionAsync(browser, "setLibraryFontSize", fontSize);
-                if(result != null)
-                    libraryFontSize = fontSize;
+                try
+                {
+                    var result = await ExecuteScriptFunctionAsync(browser, "setLibraryFontSize", fontSize);
+                    if (result != null)
+                        libraryFontSize = fontSize;
+                }
+                catch (Exception ex)
+                {
+                    LogToDynamoConsole("Error setting the font size: " + ex.Message);
+                }
             }
         }
 
@@ -495,7 +502,14 @@ namespace Dynamo.LibraryViewExtensionWebView2
         {
             var jsonTooltipText = new { create = Resources.TooltipTextCreate, action = Resources.TooltipTextAction, query = Resources.TooltipTextQuery };
             var jsonString = JsonConvert.SerializeObject(jsonTooltipText);
-            var result = await ExecuteScriptFunctionAsync(browser, "setTooltipText", jsonString);
+            try
+            {
+                var result = await ExecuteScriptFunctionAsync(browser, "setTooltipText", jsonString);
+            }
+            catch (Exception ex)
+            {
+                LogToDynamoConsole("Error setting the tooltip text: " + ex.Message);
+            }
         }
 
         #region Tooltip
@@ -772,8 +786,22 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// <param name="type"></param>
         internal void UpdateContext(string type)
         {
-            ExecuteScriptFunctionAsync(browser,"libController.setHostContext", type);
-            ExecuteScriptFunctionAsync(browser, "replaceImages");
+            try
+            {
+                ExecuteScriptFunctionAsync(browser, "libController.setHostContext", type);
+            }
+            catch (Exception ex)
+            {
+                LogToDynamoConsole("Error setting the host context: " + ex.Message);
+            }
+            try
+            {
+                ExecuteScriptFunctionAsync(browser, "replaceImages");
+            }
+            catch (Exception ex)
+            {
+                LogToDynamoConsole("Error replacing images: " + ex.Message);
+            }
         }
     }
 }

--- a/src/LibraryViewExtensionWebView2/ScriptingObject.cs
+++ b/src/LibraryViewExtensionWebView2/ScriptingObject.cs
@@ -101,8 +101,15 @@ namespace Dynamo.LibraryViewExtensionWebView2
                     var searchStream = controller.searchResultDataProvider.GetResource(data, out extension);
                     var searchReader = new StreamReader(searchStream);
                     var results = searchReader.ReadToEnd();
-                    //send back results to libjs
-                    LibraryViewController.ExecuteScriptFunctionAsync(controller.browser, "completeSearch", results);
+                    //send back results to librarie.js
+                    try
+                    {
+                        LibraryViewController.ExecuteScriptFunctionAsync(controller.browser, "completeSearch", results);
+                    }
+                    catch(Exception e)
+                    {
+                        this.controller.LogToDynamoConsole($"Error while sending search results to javascript{Environment.NewLine}{e.Message}");
+                    }
                     searchReader.Dispose();
                 }
                 //When the html <div> that contains the sample package is clicked then we will be moved to the next Step in the Guide

--- a/src/LibraryViewExtensionWebView2/ScriptingObject.cs
+++ b/src/LibraryViewExtensionWebView2/ScriptingObject.cs
@@ -102,14 +102,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
                     var searchReader = new StreamReader(searchStream);
                     var results = searchReader.ReadToEnd();
                     //send back results to librarie.js
-                    try
-                    {
-                        LibraryViewController.ExecuteScriptFunctionAsync(controller.browser, "completeSearch", results);
-                    }
-                    catch(Exception e)
-                    {
-                        this.controller.LogToDynamoConsole($"Error while sending search results to javascript{Environment.NewLine}{e.Message}");
-                    }
+                    LibraryViewController.ExecuteScriptFunctionAsync(controller.browser, "completeSearch", results);
                     searchReader.Dispose();
                 }
                 //When the html <div> that contains the sample package is clicked then we will be moved to the next Step in the Guide


### PR DESCRIPTION
### Purpose
From crash callstacks, looks like ExecuteScriptFunctionAsync call could rarely crash at https://github.com/DynamoDS/Dynamo/blob/RC3.0.3_master/src/LibraryViewExtensionWebView2/LibraryViewController.cs#L474, add code to guard that

Callstack:
![image](https://github.com/DynamoDS/Dynamo/assets/3942418/21ed5dbe-d62b-4b06-a43d-145c7a4f701b)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

 Add code to guard the fact ExecuteScriptFunctionAsync call could rarely crash in Library view

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
