### PR TITLE
DYN-6620 Add version size data to Package Details

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
     <PackageReference Include="Autodesk.IDSDK" Version="1.1.8" />
-    <PackageReference Include="Greg" Version="3.0.1.4707" />
+    <PackageReference Include="Greg" Version="3.0.2.5756" />
     <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" CopyXML="true" />
     <PackageReference Include="RestSharp" Version="108.0.1" CopyXML="true" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UILib>true</UILib>
   </PropertyGroup>
@@ -31,9 +31,9 @@
       </Exec>
       <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high" />
       <!--This command updates the npm registry configuration if necessary-->
-      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" Condition="$(ShouldInstall)"/>
+      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" Condition="$(ShouldInstall)" />
       <!--This command gets a specific splash screen build from npm-->
-      <Exec Command="npm pack @dynamods/splash-screen@$(PackageVersion)"  Condition="$(ShouldInstall)"/>
+      <Exec Command="npm pack @dynamods/splash-screen@$(PackageVersion)" Condition="$(ShouldInstall)" />
   </Target>
 
     <Target Name="ExtractTGZFile" DependsOnTargets="NpmRunBuild" BeforeTargets="BeforeBuild" Condition="$(ShouldInstall)">      
@@ -67,7 +67,7 @@
         </Exec>
         <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" Condition="$(ShouldInstall)" />
         <!--Download a specific build of the Dynamo Home package from npm-->
         <Exec Command="npm pack @dynamods/dynamo-home@$(PackageVersion)" Condition="$(ShouldInstall)" />
     </Target>
@@ -186,7 +186,7 @@
       <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" />
     <PackageReference Include="FontAwesome5" Version="2.1.11" />
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
-    <PackageReference Include="Greg" Version="3.0.1.4707" />
+    <PackageReference Include="Greg" Version="3.0.2.5756" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="108.0.1" />

--- a/src/DynamoMLDataPipeline/DynamoMLDataPipeline.csproj
+++ b/src/DynamoMLDataPipeline/DynamoMLDataPipeline.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="RestSharp" Version="108.0.1" />
-        <PackageReference Include="Greg" Version="3.0.1.4707" />
+        <PackageReference Include="Greg" Version="3.0.2.5756" />
   </ItemGroup>
   <ItemGroup>
 	<ProjectReference Include="..\DynamoCore\DynamoCore.csproj">

--- a/src/DynamoPackages/DynamoPackages.csproj
+++ b/src/DynamoPackages/DynamoPackages.csproj
@@ -30,7 +30,7 @@
     <Content Include="PackageManagerExtension_ExtensionDefinition.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Greg" Version="3.0.1.4707" />
+    <PackageReference Include="Greg" Version="3.0.2.5756" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="108.0.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />

--- a/src/PackageDetailsViewExtension/PackageDetailItem.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailItem.cs
@@ -196,8 +196,7 @@ namespace Dynamo.PackageDetails
             this.CopyRightYear = PackageVersion.copyright_year;
             this.CanInstall = canInstall;
             this.IsEnabledForInstall = isEnabledForInstall && canInstall;
-            //TODO: point this property to the package version size after it has been added to the db.
-            this.PackageSize = Dynamo.Properties.Resources.NoneString;
+            this.PackageSize = string.IsNullOrEmpty(PackageVersion.size) ? "--" : PackageVersion.size;
 
 
             // To avoid displaying package self-dependencies.

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -684,7 +684,7 @@
 
                         <!--  Size  -->
                         <DataGridTextColumn MinWidth="110"
-                                            Binding="{Binding PythonVersion}"
+                                            Binding="{Binding PackageSize}"
                                             Header="{x:Static p:Resources.PackageDetailsSize}"
                                             HeaderStyle="{StaticResource DataGridColumnHeaderText}"
                                             IsReadOnly="True" />

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
@@ -14,7 +14,7 @@
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Greg" Version="3.0.1.4707" />
+	<PackageReference Include="Greg" Version="3.0.2.5756" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	<PackageReference Include="RestSharp" Version="108.0.1" />
   </ItemGroup>

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
-        <PackageReference Include="Greg" Version="3.0.1.4707" />
+        <PackageReference Include="Greg" Version="3.0.2.5756" />
         <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" />
         <PackageReference Include="Magick.NET.Core" Version="7.0.1" />
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -34,7 +34,7 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Greg" Version="3.0.1.4707">
+        <PackageReference Include="Greg" Version="3.0.2.5756">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -37,7 +37,7 @@
       
     <PackageReference Include="Moq" Version="4.18.4" />
 	  <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
-	  <PackageReference Include="Greg" Version="3.0.1.4707">
+	  <PackageReference Include="Greg" Version="3.0.2.5756">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/test/DynamoCoreWpfTests/ViewExtensions/PackageDetailsViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/PackageDetailsViewExtensionTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Dynamo.PackageDetails;
 using Dynamo.PackageManager;
@@ -49,6 +49,7 @@ namespace DynamoCoreWpfTests
                 host_dependencies = new List<string>(Hosts),
                 version = "0.0.1",
                 name = "test",
+                size = "2.19 MiB",
             },
             new PackageVersion
             {
@@ -61,6 +62,7 @@ namespace DynamoCoreWpfTests
                 host_dependencies = new List<string>(Hosts),
                 version = "0.0.2",
                 name = "test",
+                size = "4.19 MiB",
             },
             new PackageVersion
             {
@@ -73,6 +75,7 @@ namespace DynamoCoreWpfTests
                 host_dependencies = new List<string>(Hosts),
                 version = "0.0.3",
                 name = "test",
+                size = "5.19 MiB",
             },
         };
         private static List<string> DependencyVersions { get; } = new List<string> {"1", "2", "3"};
@@ -418,6 +421,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(packageToOpen, packageDetailsViewModel.PackageName);
             Assert.AreEqual(packageAuthor.First().username, packageDetailsViewModel.PackageAuthorName);
             Assert.AreEqual(packageDescription, packageDetailsViewModel.PackageDescription);
+            Assert.AreEqual(false, string.IsNullOrEmpty(packageDetailsViewModel.PackageDetailItems.FirstOrDefault().PackageSize));
         }
     }
 }

--- a/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
+++ b/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
@@ -20,7 +20,7 @@
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="Greg" Version="3.0.1.4707">
+        <PackageReference Include="Greg" Version="3.0.2.5756">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
### Purpose

The PR will add package version size data to Package details table.
- Size is extracted from package metadata received from Package Manager
- Size already formatted in readable units
- Using KiB, MiB notations as supported by AWS ([Mutiple Byte Units](https://en.wikipedia.org/wiki/Byte#Multiple-byte_units))

Update Greg nuget version to `3.0.2.5756`

<img width="1081" alt="Screenshot 2024-07-30 at 1 00 36 AM" src="https://github.com/user-attachments/assets/49298582-0fca-4425-a197-1fb47ff72ca7">

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Added size data to Package details view

### Reviewers

@DynamoDS/dynamo 

