### PR TITLE
DYN-5709: publish version fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -998,6 +998,7 @@ namespace Dynamo.PackageManager
             var pkgs = PackageManagerClientViewModel.ListAll();
 
             pkgs.Sort((e1, e2) => e1.Name.ToLower().CompareTo(e2.Name.ToLower()));
+            pkgs = pkgs.Where(x => x.Header.versions != null && x.Header.versions.Count > 0).ToList(); // We expect compliant data structure
             LastSync = pkgs;
 
             PopulateMyPackages();   // adding 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -180,7 +180,7 @@ namespace Dynamo.ViewModels
             Model = model;
 
             PublishNewPackageVersionCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackageVersion), IsOwner);
-            PublishNewPackageCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackage), IsOwner);
+            PublishNewPackageCommand = new DelegateCommand(() => ExecuteWithTou(PublishNewPackage), CanSubmitNewPackage);
             UninstallCommand = new DelegateCommand(Uninstall, CanUninstall);
             UnmarkForUninstallationCommand = new DelegateCommand(UnmarkForUninstallation, CanUnmarkForUninstallation);
             LoadCommand = new DelegateCommand(Load, CanLoad);
@@ -408,6 +408,20 @@ namespace Dynamo.ViewModels
         {
             if (!CanPublish) return false;
             return packageManagerClient.DoesCurrentUserOwnPackage(Model, dynamoModel.AuthenticationManager.Username);
+        }
+
+        /// <summary>
+        /// You should only be able to use this if you have an installed local package and submit for the first time
+        /// If a package with such name already exists, the process will fail during the API call, here we are not checking for that
+        /// </summary>
+        /// <returns></returns>
+        private bool CanSubmitNewPackage()
+        {
+            if (!CanPublish) return false;
+            // This is a round-about way to say, if we can publish a version,
+            // then the publish has already been published,
+            // so only allow 'Publish version'
+            return !packageManagerClient.DoesCurrentUserOwnPackage(Model, dynamoModel.AuthenticationManager.Username);
         }
 
         private bool CanDeprecate()

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -184,7 +184,7 @@ namespace Dynamo.PackageManager
             get { return _uploadHandle; }
             set
             {
-                if (_uploadHandle != value)
+                if (value != null && _uploadHandle != value)
                 {
                     _uploadHandle = value;
                     _uploadHandle.PropertyChanged += UploadHandleOnPropertyChanged;

--- a/src/DynamoPackages/PackageDirectoryBuilder.cs
+++ b/src/DynamoPackages/PackageDirectoryBuilder.cs
@@ -328,17 +328,18 @@ namespace Dynamo.PackageManager
 
                     var destPath = Path.Combine(rootDir.FullName, relativePath.TrimStart('\\'));
 
-                    if (fileSystem.FileExists(destPath))
-                    {
-                        fileSystem.DeleteFile(destPath);
-                    }
-
                     if (!Directory.Exists(Path.GetDirectoryName(destPath)))
                     {
-                        Directory.CreateDirectory(Path.GetDirectoryName(destPath));
+                        Directory.CreateDirectory(Path.GetDirectoryName(destPath)); 
                     }
 
-                    fileSystem.CopyFile(file, destPath);
+                    if (!fileSystem.FileExists(destPath))
+                    {
+                        // Only copy new files into the destination folder.
+                        // Under `retain folder structure`, if the destination file == source file,
+                        // then that is simply the actual Package file we want to work with. 
+                        fileSystem.CopyFile(file, destPath);
+                    }
 
                     if (file.ToLower().EndsWith(".dyf"))
                     {


### PR DESCRIPTION
### Purpose

Following up on a https://jira.autodesk.com/browse/DYN-5709, this PR addresses a bigger concern. The `Publish Version` experience has been broken for a while now. After a lengthy research and trying several options, the proposed solution is very simple. 

Context - the retain folder structure option was introduced as an alternative way to publish a package. It was modeled after the `existing` and only way, which lead Dynamo predefine a set of 4 folders (`bin`, `doc`, `dyf`, `extra`), and allocate packages accordingly. As one of the steps, this flow would check and delete pre-existing files in the above locations before copying the files to a finalize package structure. This made sense, as the files would come from a separate place to be copied in this new package folder structure.  

In contrast, the `retain folder structure` takes files and folders exactly as they are, and copies them to the default package folder, so the final package is loaded in Dynamo and ready to use. However, in case there is a folder already installed locally, and the user needs to submit it for the first time online, or submit it as a new version, the source files will be the same as the target files. In this case, it makes no sense to try to override the file with the same file, so we simply skip it. 

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- fixing the publish version workflow by removing the deletion of existing files from the 'retain folder structure' route
- a few minor issues found, fix


### Reviewers

@aparajit-pratap 
@reddyashish 
@QilongTang 
@zeusongit 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
