### PR TITLE
DYN-7218 Revit Crash FileTrust Popup

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2787,6 +2787,8 @@ namespace Dynamo.ViewModels
                 if (_fileDialog.ShowDialog() == DialogResult.OK)
                 {
                     SaveAs(_fileDialog.FileName);
+                    if(FileTrustViewModel != null)
+                        FileTrustViewModel.DynFileDirectoryName = _fileDialog.FileName;
                     LastSavedLocation = Path.GetDirectoryName(_fileDialog.FileName);
                     //set the IsTemplate to false, after saving it as a file
                     vm.Model.CurrentWorkspace.IsTemplate = false;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1906,6 +1906,11 @@ namespace Dynamo.Controls
             {
                 isPSSCalledOnViewModelNoCancel = true;
             }
+            //Validates that when Dynamo is being closed we need to close the FileTrust Popup (if is opened)
+            if(fileTrustWarningPopup != null && fileTrustWarningPopup.IsOpen)
+            {
+                fileTrustWarningPopup.IsOpen = false;
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1906,11 +1906,6 @@ namespace Dynamo.Controls
             {
                 isPSSCalledOnViewModelNoCancel = true;
             }
-            //Validates that when Dynamo is being closed we need to close the FileTrust Popup (if is opened)
-            if(fileTrustWarningPopup != null && fileTrustWarningPopup.IsOpen)
-            {
-                fileTrustWarningPopup.IsOpen = false;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose
Fixing Revit Crash when closing the FileTrust Popup
Under a specific case when the FileTrust Popup is visible and Dynamo is closed the Popup remains open then if the user clicks any button Revit crashes. For fixing this problem I've added a piece of code that will be closing the FileTrust Popup when Dynamo is closed.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Revit Crash when closing the FileTrust Popup

### Reviewers

@QilongTang 

### FYIs


