### PR TITLE
new wizzard control

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -501,7 +501,9 @@
     <Compile Include="Views\PackageManager\Controls\PackageManagerPackagesControl.xaml.cs" />
     <Compile Include="Views\PackageManager\Controls\PackageManagerPublishControl.xaml.cs" />
     <Compile Include="Views\PackageManager\Controls\PackageManagerSearchControl.xaml.cs" />
+    <Compile Include="Views\PackageManager\Controls\PackageManagerWizardControl.xaml.cs" />
     <Compile Include="Views\PackageManager\Controls\SearchBoxControl.xaml.cs" />
+    <Compile Include="Views\PackageManager\Controls\StepIndicatorControl.xaml.cs" />
     <Compile Include="Views\PackageManager\PackageManagerView.xaml.cs" />
     <Compile Include="Views\Menu\TrustedPathView.xaml.cs" />
     <Compile Include="Views\Output\OutputEditor.cs" />
@@ -721,6 +723,10 @@
         <SubType>Designer</SubType>
         <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Views\PackageManager\Controls\StepIndicatorControl.xaml">
+        <SubType>Designer</SubType>
+        <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\Menu\TrustedPathView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -744,6 +750,10 @@
     <Page Include="Views\PackageManager\Controls\PackageManagerPublishControl.xaml">
         <Generator>MSBuild:Compile</Generator>
         <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\PackageManager\Controls\PackageManagerWizardControl.xaml">
+        <SubType>Designer</SubType>
+        <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Windows\ExtensionWindow.xaml">
       <SubType>Designer</SubType>
@@ -1834,6 +1844,12 @@
       <Generator>MSBuild:Compile</Generator>
     </None>
     <None Update="Views\PackageManager\Controls\NumericUpDownControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+    <None Update="Views\PackageManager\Controls\PackageManagerWizardControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+    <None Update="Views\PackageManager\Controls\StepIndicatorControl.xaml">
       <Generator>MSBuild:Compile</Generator>
     </None>
     <None Update="Views\PackageManager\Pages\PublishPackageFinishPage.xaml">

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1245,6 +1245,8 @@ Dynamo.PackageManager.UI.PackageManagerView.InitializeComponent() -> void
 Dynamo.PackageManager.UI.PackageManagerView.PackageManagerView(Dynamo.Controls.DynamoView dynamoView, Dynamo.PackageManager.PackageManagerViewModel packageManagerViewModel) -> void
 Dynamo.PackageManager.UI.PackageManagerView.PackageManagerViewModel.get -> Dynamo.PackageManager.PackageManagerViewModel
 Dynamo.PackageManager.UI.PackageManagerView.PackageManagerViewModel.set -> void
+Dynamo.PackageManager.UI.PackageManagerWizardControl
+Dynamo.PackageManager.UI.PackageManagerWizardControl.PackageManagerWizardControl() -> void
 Dynamo.PackageManager.UI.PackageNameLengthValidationRule
 Dynamo.PackageManager.UI.PackageNameLengthValidationRule.PackageNameLengthValidationRule() -> void
 Dynamo.PackageManager.UI.PublishPackagePreviewPage
@@ -1277,6 +1279,18 @@ Dynamo.PackageManager.UI.SortingConverter
 Dynamo.PackageManager.UI.SortingConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.PackageManager.UI.SortingConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.PackageManager.UI.SortingConverter.SortingConverter() -> void
+Dynamo.PackageManager.UI.StepIndicatorControl
+Dynamo.PackageManager.UI.StepIndicatorControl.State.get -> Dynamo.PackageManager.UI.StepIndicatorControl.StepState
+Dynamo.PackageManager.UI.StepIndicatorControl.State.set -> void
+Dynamo.PackageManager.UI.StepIndicatorControl.StepIndicatorControl() -> void
+Dynamo.PackageManager.UI.StepIndicatorControl.StepNumber.get -> string
+Dynamo.PackageManager.UI.StepIndicatorControl.StepNumber.set -> void
+Dynamo.PackageManager.UI.StepIndicatorControl.StepState
+Dynamo.PackageManager.UI.StepIndicatorControl.StepState.Active = 1 -> Dynamo.PackageManager.UI.StepIndicatorControl.StepState
+Dynamo.PackageManager.UI.StepIndicatorControl.StepState.Inactive = 0 -> Dynamo.PackageManager.UI.StepIndicatorControl.StepState
+Dynamo.PackageManager.UI.StepIndicatorControl.StepState.Ok = 2 -> Dynamo.PackageManager.UI.StepIndicatorControl.StepState
+Dynamo.PackageManager.UI.StepIndicatorControl.Title.get -> string
+Dynamo.PackageManager.UI.StepIndicatorControl.Title.set -> void
 Dynamo.PackageManager.UI.TermsOfUseView
 Dynamo.PackageManager.UI.TermsOfUseView.AcceptedTermsOfUse.get -> bool
 Dynamo.PackageManager.UI.TermsOfUseView.InitializeComponent() -> void
