### PR TITLE
DYN-7255 Add crash guard code to DependencyRegen function and code clean up

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml.cs
@@ -30,12 +30,11 @@ namespace Dynamo.WorkspaceDependency
         /// The hyper link where Dynamo user will be forwarded to for submitting comments.
         /// </summary>
         private readonly string FeedbackLink = "https://forum.dynamobim.com/t/call-for-feedback-on-dynamo-graph-package-dependency-display/37229";
-        private readonly string customNodeExtension = ".dyf";
 
         internal ViewLoadedParams loadedParams;
-        private WorkspaceDependencyViewExtension dependencyViewExtension;
+        private readonly WorkspaceDependencyViewExtension dependencyViewExtension;
 
-        private IPackageInstaller packageInstaller;
+        private readonly IPackageInstaller packageInstaller;
 
         private Boolean hasDependencyIssue = false;
 

--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyViewExtension.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Core;
-using Dynamo.Extensions;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.PackageManager;
@@ -22,7 +21,7 @@ namespace Dynamo.WorkspaceDependency
     public class WorkspaceDependencyViewExtension : ViewExtensionBase, IViewExtension, ILogSource
     {
         internal MenuItem workspaceReferencesMenuItem;
-        private readonly String extensionName = Properties.Resources.ExtensionName;
+        private readonly String extensionName = Resources.ExtensionName;
         private readonly string customNodeExtension = ".dyf";
 
         internal WorkspaceDependencyView DependencyView
@@ -145,7 +144,7 @@ namespace Dynamo.WorkspaceDependency
             viewLoadedParams.AddExtensionMenuItem(workspaceReferencesMenuItem);
         }
 
-                /// <summary>
+        /// <summary>
         /// Regenerate dependency table
         /// </summary>
         /// <param name="ws">workspace model</param>
@@ -154,7 +153,7 @@ namespace Dynamo.WorkspaceDependency
         {
             DependencyView.RestartBanner.Visibility = Visibility.Hidden;
             ws.ForceComputeWorkspaceReferences = forceCompute;
-
+            // Dependency infos for each category
             var packageDependencies = ws.NodeLibraryDependencies?.Where(d => d is PackageDependencyInfo).ToList();
             var localDefinitions = ws.NodeLocalDefinitions?.Where(d => d is DependencyInfo).ToList();
             var externalFiles = ws.ExternalFiles?.Where(d => d is DependencyInfo).ToList();
@@ -178,9 +177,8 @@ namespace Dynamo.WorkspaceDependency
                 }
                 catch (Exception ex)
                 {
-                    OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
+                    OnMessageLogged(LogMessage.Info(string.Format(Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
                 }
-
                 HasDependencyIssue = string.IsNullOrEmpty(info.Path);
             }
 
@@ -198,11 +196,11 @@ namespace Dynamo.WorkspaceDependency
                 HasDependencyIssue = true;
             }
 
-            if (packageDependencies.Any())
+            if (packageDependencies.Count != 0)
             {
                 Boolean hasPackageMarkedForUninstall = false;
                 // If package is set to uninstall state, update the package info
-                foreach (var package in pmExtension.PackageLoader.LocalPackages.Where(x => 
+                foreach (var package in pmExtension.PackageLoader.LocalPackages.Where(x =>
                 x.LoadState.ScheduledState == PackageLoadState.ScheduledTypes.ScheduledForDeletion || x.LoadState.ScheduledState == PackageLoadState.ScheduledTypes.ScheduledForUnload))
                 {
                     try
@@ -213,11 +211,11 @@ namespace Dynamo.WorkspaceDependency
                     }
                     catch (Exception ex)
                     {
-                        OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, $"failure to set package uninstall state |{ ex.ToString()}")));
+                        OnMessageLogged(LogMessage.Info(string.Format(Resources.DependencyViewExtensionErrorTemplate, $"failure to set package uninstall state |{ex.ToString()}")));
                     }
                 }
 
-                DependencyView.RestartBanner.Visibility = hasPackageMarkedForUninstall ? Visibility.Visible: Visibility.Hidden;
+                DependencyView.RestartBanner.Visibility = hasPackageMarkedForUninstall ? Visibility.Visible : Visibility.Hidden;
             }
 
             if (pmExtension != null)
@@ -234,24 +232,30 @@ namespace Dynamo.WorkspaceDependency
                     }
                     catch (Exception ex)
                     {
-                        OnMessageLogged(LogMessage.Info(string.Format(Properties.Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
+                        OnMessageLogged(LogMessage.Info(string.Format(Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
                     }
                 }
             }
+            try
+            {
+                dataRows = packageDependencies?.Select(d => new PackageDependencyRow(d as PackageDependencyInfo));
+                localDefinitionDataRows = localDefinitions?.Select(d => new DependencyRow(d as DependencyInfo));
+                externalFilesDataRows = externalFiles?.Select(d => new DependencyRow(d as DependencyInfo));
 
-            dataRows = packageDependencies.Select(d => new PackageDependencyRow(d as PackageDependencyInfo));
-            localDefinitionDataRows = localDefinitions.Select(d => new DependencyRow(d as DependencyInfo));
-            externalFilesDataRows = externalFiles.Select(d => new DependencyRow(d as DependencyInfo));
+                DependencyView.Packages.IsExpanded = dataRows.Any();
+                DependencyView.LocalDefinitions.IsExpanded = localDefinitionDataRows.Any();
+                DependencyView.ExternalFiles.IsExpanded = externalFilesDataRows.Any();
 
-            DependencyView.Packages.IsExpanded = dataRows.Count() > 0;
-            DependencyView.LocalDefinitions.IsExpanded = localDefinitionDataRows.Count() > 0;
-            DependencyView.ExternalFiles.IsExpanded = externalFilesDataRows.Count() > 0;
+                ws.ForceComputeWorkspaceReferences = false;
 
-            ws.ForceComputeWorkspaceReferences = false;
-
-            DependencyView.PackageDependencyTable.ItemsSource = dataRows;
-            DependencyView.LocalDefinitionsTable.ItemsSource = localDefinitionDataRows;
-            DependencyView.ExternalFilesTable.ItemsSource = externalFilesDataRows;
+                DependencyView.PackageDependencyTable.ItemsSource = dataRows;
+                DependencyView.LocalDefinitionsTable.ItemsSource = localDefinitionDataRows;
+                DependencyView.ExternalFilesTable.ItemsSource = externalFilesDataRows;
+            }
+            catch(Exception ex)
+            {
+                OnMessageLogged(LogMessage.Info(string.Format(Resources.DependencyViewExtensionErrorTemplate, ex.ToString())));
+            }
         }
 
         public override void Closed()


### PR DESCRIPTION
### Purpose

Per https://jira.autodesk.com/browse/DYN-7255 and https://github.com/DynamoDS/Dynamo/issues/15404. Add crash guard code to DependencyRegen function to avoid Workspace References view extension to crash and code clean up

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add crash guard code to DependencyRegen function to avoid Workspace References view extension to crash and code clean up

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
