### PR TITLE
DYN-7038-Build-In-Packages-Duplicates

### DIFF
--- a/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dynamo.Core;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
@@ -34,6 +35,10 @@ namespace Dynamo.Search.SearchElements
             ElementType = ElementTypes.ZeroTouch;
             if(typeLoadData.IsPackageMember)
                 ElementType |= ElementTypes.Packaged;
+            if(typeLoadData.Assembly.Location.Contains(PathManager.BuiltinPackagesDirectory))
+            {
+                ElementType |= ElementTypes.BuiltIn;
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose

Fixing duplicate package nodes in Library and Add-ons section
When loading a package that contains the extra/layoutSpecs.json file the nodes were showing duplicate in the Library and in the Add-Ons section. Then the fix was adding to ElementType the missing ElementTypes.BuiltIn when is in theBuilt-In Packages directory.


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing duplicate package nodes in Library and Add-ons section

### Reviewers

@QilongTang @saintentropy 

### FYIs

@BogdanZavu 
