### PR TITLE
DYN-7268 Package manager loading fix when no IDSDK is available

### DIFF
--- a/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
+++ b/src/DynamoCoreWpf/Views/HomePage/HomePage.xaml.cs
@@ -125,7 +125,7 @@ namespace Dynamo.UI.Views
 
         private void DynamoViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if(dynWebView?.CoreWebView2 != null && e.PropertyName.Equals(nameof(startPage.DynamoViewModel.ShowStartPage)))
+            if(e.PropertyName == nameof(startPage.DynamoViewModel.ShowStartPage) && dynWebView?.CoreWebView2 != null)
             {
                 dynWebView.CoreWebView2.ExecuteScriptAsync(@$"window.setShowStartPageChanged('{startPage.DynamoViewModel.ShowStartPage}')");
             }


### PR DESCRIPTION


<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

When there's no IDSDK available, IDSDKManager.cs raises a `DynamoConsoleLogger.OnLogMessageToDynamoConsole`. This eventually ends up invoking a `HomePage.DynamoViewModel_PropertyChanged`. Issue arises when this process starts from a background thread, for example loading the list of packages: `PackageManagerSearchViewModel` starts a new `RefreshAndSearch` Task in the Thread Pool, which most likely won't be scheduled in the Main Thread.

Thus this commit safeguards `HomePage.DynamoViewModel_PropertyChanged` from accessing `dynWebView?.CoreWebView2` UI element from a background thread and raising an `Exception` by changing the shortcirtuited evaluation order and first checking the changed property is `ShowStartPage`, which currently only gets invoked from the Main Thread.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix dynamo package manager loading when there's no IDSDK installed.

### Reviewers

@DynamoDS/dynamo

### FYIs
