### PR TITLE
[DYN-7332] Add pins to groups

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -182,7 +182,7 @@ namespace Dynamo.Graph.Annotations
             {
                 // Unsubscribe all content in group before
                 // overwriting with the new content.
-                // If we dont do this we end up with
+                // If we don't do this we end up with
                 // lots of memory leaks that eventually will
                 // lead to a stackoverflow exception
                 if (nodes != null && nodes.Any())
@@ -194,15 +194,7 @@ namespace Dynamo.Graph.Annotations
                     }
                 }
 
-                // First remove all pins from the input
-                var valuesWithoutPins = value
-                    .Where(x => !(x is ConnectorPinModel));
-
-                // then recalculate which pins belongs to the
-                // group and add them to the nodes collection
-                var pinModels = GetPinsFromNodes(value.OfType<NodeModel>());
-                nodes = valuesWithoutPins.Concat(pinModels)
-                    .ToHashSet<ModelBase>();
+                nodes = value.ToHashSet<ModelBase>();
 
                 if (nodes != null && nodes.Any())
                 {

--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -182,7 +182,7 @@ namespace Dynamo.Graph.Annotations
             {
                 // Unsubscribe all content in group before
                 // overwriting with the new content.
-                // If we don't do this we end up with
+                // If we dont do this we end up with
                 // lots of memory leaks that eventually will
                 // lead to a stackoverflow exception
                 if (nodes != null && nodes.Any())

--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -194,7 +194,15 @@ namespace Dynamo.Graph.Annotations
                     }
                 }
 
-                nodes = value.ToHashSet<ModelBase>();
+                // First separate all pins from the input
+                var pinModels = value.OfType<ConnectorPinModel>().ToList();
+                var valuesWithoutPins = value.Except(pinModels);
+
+                // then recalculate which pins belong to the group based on the nodes
+                var pinsFromNodes = GetPinsFromNodes(valuesWithoutPins.OfType<NodeModel>());
+
+                // Combine all
+                nodes = valuesWithoutPins.Concat(pinModels).Concat(pinsFromNodes).ToHashSet<ModelBase>();
 
                 if (nodes != null && nodes.Any())
                 {

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -108,5 +108,36 @@ namespace DynamoCoreWpfTests
             // Assert
             Assert.That(groupContent.All(x => x.IsCollapsed == false));
         }
+
+        [Test]
+        public void AddConnectorPinsToGroups()
+        {
+            // Arrange
+            Open(@"core\annotationViewModelTests\groupsTestFile.dyn");
+
+            var groupGuid = new Guid("8324afb7-2d77-4a75-aa5e-f10e59964c2b");
+            var connectorGuid = new Guid("17318da5-dd19-4962-a7b7-51344001f14b");
+
+            // Act
+            var ws = this.Model.CurrentWorkspace;
+            var group1 = ws.Annotations.FirstOrDefault(annotation => annotation.GUID == groupGuid);
+            var connector = ws.Connectors.FirstOrDefault(connector => connector.GUID == connectorGuid);
+            var connectorPin = connector.ConnectorPinModels.FirstOrDefault();
+
+            // Assert
+            Assert.IsNotNull(group1, $"Expected to find annotation group with GUID {groupGuid}, but it was not found.");
+            Assert.IsNotNull(connector, $"Expected to find connector with GUID {connectorGuid}, but it was not found.");
+            Assert.IsNotNull(connectorPin, "Expected to find a ConnectorPinModel associated with the connector, but it was not found.");
+
+            var initialNodeCount = group1.Nodes.Count();
+            Assert.AreEqual(2, initialNodeCount, $"Expected the group to contain 2 nodes initially, but found {initialNodeCount}.");
+
+            // Act: Add the connectorPin to the group
+            group1.AddToTargetAnnotationModel(connectorPin);
+
+            // Assert
+            var finalNodeCount = group1.Nodes.Count();
+            Assert.AreEqual(3, finalNodeCount, $"Expected the group to contain 3 nodes after adding the connector pin, but found {finalNodeCount}.");
+        }
     }
 }


### PR DESCRIPTION
### Purpose

PR aiming to address https://jira.autodesk.com/browse/DYN-7332 . Allows users to manually add connectorPins to groups.
Unit test included.

Hope that's okay 🤞

![DYN-7332_Fix](https://github.com/user-attachments/assets/55f377ae-e6e8-4d67-83cd-14beed1ead36)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Users can now manually add pin to group even if the related nodes are outside that group.

### Reviewers

@dnenov
@reddyashish

### FYIs

@Amoursol