@@ -5568,6 +5582,9 @@ static readonly Dynamo.PackageManager.UI.NumericUpDownControl.ValueProperty -> S
 static readonly Dynamo.PackageManager.UI.NumericUpDownControl.WatermarkProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.PackageManager.UI.PackageManagerPackagesControl.SearchItemsProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.PackageManager.UI.PackageManagerPackagesControl.SelectedItemProperty -> System.Windows.DependencyProperty
+static readonly Dynamo.PackageManager.UI.StepIndicatorControl.StateProperty -> System.Windows.DependencyProperty
+static readonly Dynamo.PackageManager.UI.StepIndicatorControl.StepNumberProperty -> System.Windows.DependencyProperty
+static readonly Dynamo.PackageManager.UI.StepIndicatorControl.TitleProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.PackageManager.UI.TreeViewItemHelper.IndentProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.UI.Controls.CodeCompletionEditor.CodeProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.UI.Controls.DynamoToolTip.AttachmentSideProperty -> System.Windows.DependencyProperty

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerWizardControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerWizardControl.xaml
@@ -1,0 +1,79 @@
+<UserControl x:Class="Dynamo.PackageManager.UI.PackageManagerWizardControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Dynamo.PackageManager.UI"
+             xmlns:ui="clr-namespace:Dynamo.UI"
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+            
+            <Style TargetType="TextBlock">
+                <Setter Property="Foreground" Value="#f5f5f5"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="0 0 0 8"/>
+                <Setter Property="UseLayoutRounding" Value="True"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid Background="#535353" VerticalAlignment="Center">
+
+        <!-- Progress bar section -->
+        <Grid Grid.Row="0" Margin="10"> 
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Line connecting steps -->
+            <Line Grid.Row="1" 
+                  Grid.ColumnSpan="5"
+                  X1="0" Y1="0" 
+                  X2="1" Y2="0" 
+                  Stroke="#979797" 
+                  StrokeThickness="2" 
+                  Stretch="Fill"
+                  HorizontalAlignment="Stretch" 
+                  VerticalAlignment="Center"
+                  Margin="80 25 80 0"/>
+
+            <!-- Step 1 -->
+            <local:StepIndicatorControl Title="Package details" StepNumber="1" State="Active" Grid.Column="0" Grid.Row="1" VerticalAlignment="Bottom" 
+                            MouseLeftButtonDown="StepIndicatorControl_MouseDoubleClick" Width="120" Height="50"/>
+
+            <!-- Step 2 -->
+            <local:StepIndicatorControl Title="Compatibility" StepNumber="2" State="Inactive" Grid.Column="1" Grid.Row="1" VerticalAlignment="Bottom"
+                            MouseLeftButtonDown="StepIndicatorControl_MouseDoubleClick" Width="120" Height="50"/>
+
+            <!-- Step 3 -->
+            <local:StepIndicatorControl Title="Select files" StepNumber="3" State="Inactive" Grid.Column="2" Grid.Row="1" VerticalAlignment="Bottom"
+                            MouseLeftButtonDown="StepIndicatorControl_MouseDoubleClick" Width="120" Height="50"/>
+
+            <!-- Step 4 -->
+            <local:StepIndicatorControl Title="Preview files" StepNumber="4" State="Inactive" Grid.Column="3" Grid.Row="1" VerticalAlignment="Bottom"
+                            MouseLeftButtonDown="StepIndicatorControl_MouseDoubleClick" Width="120" Height="50"/>
+
+            <!-- Step 5 -->
+            <local:StepIndicatorControl Title="Confirm" StepNumber="5" State="Inactive" Grid.Column="4" Grid.Row="1" VerticalAlignment="Bottom"
+                            MouseLeftButtonDown="StepIndicatorControl_MouseDoubleClick" Width="120" Height="50"/>
+
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerWizardControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerWizardControl.xaml.cs
@@ -1,0 +1,72 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Dynamo.PackageManager.UI
+{
+    /// <summary>
+    /// Interaction logic for PackageManagerWizardControl.xaml
+    /// </summary>
+    public partial class PackageManagerWizardControl : UserControl
+    {
+        private int currentStep;
+
+        public PackageManagerWizardControl()
+        {
+            InitializeComponent();
+            currentStep = 1;
+        }
+
+        private void StepIndicatorControl_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var indicator = sender as StepIndicatorControl;
+            if (indicator != null)
+            {
+                int step;
+                if (int.TryParse(indicator.StepNumber, out step))
+                {
+                    currentStep = step;
+                    UpdateSteps();
+                }
+            }
+        }
+
+        private void UpdateSteps()
+        {
+            UpdateStepStateRecursive(this);
+        }
+
+        private void UpdateStepStateRecursive(DependencyObject parent)
+        {
+            if (parent == null)
+                return;
+
+            foreach (object child in LogicalTreeHelper.GetChildren(parent))
+            {
+                if (child is StepIndicatorControl indicator)
+                {
+                    int step;
+                    if (int.TryParse(indicator.StepNumber, out step))
+                    {
+                        if (step < currentStep)
+                        {
+                            indicator.State = StepIndicatorControl.StepState.Ok;
+                        }
+                        else if (step == currentStep)
+                        {
+                            indicator.State = StepIndicatorControl.StepState.Active;
+                        }
+                        else
+                        {
+                            indicator.State = StepIndicatorControl.StepState.Inactive;
+                        }
+                    }
+                }
+                else if (child is DependencyObject dependencyChild)
+                {
+                    UpdateStepStateRecursive(dependencyChild);
+                }
+            }
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/StepIndicatorControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/StepIndicatorControl.xaml
@@ -1,0 +1,128 @@
+<UserControl x:Class="Dynamo.PackageManager.UI.StepIndicatorControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Dynamo.PackageManager.UI"
+             xmlns:ui="clr-namespace:Dynamo.UI"
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="100" 
+             IsHitTestVisible="True"
+             Background="Transparent">
+    <UserControl.Resources>
+
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <SolidColorBrush x:Key="EllipseStrokeBrush" Color="#979797"/>
+            <SolidColorBrush x:Key="EllipseFillBrush" Color="#535353"/>
+            
+            <!-- Tick Icon Path --> 
+            <PathGeometry x:Key="TickIcon" Figures="M4.18021 9L0 5.1129L1.29587 3.8214L4.15699 6.4647L10.6791 0L12 1.2681L4.18021 9Z" />
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid Background="Transparent" IsHitTestVisible="True">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="StepStates">
+                <!-- Active State -->
+                <VisualState x:Name="Active">
+                    <Storyboard>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Stroke).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#38abdf" Duration="0:0:0.3">
+                        </ColorAnimation>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#535353" Duration="0:0:0.3"/>
+                    </Storyboard>
+                </VisualState>
+
+                <!-- Inactive State -->
+                <VisualState x:Name="Inactive">
+                    <Storyboard>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Stroke).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#979797" Duration="0:0:0.3"/>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#535353" Duration="0:0:0.3"/>
+                    </Storyboard>
+                </VisualState>
+
+                <!-- Ok State -->
+                <VisualState x:Name="Ok">
+                    <Storyboard>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Stroke).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#38abdf" Duration="0:0:0.3"/>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#38abdf" Duration="0:0:0.3"/>
+                    </Storyboard>
+                </VisualState>
+
+                <!-- Mouse Over State -->
+                <VisualState x:Name="MouseOver">
+                    <Storyboard>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Stroke).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#b0b0b0" Duration="0:0:0.3"/>
+                        <ColorAnimation Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                     Storyboard.TargetName="Ellipse"
+                                     To="#696969" Duration="0:0:0.3"/>
+                    </Storyboard>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Name="StepTitle"
+                   Text="{Binding Title, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                   VerticalAlignment="Bottom"
+                   HorizontalAlignment="Center"
+                   FontWeight="Normal"
+                   Margin="0 0 0 8"/>
+        <Canvas Grid.Row="1" Height="20" Width="20">
+            <Ellipse Name="Ellipse" 
+                  Width="20" 
+                  Height="20"   
+                  Stroke="{StaticResource EllipseStrokeBrush}" 
+                  Fill="{StaticResource EllipseFillBrush}"
+                  StrokeThickness="2" 
+                  SnapsToDevicePixels="True"
+                  UseLayoutRounding="True"
+                  MouseEnter="Ellipse_MouseEnter"
+                  MouseLeave="Ellipse_MouseLeave"
+                  MouseLeftButtonDown="Ellipse_MouseLeftButtonDown"/>
+
+            <TextBlock Name="StepNumberText"
+                    Padding="6 2 0 0"
+                    Margin="0"
+                    Width="20"  
+                    Height="20"
+                    IsHitTestVisible="False"
+                    Foreground="#979797"
+                    FontSize="12"   
+                    Text="{Binding StepNumber, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                    FontWeight="Bold"/>
+            
+            <!-- OK Icon -->
+            <Grid Name="OkIcon" Visibility="Visible" IsHitTestVisible="False">
+                <Canvas  Width="20" Height="20">
+                    <Viewbox Width="10" Height="12" Canvas.Left="5" Canvas.Top="4" >
+                        <Path Data="{StaticResource TickIcon}"
+                            Fill="White" />
+                    </Viewbox>
+                </Canvas>
+            </Grid>
+        </Canvas>
+    </Grid>
+</UserControl>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/StepIndicatorControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/StepIndicatorControl.xaml.cs
@@ -1,0 +1,134 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using Dynamo.UI;
+
+namespace Dynamo.PackageManager.UI
+{
+    /// <summary>
+    /// Interaction logic for StepIndicatorControl.xaml
+    /// </summary>
+    public partial class StepIndicatorControl : UserControl
+    {
+        private StepState _previousState;
+        private bool _clickedDuringMouseOver;
+
+        public StepIndicatorControl()
+        {
+            InitializeComponent();
+            this.UpdateVisualState(State);
+            this._clickedDuringMouseOver = false;
+        }
+
+        public static readonly DependencyProperty TitleProperty =
+         DependencyProperty.Register("Title", typeof(string), typeof(StepIndicatorControl), new PropertyMetadata("Step"));
+
+        public string Title
+        {
+            get { return (string)GetValue(TitleProperty); }
+            set { SetValue(TitleProperty, value); }
+        }
+
+        public static readonly DependencyProperty StepNumberProperty =
+        DependencyProperty.Register("StepNumber", typeof(string), typeof(StepIndicatorControl),
+            new PropertyMetadata("1", OnStepNumberChanged));
+
+        public string StepNumber
+        {
+            get { return (string)GetValue(StepNumberProperty); }
+            set { SetValue(StepNumberProperty, value); }
+        }
+
+        private static void OnStepNumberChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (StepIndicatorControl)d;
+            control.StepNumberText.Text = (string)e.NewValue;
+        }
+
+        public enum StepState
+        {
+            Inactive,
+            Active,
+            Ok
+        }
+
+        public static readonly DependencyProperty StateProperty =
+            DependencyProperty.Register("State", typeof(StepState), typeof(StepIndicatorControl),
+                new PropertyMetadata(StepState.Inactive, OnStateChanged));
+
+        public StepState State
+        {
+            get { return (StepState)GetValue(StateProperty); }
+            set { SetValue(StateProperty, value); }
+        }
+
+        private static void OnStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (StepIndicatorControl)d;
+            var state = (StepState)e.NewValue;
+            control.UpdateVisualState(state);
+        }
+
+        private void Ellipse_MouseEnter(object sender, MouseEventArgs e)
+        {
+            _previousState = State; // Save the current state
+            VisualStateManager.GoToState(this, "MouseOver", true);
+        }
+
+        private void Ellipse_MouseLeave(object sender, MouseEventArgs e)
+        {
+            if (!_clickedDuringMouseOver)
+            {
+                UpdateVisualState(_previousState);
+            }
+            _clickedDuringMouseOver = false;
+        }
+
+        private void Ellipse_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            _clickedDuringMouseOver = true;
+
+            if (State == StepState.Inactive)
+            {
+                State = StepState.Active; // Change to Active on click
+            }
+            else if (State == StepState.Active)
+            {
+                State = StepState.Ok; // Change to Ok on click
+            }
+
+            UpdateVisualState(State); // Update to the new state immediately
+        }
+
+        private void UpdateVisualState(StepState state)
+        {
+            switch (state)
+            {
+                case StepState.Active:
+                    StepNumberText.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#38abdf"));
+                    StepNumberText.Visibility = Visibility.Visible;
+                    OkIcon.Visibility = Visibility.Collapsed;
+                    StepTitle.FontFamily = SharedDictionaryManager.DynamoModernDictionary["ArtifaktElementBold"] as FontFamily;
+                    break;
+                    
+                case StepState.Inactive:
+                    StepNumberText.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#979797"));
+                    StepNumberText.Visibility = Visibility.Visible;
+                    OkIcon.Visibility = Visibility.Collapsed;
+                    StepTitle.FontFamily = SharedDictionaryManager.DynamoModernDictionary["ArtifaktElementRegular"] as FontFamily;
+                    break;
+
+                case StepState.Ok:  
+                    StepNumberText.Visibility = Visibility.Collapsed;
+                    OkIcon.Visibility = Visibility.Visible;
+                    StepTitle.FontFamily = SharedDictionaryManager.DynamoModernDictionary["ArtifaktElementRegular"] as FontFamily;
+                    break;
+
+            }
+
+            string stateName = state.ToString();
+            VisualStateManager.GoToState(this, stateName, true);
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/StepIndicatorControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/StepIndicatorControl.xaml.cs
@@ -21,19 +21,31 @@ namespace Dynamo.PackageManager.UI
             this._clickedDuringMouseOver = false;
         }
 
