### PR TITLE
DYN-7082: Adding a new node List.StringifyIndexOf

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -162,6 +162,7 @@ namespace DSCore
 
         /// <summary>
         ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
+        ///     Use StringifyIndexOf to avoid negative index values.
         /// </summary>
         /// <param name="list">The list to find the element in.</param>
         /// <param name="element">The element whose index is to be returned.</param>
@@ -175,7 +176,6 @@ namespace DSCore
 
         /// <summary>
         ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
-        ///     Use this node to avoid negative index values.
         /// </summary>
         /// <param name="list">The list to find the element in.</param>
         /// <param name="element">The element whose index is to be returned.</param>

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -161,7 +161,7 @@ namespace DSCore
         }
 
         /// <summary>
-        ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
+        ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.).
         ///     Use StringifyIndexOf to avoid negative index values.
         /// </summary>
         /// <param name="list">The list to find the element in.</param>

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -175,7 +175,7 @@ namespace DSCore
         }
 
         /// <summary>
-        ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
+        ///     Returns the stringified index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
         /// </summary>
         /// <param name="list">The list to find the element in.</param>
         /// <param name="element">The element whose index is to be returned.</param>

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -174,6 +174,21 @@ namespace DSCore
         }
 
         /// <summary>
+        ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
+        ///     Use this node to avoid negative index values.
+        /// </summary>
+        /// <param name="list">The list to find the element in.</param>
+        /// <param name="element">The element whose index is to be returned.</param>
+        /// <returns name="string">The stringified index of the element in the list. Invalid index null will be returned if strict match not found.</returns>
+        /// <search>index,indexof</search>
+        [IsVisibleInDynamoLibrary(true)]
+        public static string StringifyIndexOf(IList list, object element)
+        {
+            var index = list.IndexOf(element);
+            return index < 0 ? null : index.ToString();
+        }
+
+        /// <summary>
         ///     Returns the number of false boolean values in the given list.
         /// </summary>
         /// <param name="list">The list find the false boolean values.</param>

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -162,30 +162,16 @@ namespace DSCore
 
         /// <summary>
         ///     Returns the index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.).
-        ///     Use StringifyIndexOf to avoid negative index values.
         /// </summary>
         /// <param name="list">The list to find the element in.</param>
         /// <param name="element">The element whose index is to be returned.</param>
         /// <returns name="int">The index of the element in the list. Invalid index -1 will be returned if strict match not found.</returns>
         /// <search>index,indexof</search>
         [IsVisibleInDynamoLibrary(true)]
-        public static int IndexOf(IList list, object element)
-        {
-            return list.IndexOf(element);
-        }
-
-        /// <summary>
-        ///     Returns the stringified index of the element in the given list. Match between given list and target element must be a strict match (i.e. int to int, double to double, string to string, object to object etc.)
-        /// </summary>
-        /// <param name="list">The list to find the element in.</param>
-        /// <param name="element">The element whose index is to be returned.</param>
-        /// <returns name="string">The stringified index of the element in the list. Invalid index null will be returned if strict match not found.</returns>
-        /// <search>index,indexof</search>
-        [IsVisibleInDynamoLibrary(true)]
-        public static string StringifyIndexOf(IList list, object element)
+        public static int? IndexOf(IList list, object element)
         {
             var index = list.IndexOf(element);
-            return index < 0 ? null : index.ToString();
+            return index < 0 ? null : index;
         }
 
         /// <summary>

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Dynamo.Graph.Nodes;
 using NUnit.Framework;
 using List = DSCore.List;
 
@@ -180,7 +179,7 @@ namespace DSCoreNodesTests
         public static void ListIndexOf()
         {
             Assert.AreEqual(1, List.IndexOf(new ArrayList { "x", "y", 1 }, "y"));
-            Assert.AreEqual(-1, List.IndexOf(new ArrayList { 3, 4, 6, 8 }, 9));
+            Assert.AreEqual(null, List.IndexOf(new ArrayList { 3, 4, 6, 8 }, 9));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7082
In reference to https://github.com/DynamoDS/Dynamo/pull/15268, to avoid negative index values being returned, we created a new node StringifyIndexOf that will return null when the element is not found in the list. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Adding a new node List.StringifyIndexOf

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

