### PR TITLE
DYN-7139 WebView2 Crash when Opening Dialog

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Shipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Shipped.txt
@@ -1,1 +1,4 @@
-﻿
+﻿Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.set -> void
+Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.set -> void

--- a/src/DynamoCoreWpf/PublicAPI.Shipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Shipped.txt
@@ -1,4 +1,1 @@
-﻿Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
-Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.set -> void
-Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
-Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.set -> void
+﻿

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2067,6 +2067,10 @@ Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultCommand.get -> Dyna
 Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultCommand.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogCommand.set -> void
+Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.set -> void
+Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowPackageManagerCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.ShowPackageManagerCommand.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowPackageManagerSearchCommand.get -> Dynamo.UI.Commands.DelegateCommand

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2067,9 +2067,9 @@ Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultCommand.get -> Dyna
 Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultCommand.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogCommand.set -> void
-Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.ShowOpenDialogAndOpenResultAsyncCommand.set -> void
-Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.get  -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.ShowOpenTemplateDialogAsyncCommand.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowPackageManagerCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.ShowPackageManagerCommand.set -> void

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2187,9 +2187,7 @@ namespace Dynamo.ViewModels
 
         private async void ShowOpenDialogAndOpenResultAsync(object parameter)
         {
-            await Task.Yield();
-
-            ShowOpenDialogAndOpenResult(parameter);
+            UIDispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () => ShowOpenDialogAndOpenResult(parameter));
         }
 
         private void SetDefaultInitialDirectory(DynamoOpenFileDialog _fileDialog)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2185,7 +2185,7 @@ namespace Dynamo.ViewModels
             }
         }
 
-        internal async void ShowOpenDialogAndOpenResultAsync(object parameter)
+        private async void ShowOpenDialogAndOpenResultAsync(object parameter)
         {
             await Task.Yield();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2185,6 +2185,13 @@ namespace Dynamo.ViewModels
             }
         }
 
+        internal async void ShowOpenDialogAndOpenResultAsync(object parameter)
+        {
+            await Task.Yield();
+
+            ShowOpenDialogAndOpenResult(parameter);
+        }
+
         private void SetDefaultInitialDirectory(DynamoOpenFileDialog _fileDialog)
         {
             try

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -18,6 +18,8 @@ namespace Dynamo.ViewModels
             SaveCommand = new DelegateCommand(Save, CanSave);
             SaveAsCommand = new DelegateCommand(SaveAs, CanSaveAs);
             ShowOpenDialogAndOpenResultCommand = new DelegateCommand(ShowOpenDialogAndOpenResult, CanShowOpenDialogAndOpenResultCommand);
+            ShowOpenDialogAndOpenResultAsyncCommand = new DelegateCommand(ShowOpenDialogAndOpenResultAsync, CanShowOpenDialogAndOpenResultCommand);
+            ShowOpenTemplateDialogAsyncCommand = new DelegateCommand(ShowOpenDialogAndOpenResultAsync, CanShowOpenDialogAndOpenResultCommand);
             ShowOpenTemplateDialogCommand = new DelegateCommand(ShowOpenDialogAndOpenResult, CanShowOpenDialogAndOpenResultCommand);
             ShowInsertDialogAndInsertResultCommand = new DelegateCommand(ShowInsertDialogAndInsertResult, CanShowInsertDialogAndInsertResultCommand);
             ShowSaveDialogAndSaveResultCommand = new DelegateCommand(ShowSaveDialogAndSaveResult, CanShowSaveDialogAndSaveResult);
@@ -99,8 +101,10 @@ namespace Dynamo.ViewModels
         public DelegateCommand OpenFromJsonCommand { get; set; }
         public DelegateCommand OpenIfSavedCommand { get; set; }
         public DelegateCommand OpenCommand { get; set; }
+        public DelegateCommand ShowOpenDialogAndOpenResultAsyncCommand { get; set; }
         public DelegateCommand ShowOpenDialogAndOpenResultCommand { get; set; }
         public DelegateCommand ShowOpenTemplateDialogCommand { get; set; }
+        public DelegateCommand ShowOpenTemplateDialogAsyncCommand { get; set; }
         public DelegateCommand ShowInsertDialogAndInsertResultCommand { get; set; }
         public DelegateCommand WriteToLogCmd { get; set; }
         public DelegateCommand PostUiActivationCommand { get; set; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -114,10 +114,10 @@
                     Command="{Binding Path=DataContext.ShowSaveDialogAndSaveResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="O"
                     Modifiers="Control"
-                    Command="{Binding Path=DataContext.ShowOpenDialogAndOpenResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ShowOpenDialogAndOpenResultAsyncCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="T"
                     Modifiers="Control"
-                    Command="{Binding Path=DataContext.ShowOpenTemplateDialogCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Command="{Binding Path=DataContext.ShowOpenTemplateDialogAsyncCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                     CommandParameter="Template"/>
         <KeyBinding Key="I"
                     Modifiers="Control+Shift"

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -520,7 +520,7 @@ namespace Dynamo.UI.Views
                 return;
             }
 
-            this.startPage?.DynamoViewModel?.ShowOpenDialogAndOpenResultCommand.Execute(null);
+            this.startPage?.DynamoViewModel?.ShowOpenDialogAndOpenResultAsync(null);
             Logging.Analytics.TrackEvent(Logging.Actions.Open, Logging.Categories.DynamoHomeOperations, "Workspace");
         }
 

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -520,7 +520,7 @@ namespace Dynamo.UI.Views
                 return;
             }
 
-            this.startPage?.DynamoViewModel?.ShowOpenDialogAndOpenResultAsync(null);
+            this.startPage?.DynamoViewModel?.ShowOpenDialogAndOpenResultAsyncCommand.Execute(null);
             Logging.Analytics.TrackEvent(Logging.Actions.Open, Logging.Categories.DynamoHomeOperations, "Workspace");
         }
 
@@ -575,7 +575,7 @@ namespace Dynamo.UI.Views
             }
 
             // Equivalent to CommandParameter="Template"
-            this.startPage?.DynamoViewModel?.ShowOpenTemplateDialogCommand.Execute("Template");
+            this.startPage?.DynamoViewModel?.ShowOpenTemplateDialogAsyncCommand.Execute("Template");
             Logging.Analytics.TrackEvent(Logging.Actions.Open, Logging.Categories.DynamoHomeOperations, "Template");
         }
 


### PR DESCRIPTION
### Purpose

WebView2 was crashing when opening the OpenFile Dialog or the OpenTemplate Dialog, it was due that we were not using an async method for opening the file/template. Then I added an async method and will be called by the HomeApp component.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

WebView2 was crashing when opening the OpenFile Dialog

### Reviewers

@QilongTang 

### FYIs

@reddyashish 
