### PR TITLE
DYN-7312 Introducing new properties to HostAnalyticsInfo

### DIFF
--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -124,7 +124,7 @@ namespace Dynamo.Logging
             Session.Start();
 
             var hostName = string.IsNullOrEmpty(hostAnalyticsInfo.HostName) ? Configurations.DynamoAsString : hostAnalyticsInfo.HostName;
-            var appversion = hostAnalyticsInfo.HostVersion != null ? hostAnalyticsInfo.HostVersion.ToString() : string.Empty;
+            var appversion = hostAnalyticsInfo.HostVersion?.ToString();
 
             hostInfo = new HostContextInfo() { ParentId = hostAnalyticsInfo.ParentId, SessionId = hostAnalyticsInfo.SessionId };
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -105,7 +105,7 @@ namespace Dynamo.Models
         // Dynamo host application name, e.g. Revit
         public string HostAppName;
         // Dynamo host application version, e.g. 2025
-        public string HostAppVersion;
+        public Version HostAppVersion;
         // Dynamo host parent id for analytics purpose.
         public string ParentId;
         // Dynamo host session id for analytics purpose.

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -103,9 +103,9 @@ namespace Dynamo.Models
         // Dynamo variation version specific to host
         public Version HostVersion;
         // Dynamo host application name, e.g. Revit
-        public string HostAppName;
-        // Dynamo host application version, e.g. 2025
-        public Version HostAppVersion;
+        public string HostProductName;
+        // Dynamo host application version, e.g. 2025.2.0
+        public Version HostProductVersion;
         // Dynamo host parent id for analytics purpose.
         public string ParentId;
         // Dynamo host session id for analytics purpose.

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -98,10 +98,14 @@ namespace Dynamo.Models
     /// </summary>
     public struct HostAnalyticsInfo
     {
-        // Dynamo variation identified by host.
+        // Dynamo variation identified by host, e.g. Dynamo Revit
         public string HostName;
         // Dynamo variation version specific to host
         public Version HostVersion;
+        // Dynamo host application name, e.g. Revit
+        public string HostAppName;
+        // Dynamo host application version, e.g. 2025
+        public string HostAppVersion;
         // Dynamo host parent id for analytics purpose.
         public string ParentId;
         // Dynamo host session id for analytics purpose.

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -2042,7 +2042,7 @@ Dynamo.Models.EvaluationCompletedEventArgs.EvaluationTookPlace.get -> bool
 Dynamo.Models.HostAnalyticsInfo
 Dynamo.Models.HostAnalyticsInfo.HostAnalyticsInfo() -> void
 Dynamo.Models.HostAnalyticsInfo.HostAppName -> string
-Dynamo.Models.HostAnalyticsInfo.HostAppVersion -> string
+Dynamo.Models.HostAnalyticsInfo.HostAppVersion -> System.Version
 Dynamo.Models.HostAnalyticsInfo.HostName -> string
 Dynamo.Models.HostAnalyticsInfo.HostVersion -> System.Version
 Dynamo.Models.HostAnalyticsInfo.ParentId -> string

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -2041,6 +2041,8 @@ Dynamo.Models.EvaluationCompletedEventArgs.EvaluationSucceeded.get -> bool
 Dynamo.Models.EvaluationCompletedEventArgs.EvaluationTookPlace.get -> bool
 Dynamo.Models.HostAnalyticsInfo
 Dynamo.Models.HostAnalyticsInfo.HostAnalyticsInfo() -> void
+Dynamo.Models.HostAnalyticsInfo.HostAppName -> string
+Dynamo.Models.HostAnalyticsInfo.HostAppVersion -> string
 Dynamo.Models.HostAnalyticsInfo.HostName -> string
 Dynamo.Models.HostAnalyticsInfo.HostVersion -> System.Version
 Dynamo.Models.HostAnalyticsInfo.ParentId -> string

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -2041,8 +2041,8 @@ Dynamo.Models.EvaluationCompletedEventArgs.EvaluationSucceeded.get -> bool
 Dynamo.Models.EvaluationCompletedEventArgs.EvaluationTookPlace.get -> bool
 Dynamo.Models.HostAnalyticsInfo
 Dynamo.Models.HostAnalyticsInfo.HostAnalyticsInfo() -> void
-Dynamo.Models.HostAnalyticsInfo.HostAppName -> string
-Dynamo.Models.HostAnalyticsInfo.HostAppVersion -> System.Version
+Dynamo.Models.HostAnalyticsInfo.HostProductName -> string
+Dynamo.Models.HostAnalyticsInfo.HostProductVersion -> System.Version
 Dynamo.Models.HostAnalyticsInfo.HostName -> string
 Dynamo.Models.HostAnalyticsInfo.HostVersion -> System.Version
 Dynamo.Models.HostAnalyticsInfo.ParentId -> string


### PR DESCRIPTION
### Purpose

Introducing new properties to HostAnalyticsInfo object which is used for DynamoModel construction to indicate more information about the running environment so other Dynamo components could customize its behavior, e.g. Package Manager could pre-fill the host name and version during package publishing.

e.g. if DynamoRevit could pass additional information at https://github.com/DynamoDS/DynamoRevit/blob/master/src/DynamoRevit/DynamoRevit.cs#L575

Then package manager in Dynamo could get information that the current DynamoCore is running in Revit 2025.2, etc. Notice this ability currently is not available anywhere.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Introducing new properties to indicate more information about the running environment.

### Reviewers

@Mikhinja @DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
