### PR TITLE
DYN-7433 Cleanup Node Layout Crash

### DIFF
--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -108,6 +108,9 @@ namespace GraphLayout
         /// <param name="endY">The y coordinate of the connector's right end point.</param>
         public void AddEdge(Guid startId, Guid endId, double startX, double startY, double endX, double endY)
         {
+            //Validates that the two nodes that will be used to create the Edge exist
+            if (Nodes.Where(node => node.Id == startId).Count() == 0  || Nodes.Where(node => node.Id == endId).Count() == 0) return;
+
             var edge = new Edge(startId, endId, startX, startY, endX, endY, this);
             Edges.Add(edge);
         }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -109,7 +109,7 @@ namespace GraphLayout
         public void AddEdge(Guid startId, Guid endId, double startX, double startY, double endX, double endY)
         {
             //Validates that the two nodes that will be used to create the Edge exist
-            if (Nodes.Where(node => node.Id == startId).Count() == 0  || Nodes.Where(node => node.Id == endId).Count() == 0) return;
+            if (!Nodes.Where(node => node.Id == startId).Any()  || !Nodes.Where(node => node.Id == endId).Any()) return;
 
             var edge = new Edge(startId, endId, startX, startY, endX, endY, this);
             Edges.Add(edge);


### PR DESCRIPTION
### Purpose

Crash when we have a pin inside a group and using the GraphLayout functionality.
When trying to add an Edge was using nodes that doesn't exist in the GraphLayout so it was crashing when trying to access the node coordinates (there is no null validations) so I've added a validation that check if the two nodes exist before trying to create the Edge. I noticed that there is a re-organization layout problem when using the CleanNodeLayout functionality and having a pin inside a group or in the Canvas (seems that the wires and pins are re-organized in a weird way) but I consider that we should create a task for this specific case (just if is a bug, due that pins behave weird when re-organizing).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Crash when we have a pin inside a group and using the GraphLayout functionality.

### Reviewers

@QilongTang 

### FYIs

@achintyabhat 
