### PR TITLE
do not use TypeNameHandling.Auto when deserializing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,11 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+dotnet_diagnostic.CA2327.severity = error
+dotnet_diagnostic.CA2329.severity = error
+dotnet_diagnostic.CA2330.severity = error
+dotnet_diagnostic.CA2328.severity = error
+dotnet_diagnostic.CA2326.severity = warning
 
 [*.tt]
 insert_final_newline = false

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -181,4 +181,8 @@
         <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)/BuiltInAndOperators/BuiltInImages.resx" OutputResources="$(ProjectDir)/BuiltInAndOperators/BuiltInImages.resources" />
         <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)/BuiltInAndOperators/BuiltInImages.resources" OutputAssembly="$(OutDir)BuiltIn.customization.dll" Version="%(AssemblyInfo.Version)" />
     </Target>
+    <PropertyGroup>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisModeSecurity>All</AnalysisModeSecurity>
+    </PropertyGroup>
 </Project>

--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.DesignScript.Runtime;
+using Autodesk.DesignScript.Runtime;
 using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Graph.Nodes.NodeLoaders;
@@ -546,7 +546,7 @@ namespace Dynamo.Graph.Nodes
                     Console.WriteLine(args.ErrorContext.Error);
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameHandling = TypeNameHandling.None,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Culture = CultureInfo.InvariantCulture,
                 Converters = new List<JsonConverter>{

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -41,6 +41,8 @@ namespace Dynamo.Graph.Workspaces
     /// </summary>
     public class ExtraWorkspaceViewInfo
     {
+        //TODO is this unsafe? Can we deserialize any object here?
+        //test and if so create a type.
         public object Camera;
         public IEnumerable<ExtraNodeViewInfo> NodeViews;
         public IEnumerable<ExtraNoteViewInfo> Notes;
@@ -70,7 +72,7 @@ namespace Dynamo.Graph.Workspaces
                     Console.WriteLine(args.ErrorContext.Error);
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameHandling = TypeNameHandling.None,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Culture = CultureInfo.InvariantCulture
             };
@@ -2289,7 +2291,7 @@ namespace Dynamo.Graph.Workspaces
                     Console.WriteLine(args.ErrorContext.Error);
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameHandling = TypeNameHandling.None,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Culture = CultureInfo.InvariantCulture,
                 Converters = new List<JsonConverter>{
@@ -2326,7 +2328,7 @@ namespace Dynamo.Graph.Workspaces
                     Console.WriteLine(args.ErrorContext.Error);
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameHandling = TypeNameHandling.None,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Culture = CultureInfo.InvariantCulture,
                 Converters = new List<JsonConverter>{

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -41,8 +41,6 @@ namespace Dynamo.Graph.Workspaces
     /// </summary>
     public class ExtraWorkspaceViewInfo
     {
-        //TODO is this unsafe? Can we deserialize any object here?
-        //test and if so create a type.
         public object Camera;
         public IEnumerable<ExtraNodeViewInfo> NodeViews;
         public IEnumerable<ExtraNoteViewInfo> Notes;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2118,7 +2118,7 @@ namespace Dynamo.Models
                     Console.WriteLine(args.ErrorContext.Error);
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameHandling = TypeNameHandling.None,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Culture = CultureInfo.InvariantCulture
             };

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -31,24 +31,6 @@ namespace Dynamo.Models
             // See property for more details.
             protected bool redundant = false;
 
-            /// <summary>
-            /// Settings that is used for serializing commands
-            /// </summary>
-            protected static JsonSerializerSettings jsonSettings;
-
-            /// <summary>
-            /// Initialize commands serializing settings
-            /// </summary>
-            static RecordableCommand()
-            {
-                jsonSettings = new JsonSerializerSettings()
-                {
-                    TypeNameHandling = TypeNameHandling.Objects,
-                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                    Culture = CultureInfo.InvariantCulture
-                };
-            }
-
             #endregion
 
             #region Public Class Operational Methods
@@ -107,18 +89,6 @@ namespace Dynamo.Models
                 XmlElement element = document.CreateElement(commandName);
                 SerializeCore(element);
                 return element;
-            }
-
-            /// <summary>
-            /// This method serializes the RecordableCommand object in the json form.
-            /// The resulting string contains command type name and all the
-            /// arguments that are required by this command.
-            /// </summary>
-            /// <returns>The string can be used for reconstructing RecordableCommand
-            /// using Deserialize method</returns>
-            internal string Serialize()
-            {
-                return JsonConvert.SerializeObject(this, jsonSettings);
             }
 
             /// <summary>
@@ -220,29 +190,6 @@ namespace Dynamo.Models
                 throw new ArgumentException(message);
             }
 
-            /// <summary>
-            /// Call this static method to reconstruct a RecordableCommand from json
-            /// string that contains command name - name of corresponding class inherited
-            /// from RecordableCommand, - and all the arguments that are required by this
-            /// command.
-            /// </summary>
-            /// <param name="jsonString">Json string that contains command name and all
-            /// its arguments.</param>
-            /// <returns>Reconstructed RecordableCommand</returns>
-            internal static RecordableCommand Deserialize(string jsonString)
-            {
-                RecordableCommand command = null;
-                try
-                {
-                    command = JsonConvert.DeserializeObject(jsonString, jsonSettings) as RecordableCommand;
-                    command.IsInPlaybackMode = true;
-                    return command;
-                }
-                catch
-                {
-                    throw new ApplicationException("Invalid jsonString for creating RecordableCommand");
-                }
-            }
             #endregion
 
             #region Public Command Properties

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -2723,7 +2723,6 @@ static Dynamo.Models.DynamoModel.IsTestMode.set -> void
 static Dynamo.Models.DynamoModel.ModelBasedRecordableCommand.DeserializeGuid(System.Xml.XmlElement element, Dynamo.Utilities.XmlElementHelper helper) -> System.Collections.Generic.IEnumerable<System.Guid>
 static Dynamo.Models.DynamoModel.OnRequestDispatcherBeginInvoke(System.Action action) -> void
 static Dynamo.Models.DynamoModel.OnRequestDispatcherInvoke(System.Action action) -> void
-static Dynamo.Models.DynamoModel.RecordableCommand.jsonSettings -> Newtonsoft.Json.JsonSerializerSettings
 static Dynamo.Models.DynamoModel.RequestDispatcherBeginInvoke -> Dynamo.Models.ActionHandler
 static Dynamo.Models.DynamoModel.RequestDispatcherInvoke -> Dynamo.Models.ActionHandler
 static Dynamo.Models.DynamoModel.SetUICulture(string locale) -> void

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -794,7 +794,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         Console.WriteLine(args.ErrorContext.Error);
                     },
                     ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                    TypeNameHandling = TypeNameHandling.Auto,
