### PR TITLE
DYN-6569 Extended Characters Md2HTML Fix

### DIFF
--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -125,7 +125,7 @@ namespace Dynamo.Utilities
                             else
                             {
                                 line = process.StandardOutput.ReadLine();
-                                DecodeHTMLContent(ref line);
+                                Md2Html.DecodeHTMLContent(ref line);
                             }
                             
                            
@@ -163,47 +163,6 @@ namespace Dynamo.Utilities
             //if the completed task was our read std out task, then return the data
             //else we timed out, so return an empty string.
             return completedTask == readStdOutTask ? readStdOutTask.Result : string.Empty;
-        }
-
-        private void DecodeHTMLContent(ref string htmlContent)
-        {
-            //Usually the response from Md2Html.exe are in the format <<<<< response >>>>> so we avoid decoding those strings
-            if (!htmlContent.Contains("<<<<<"))
-            {
-                //Decode HTML File paragraphs
-                DecodeBase64(ref htmlContent, @"<p>(.*?)</p>");
-
-                //Decode HTML File headers
-                DecodeBase64(ref htmlContent, @"<h2\s.*>(.*?)</h2>");
-            }
-        }
-
-        private void DecodeBase64(ref string htmlContent, string regExp)
-        {
-            if (!string.IsNullOrEmpty(htmlContent))
-            {
-                //TODO- missing to support other HTML tags
-                var Matches = Regex.Matches(htmlContent, regExp, RegexOptions.IgnoreCase);
-                string encodedString = string.Empty;
-                if (Matches.Count > 0)
-                {
-                    //Add validation is groups is null
-                    encodedString = Matches[0].Groups[1].Value;
-                    if (!string.IsNullOrEmpty(encodedString) && !encodedString.Trim().StartsWith("<img"))
-                    {
-                        //Due that in some cases there are nested tags inside <p> or <h2> and if the info is not encoded then it will send an exception so we will leave it as it is
-                        try
-                        {
-                            var base64Line = Convert.FromBase64String(encodedString);
-                            var decodedString = Encoding.UTF8.GetString(base64Line);
-                            htmlContent = htmlContent.Replace(encodedString, decodedString);
-                        }
-                        catch (Exception ex)
-                        {
-                        }
-                    }
-                }                            
-            }
         }
 
         protected void RaiseMessageLogged(string message)

--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -39,7 +39,8 @@ namespace Dynamo.Utilities
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,
                 RedirectStandardError = true,
-
+                StandardInputEncoding = Encoding.UTF8,
+                StandardOutputEncoding = Encoding.UTF8,
                 UseShellExecute = false,
                 Arguments = argString,
                 FileName = GetToolPath(relativeEXEPath)
@@ -125,7 +126,6 @@ namespace Dynamo.Utilities
                             else
                             {
                                 line = process.StandardOutput.ReadLine();
-                                Md2Html.DecodeHTMLContent(ref line);
                             }
                             
                            

--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Dynamo.Utilities
@@ -123,6 +125,7 @@ namespace Dynamo.Utilities
                             else
                             {
                                 line = process.StandardOutput.ReadLine();
+                                DecodeHTMLContent(ref line);
                             }
                             
                            
@@ -160,6 +163,47 @@ namespace Dynamo.Utilities
             //if the completed task was our read std out task, then return the data
             //else we timed out, so return an empty string.
             return completedTask == readStdOutTask ? readStdOutTask.Result : string.Empty;
