### PR TITLE
DYN-7345 Add parent window when displaying TOU

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using Dynamo.Controls;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
@@ -168,7 +169,7 @@ namespace Dynamo.ViewModels
             if (resourceProvider != null)
                 additionalTerms = resourceProvider.AdditionalPackagePublisherTermsOfUse;
 
-            if (!ShowTermsOfUseDialog(true, additionalTerms))
+            if (!ShowTermsOfUseDialog(true, additionalTerms, WpfUtilities.FindUpVisualTree<DynamoView>(viewParent)))
                 return; // Terms of use not accepted.
 
             // If user accepts the terms of use, then update the record on 
@@ -530,7 +531,7 @@ namespace Dynamo.ViewModels
             var touAccepted = prefSettings.PackageDownloadTouAccepted;
             if (!touAccepted)
             {
-                touAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null);
+                touAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, WpfUtilities.FindUpVisualTree<DynamoView>(viewParent));
                 prefSettings.PackageDownloadTouAccepted = touAccepted;
                 if (!touAccepted)
                 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -323,7 +323,8 @@ namespace Dynamo.ViewModels
                         AcceptanceCallback = () => ShowNodePublishInfo(new[]
                         {
                             Tuple.Create(currentFunInfo, currentFunDef)
-                        })
+                        }),
+                        Parent = ViewModelOwner ?? DynamoViewModel.Owner,
                     };
 
                     var termsOfUseCheck = new TermsOfUseHelper(touParams);
@@ -352,7 +353,7 @@ namespace Dynamo.ViewModels
                 AuthenticationManager = AuthenticationManager,
                 ResourceProvider = DynamoViewModel.BrandingResourceProvider,
                 AcceptanceCallback = ShowNodePublishInfo,
-                Parent = ViewModelOwner,
+                Parent = ViewModelOwner ?? DynamoViewModel.Owner,
             });
 
             termsOfUseCheck.Execute(true);
@@ -379,7 +380,7 @@ namespace Dynamo.ViewModels
                     {
                         Tuple.Create(currentFunInfo, m.Definition)
                     }),
-                    Parent = ViewModelOwner,
+                    Parent = ViewModelOwner ?? DynamoViewModel.Owner,
 
                 });
 
@@ -439,7 +440,7 @@ namespace Dynamo.ViewModels
                 AuthenticationManager = AuthenticationManager,
                 ResourceProvider = DynamoViewModel.BrandingResourceProvider,
                 AcceptanceCallback = () => ShowNodePublishInfo(defs),
-                Parent = ViewModelOwner,
+                Parent = ViewModelOwner ?? DynamoViewModel.Owner,
             });
 
             termsOfUseCheck.Execute(true);

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -169,7 +169,7 @@ namespace Dynamo.ViewModels
             if (resourceProvider != null)
                 additionalTerms = resourceProvider.AdditionalPackagePublisherTermsOfUse;
 
-            if (!ShowTermsOfUseDialog(true, additionalTerms, WpfUtilities.FindUpVisualTree<DynamoView>(viewParent)))
+            if (!ShowTermsOfUseDialog(true, additionalTerms))
                 return; // Terms of use not accepted.
 
             // If user accepts the terms of use, then update the record on 
@@ -531,7 +531,7 @@ namespace Dynamo.ViewModels
             var touAccepted = prefSettings.PackageDownloadTouAccepted;
             if (!touAccepted)
             {
-                touAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, WpfUtilities.FindUpVisualTree<DynamoView>(viewParent));
+                touAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, WpfUtilities.FindUpVisualTree<DynamoView>(ViewModelOwner));
                 prefSettings.PackageDownloadTouAccepted = touAccepted;
                 if (!touAccepted)
                 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -542,7 +542,7 @@ namespace Dynamo.ViewModels
             var touAccepted = prefSettings.PackageDownloadTouAccepted;
             if (!touAccepted)
             {
-                touAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, WpfUtilities.FindUpVisualTree<DynamoView>(ViewModelOwner));
+                touAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, ViewModelOwner);
                 prefSettings.PackageDownloadTouAccepted = touAccepted;
                 if (!touAccepted)
                 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -474,7 +474,8 @@ namespace Dynamo.ViewModels
                 PackageManagerClient = dynamoModel.GetPackageManagerExtension().PackageManagerClient,
                 AuthenticationManager = dynamoModel.AuthenticationManager,
                 ResourceProvider = dynamoViewModel.BrandingResourceProvider,
-                AcceptanceCallback = acceptanceCallback
+                AcceptanceCallback = acceptanceCallback,
+                Parent = null,
             });
 
             termsOfUseCheck.Execute(false);

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -475,7 +475,7 @@ namespace Dynamo.ViewModels
                 AuthenticationManager = dynamoModel.AuthenticationManager,
                 ResourceProvider = dynamoViewModel.BrandingResourceProvider,
                 AcceptanceCallback = acceptanceCallback,
-                Parent = null,
+                Parent = packageManagerClientViewModel.ViewModelOwner ?? dynamoViewModel.Owner,
             });
 
             termsOfUseCheck.Execute(false);

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1469,14 +1469,9 @@ namespace Dynamo.Controls
         {
             var prefSettings = dynamoViewModel.Model.PreferenceSettings;
             if (prefSettings.PackageDownloadTouAccepted)
-                return true; // User accepts the terms of use.
+                return true; // User accepted the terms of use.
 
-            Window packageManParent = null;
-            //If any Guide is being executed then the ShowTermsOfUse Window WON'T be modal otherwise will be modal (as in the normal behavior)
-            if (dynamoViewModel.MainGuideManager != null && GuideFlowEvents.IsAnyGuideActive)
-                packageManParent = _this;
-            var acceptedTermsOfUse = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, packageManParent);
-            prefSettings.PackageDownloadTouAccepted = acceptedTermsOfUse;
+            prefSettings.PackageDownloadTouAccepted = TermsOfUseHelper.ShowTermsOfUseDialog(false, null, _this);
 
             // User may or may not accept the terms.
             return prefSettings.PackageDownloadTouAccepted;

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1726,6 +1726,7 @@ namespace Dynamo.Controls
                 categoryBox = { Text = e.Category },
                 DescriptionInput = { Text = e.Description },
                 nameBox = { Text = e.Name },
+                Owner = this,
             };
 
             if (e.CanEditName)


### PR DESCRIPTION
### Purpose

Add parent window when displaying DPM TOU, this PR now covers more case while it does NOT cover the cases where Dynamo Package Manager does not show and Dynamo needs to access package related functions. That seems to be a bigger problem to solve. e.g. setting Owner for DynamoViewModel when Dynamo launches. Because the performance and memory consumption is unknown, I intentionally left that change out.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add parent window when displaying DPM TOU, this PR now covers more case while it does NOT cover the cases where Dynamo Package Manager does not show and Dynamo needs to access package related functions. 

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
