### PR TITLE
[DYN-7466] Navigate-to-corresponding-node/group-by-clicking-it-in-the-TuneUp-list

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4481,6 +4481,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No group could be found with that Id..
+        /// </summary>
+        public static string MessageFailedToFindGroupById {
+            get {
+                return ResourceManager.GetString("MessageFailedToFindGroupById", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No node could be found with that Id..
         /// </summary>
         public static string MessageFailedToFindNodeById {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1320,6 +1320,9 @@ You can always redownload the package.</value>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>
   </data>
+    <data name="MessageFailedToFindGroupById" xml:space="preserve">
+    <value>No group could be found with that Id.</value>
+  </data>
   <data name="MessageFailedToOpenCorruptedFile" xml:space="preserve">
     <value>Error opening corrupted file: {0}</value>
     <comment>Message box content</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1912,6 +1912,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>
   </data>
+    <data name="MessageFailedToFindGroupById" xml:space="preserve">
+    <value>No group could be found with that Id.</value>
+  </data>
   <data name="MessageFailedToOpenCorruptedFile" xml:space="preserve">
     <value>Error opening corrupted file: {0}</value>
     <comment>Message box content</comment>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4833,6 +4833,7 @@ static Dynamo.Wpf.Properties.Resources.MessageFailedToDelete.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToDownloadPackage.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToDownloadPackageVersion.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToFindNodeById.get -> string
+static Dynamo.Wpf.Properties.Resources.MessageFailedToFindGroupById.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToOpenCorruptedFile.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToSaveAsImage.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToUnload.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2586,31 +2586,35 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="e"></param>
         /// <param name="forceShowElement"></param>
-        internal void ShowElement(NodeModel e, bool forceShowElement = true)
+        internal void ShowElement(ModelBase e, bool forceShowElement = true)
         {
             if (HomeSpace.RunSettings.RunType == RunType.Automatic && forceShowElement)
                 return;
 
-            if (!model.CurrentWorkspace.Nodes.Contains(e))
+            // Handle NodeModel
+            if (e is NodeModel node)
             {
-                if (HomeSpace != null && HomeSpace.Nodes.Contains(e))
+                if (!model.CurrentWorkspace.Nodes.Contains(e))
                 {
-                    //Show the homespace
-                    model.CurrentWorkspace = HomeSpace;
-                }
-                else
-                {
-                    foreach (
-                        var customNodeWorkspace in
-                            model.CustomNodeManager.LoadedWorkspaces.Where(
-                                customNodeWorkspace => customNodeWorkspace.Nodes.Contains(e)))
+                    if (HomeSpace != null && HomeSpace.Nodes.Contains(e))
                     {
-                        FocusCustomNodeWorkspace(customNodeWorkspace.CustomNodeId);
-                        break;
+                        //Show the homespace
+                        model.CurrentWorkspace = HomeSpace;
+                    }
+                    else
+                    {
+                        foreach (
+                            var customNodeWorkspace in
+                                model.CustomNodeManager.LoadedWorkspaces.Where(
+                                    customNodeWorkspace => customNodeWorkspace.Nodes.Contains(e)))
+                        {
+                            FocusCustomNodeWorkspace(customNodeWorkspace.CustomNodeId);
+                            break;
+                        }
                     }
                 }
             }
-
+            // Center the view on the model
             this.CurrentSpaceViewModel.OnRequestCenterViewOnElement(this, new ModelEventArgs(e));
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1646,6 +1646,25 @@ namespace Dynamo.ViewModels
             {
                 DynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.MessageFailedToFindNodeById);
             }
+
+            try
+            {
+                var group = DynamoViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault(x => x.GUID.ToString() == id.ToString());
+
+                if (group != null)
+                {
+                    //select the element
+                    DynamoSelection.Instance.ClearSelection();
+                    DynamoSelection.Instance.Selection.Add(group);
+
+                    //focus on the element
+                    DynamoViewModel.ShowElement(group);
+                }
+            }
+            catch
+            {
+                DynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.MessageFailedToFindGroupById);
+            }
         }
 
         private static bool CanFindById(object id)


### PR DESCRIPTION
### Purpose

PR aims to address https://jira.autodesk.com/browse/DYN-7466 .

Changes to `DynamoViewModel.ShowElement` and `WorkspaceViewModel.FindById` now enable group nodes in TuneUp to be selected and centered in the current workspace, similar to node elements.

Goes along with https://github.com/DynamoDS/TuneUp/pull/61

![DYN-7466_Fix](https://github.com/user-attachments/assets/11220141-3664-4ecd-91f3-817942a0f12c)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Changes in `DynamoViewModel.ShowElement` & `WorkspaceViewModel.FindById` allow group nodes in TuneUp to be selected and centered in the current workspace, similarly to nodes.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@Amoursol 
@dnenov 
