### PR TITLE
custom node modal update 

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4141,7 +4141,6 @@ override Dynamo.Controls.ZoomBorder.Child.set -> void
 override Dynamo.Nodes.DynamoTextBox.OnLostFocus(System.Windows.RoutedEventArgs e) -> void
 override Dynamo.Nodes.DynamoTextBox.OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e) -> void
 override Dynamo.Nodes.DynamoTextBox.OnTextChanged(System.Windows.Controls.TextChangedEventArgs e) -> void
-override Dynamo.Nodes.FunctionNamePrompt.OnClosed(System.EventArgs e) -> void
 override Dynamo.Nodes.StringTextBox.OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e) -> void
 override Dynamo.PackageManager.UI.PackageItemInternalViewModel.Items.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.PackageManager.UI.PackageItemViewModel>
 override Dynamo.PackageManager.UI.PackageItemInternalViewModel.Items.set -> void

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4141,6 +4141,7 @@ override Dynamo.Controls.ZoomBorder.Child.set -> void
 override Dynamo.Nodes.DynamoTextBox.OnLostFocus(System.Windows.RoutedEventArgs e) -> void
 override Dynamo.Nodes.DynamoTextBox.OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e) -> void
 override Dynamo.Nodes.DynamoTextBox.OnTextChanged(System.Windows.Controls.TextChangedEventArgs e) -> void
+override Dynamo.Nodes.FunctionNamePrompt.OnClosed(System.EventArgs e) -> void
 override Dynamo.Nodes.StringTextBox.OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e) -> void
 override Dynamo.PackageManager.UI.PackageItemInternalViewModel.Items.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.PackageManager.UI.PackageItemViewModel>
 override Dynamo.PackageManager.UI.PackageItemInternalViewModel.Items.set -> void

--- a/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml
@@ -4,14 +4,12 @@
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
         xmlns:ui="clr-namespace:Dynamo.UI"
         Title="{x:Static p:Resources.CustomNodePropertyWindowTitle}"
-        Width="450"
         WindowStartupLocation="CenterOwner"
-        WindowStyle="None">
-    <Window.Background>
-        <SolidColorBrush Opacity="0" />
-    </Window.Background>
-    <Window.AllowsTransparency>True</Window.AllowsTransparency>
-
+        Width="450"
+        Height="540"
+        AllowsTransparency="True"
+        WindowStyle="None"
+        Background="Transparent">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Dynamo.Nodes.FunctionNamePrompt"
+<Window x:Class="Dynamo.Nodes.FunctionNamePrompt"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
@@ -231,6 +231,8 @@
         <Border Name="titleBar"
                 Grid.Row="0"
                 Grid.RowSpan="3"
+                BorderBrush="{StaticResource WorkspaceBackgroundHomeBrush}"
+                BorderThickness="1"
                 Background="{StaticResource DarkMidGreyBrush}"
                 CornerRadius="4"
                 MouseDown="FunctionNamePrompt_MouseDown">
@@ -379,5 +381,14 @@
                     Style="{DynamicResource ResourceKey=CtaButtonStyle}"
                     TabIndex="2" />
         </DockPanel>
+
+        <Border Name="frame"
+                Grid.Row="0"
+                Grid.RowSpan="3"
+                BorderBrush="{StaticResource WorkspaceBackgroundHomeBrush}"
+                BorderThickness="1"
+                Background="Transparent"
+                IsHitTestVisible="False"
+                CornerRadius="4"/>
     </Grid>
 </Window>

--- a/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Dynamo.Controls;
-using Dynamo.Utilities;
 using Dynamo.Wpf.Utilities;
 using DynamoUtilities;
 
@@ -19,9 +18,6 @@ namespace Dynamo.Nodes
         {
             InitializeComponent();
 
-            Owner = WpfUtilities.FindUpVisualTree<DynamoView>(this);
-            WindowStartupLocation = WindowStartupLocation.CenterOwner;
-
             nameBox.Focus();
 
             var sortedCats = categories.ToList();
@@ -31,7 +27,10 @@ namespace Dynamo.Nodes
             {
                 categoryBox.Items.Add(item);
             }
+
+            this.ContentRendered += FunctionNamePrompt_ContentRendered;
         }
+       
 
         void OK_Click(object sender, RoutedEventArgs e)
         {
@@ -119,5 +118,28 @@ namespace Dynamo.Nodes
                 ErrorUnderline.Visibility = Visibility.Collapsed;
             }
         }
+
+        #region Recenter Window 
+        private void FunctionNamePrompt_ContentRendered(object sender, EventArgs e)
+        {
+            CenterWindow();
+        }
+
+        private void CenterWindow()
+        {
+            if (Owner != null)
+            {
+                this.Left = Owner.Left + (Owner.Width - this.ActualWidth) / 2;
+                this.Top = Owner.Top + (Owner.Height - this.ActualHeight) / 2;
+            }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            this.ContentRendered -= FunctionNamePrompt_ContentRendered;
+
+            base.OnClosed(e);
+        }
+        #endregion
     }
 }

--- a/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml.cs
@@ -1,9 +1,10 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Dynamo.Controls;
+using Dynamo.Utilities;
 using Dynamo.Wpf.Utilities;
 using DynamoUtilities;
 
@@ -18,6 +19,9 @@ namespace Dynamo.Nodes
         {
             InitializeComponent();
 
+            Owner = WpfUtilities.FindUpVisualTree<DynamoView>(this);
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
             nameBox.Focus();
 
             var sortedCats = categories.ToList();
@@ -27,8 +31,6 @@ namespace Dynamo.Nodes
             {
                 categoryBox.Items.Add(item);
             }
-
-            this.ContentRendered += FunctionNamePrompt_ContentRendered;
         }
        
 
@@ -118,28 +120,5 @@ namespace Dynamo.Nodes
                 ErrorUnderline.Visibility = Visibility.Collapsed;
             }
         }
-
-        #region Recenter Window 
-        private void FunctionNamePrompt_ContentRendered(object sender, EventArgs e)
-        {
-            CenterWindow();
-        }
-
-        private void CenterWindow()
-        {
-            if (Owner != null)
-            {
-                this.Left = Owner.Left + (Owner.Width - this.ActualWidth) / 2;
-                this.Top = Owner.Top + (Owner.Height - this.ActualHeight) / 2;
-            }
-        }
-
-        protected override void OnClosed(EventArgs e)
-        {
-            this.ContentRendered -= FunctionNamePrompt_ContentRendered;
-
-            base.OnClosed(e);
-        }
-        #endregion
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1726,8 +1726,6 @@ namespace Dynamo.Controls
                 categoryBox = { Text = e.Category },
                 DescriptionInput = { Text = e.Description },
                 nameBox = { Text = e.Name },
-                Owner = this,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
             };
 
             if (e.CanEditName)


### PR DESCRIPTION
### Purpose

A small update to the Custom Node modal window adding stroke to the frame of the window and fixing the issue where the window will be launched off-center.

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/ae369d27-7c30-4556-9625-7caca20f6cb8)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- added stroke to window border to align with weave pattern 
- recenter the window after initialization

### Reviewers

@QilongTang 

### FYIs

@Amoursol 