+        }
+
+        private void DecodeHTMLContent(ref string htmlContent)
+        {
+            //Usually the response from Md2Html.exe are in the format <<<<< response >>>>> so we avoid decoding those strings
+            if (!htmlContent.Contains("<<<<<"))
+            {
+                //Decode HTML File paragraphs
+                DecodeBase64(ref htmlContent, @"<p>(.*?)</p>");
+
+                //Decode HTML File headers
+                DecodeBase64(ref htmlContent, @"<h2\s.*>(.*?)</h2>");
+            }
+        }
+
+        private void DecodeBase64(ref string htmlContent, string regExp)
+        {
+            if (!string.IsNullOrEmpty(htmlContent))
+            {
+                //TODO- missing to support other HTML tags
+                var Matches = Regex.Matches(htmlContent, regExp, RegexOptions.IgnoreCase);
+                string encodedString = string.Empty;
+                if (Matches.Count > 0)
+                {
+                    //Add validation is groups is null
+                    encodedString = Matches[0].Groups[1].Value;
+                    if (!string.IsNullOrEmpty(encodedString) && !encodedString.Trim().StartsWith("<img"))
+                    {
+                        //Due that in some cases there are nested tags inside <p> or <h2> and if the info is not encoded then it will send an exception so we will leave it as it is
+                        try
+                        {
+                            var base64Line = Convert.FromBase64String(encodedString);
+                            var decodedString = Encoding.UTF8.GetString(base64Line);
+                            htmlContent = htmlContent.Replace(encodedString, decodedString);
+                        }
+                        catch (Exception ex)
+                        {
+                        }
+                    }
+                }                            
+            }
         }
 
         protected void RaiseMessageLogged(string message)

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -79,7 +79,7 @@ namespace Dynamo.Utilities
             return GetData(processCommunicationTimeoutms);
         }
 
-        private void EncodeMDContent(ref string mdContent)
+        internal static void EncodeMDContent(ref string mdContent)
         {
             //Encode to base64 due that the Tools / Md2Html console app is using a different encoding and special characters are lost when sending info to Stdio
 
@@ -95,7 +95,7 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="mdContent">MD file content read usually from the fallback_docs folder</param>
         /// <param name="regEx">Regular Expression that will be applied over the md content</param>
-        private void EncodeBase64(ref string mdContent, string regEx)
+        internal static void EncodeBase64(ref string mdContent, string regEx)
         {
             Regex rxExp = new Regex(regEx, RegexOptions.Singleline);
             MatchCollection matches = rxExp.Matches(mdContent);

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -66,7 +66,6 @@ namespace Dynamo.Utilities
             {
                 process.StandardInput.WriteLine(@"<<<<<Convert>>>>>");
                 process.StandardInput.WriteLine(mdPath);
-                EncodeMDContent(ref mdString);
                 process.StandardInput.WriteLine(mdString);
                 process.StandardInput.WriteLine(@"<<<<<Eod>>>>>");
             }
@@ -77,81 +76,6 @@ namespace Dynamo.Utilities
             }
 
             return GetData(processCommunicationTimeoutms);
-        }
-
-        internal static void EncodeMDContent(ref string mdContent)
-        {
-            //Encode to base64 due that the Tools / Md2Html console app is using a different encoding and special characters are lost when sending info to Stdio
-
-            //Get the MD file content and encode it
-            EncodeBase64(ref mdContent, @"#+\s[^\n]*\n(.*?)(?=\n##?\s|$)");
-
-            //Get the MD file headers and encode it
-            EncodeBase64(ref mdContent, @"#+\s(.*?\n)");
-        }
-
-        /// <summary>
-        /// This method will apply the Regular Expression provided over the md content and then encode the md content to base64 
-        /// </summary>
-        /// <param name="mdContent">MD file content read usually from the fallback_docs folder</param>
-        /// <param name="regEx">Regular Expression that will be applied over the md content</param>
-        internal static void EncodeBase64(ref string mdContent, string regEx)
-        {
-            Regex rxExp = new Regex(regEx, RegexOptions.Singleline);
-            MatchCollection matches = rxExp.Matches(mdContent);
-            foreach (Match match in matches)
-            {
-                if (match.Groups.Count == 0) continue;
-
-                var UTF8Content = match.Groups[1].Value.Trim();
-
-                //When the line starts with ![ then means that the value is a image then we don't encode the content
-                if (!string.IsNullOrEmpty(UTF8Content) && !UTF8Content.StartsWith("!["))
-                {
-                    var UTF8ContentBytes = Encoding.UTF8.GetBytes(UTF8Content);
-                    var contentBase64String = Convert.ToBase64String(UTF8ContentBytes);
-                    mdContent = mdContent.Replace(UTF8Content, contentBase64String);                   
-                }
-            }                 
-        }
-
-        internal static void DecodeHTMLContent(ref string htmlContent)
-        {
-            //Usually the response from Md2Html.exe are in the format <<<<< response >>>>> so we avoid decoding those strings
-            if (!htmlContent.Contains("<<<<<"))
-            {
-                //Decode HTML File paragraphs
-                DecodeBase64(ref htmlContent, @"<p>(.*?)</p>");
-
-                //Decode HTML File headers
-                DecodeBase64(ref htmlContent, @"<h2\s.*>(.*?)</h2>");
-            }
-        }
-
-        internal static void DecodeBase64(ref string htmlContent, string regExp)
-        {
-            if (!string.IsNullOrEmpty(htmlContent))
-            {
-                //TODO- missing to support other HTML tags
-                var Matches = Regex.Matches(htmlContent, regExp, RegexOptions.IgnoreCase);
-                string encodedString = string.Empty;
-                if (Matches.Count > 0)
-                {
-                    //Add validation is groups is null
-                    encodedString = Matches[0].Groups[1].Value;
-                    if (!string.IsNullOrEmpty(encodedString) && !encodedString.Trim().StartsWith("<img"))
-                    {
-                        //Due that in some cases there are nested tags inside <p> or <h2> and if the info is not encoded then it will send an exception so we will leave it as it is
-                        try
-                        {
-                            var base64Line = Convert.FromBase64String(encodedString);
-                            var decodedString = Encoding.UTF8.GetString(base64Line);
-                            htmlContent = htmlContent.Replace(encodedString, decodedString);
-                        }
-                        catch (Exception) { }
-                    }
-                }
-            }
         }
 
         /// <summary>

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -1,7 +1,5 @@
 using System;
 using System.IO;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using DynamoUtilities.Properties;
 using Newtonsoft.Json.Linq;