+                    TypeNameHandling = TypeNameHandling.None,
                     Formatting = Newtonsoft.Json.Formatting.Indented,
                     Culture = CultureInfo.InvariantCulture
                 };

--- a/test/DynamoCoreTests/Models/RecordableCommandsTest.cs
+++ b/test/DynamoCoreTests/Models/RecordableCommandsTest.cs
@@ -94,7 +94,6 @@ namespace Dynamo.Tests.ModelsTest
 
             var xmlAddPresetCommand = AddPresetCommand.Serialize(xmlDocument);
 
-
             var helper = new XmlElementHelper(elementAddPresetCommand);
             Guid gWorkspace = Guid.NewGuid();
             Guid gState = Guid.NewGuid();
@@ -117,8 +116,6 @@ namespace Dynamo.Tests.ModelsTest
             //This will check that the Deserialized commands are valid
             Assert.IsNotNull(deserializedAddPresetCommand);
             Assert.IsNotNull(deserializedApplyPresetCommand);
-            Assert.Throws<ApplicationException>(() => DynamoModel.RecordableCommand.Deserialize(xmlAddPresetCommand));
-
 
         }
     }

--- a/test/DynamoCoreTests/Models/RecordableCommandsTest.cs
+++ b/test/DynamoCoreTests/Models/RecordableCommandsTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -53,12 +53,12 @@ namespace Dynamo.Tests.ModelsTest
             //The tag passed as parameter is null, then it will raise an exception later
             var cmd = new Mock<DynamoModel.RecordableCommand>(null);
             var pausePlaybackCommand = new DynamoModel.PausePlaybackCommand(20);
-
+            var xmldoc= new XmlDocument();
             //Act
-            var xmlElements = pausePlaybackCommand.Serialize();
-    
+            var xmlElements = pausePlaybackCommand.Serialize(xmldoc);
+
             //Assert
-            Assert.IsNotNull(JToken.Parse(xmlElements));//Verify that the json serialized is valid
+            Assert.IsNotNull(xmlElements);
 
             //This will execute the exception section in RecordableCommand(string tag), because tag is null
             Assert.Throws<System.Reflection.TargetInvocationException>(() => executive.ExecuteCommand(cmd.Object, "TestRecordable", "ExtensionTests"));
@@ -92,7 +92,7 @@ namespace Dynamo.Tests.ModelsTest
             XmlDocument xmlDocument = new XmlDocument();
             XmlElement elementAddPresetCommand = AddPresetCommand.Serialize(xmlDocument);
 
-            var jsonAddPresetCommand = AddPresetCommand.Serialize();
+            var xmlAddPresetCommand = AddPresetCommand.Serialize(xmlDocument);
 
 
             var helper = new XmlElementHelper(elementAddPresetCommand);
@@ -109,12 +109,6 @@ namespace Dynamo.Tests.ModelsTest
             var deserializedAddPresetCommand = DynamoModel.RecordableCommand.Deserialize(elementAddPresetCommand);
             var deserializedApplyPresetCommand = DynamoModel.RecordableCommand.Deserialize(elementApplyPresetCommand);
 
-            //This will execute the overloaded Deserialize method (the one receiving a string as parameter)
-            var deserializedFromJson = DynamoModel.RecordableCommand.Deserialize(jsonAddPresetCommand);
-
-            //This will generate a invalid json string, so when it's deserialized will raise an exception
-            jsonAddPresetCommand = jsonAddPresetCommand.Replace('{', '<');
-
             //This is a fake command so when it's deserialized will raise an exception
             XmlElement elemTest = xmlDocument.CreateElement("TestCommand");
             Assert.Throws<ArgumentException>(() => DynamoModel.RecordableCommand.Deserialize(elemTest));
@@ -123,8 +117,7 @@ namespace Dynamo.Tests.ModelsTest
             //This will check that the Deserialized commands are valid
             Assert.IsNotNull(deserializedAddPresetCommand);
             Assert.IsNotNull(deserializedApplyPresetCommand);
-            Assert.IsNotNull(deserializedFromJson);
-            Assert.Throws<ApplicationException>(() => DynamoModel.RecordableCommand.Deserialize(jsonAddPresetCommand));
+            Assert.Throws<ApplicationException>(() => DynamoModel.RecordableCommand.Deserialize(xmlAddPresetCommand));
 
 
         }


### PR DESCRIPTION
### Purpose

* testing if we actually need `typenamehandling.auto` anywhere
* enabling security analyzers
* turning some json deserialization warnings into errors
* removing old json serialization for recordable commands as it seems unused.
* update some old tests.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
