### PR TITLE
DYN-7217 Fix DateTime node tooltip

### DIFF
--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -177,7 +177,7 @@ namespace DSCore
         /// <returns name="hour">Numeric representation of the hour (0-23)</returns>
         /// <returns name="minute">Numeric representation of minutes (0-59)</returns>
         /// <returns name="second">Numeric representation of seconds(0-59)</returns>
-        /// <returns name="millisecond">Numeric representation of seconds(0-999)</returns>
+        /// <returns name="millisecond">Numeric representation of milliseconds(0-999)</returns>
         [MultiReturn("year", "month", "day", "hour", "minute", "second", "millisecond")]
         public static Dictionary<string, int> Components(System.DateTime dateTime)
         {


### PR DESCRIPTION
### Purpose

Fix the DateTime node tooltip (seconds -> milliseconds)

<img width="581" alt="Screenshot 2024-08-15 at 1 52 16 PM" src="https://github.com/user-attachments/assets/d8c86939-43ac-4ff6-ab22-a9ef202db7c8">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Fix the DateTime node tooltip (seconds -> milliseconds)

### Reviewers