--- a/src/Tools/Md2Html/Program.cs
+++ b/src/Tools/Md2Html/Program.cs
@@ -24,16 +24,15 @@ namespace Md2Html
             try
             {
                 Console.WriteLine("");
-
                 while (true)
                 {
                     var line = Console.ReadLine();
-                    if (line == @"<<<<<Sanitize>>>>>")
+                    if (line.Contains(@"<<<<<Sanitize>>>>>"))
                     {
                         Console.WriteLine(@"<<<<<Sod>>>>>");
                         Sanitize();
                     }
-                    else if (line == @"<<<<<Convert>>>>>")
+                    else if (line.Contains(@"<<<<<Convert>>>>>"))
                     {
                         Console.WriteLine(@"<<<<<Sod>>>>>");
                         Convert();

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -1033,8 +1033,18 @@ namespace DynamoCoreWpfTests
                     if(!UTF8Content.StartsWith("![")) 
                     {
                         // Assert
-                        //Validates that the content of the md file is exactly the same that the one in the html file
-                        Assert.That(html.Contains(UTF8Content), "Part of the MD file content was not found in the HTML File");
+                        //Clean the content to remove characters also removed by the Md2Html.exe tool
+                        var cleanedContent = UTF8Content.Replace("___", string.Empty).Trim();
+
+                        //Apply a Regular Expresion in the HTML file for getting the first <p> 
+                        Match m = Regex.Match(html, "<p>(.+?)<\\/p>", RegexOptions.IgnoreCase);
+                        string specificHTMLContent = string.Empty;
+                        if (m.Success)
+                        {
+                            specificHTMLContent = m.Groups[1].Value; 
+                        }
+
+                        Assert.IsTrue(specificHTMLContent == cleanedContent, "Part of the MD file content was not found in the HTML File");
                     }                   
                 }
             }

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -1001,8 +1001,9 @@ namespace DynamoCoreWpfTests
         [TestCase("ko-KR")]
         public void CheckThatExtendedCharactersAreCorrectlyInHTML(string language)
         {
+            var testDirectory = GetTestDirectory(ExecutingDirectory);
             string mdFile = "Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md";
-            string resource = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), language, "fallback_docs", mdFile);
+            string resource = Path.Combine(testDirectory, "Tools", "docGeneratorTestFiles", "fallback_docs", language, mdFile);
 
             Assert.True(File.Exists(resource), "The resource provided {0} doesn't exist in the path {1}", mdFile, resource);
 
