### PR TITLE
use hardcoded string for type name instead of typeof operator

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1061,7 +1061,7 @@ namespace Dynamo.Configuration
                     {
                         if (namespaces[index] == "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.Panel")
                         {
-                            namespaces[index] = $"ProtoGeometry.dll:{typeof(Autodesk.DesignScript.Geometry.PanelSurface).FullName}";
+                            namespaces[index] = "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.PanelSurface";
                         }
                     }
                     fs.Close(); // Release file lock
@@ -1188,7 +1188,7 @@ namespace Dynamo.Configuration
                 NamespacesToExcludeFromLibrary = new List<string>()
                 {
                     "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline",
-                    $"ProtoGeometry.dll:{typeof(Autodesk.DesignScript.Geometry.PanelSurface).FullName}"
+                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.PanelSurface"
                 };  
                 NamespacesToExcludeFromLibrarySpecified = true;
             }

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1271,11 +1271,11 @@ namespace Dynamo.ViewModels
             get
             {
                 return !preferenceSettings.NamespacesToExcludeFromLibrary.Contains(
-                    $"ProtoGeometry.dll:{typeof(Autodesk.DesignScript.Geometry.PanelSurface).FullName}");
+                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.PanelSurface");
             }
             set
             {
-                HideUnhideNamespace(!value, "ProtoGeometry.dll", typeof(Autodesk.DesignScript.Geometry.PanelSurface).FullName);
+                HideUnhideNamespace(!value, "ProtoGeometry.dll", "Autodesk.DesignScript.Geometry.PanelSurface");
                 RaisePropertyChanged(nameof(EnablePanelingIsChecked));
             }
         }


### PR DESCRIPTION
### Purpose

This fixes a potential issue where an older version of DynamoCore not containing the PanelSurface type is run with Player pointing to a new version of DynamoCore that contains that type. To avoid potential type load exceptions in this scenario, this PR avoids the use of `typeof` operator and uses a hardcoded string instead for the type.

❕ This needs to be cherry-picked into 3.2.2.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