+        /// <summary>
+        /// Title Dependency Property
+        /// </summary>
         public static readonly DependencyProperty TitleProperty =
          DependencyProperty.Register("Title", typeof(string), typeof(StepIndicatorControl), new PropertyMetadata("Step"));
 
+        /// <summary>
+        /// Title property displayed on top of the step number
+        /// </summary>
         public string Title
         {
             get { return (string)GetValue(TitleProperty); }
             set { SetValue(TitleProperty, value); }
         }
 
+        /// <summary>
+        /// Step Number Dependency Property
+        /// </summary>
         public static readonly DependencyProperty StepNumberProperty =
         DependencyProperty.Register("StepNumber", typeof(string), typeof(StepIndicatorControl),
             new PropertyMetadata("1", OnStepNumberChanged));
 
+        /// <summary>
+        /// Step Number property showing the number
+        /// </summary>
         public string StepNumber
         {
             get { return (string)GetValue(StepNumberProperty); }
@@ -46,6 +58,9 @@ namespace Dynamo.PackageManager.UI
             control.StepNumberText.Text = (string)e.NewValue;
         }
 
+        /// <summary>
+        /// Enum with the possible control states
+        /// </summary>
         public enum StepState
         {
             Inactive,
@@ -53,10 +68,16 @@ namespace Dynamo.PackageManager.UI
             Ok
         }
 
