### PR TITLE
DYN-7201 Fix info bubble updates

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -708,6 +708,9 @@ namespace Dynamo.Graph.Workspaces
                 }
             }
 
+            // All nodes that have runtime warnings or infos
+            HashSet<Guid> nodesWithInfos = [.. warnings.Keys];
+
             // Update node info message.
             foreach (var info in updateTask.RuntimeInfos)
             {
@@ -715,6 +718,8 @@ namespace Dynamo.Graph.Workspaces
                 var node = workspace.Nodes.FirstOrDefault(n => n.GUID == guid);
                 if (node == null)
                     continue;
+
+                nodesWithInfos.Add(guid);
 
                 // Block Infos updates during the many errors/warnings/notifications added here
                 // InfoBubbles will be updated on NodeViewModel's EvaluationCompleted handler.
@@ -735,8 +740,8 @@ namespace Dynamo.Graph.Workspaces
             // Dispatch the failure message display for execution on UI thread.
             // 
             EvaluationCompletedEventArgs e = task.Exception == null || IsTestMode
-                ? new EvaluationCompletedEventArgs(true,warnings.Keys,null)
-                : new EvaluationCompletedEventArgs(true, warnings.Keys, task.Exception);
+                ? new EvaluationCompletedEventArgs(true, nodesWithInfos, null)
+                : new EvaluationCompletedEventArgs(true, nodesWithInfos, task.Exception);
 
             EvaluationCount ++;
 

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -7,6 +8,7 @@ using System.Windows.Input;
 using CoreNodeModels;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
@@ -913,6 +915,23 @@ namespace DynamoCoreWpfTests
 
             // Assert
             Assert.AreEqual(singleItemTreeExpected, clipboardContent);
+        }
+
+        [Test]
+        public void GeometryScalingInfoBubble()
+        {
+            Open(@"UI\GeometryScalingInfoBubble.dyn");
+            var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+            Debug.Assert(workspace != null, nameof(workspace) + " != null");
+            workspace.Run();
+
+            List<NodeModel> errorNodes = ViewModel.Model.CurrentWorkspace.Nodes.ToList().FindAll(n => n.State == ElementState.Error);
+            List<NodeModel> warningNodes = ViewModel.Model.CurrentWorkspace.Nodes.ToList().FindAll(n => n.State == ElementState.Warning || n.State == ElementState.PersistentWarning);
+            List<NodeModel> infoNodes = ViewModel.Model.CurrentWorkspace.Nodes.ToList().FindAll(n => n.State == ElementState.Info);
+
+            Assert.AreEqual(0, errorNodes.Count);
+            Assert.AreEqual(0, warningNodes.Count);
+            Assert.AreEqual(1, infoNodes.Count);
         }
 
         private bool ElementIsInContainer(FrameworkElement element, FrameworkElement container, int offset)

--- a/test/UI/GeometryScalingInfoBubble.dyn
+++ b/test/UI/GeometryScalingInfoBubble.dyn
@@ -1,0 +1,160 @@
+{
+  "Uuid": "dbf58b8e-9c0f-4739-b651-86909a9ff802",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "GeometryScalingInfoBubble",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "f16400ac984e4818800d15aa324a0956",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "aff3dd620552421a8628da8a3712cc98",
+          "Name": "x",
+          "Description": "X coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2ac43c47bd4149d988fa8f62896bfd05",
+          "Name": "y",
+          "Description": "Y coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d56001c28a0247409c740f4f48c79126",
+          "Name": "z",
+          "Description": "Z coordinate\n\ndouble\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7069ed19976246f382c3765f78657b08",
+          "Name": "Point",
+          "Description": "Point created by coordinates",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Replication": "Auto",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NumberType": "Double",
+      "Id": "7556b378a2484190bb10ee4c5c8f89cc",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "05869dc333194864b3dff3efda633d9e",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number",
+      "InputValue": 2000000000.0
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "05869dc333194864b3dff3efda633d9e",
+      "End": "d56001c28a0247409c740f4f48c79126",
+      "Id": "761c9400d67e4425b0c559faec43f5b2",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": null,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.2",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.2.1.5440",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "f16400ac984e4818800d15aa324a0956",
+        "Name": "Point.ByCoordinates",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 404.79999999999995,
+        "Y": 194.00000000000006
+      },
+      {
+        "Id": "7556b378a2484190bb10ee4c5c8f89cc",
+        "Name": "Number",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 2.0000000000001137,
+        "Y": 326.4000000000001
+      }
+    ],
+    "Annotations": [],
+    "X": 28.600000000000023,
+    "Y": -12.400000000000091,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
Issue:
Info bubbles (as opposed to warnings or errors) do not show up on nodes after graph execution
![image](https://github.com/DynamoDS/Dynamo/assets/46732933/4296881c-da7f-414c-b3a8-7ecdb17243c8)


### Purpose

In this PR I updated the node GUIDS that are passed to the `UpdateNodeInfoBubbleContent` method

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix regression where information bubbles did not show on nodes after graph execution

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
