### PR TITLE
DYN-7110 Fix crash when connecting nodes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -179,7 +179,6 @@ namespace Dynamo.ViewModels
             try
             {
                 portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
-                this.DynamoViewModel.Model.Logger.Log("test connection");
             }
             catch(Exception ex)
             {
@@ -207,7 +206,7 @@ namespace Dynamo.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine(ex.Message);
+                    this.DynamoViewModel.Model.Logger.Log(ex.Message);
                 }
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -179,10 +179,11 @@ namespace Dynamo.ViewModels
             try
             {
                 portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
+                this.DynamoViewModel.Model.Logger.Log("test connection");
             }
             catch(Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine("Failed to make connection: " + ex.Message);
+                this.DynamoViewModel.Model.Logger.Log("Failed to make connection: " + ex.Message);
                 return;
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -174,8 +174,17 @@ namespace Dynamo.ViewModels
         {
             bool isInPort = portType == PortType.Input;
 
-            if (!(Model.GetModelInternal(nodeId) is NodeModel node)) return;
-            PortModel portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
+            if (Model.GetModelInternal(nodeId) is not NodeModel node) return;
+            PortModel portModel;
+            try
+            {
+                portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
+            }
+            catch(Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to make connection: " + ex.Message);
+                return;
+            }
 
             // Test if port already has a connection, if so grab it and begin connecting 
             // to somewhere else (we don't allow the grabbing of the start connector).


### PR DESCRIPTION
### Purpose

The crash occurred when connecting nodes but the port index was out of bounds from the source collection.
The retrieval code is now in a try-catch block for better error handling.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Fix crash when connecting nodes

### Reviewers

@DynamoDS/dynamo 