@@ -1056,6 +1057,12 @@ namespace DynamoCoreWpfTests
             var docsDirectory = Path.Combine(directory.Parent.Parent.Parent.FullName, @"src\DocumentationBrowserViewExtension\Docs");
 
             return Directory.GetFiles(docsDirectory, wildcard);
+        }
+
+        public static string GetTestDirectory(string executingDirectory)
+        {
+            var directory = new DirectoryInfo(executingDirectory);
+            return Path.Combine(directory.Parent.Parent.Parent.FullName, "test");
         }
 
         #endregion

--- a/test/Tools/docGeneratorTestFiles/fallback_docs/cs-CZ/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md
+++ b/test/Tools/docGeneratorTestFiles/fallback_docs/cs-CZ/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md
@@ -1,0 +1,7 @@
+## Podrobnosti
+Uzel SweepAsSurface vytvoří povrch tažením vstupní křivky podél zadané trajektorie. V níže uvedeném příkladu vytvoříme křivku k tažení pomocí bloku kódu, který vytvoří tři body pro uzel Arc.ByThreePoints. Křivka trajektorie se vytvoří pomocí jednoduché čáry podél osy x. Uzel SweepAsSurface přesune křivku profilu podél křivky trajektorie, čímž vytvoří povrch.
+___
+## Vzorový soubor
+
+![SweepAsSurface](./Autodesk.DesignScript.Geometry.Curve.SweepAsSurface_img.jpg)
+

--- a/test/Tools/docGeneratorTestFiles/fallback_docs/en-US/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md
+++ b/test/Tools/docGeneratorTestFiles/fallback_docs/en-US/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md
@@ -1,0 +1,7 @@
+## In Depth
+SweepAsSurface will create a surface by sweeping an input curve along a specfied path. In the example below, we create a curve to sweep by useing a Code Block to create three points of an Arc.ByThreePoints node. A path curve is created a simple line along the x-axis. SweepAsSurface moves the profile curve along the path curve creating a surface.
+___
+## Example File
+
+![SweepAsSurface](./Autodesk.DesignScript.Geometry.Curve.SweepAsSurface_img.jpg)
+

--- a/test/Tools/docGeneratorTestFiles/fallback_docs/ko-KR/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md
+++ b/test/Tools/docGeneratorTestFiles/fallback_docs/ko-KR/Autodesk.DesignScript.Geometry.Curve.SweepAsSurface.md
@@ -1,0 +1,7 @@
+## 상세
+SweepAsSurface는 지정된 경로를 따라 입력 곡선을 스윕하여 표면을 작성합니다. 아래 예에서는 Arc.ByThreePoints 노드의 세 점을 작성하기 위해 코드 블록을 사용하여 스윕할 곡선을 작성합니다. 경로 곡선은 X축을 따라 단순한 선으로 작성됩니다. SweepAsSurface는 경로 곡선을 따라 종단 곡선을 이동하여 표면을 작성합니다.
+___
+## 예제 파일
+
+![SweepAsSurface](./Autodesk.DesignScript.Geometry.Curve.SweepAsSurface_img.jpg)
+


### PR DESCRIPTION
  ### Purpose

Fixing problem when displaying extended characters in DocumentationBrowser
When sending extended characters to the Md2HTML tool (using stdin and stdout) was replacing the characters by other weird symbols then for fixing this problem I'm encoding the info to base64 when sending and decoding the info when getting the html (from Md2HTML).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing problem when displaying extended characters in DocumentationBrowser

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 
