### PR TITLE
DYN-7111 Enable package search to show results for package authors as the search key

### DIFF
--- a/src/DynamoCore/Configuration/LuceneConfig.cs
+++ b/src/DynamoCore/Configuration/LuceneConfig.cs
@@ -185,7 +185,12 @@ namespace Dynamo.Configuration
             /// <summary>
             /// Node Input Parameters as string (there are nodes with same name and category but different parameters)
             /// </summary>
-            Parameters
+            Parameters,
+
+            /// <summary>
+            /// Package author name
+            /// </summary>
+            Author
         }
 
         /// <summary>
@@ -208,6 +213,7 @@ namespace Dynamo.Configuration
         public static string[] PackageIndexFields = { nameof(NodeFieldsEnum.Name),
                                                       nameof(NodeFieldsEnum.Description),
                                                       nameof(NodeFieldsEnum.SearchKeywords),
-                                                      nameof(NodeFieldsEnum.Hosts)};
+                                                      nameof(NodeFieldsEnum.Hosts),
+                                                      nameof(NodeFieldsEnum.Author)};
     }
 }

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -295,6 +295,7 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="fields">All fields to be searched in.</param>
         /// <param name="SearchTerm">Search key to be searched for.</param>
+        /// <param name="IsPackageContext">Set this to true if the search context is packages instead of nodes.</param>
         /// <returns></returns>
         internal string CreateSearchQuery(string[] fields, string SearchTerm, bool IsPackageContext = false)
         {

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -214,10 +214,11 @@ namespace Dynamo.Utilities
             var description = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Description), string.Empty, Field.Store.YES);
             var keywords = new TextField(nameof(LuceneConfig.NodeFieldsEnum.SearchKeywords), string.Empty, Field.Store.YES);
             var hosts = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Hosts), string.Empty, Field.Store.YES);
+            var author = new TextField(nameof(LuceneConfig.NodeFieldsEnum.Author), string.Empty, Field.Store.YES);
 
             var d = new Document()
             {
-               name, description, keywords, hosts
+               name, description, keywords, hosts, author
             };
             return d;
         }
@@ -295,7 +296,7 @@ namespace Dynamo.Utilities
         /// <param name="fields">All fields to be searched in.</param>
         /// <param name="SearchTerm">Search key to be searched for.</param>
         /// <returns></returns>
-        internal string CreateSearchQuery(string[] fields, string SearchTerm)
+        internal string CreateSearchQuery(string[] fields, string SearchTerm, bool IsPackageContext = false)
         {
             //By Default the search will be normal
             SearchType searchType = SearchType.Normal;
@@ -314,12 +315,13 @@ namespace Dynamo.Utilities
             var booleanQuery = new BooleanQuery();
             string searchTerm = QueryParser.Escape(SearchTerm);
 
-            if (searchTerm.Contains('.'))
-                searchType = SearchType.ByCategory;
-            else if (searchTerm.Contains(' '))
-                hasEmptySpaces = true;
-            else
-                searchType = SearchType.Normal;
+            if (!IsPackageContext)
+            {
+                if (searchTerm.Contains('.'))
+                    searchType = SearchType.ByCategory;
+                else if (searchTerm.Contains(' '))
+                    hasEmptySpaces = true;
+            }
 
             var trimmedSearchTerm = hasEmptySpaces == true ? searchTerm.Replace(" ", "") : searchTerm;
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -593,6 +593,7 @@ namespace Dynamo.PackageManager
 
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), package.Name);
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), package.Description);
+            LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Author), package.Maintainers);
 
             if (package.Keywords.Length > 0)
             {
@@ -1457,7 +1458,7 @@ namespace Dynamo.PackageManager
                     FuzzyMinSim = LuceneConfig.MinimumSimilarity
                 };
 
-                Query query = parser.Parse(LuceneUtility.CreateSearchQuery(LuceneConfig.PackageIndexFields, searchTerm));
+                Query query = parser.Parse(LuceneUtility.CreateSearchQuery(LuceneConfig.PackageIndexFields, searchTerm, true));
 
                 //indicate we want the first 50 results
                 TopDocs topDocs = LuceneUtility.Searcher.Search(query, n: LuceneConfig.DefaultResultsCount);

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -537,8 +537,8 @@ namespace Dynamo.PackageManager.Wpf.Tests
             packageManagerSearchViewModel.NonHostFilter[3].FilterCommand.Execute(string.Empty);
             Assert.IsFalse(packageManagerSearchViewModel.NonHostFilter[4].OnChecked);
         }
-		
-		/// <summary>
+
+        /// <summary>
         /// This unit test will validate that we can search packages in different languages and they will be found.
         /// </summary>
         [Test]
@@ -549,6 +549,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
             string packageVersionNumber = "1.0.0.0";
             string packageCreatedDateString = "2016 - 12 - 02T13:13:20.135000 + 00:00";
             string formItFilterName = "FormIt";
+            var packageMaintainer = new User(){ username = "DynamoTest", _id = "90-63-17" };
 
             //Packages list
             List<string> packagesNameDifferentLanguages = new List<string> { "paquete", "упаковка", "包裹" };
@@ -579,6 +580,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
                     name = package,
                     versions = new List<PackageVersion> { tmpPackageVersion },
                     host_dependencies = new List<string> { formItFilterName },
+                    maintainers = new List<User> { packageMaintainer },
                 }), false);
                 packageManagerSearchViewModel.AddToSearchResults(tmpPackage);
             }


### PR DESCRIPTION
### Purpose

The PR adds package authors to indexed data, this will enable users to search for packages based on the username of the desired author.

Before - After screenshots for search comparison:

![d5](https://github.com/DynamoDS/Dynamo/assets/32665108/b306db5c-3f5f-498f-b96e-846228ec62c5)
![d4](https://github.com/DynamoDS/Dynamo/assets/32665108/54b4e4a7-298e-49fb-bd85-cd4b66e29db5)
![d3](https://github.com/DynamoDS/Dynamo/assets/32665108/02a840b9-877a-4178-8fea-8a5b79f13dd7)
![d2](https://github.com/DynamoDS/Dynamo/assets/32665108/a54c7b0b-3f43-4620-80b7-e9d2bd16c96a)
![d1](https://github.com/DynamoDS/Dynamo/assets/32665108/cd3fea90-e9e0-4b87-9ada-986d330b7ba2)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Enable users to search for packages based on the username of the desired author.

### Reviewers

@DynamoDS/dynamo 

### FYIs

@Amoursol 
