### PR TITLE
DYN-7393 Align WebView 2 version with Revit GL

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -586,7 +586,7 @@ Xceed Extended WPF Toolkit v.5.0.103:
 Microsoft Public License
 https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md
 
-Microsoft.Web.WebView2 v.1.0.2045.28
+Microsoft.Web.WebView2 v.1.0.2478.35
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -1432,7 +1432,7 @@ HYPERLINK https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627
 48af2c825dc485276300000000a5ab0003004f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af40\afs20 \ltrch\fcs0 \b\f40\fs20\kerning1\insrsid16677021 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft.Web.WebView2 v.1.0.2045.28
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft.Web.WebView2 v.1.0.2478.35
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (C) Microsoft Corporation. All rights reserved.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without

--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewExtension.csproj
@@ -100,7 +100,7 @@
     <EmbeddedResource Include="Docs\syntaxHighlight.html" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -190,7 +190,7 @@
     <PackageReference Include="FontAwesome5" Version="2.1.11" />
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
     <PackageReference Include="Greg" Version="3.0.2.5756" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="108.0.1" />
     <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />

--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -211,7 +211,7 @@
     <EmbeddedResource Include="Packages\LibrarieJS\resources\Tessellation.Voronoi.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Dynamo.Microsoft.Xaml.Behaviors">

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -63,7 +63,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FontAwesome5" Version="2.1.11" />
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
+		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\DynamoCoreWpf\DynamoCoreWpf.csproj">


### PR DESCRIPTION
### Purpose

Align WebView 2 version with Revit GL, Revit is currently using [1.0.2478.35](https://git.autodesk.com/AutodeskNET/Autodesk.UI/blob/master/src/Autodesk.UI.Windows.WebOnDesktop/Autodesk.UI.Windows.WebOnDesktop.csproj#L33) and may update again before GL. I tested locally everything is working in evergreen mode. Notice in evergreen mode, exact version alignment isn't required, this PR is just gap is reduced.
![image](https://github.com/user-attachments/assets/d4a8d85a-c335-47a3-a7ae-3442d65186d7)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Align WebView 2 version with Revit GL

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
