### PR TITLE
DYN-7086 Correctly cast package search results to show updated package info

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1488,14 +1488,7 @@ namespace Dynamo.PackageManager
         /// <returns></returns>
         private PackageManagerSearchElementViewModel GetViewModelForPackageSearchElement(string packageName)
         {
-            var result = PackageManagerClientViewModel.CachedPackageList.Where(e =>
-            {
-                if (e.Name.Equals(packageName))
-                {
-                    return true;
-                }
-                return false;
-            });
+            var result = PackageManagerClientViewModel.CachedPackageList.Where(e => e.Name.Equals(packageName));
 
             if (!result.Any())
             {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -652,9 +652,8 @@ namespace Dynamo.PackageManager
             var pkgs = PackageManagerClientViewModel.CachedPackageList.Where(x => x.Maintainers != null && x.Maintainers.Contains(name)).ToList();
             foreach(var pkg in pkgs)
             {
-                var p = new PackageManagerSearchElementViewModel(pkg,
-                                                                 PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
-                                                                 CanInstallPackage(pkg.Name));
+                var p = GetSearchElementViewModel(pkg, true);
+
                 p.RequestDownload += this.PackageOnExecuted;
                 p.RequestShowFileDialog += this.OnRequestShowFileDialog;
                 p.IsOnwer = true;
@@ -1503,12 +1502,18 @@ namespace Dynamo.PackageManager
                 return null;
             }
 
-            return GetSearchElementViewModel(result.ElementAt(0));
+            return GetSearchElementViewModel(result.FirstOrDefault());
         }
 
-        private PackageManagerSearchElementViewModel GetSearchElementViewModel(PackageManagerSearchElement package)
+        /// <summary>
+        ///    Returns a new PackageManagerSearchElementViewModel for the given package, with updated properties.
+        /// </summary>
+        /// <param name="package">Package to cast</param>
+        /// <param name="bypassCustomPackageLocations">When true, will bypass the check for loading package from custom locations.</param>
+        /// <returns></returns>
+        private PackageManagerSearchElementViewModel GetSearchElementViewModel(PackageManagerSearchElement package, bool bypassCustomPackageLocations = false)
         {
-            var isEnabledForInstall = !(Preferences as IDisablePackageLoadingPreferences).DisableCustomPackageLocations;
+            var isEnabledForInstall = bypassCustomPackageLocations || !(Preferences as IDisablePackageLoadingPreferences).DisableCustomPackageLocations;
             return new PackageManagerSearchElementViewModel(package,
                 PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
                 CanInstallPackage(package.Name),

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1353,9 +1353,7 @@ namespace Dynamo.PackageManager
 
             // Filter based on user preference
             // A package has dependencies if the number of direct_dependency_ids is more than 1
-            var initialResults = LastSync?.Select(x => new PackageManagerSearchElementViewModel(x,
-                                                   PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
-                                                   CanInstallPackage(x.Name), isEnabledForInstall));
+            var initialResults = LastSync?.Select(x => GetSearchElementViewModel(x));
             list = ApplyNonHostFilters(initialResults);
             list = ApplyHostFilters(list).ToList();
 
@@ -1491,14 +1489,30 @@ namespace Dynamo.PackageManager
         /// <returns></returns>
         private PackageManagerSearchElementViewModel GetViewModelForPackageSearchElement(string packageName)
         {
-            var result = SearchResults.Where(e => e.Name.Equals(packageName));
+            var result = PackageManagerClientViewModel.CachedPackageList.Where(e =>
+            {
+                if (e.Name.Equals(packageName))
+                {
+                    return true;
+                }
+                return false;
+            });
 
             if (!result.Any())
             {
                 return null;
             }
 
-            return result.ElementAt(0);
+            return GetSearchElementViewModel(result.ElementAt(0));
+        }
+
+        private PackageManagerSearchElementViewModel GetSearchElementViewModel(PackageManagerSearchElement package)
+        {
+            var isEnabledForInstall = !(Preferences as IDisablePackageLoadingPreferences).DisableCustomPackageLocations;
+            return new PackageManagerSearchElementViewModel(package,
+                PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
+                CanInstallPackage(package.Name),
+                isEnabledForInstall);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This is fixing a regression in the master for package search. 
The search results should be cast to `PackageManagerSearchElementViewModel` using the new method `GetSearchElementViewModel` to populate it's install status, this will help correctly display the package info in Package manager window. 

![yp5jqDC9bT](https://github.com/DynamoDS/Dynamo/assets/32665108/94b56959-afcf-4a48-bee7-389503de3035)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Correctly cast package search results to show updated package info

### Reviewers

@DynamoDS/dynamo 
