### PR TITLE
DYN-6208 Update Dynamo Website Menu Item behavior

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1973,6 +1973,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dynamo _Repository.
+        /// </summary>
+        public static string DynamoViewHelpMenuGotoRepo {
+            get {
+                return ResourceManager.GetString("DynamoViewHelpMenuGotoRepo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dynamo _Website.
         /// </summary>
         public static string DynamoViewHelpMenuGotoWebsite {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -661,6 +661,10 @@ Don't worry, you'll have the option to save your work.</value>
     <value>Dynamo _Website</value>
     <comment>Help menu | Go go Dynamo website</comment>
   </data>
+  <data name="DynamoViewHelpMenuGotoRepo" xml:space="preserve">
+    <value>Dynamo _Repository</value>
+    <comment>Help menu | Go go Dynamo repository</comment>
+  </data>
   <data name="DynamoViewHelpMenuGotoWiki" xml:space="preserve">
     <value>Dynamo _Project Wiki</value>
     <comment>Help menu | Go to wiki</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -402,6 +402,10 @@
     <value>Dynamo _Website</value>
     <comment>Help menu | Go Dynamo website</comment>
   </data>
+  <data name="DynamoViewHelpMenuGotoRepo" xml:space="preserve">
+    <value>Dynamo _Repository</value>
+    <comment>Help menu | Go go Dynamo repository</comment>
+  </data>
   <data name="DynamoViewHelpMenuGotoWiki" xml:space="preserve">
     <value>Dynamo _Project Wiki</value>
     <comment>Help menu | Go to wiki</comment>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1928,6 +1928,9 @@ Dynamo.ViewModels.DynamoViewModel.GoHomeView(object parameter) -> void
 Dynamo.ViewModels.DynamoViewModel.GoToDictionary(object parameter) -> void
 Dynamo.ViewModels.DynamoViewModel.GoToDictionaryCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.GoToDictionaryCommand.set -> void
+Dynamo.ViewModels.DynamoViewModel.GoToWebsite(object parameter) -> void
+Dynamo.ViewModels.DynamoViewModel.GoToWebsiteCommand.get -> Dynamo.UI.Commands.DelegateCommand
+Dynamo.ViewModels.DynamoViewModel.GoToWebsiteCommand.set -> void
 Dynamo.ViewModels.DynamoViewModel.GoToSourceCode(object parameter) -> void
 Dynamo.ViewModels.DynamoViewModel.GoToSourceCodeCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.GoToSourceCodeCommand.set -> void
@@ -4569,6 +4572,7 @@ static Dynamo.Wpf.Properties.Resources.DynamoViewHelpDictionary.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenu.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenuDisplayStartPage.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenuGotoWebsite.get -> string
+static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenuGotoRepo.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenuGotoWiki.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenuReportBug.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoViewHelpMenuShowInFolder.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -3317,6 +3317,15 @@ namespace Dynamo.ViewModels
         {
             return true;
         }
+        public void GoToWebsite(object parameter)
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoSiteLink) { UseShellExecute = true });
+        }
+
+        internal bool CanGoToWebsite(object parameter)
+        {
+            return true;
+        }
 
         public void GoToSourceCode(object parameter)
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -63,6 +63,7 @@ namespace Dynamo.ViewModels
             SetConnectorTypeCommand = new DelegateCommand(SetConnectorType, CanSetConnectorType);
             ReportABugCommand = new DelegateCommand(ReportABug, CanReportABug);
             GoToWikiCommand = new DelegateCommand(GoToWiki, CanGoToWiki);
+            GoToWebsiteCommand = new DelegateCommand(GoToWebsite, CanGoToWebsite);
             GoToSourceCodeCommand = new DelegateCommand(GoToSourceCode, CanGoToSourceCode);
             GoToDictionaryCommand = new DelegateCommand(GoToDictionary, CanGoToDictionary);
             DisplayStartPageCommand = new DelegateCommand(DisplayStartPage, CanDisplayStartPage);
@@ -154,6 +155,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand ReportABugCommand { get; set; }
         public DelegateCommand GoToWikiCommand { get; set; }
         public DelegateCommand GoToDictionaryCommand { get; set; }
+        public DelegateCommand GoToWebsiteCommand { get; set; }
         public DelegateCommand GoToSourceCodeCommand { get; set; }
         public DelegateCommand DisplayStartPageCommand { get; set; }
         public DelegateCommand DisplayInteractiveGuideCommand { get; set; }

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace Dynamo.UI.Views
 
         private void OnClickLink(object sender, RoutedEventArgs e)
         {
-            Process.Start(new ProcessStartInfo("http://dynamobim.org/") { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo(Configuration.Configurations.DynamoSiteLink) { UseShellExecute = true });
         }
         
         private void CloseButton_OnClick(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -662,8 +662,11 @@
                                   Command="{Binding GoToDictionaryCommand}">
                         </MenuItem>
                         <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuGotoWebsite}"
-                                  Command="{Binding GoToSourceCodeCommand}"
+                                  Command="{Binding GoToWebsiteCommand}"
                                   Name="ViewDynamoWebsite"/>
+                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuGotoRepo}"
+                                  Command="{Binding GoToSourceCodeCommand}"
+                                  Name="ViewDynamoRepo"/>
                         <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuGotoWiki}"
                                   Command="{Binding GoToWikiCommand}"
                                   Name="ViewDynamoWiki"/>


### PR DESCRIPTION
### Purpose

Clicking on Dynamo Website menu item now goes to dynamobim.org while the new Dynamo Repository menu item goes to dynamo repo (the legacy Dynamo Website menu item behavior).
![image](https://github.com/user-attachments/assets/f8a3f1f2-c436-45b3-bbc7-07ebcf2cde93)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Clicking on Dynamo Website menu item now goes to dynamobim.org while the new Dynamo Repository menu item goes to dynamo repo (the legacy Dynamo Website menu item behavior).

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
