### PR TITLE
DYN-7330 Add a button to show Sample Graph folder and Sample Dataset

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -113,6 +113,7 @@ namespace Dynamo.UI.Controls
         List<StartPageListItem> references = new List<StartPageListItem>();
         List<StartPageListItem> contributeLinks = new List<StartPageListItem>();
         string sampleFolderPath = null;
+        string sampleDatasetsPath = null;
 
         // Dynamic lists that update views on the fly.
         ObservableCollection<SampleFileEntry> sampleFiles = null;
@@ -228,7 +229,7 @@ namespace Dynamo.UI.Controls
                         //Make sure the folder's name is not "backup"
                         if (!directory.Name.Equals(Configurations.BackupFolderName))
                         {
-                            // Resursive call for each subdirectory.
+                            // Recursive call for each subdirectory.
                             SampleFileEntry sampleFileEntry =
                                 new SampleFileEntry(directory.Name, directory.FullName);
                             WalkDirectoryTree(directory, sampleFileEntry);
@@ -248,6 +249,7 @@ namespace Dynamo.UI.Controls
                         if (sampleFolderPath == null)
                         {
                             sampleFolderPath = Path.GetDirectoryName(file.FullName);
+                            SetSampleDatasetsPath();
                         }
 
                         // Add each file under the root directory property list.
@@ -267,6 +269,37 @@ namespace Dynamo.UI.Controls
             {
                 // Perhaps some permission problems?
                 DynamoViewModel.Model.Logger.Log("Error loading sample file: " + ex.StackTrace);
+            }
+        }
+
+        /// <summary>
+        /// Sets the sampleDatasetsPath based on the value of sampleFolderPath
+        /// </summary>
+        private void SetSampleDatasetsPath()
+        {
+            try
+            {
+                var directoryInfo = new DirectoryInfo(sampleFolderPath);
+
+                // Traverse the directory tree upwards to locate the "samples" folder
+                while (directoryInfo != null && directoryInfo.Name != "samples")
+                {
+                    directoryInfo = directoryInfo.Parent;
+                }
+
+                if (directoryInfo != null && directoryInfo.Name == "samples")
+                {
+                    var datasetsPath = Path.Combine(directoryInfo.FullName, "Data");
+
+                    if (Directory.Exists(datasetsPath))
+                    {
+                        sampleDatasetsPath = datasetsPath;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                DynamoViewModel.Model.Logger.Log("Error loading Dataset folder: " + ex.Message);
             }
         }
 
@@ -296,6 +329,11 @@ namespace Dynamo.UI.Controls
         public string SampleFolderPath
         {
             get { return this.sampleFolderPath; }
+        }
+
+        public string SampleDatasetsPath
+        {
+            get { return this.sampleDatasetsPath; }
         }
 
         #region Public Class Properties (Static Lists)
@@ -529,7 +567,6 @@ namespace Dynamo.UI.Controls
                 DynamoViewModel.Model.Logger.Log("Error deserializing dynamo graph file: " + ex.StackTrace);
                 return (null, null, null, null);
             }
-
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -295,16 +295,6 @@ namespace Dynamo.UI.Controls
                     {
                         sampleDatasetsPath = datasetsPath;
                     }
-                    else
-                    {
-                        DynamoViewModel.Model.Logger.Log("Datasets folder not found, setting to default path.");
-                        //sampleDatasetsPath = @"C:\Default\Datasets";
-                    }
-                }
-                else
-                {
-                    DynamoViewModel.Model.Logger.Log("Datasets folder not found, setting to default path.");
-                    //sampleDatasetsPath = @"C:\Default\Datasets";
                 }
             }
             catch (Exception ex)

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -295,6 +295,16 @@ namespace Dynamo.UI.Controls
                     {
                         sampleDatasetsPath = datasetsPath;
                     }
+                    else
+                    {
+                        DynamoViewModel.Model.Logger.Log("Datasets folder not found, setting to default path.");
+                        //sampleDatasetsPath = @"C:\Default\Datasets";
+                    }
+                }
+                else
+                {
+                    DynamoViewModel.Model.Logger.Log("Datasets folder not found, setting to default path.");
+                    //sampleDatasetsPath = @"C:\Default\Datasets";
                 }
             }
             catch (Exception ex)

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -59,7 +59,7 @@
 
     <Target Name="NpmRunBuildHomePage" BeforeTargets="BeforeBuild">
         <PropertyGroup>
-            <PackageVersion>1.0.17</PackageVersion>
+            <PackageVersion>1.0.18</PackageVersion>
             <PackageName>DynamoHome</PackageName>
         </PropertyGroup>
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1494,6 +1494,7 @@ Dynamo.UI.Controls.StartPageViewModel.RecentFiles.get -> System.Collections.Obje
 Dynamo.UI.Controls.StartPageViewModel.References.get -> System.Collections.Generic.IEnumerable<Dynamo.UI.Controls.StartPageListItem>
 Dynamo.UI.Controls.StartPageViewModel.SampleFiles.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.UI.Controls.SampleFileEntry>
 Dynamo.UI.Controls.StartPageViewModel.SampleFolderPath.get -> string
