### PR TITLE
DYN-7156: initialize libview only once

### DIFF
--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Interop;
 using CoreNodeModels.Properties;
 using Dynamo.Extensions;
 using Dynamo.LibraryViewExtensionWebView2.Handlers;
@@ -23,6 +22,7 @@ using Dynamo.Wpf.Interfaces;
 using Dynamo.Wpf.UI.GuidedTour;
 using Dynamo.Wpf.Utilities;
 using Dynamo.Wpf.ViewModels;
+using DynamoUtilities;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 using Newtonsoft.Json;
@@ -81,6 +81,7 @@ namespace Dynamo.LibraryViewExtensionWebView2
         private const string CreateNodeInstrumentationString = "Search-NodeAdded";
         // TODO remove this when we can control the library state from Dynamo more precisely.
         private bool disableObserver = false;
+        internal AsyncMethodState initState = AsyncMethodState.NotStarted;
 
         private LayoutSpecProvider layoutProvider;
         private NodeItemDataProvider nodeProvider;
@@ -309,41 +310,48 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
         async void InitializeAsync()
         {
-            try
+            if (initState == AsyncMethodState.NotStarted)
             {
-                var absolutePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                    @"runtimes\win-x64\native");
-                CoreWebView2Environment.SetLoaderDllFolderPath(absolutePath);
-            }
-            catch (InvalidOperationException e)
-            {
-                LogToDynamoConsole("WebView2Loader.dll is already loaded successfully.");
-            }
-            
-            browser.CoreWebView2InitializationCompleted += Browser_CoreWebView2InitializationCompleted;
+                initState = AsyncMethodState.Started;
 
-            if (!string.IsNullOrEmpty(WebBrowserUserDataFolder))
-            {
-                //This indicates in which location will be created the WebView2 cache folder
-                this.browser.CreationProperties = new CoreWebView2CreationProperties()
+                try
                 {
-                    UserDataFolder = WebBrowserUserDataFolder
-                };
-            }
+                    var absolutePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                        @"runtimes\win-x64\native");
+                    CoreWebView2Environment.SetLoaderDllFolderPath(absolutePath);
+                }
+                catch (InvalidOperationException e)
+                {
+                    LogToDynamoConsole("WebView2Loader.dll is already loaded successfully.");
+                }
 
-            try
-            {
-                await browser.Initialize(LogToDynamoConsole);
+                browser.CoreWebView2InitializationCompleted += Browser_CoreWebView2InitializationCompleted;
 
-                this.browser.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
-                twoWayScriptingObject = new ScriptingObject(this);
-                //register the interop object into the browser.
-                this.browser.CoreWebView2.AddHostObjectToScript("bridgeTwoWay", twoWayScriptingObject);
-                browser.CoreWebView2.Settings.IsZoomControlEnabled = true;
-            }
-            catch (ObjectDisposedException ex)
-            {
-                LogToDynamoConsole(ex.Message);
+                if (!string.IsNullOrEmpty(WebBrowserUserDataFolder))
+                {
+                    //This indicates in which location will be created the WebView2 cache folder
+                    this.browser.CreationProperties = new CoreWebView2CreationProperties()
+                    {
+                        UserDataFolder = WebBrowserUserDataFolder
+                    };
+                }
+
+                try
+                {
+                    await browser.Initialize(LogToDynamoConsole);
+
+                    this.browser.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
+                    twoWayScriptingObject = new ScriptingObject(this);
+                    //register the interop object into the browser.
+                    this.browser.CoreWebView2.AddHostObjectToScript("bridgeTwoWay", twoWayScriptingObject);
+                    browser.CoreWebView2.Settings.IsZoomControlEnabled = true;
+
+                    initState = AsyncMethodState.Done;
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    LogToDynamoConsole(ex.Message);
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7156
LibraryView is initialized in the Revit context. This means that when you try to create a single node, multiple nodes are place inside the workspace. 
This PR ensure that the node library view is initialzied only once

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix issue where multiple nodes are created when selecting a single node from the libray view.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
