### PR TITLE
DYN-7143 Skip install for npm packages which are already up-to-date

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -22,13 +22,21 @@
   </PropertyGroup>
 
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
+      <PropertyGroup>
+          <PackageVersion>1.0.19</PackageVersion>
+          <PackageName>SplashScreen</PackageName>
+      </PropertyGroup>
+      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+          <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
+      </Exec>
+      <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high" />
       <!--This command updates the npm registry configuration if necessary-->
-      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
+      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" Condition="$(ShouldInstall)"/>
       <!--This command gets a specific splash screen build from npm-->
-      <Exec Command="npm pack @dynamods/splash-screen@1.0.19" />
+      <Exec Command="npm pack @dynamods/splash-screen@$(PackageVersion)"  Condition="$(ShouldInstall)"/>
   </Target>
 
-    <Target Name="ExtractTGZFile" DependsOnTargets="NpmRunBuild" BeforeTargets="BeforeBuild">      
+    <Target Name="ExtractTGZFile" DependsOnTargets="NpmRunBuild" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">      
         <!--Locates the .tgz files-->
         <ItemGroup>
             <TGZFiles Include="./dynamods-splash-screen-*.tgz" />
@@ -50,13 +58,21 @@
 
 
     <Target Name="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
+        <PropertyGroup>
+            <PackageVersion>1.0.14</PackageVersion>
+            <PackageName>DynamoHome</PackageName>
+        </PropertyGroup>
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+            <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
+        </Exec>
+        <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
         <!--Download a specific build of the Dynamo Home package from npm-->
-        <Exec Command="npm pack @dynamods/dynamo-home@1.0.14" />
+        <Exec Command="npm pack @dynamods/dynamo-home@1.0.14"  Condition="$(ShouldInstall)"/>
     </Target>
 
-    <Target Name="ExtractTGZFileDynamoHome" DependsOnTargets="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
+    <Target Name="ExtractTGZFileDynamoHome" DependsOnTargets="NpmRunBuildHomePage" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">
         <!--Locate the .tgz files for the Dynamo Home package-->
         <ItemGroup>
             <TGZFilesDynamoHome Include="./dynamods-dynamo-home-*.tgz" />

--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -27,7 +27,7 @@
         <!--This command updates the npm registry configuration if necessary-->
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
         <!--This command gets a specific build of the notifcation center from npm-->
-        <Exec Command="npm pack @dynamods/librariejs@1.0.5"  Condition="$(ShouldInstall)"/>
+        <Exec Command="npm pack @dynamods/librariejs@$(PackageVersion)"  Condition="$(ShouldInstall)"/>
     </Target>
 
     <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">

--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -16,13 +16,21 @@
   </PropertyGroup>
   
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
+      <PropertyGroup>
+          <PackageVersion>1.0.5</PackageVersion>
+          <PackageName>LibrarieJS</PackageName>
+      </PropertyGroup>
+      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+          <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
+      </Exec>
+      <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
         <!--This command gets a specific build of the notifcation center from npm-->
-        <Exec Command="npm pack @dynamods/librariejs@1.0.5" />
+        <Exec Command="npm pack @dynamods/librariejs@1.0.5"  Condition="$(ShouldInstall)"/>
     </Target>
 
-    <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild">
+    <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">
         <!--Locates the .tgz files-->
         <ItemGroup>
             <TGZFiles Include="./dynamods-librariejs-*.tgz" />

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -27,7 +27,7 @@
         <!--This command updates the npm registry configuration if necessary-->
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
         <!--This command gets a specific build of the notifcation center from npm-->
-        <Exec Command="npm pack @dynamods/notifications-center@0.0.29"  Condition="$(ShouldInstall)"/>
+        <Exec Command="npm pack @dynamods/notifications-center@$(PackageVersion)"  Condition="$(ShouldInstall)"/>
     </Target>
 
     <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -15,13 +15,22 @@
 	</PropertyGroup>
 
     <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
+        <PropertyGroup>
+            <PackageVersion>0.0.29</PackageVersion>
+            <PackageName>NotificationCenter</PackageName>
+        </PropertyGroup>
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+            <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
+        </Exec>
+        <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
+        
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" />
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
         <!--This command gets a specific build of the notifcation center from npm-->
-        <Exec Command="npm pack @dynamods/notifications-center@0.0.29" />
+        <Exec Command="npm pack @dynamods/notifications-center@0.0.29"  Condition="$(ShouldInstall)"/>
     </Target>
 
-    <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild">
+    <Target Name="ExtractTGZFile" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">
         <!--Locates the .tgz files-->
         <ItemGroup>
             <TGZFiles Include="./dynamods-notifications-center-*.tgz" />

--- a/src/pkgexist.ps1
+++ b/src/pkgexist.ps1
@@ -1,0 +1,15 @@
+$pkgname=$args[0]
+$pkgver=$args[1]
+
+If (-Not (Test-Path .\Packages\$pkgname)) {
+	echo true
+	return
+}
+
+$currver=(Get-Content .\Packages\$pkgname\package.json | ConvertFrom-Json).version
+If ($currver -ne $pkgver) {
+	echo true
+}
+else {
+	echo false
+}

--- a/src/pkgexist.ps1
+++ b/src/pkgexist.ps1
@@ -1,7 +1,7 @@
 $pkgname=$args[0]
 $pkgver=$args[1]
 
-If (-Not (Test-Path .\Packages\$pkgname)) {
+If ((-Not (Test-Path .\Packages\$pkgname)) -Or (-Not (Test-Path .\Packages\$pkgname\package.json))) {
 	echo true
 	return
 }


### PR DESCRIPTION
### Purpose

The PR adds a pwsh script that checks if the package is already installed, i.e the version is matched and folder exist.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Skip npm package installation if it is already up-to-date

### Reviewers

@DynamoDS/dynamo