+Dynamo.UI.Controls.StartPageViewModel.SampleDatasetsPath.get -> string
 Dynamo.UI.Controls.StateChangedEventHandler
 Dynamo.UI.Controls.ToolTipWindow
 Dynamo.UI.Controls.ToolTipWindow.CopyIconMouseClick(object sender, System.Windows.Input.MouseButtonEventArgs e) -> void
@@ -1592,9 +1593,10 @@ Dynamo.UI.Views.ScriptHomeObject.NewWorkspace() -> void
 Dynamo.UI.Views.ScriptHomeObject.OpenFile(string path) -> void
 Dynamo.UI.Views.ScriptHomeObject.OpenWorkspace() -> void
 Dynamo.UI.Views.ScriptHomeObject.SaveSettings(string settings) -> void
-Dynamo.UI.Views.ScriptHomeObject.ScriptHomeObject(System.Action<string> requestOpenFile, System.Action requestNewWorkspace, System.Action requestOpenWorkspace, System.Action requestNewCustomNodeWorkspace, System.Action requestApplicationLoaded, System.Action<string> requestShowGuidedTour, System.Action requestShowSampleFilesInFolder, System.Action requestShowBackupFilesInFolder, System.Action requestShowTemplate, System.Action<string> requestSaveSettings) -> void
+Dynamo.UI.Views.ScriptHomeObject.ScriptHomeObject(System.Action<string> requestOpenFile, System.Action requestNewWorkspace, System.Action requestOpenWorkspace, System.Action requestNewCustomNodeWorkspace, System.Action requestApplicationLoaded, System.Action<string> requestShowGuidedTour, System.Action requestShowSampleFilesInFolder, System.Action requestShowSampleDatasetsInFolder, System.Action requestShowBackupFilesInFolder, System.Action requestShowTemplate, System.Action<string> requestSaveSettings) -> void
 Dynamo.UI.Views.ScriptHomeObject.ShowBackupFilesInFolder() -> void
 Dynamo.UI.Views.ScriptHomeObject.ShowSampleFilesInFolder() -> void
+Dynamo.UI.Views.ScriptHomeObject.ShowSampleDatasetsInFolder() -> void
 Dynamo.UI.Views.ScriptHomeObject.ShowTempalte() -> void
 Dynamo.UI.Views.ScriptHomeObject.StartGuidedTour(string path) -> void
 Dynamo.UI.Views.ScriptObject

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2067,7 +2067,7 @@ namespace Dynamo.Controls
 
         // the key press event is being intercepted before it can get to
         // the active workspace. This code simply grabs the key presses and
-        // passes it to thecurrent workspace
+        // passes it to the current workspace
         private void DynamoView_KeyDown(object sender, KeyEventArgs e)
         {
             Analytics.TrackActivityStatus(HeartBeatType.User.ToString());
@@ -2187,6 +2187,7 @@ namespace Dynamo.Controls
         private void LoadSamplesMenu()
         {
             var samplesDirectory = dynamoViewModel.Model.PathManager.SamplesDirectory;
+
             if (Directory.Exists(samplesDirectory))
             {
                 var sampleFiles = new System.Collections.Generic.List<string>();
@@ -2209,7 +2210,7 @@ namespace Dynamo.Controls
                     }
                 }
 
-                // handle top-level dirs, TODO - factor out to a seperate function, make recusive
+                // handle top-level dirs, TODO - factor out to a separate function, make recursive
                 if (dirPaths.Any())
                 {
                     foreach (string dirPath in dirPaths)

--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -54,6 +54,7 @@ namespace Dynamo.UI.Views
         internal Action RequestNewCustomNodeWorkspace;
         internal Action RequestApplicationLoaded;
         internal Action RequestShowSampleFilesInFolder;
+        internal Action RequestShowSampleDatasetsInFolder;
         internal Action RequestShowBackupFilesInFolder;
         internal Action RequestShowTemplate;
         internal Action<string> RequestSaveSettings;
@@ -87,13 +88,13 @@ namespace Dynamo.UI.Views
             RequestOpenWorkspace = OpenWorkspace;
             RequestNewCustomNodeWorkspace = NewCustomNodeWorkspace;
             RequestShowSampleFilesInFolder = ShowSampleFilesInFolder;
+            RequestShowSampleDatasetsInFolder = ShowSampleDatasetsInFolder;
             RequestShowBackupFilesInFolder = ShowBackupFilesInFolder;
             RequestShowTemplate = OpenTemplate;
             RequestApplicationLoaded = ApplicationLoaded;
             RequestSaveSettings = SaveSettings;
 
             DataContextChanged += OnDataContextChanged;
-
         }
             
         private void InitializeGuideTourItems()
@@ -169,7 +170,7 @@ namespace Dynamo.UI.Views
                 this.dynWebView.CoreWebView2.Settings.AreDevToolsEnabled = true;
                 this.dynWebView.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
 
-                // Load the embeded resources
+                // Load the embedded resources
                 var assembly = Assembly.GetExecutingAssembly();
 
                 htmlString = PathHelper.LoadEmbeddedResourceAsString(htmlEmbeddedFile, assembly);
@@ -202,6 +203,7 @@ namespace Dynamo.UI.Views
                                         RequestApplicationLoaded,
                                         RequestShowGuidedTour,
                                         RequestShowSampleFilesInFolder,
+                                        RequestShowSampleDatasetsInFolder,
                                         RequestShowBackupFilesInFolder,
                                         RequestShowTemplate,
                                         RequestSaveSettings));
