### PR TITLE
DYN-7222 DefaultValues Locale

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -313,7 +313,7 @@ namespace Dynamo.DocumentationBrowser
              var stringArr = element.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
              foreach (var line in stringArr)
              {
-                 if (line.ToLowerInvariant().Contains("default value"))
+                 if (line.ToLowerInvariant().Contains(Resources.InputDefaultValue))
                  {
                      return line.Remove(0, 16);
                  }

--- a/src/DocumentationBrowserViewExtension/Properties/Resources.Designer.cs
+++ b/src/DocumentationBrowserViewExtension/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace Dynamo.DocumentationBrowser.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to default value.
+        /// </summary>
+        public static string InputDefaultValue {
+            get {
+                return ResourceManager.GetString("InputDefaultValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inserted Dynamo graph.
         /// </summary>
         public static string InsertedGroupSubTitle {

--- a/src/DocumentationBrowserViewExtension/Properties/Resources.en-US.resx
+++ b/src/DocumentationBrowserViewExtension/Properties/Resources.en-US.resx
@@ -142,6 +142,9 @@
     <value>Zoom out</value>
     <comment>Image Control ToolTip</comment>
   </data>
+  <data name="InputDefaultValue" xml:space="preserve">
+    <value>default value</value>
+  </data>
   <data name="InsertedGroupSubTitle" xml:space="preserve">
     <value>Inserted Dynamo graph</value>
   </data>

--- a/src/DocumentationBrowserViewExtension/Properties/Resources.resx
+++ b/src/DocumentationBrowserViewExtension/Properties/Resources.resx
@@ -216,4 +216,7 @@
   <data name="ToastFileNotFoundLocationNotificationText" xml:space="preserve">
     <value>Example file from {0} could not be found</value>
   </data>
+  <data name="InputDefaultValue" xml:space="preserve">
+    <value>default value</value>
+  </data>
 </root>


### PR DESCRIPTION

### Purpose

Input DefaultValue not showing when Dynamo is in a different language than English
Due that there was a hard-coded string in the code the DocumentationBrowser was not showing the Input Default Values when Dynamo is in a different language than English. So I added the hard-coded string as a Resource


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Input DefaultValue not showing when Dynamo is in a different language than English

### Reviewers

@QilongTang 

### FYIs

