### PR TITLE
[Cherrypick] DYN-7033: Home Open button should remember last opened location

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2150,14 +2150,14 @@ namespace Dynamo.ViewModels
                     _fileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyComputer);
                 }
             }
-            else // use the samples directory, if it exists
+            else if (string.IsNullOrEmpty(LastSavedLocation)) //If there is no last saved location, use the samples directory(if it exists) 
             {
                 Assembly dynamoAssembly = Assembly.GetExecutingAssembly();
                 string location = Path.GetDirectoryName(dynamoAssembly.Location);
                 string UICulture = CultureInfo.CurrentUICulture.Name;
                 string path = Path.Combine(location, "samples", UICulture);
 
-                if (string.IsNullOrEmpty(LastSavedLocation) && Directory.Exists(path))
+                if (Directory.Exists(path))
                 {
                     _fileDialog.InitialDirectory = path;
                 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2157,7 +2157,7 @@ namespace Dynamo.ViewModels
                 string UICulture = CultureInfo.CurrentUICulture.Name;
                 string path = Path.Combine(location, "samples", UICulture);
 
-                if (Directory.Exists(path))
+                if (string.IsNullOrEmpty(LastSavedLocation) && Directory.Exists(path))
                 {
                     _fileDialog.InitialDirectory = path;
                 }


### PR DESCRIPTION
### Purpose

Cherrypicking https://github.com/DynamoDS/Dynamo/pull/15323 into 3.2.1

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[Cherrypick] DYN-7033: Home Open button should remember last opened location

### Reviewers
@QilongTang 

