### PR TITLE
DYN-6836 Arrange call crash guard

### DIFF
--- a/src/DynamoCoreWpf/UI/InOutPortPanel.cs
+++ b/src/DynamoCoreWpf/UI/InOutPortPanel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
@@ -26,14 +26,21 @@ namespace Dynamo.UI.Controls
             double x = 0, y = 0;
             foreach (UIElement child in this.Children)
             {
-                var portVm = generator.ItemFromContainer(child) as PortViewModel;
-                var lineIndex = portVm.PortModel.LineIndex;
-                var multiplier = ((lineIndex == -1) ? itemIndex : lineIndex);
-                var portHeight = portVm.PortModel.Height;
+                try
+                {
+                    var portVm = generator.ItemFromContainer(child) as PortViewModel;
+                    var lineIndex = portVm.PortModel.LineIndex;
+                    var multiplier = ((lineIndex == -1) ? itemIndex : lineIndex);
+                    var portHeight = portVm.PortModel.Height;
 
-                y = multiplier * portHeight;
-                child.Arrange(new Rect(x, y, arrangeSize.Width, portHeight));
-                itemIndex = itemIndex + 1;
+                    y = multiplier * portHeight;
+                    child.Arrange(new Rect(x, y, arrangeSize.Width, portHeight));
+                    itemIndex = itemIndex + 1;
+                }
+                catch (Exception ex)
+                {
+                    Analytics.TrackException(ex, true);
+                }
             }
 
             return base.ArrangeOverride(arrangeSize);


### PR DESCRIPTION
### Purpose

Per https://jira.autodesk.com/browse/DYN-6836, add code to guard crash in ArrangeOverride function call at InOutPortPanel class, I believe such utility is used for calculating port height render when placing each node, see below:

![image](https://github.com/DynamoDS/Dynamo/assets/3942418/9bba4f2e-fd30-4b6b-b899-78536869f0e2)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

add code to guard crash in ArrangeOverride function call at InOutPortPanel class

### Reviewers

@DynamoDS/dynamo 

### FYIs

