### PR TITLE
DYN-6547: toggle depreciate

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -182,7 +182,7 @@ namespace Dynamo.ViewModels
             UninstallCommand = new DelegateCommand(Uninstall, CanUninstall);
             UnmarkForUninstallationCommand = new DelegateCommand(UnmarkForUninstallation, CanUnmarkForUninstallation);
             LoadCommand = new DelegateCommand(Load, CanLoad);
-            DeprecateCommand = new DelegateCommand(Deprecate, IsOwner);
+            DeprecateCommand = new DelegateCommand(Deprecate, CanDeprecate);
             UndeprecateCommand = new DelegateCommand(Undeprecate, CanUndeprecate);
             GoToRootDirectoryCommand = new DelegateCommand(GoToRootDirectory, () => true);
 
@@ -408,6 +408,14 @@ namespace Dynamo.ViewModels
             return packageManagerClient.DoesCurrentUserOwnPackage(Model, dynamoModel.AuthenticationManager.Username);
         }
 
+        private bool CanDeprecate()
+        {
+            var packageInfo = new PackageInfo(Model.Name, Version.Parse(Model.VersionName));
+            var packageHeader = this.packageManagerClient.GetPackageHeader(packageInfo);
+
+            return IsOwner() && !packageHeader.deprecated;
+        }
+
         private void Undeprecate()
         {
             var res = MessageBoxService.Show(String.Format(Resources.MessageToUndeprecatePackage, this.Model.Name),
@@ -419,8 +427,10 @@ namespace Dynamo.ViewModels
 
         private bool CanUndeprecate()
         {
-            if (!CanPublish) return false;
-            return packageManagerClient.DoesCurrentUserOwnPackage(Model, dynamoModel.AuthenticationManager.Username);
+            var packageInfo = new PackageInfo(Model.Name, Version.Parse(Model.VersionName));
+            var packageHeader = this.packageManagerClient.GetPackageHeader(packageInfo);
+
+            return IsOwner() && packageHeader.deprecated;
         }
 
         private void PublishNewPackageVersion()

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -123,11 +123,11 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// Gets maintainers for a specific package
+        /// Get the package Header which contains all the relevant information to the Package
         /// </summary>
         /// <param name="packageInfo"></param>
         /// <returns></returns>
-        internal PackageHeader GetPackageMaintainers(IPackageInfo packageInfo)
+        internal PackageHeader GetPackageHeader(IPackageInfo packageInfo)
         {
             var header = FailFunc.TryExecute(() =>
             {
@@ -314,7 +314,7 @@ namespace Dynamo.PackageManager
                 return value;
             }
             var pkg = new PackageInfo(package.Name, new Version(package.VersionName));
-            var mnt = GetPackageMaintainers(pkg);
+            var mnt = GetPackageHeader(pkg);
             value = (mnt != null) && (mnt.maintainers.Any(maintainer => maintainer.username.Equals(username)));
             this.packageMaintainers[package.Name] = value;
             return value;


### PR DESCRIPTION
### Purpose

Addresses the following issue: 

https://jira.autodesk.com/browse/DYN-6547

In a nutshell, we want to `deprecate` a package owned by the user which has not been deprecated. And vica verse, we want to be able to `undeprecated` a package owned by the user, which has already been deprecated. 

![image](https://github.com/DynamoDS/Dynamo/assets/5354594/bdb40cef-3859-4c72-a4c5-77c54fb34655)

- we make use of an existing greg request that fetches the Header. Renamed the method name to correctly reflect its purpose.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now effectively toggles depreciate and undepreciate depending if the package is active or not

### Reviewers

@QilongTang 
@reddyashish 

### FYIs

@Amoursol 
