### PR TITLE
DYN-6547: toggle depreciate revised

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -22,6 +22,7 @@ namespace Dynamo.ViewModels
         private readonly DynamoViewModel dynamoViewModel;
         private readonly PackageManagerClient packageManagerClient;
         private readonly DynamoModel dynamoModel;
+        private readonly PackageManagerClientViewModel packageManagerClientViewModel;
 
         public Package Model { get; private set; }
 
@@ -172,6 +173,7 @@ namespace Dynamo.ViewModels
         {
             this.dynamoViewModel = dynamoViewModel;
             this.dynamoModel = dynamoViewModel.Model;
+            this.packageManagerClientViewModel = dynamoViewModel.PackageManagerClientViewModel;
 
             var pmExtension = dynamoModel.GetPackageManagerExtension();
             this.packageManagerClient = pmExtension.PackageManagerClient;
@@ -410,10 +412,9 @@ namespace Dynamo.ViewModels
 
         private bool CanDeprecate()
         {
-            var packageInfo = new PackageInfo(Model.Name, Version.Parse(Model.VersionName));
-            var packageHeader = this.packageManagerClient.GetPackageHeader(packageInfo);
+            var isDeprecated = IsPackageDeprecated(Model.Name);
 
-            return IsOwner() && !packageHeader.deprecated;
+            return IsOwner() && !isDeprecated;
         }
 
         private void Undeprecate()
@@ -427,10 +428,9 @@ namespace Dynamo.ViewModels
 
         private bool CanUndeprecate()
         {
-            var packageInfo = new PackageInfo(Model.Name, Version.Parse(Model.VersionName));
-            var packageHeader = this.packageManagerClient.GetPackageHeader(packageInfo);
+            var isDeprecated = IsPackageDeprecated(Model.Name);
 
-            return IsOwner() && packageHeader.deprecated;
+            return IsOwner() && isDeprecated;
         }
 
         private void PublishNewPackageVersion()
@@ -464,6 +464,20 @@ namespace Dynamo.ViewModels
             });
 
             termsOfUseCheck.Execute(false);
+        }
+
+        private PackageManagerSearchElement GetPackageVersionInformationFromCached(string packageName)
+        {
+            var package = this.packageManagerClientViewModel.CachedPackageList.FirstOrDefault(x => x.Name == packageName);
+
+            return package;
+        }
+
+        private bool IsPackageDeprecated(string packageName)
+        {
+            var package = GetPackageVersionInformationFromCached(packageName);
+
+            return package != null ? package.IsDeprecated : false;
         }
     }
 }

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -123,11 +123,11 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// Get the package Header which contains all the relevant information to the Package
+        /// Gets maintainers for a specific package
         /// </summary>
         /// <param name="packageInfo"></param>
         /// <returns></returns>
-        internal PackageHeader GetPackageHeader(IPackageInfo packageInfo)
+        internal PackageHeader GetPackageMaintainers(IPackageInfo packageInfo)
         {
             var header = FailFunc.TryExecute(() =>
             {
@@ -314,7 +314,7 @@ namespace Dynamo.PackageManager
                 return value;
             }
             var pkg = new PackageInfo(package.Name, new Version(package.VersionName));
-            var mnt = GetPackageHeader(pkg);
+            var mnt = GetPackageMaintainers(pkg);
             value = (mnt != null) && (mnt.maintainers.Any(maintainer => maintainer.username.Equals(username)));
             this.packageMaintainers[package.Name] = value;
             return value;


### PR DESCRIPTION
### Purpose

This is a follow up PR on https://github.com/DynamoDS/Dynamo/pull/15365. @avidit reported that the previous implementation was not working as expected. After revising the code, I realized I was using an end point not meant for this purpose. 

Changed the implementation to fetch deprecated data directly form the Cached Package List, which should report the correct information. 

Also reverted the changes to the Get Maintainers name from the previous PR. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- previously relied on an end-point, which wasn't built for the purpose and was retrieving false information
- now fetches the deprecated status directly from the cached package list, which should contain the correct information

### Reviewers

@avidit  
@zeusongit 
@QilongTang 

### FYIs

@reddyashish 
