### PR TITLE
DYN-7222 DefaultValues DocBrowser Fix

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -315,7 +315,8 @@ namespace Dynamo.DocumentationBrowser
              {
                  if (line.ToLowerInvariant().Contains(Resources.InputDefaultValue))
                  {
-                     return line.Remove(0, 16);
+                    var index = line.IndexOf(":");
+                    return line.Remove(0, index + 1);
                  }
              }
              return string.Empty;


### PR DESCRIPTION
### Purpose

Fixing bug with the content of the Default Value in Documentation Browser
The Default Value was not appearing correctly due that previously was using a hard-coded string of 16 chars but now the length will change according to the language. Then I modified the code to find a specific char in the string and remove the text dynamically based in the string length

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing bug with the content of the Default Value in Documentation Browser

### Reviewers

@QilongTang @avidit 

### FYIs