@@ -617,7 +619,21 @@ namespace Dynamo.UI.Views
                 + this.startPage.SampleFolderPath)
             { UseShellExecute = true });
             Logging.Analytics.TrackEvent(Logging.Actions.Show, Logging.Categories.DynamoHomeOperations, "Sample Files");
+        }
+        
+        internal void ShowSampleDatasetsInFolder()
+        {
+            if (this.startPage == null) return;
+            if (DynamoModel.IsTestMode)
+            {
+                TestHook?.Invoke(string.Empty);
+                return;
+            }
 
+            Process.Start(new ProcessStartInfo("explorer.exe", /*"/select,"*/
+                /*+ */this.startPage.SampleDatasetsPath)
+            { UseShellExecute = true });
+            Logging.Analytics.TrackEvent(Logging.Actions.Show, Logging.Categories.DynamoHomeOperations, "Dataset Files");
         }
 
         internal void ShowBackupFilesInFolder()
@@ -728,6 +744,7 @@ namespace Dynamo.UI.Views
         readonly Action RequestApplicationLoaded;
         readonly Action<string> RequestShowGuidedTour;
         readonly Action RequestShowSampleFilesInFolder;
+        readonly Action RequestShowSampleDatasetsInFolder;
         readonly Action RequestShowBackupFilesInFolder;
         readonly Action RequestShowTemplate;
         readonly Action<string> RequestSaveSettings;
@@ -739,6 +756,7 @@ namespace Dynamo.UI.Views
             Action requestApplicationLoaded,
             Action<string> requestShowGuidedTour,
             Action requestShowSampleFilesInFolder,
+            Action requestShowSampleDatasetsInFolder,
             Action requestShowBackupFilesInFolder,
             Action requestShowTemplate,
             Action<string> requestSaveSettings)
@@ -750,6 +768,7 @@ namespace Dynamo.UI.Views
             RequestApplicationLoaded = requestApplicationLoaded;
             RequestShowGuidedTour = requestShowGuidedTour;
             RequestShowSampleFilesInFolder = requestShowSampleFilesInFolder;
+            RequestShowSampleDatasetsInFolder = requestShowSampleDatasetsInFolder;
             RequestShowBackupFilesInFolder = requestShowBackupFilesInFolder;
             RequestShowTemplate = requestShowTemplate;
             RequestSaveSettings = requestSaveSettings;
@@ -785,11 +804,15 @@ namespace Dynamo.UI.Views
             RequestShowSampleFilesInFolder();
         }
         [DynamoJSInvokable]
+        public void ShowSampleDatasetsInFolder()
+        {
+            RequestShowSampleDatasetsInFolder();
+        }
+        [DynamoJSInvokable]
         public void ShowBackupFilesInFolder()
         {
             RequestShowBackupFilesInFolder();
         }
-
         [DynamoJSInvokable]
         public void ShowTempalte()
         {

--- a/test/DynamoCoreWpfTests/HomePageTests.cs
+++ b/test/DynamoCoreWpfTests/HomePageTests.cs
@@ -50,6 +50,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(homePage.RequestNewCustomNodeWorkspace);
             Assert.IsNotNull(homePage.RequestApplicationLoaded);
             Assert.IsNotNull(homePage.RequestShowSampleFilesInFolder);
+            Assert.IsNotNull(homePage.RequestShowSampleDatasetsInFolder);
             Assert.IsNotNull(homePage.RequestShowBackupFilesInFolder);
             Assert.IsNotNull(homePage.RequestShowTemplate);
         }


### PR DESCRIPTION
### Purpose

PR to address https://jira.autodesk.com/browse/DYN-7330.
Adds a button for a dropdown to allow users to find Sample Graph folder and Sample Dataset. The button replaces the current "Show samples in folder button"

Goes along with  :  https://github.com/DynamoDS/DynamoHome/pull/28

Hope that's okay 🤞

![DYN-7330_Fix](https://github.com/user-attachments/assets/3891d515-7900-4949-aaf4-352cb46b723d)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Adds a button for a dropdown to allow users to find Sample Graph folder and Sample Dataset. The button replaces the current "Show samples in folder button"

### Reviewers

@dnenov
@reddyashish

### FYIs

@Amoursol
