### PR TITLE
DYN-4626: Allow PythonNet extension to access Python Services internals

### DIFF
--- a/src/NodeServices/Properties/AssemblyInfo.cs
+++ b/src/NodeServices/Properties/AssemblyInfo.cs
@@ -43,3 +43,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamoConnector")]
 [assembly: InternalsVisibleTo("DynamoApplications")]
 [assembly: InternalsVisibleTo("DynamoUnits")]
+[assembly: InternalsVisibleTo("DSPythonNet")]

--- a/src/NodeServices/Properties/AssemblyInfo.cs
+++ b/src/NodeServices/Properties/AssemblyInfo.cs
@@ -43,4 +43,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamoConnector")]
 [assembly: InternalsVisibleTo("DynamoApplications")]
 [assembly: InternalsVisibleTo("DynamoUnits")]
-[assembly: InternalsVisibleTo("DSPythonNet")]
+[assembly: InternalsVisibleTo("DSPythonNet3")]


### PR DESCRIPTION
### Purpose

Adding an exception for the PythonNet extension

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Adding an exception for the PythonNet extension

### Reviewers


### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