+        /// <summary>
+        /// Step State Dependency Property
+        /// </summary>
         public static readonly DependencyProperty StateProperty =
             DependencyProperty.Register("State", typeof(StepState), typeof(StepIndicatorControl),
                 new PropertyMetadata(StepState.Inactive, OnStateChanged));
 
+        /// <summary>
+        /// State Property accounting for the current state of the control
+        /// </summary>
         public StepState State
         {
             get { return (StepState)GetValue(StateProperty); }
@@ -127,7 +148,7 @@ namespace Dynamo.PackageManager.UI
 
             }
 
-            string stateName = state.ToString();
+            var stateName = state.ToString();
             VisualStateManager.GoToState(this, stateName, true);
         }
     }


### PR DESCRIPTION
### Purpose

A PR containing the preliminary UI work for the design rehaul of the Package Manager publishing package. "Step-by-step wizard. Users should be able to navigate around by clicking the numbers at the top (once each step has been successfully fulfilled)."

The control has not been implemented anywhere in code yet. 

Link to the Figma board: https://www.figma.com/design/MJh76m7bbafE3sjwLUTZhZ/Dynamo-package-manager-update?node-id=2409-15319&t=4BQN0lZMCg2MRHTp-0

### UI Changes

![CIGMsb99xD](https://github.com/user-attachments/assets/1ebb2af2-8049-4c25-b325-0c2cce226bb0)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- new wizard-style custom user control

### Reviewers

@QilongTang 
@Amoursol 

### FYIs

@reddyashish 
