### PR TITLE
DYN-7222 Documentation Browser German Localization Bug

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -313,7 +313,7 @@ namespace Dynamo.DocumentationBrowser
              var stringArr = element.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
              foreach (var line in stringArr)
              {
-                 if (line.ToLowerInvariant().Contains(Resources.InputDefaultValue))
+                 if (line.ToLowerInvariant().Contains(Resources.InputDefaultValue.ToLower()))
                  {
                     var index = line.IndexOf(":");
                     return line.Remove(0, index + 1);


### PR DESCRIPTION
### Purpose

Default Values are not appearing when the Dynamo language is German (deutsch) 
The default values for some nodes were not appearing in German (deutsch) due that the resource was translated using the first letter in uppercase, this fix is for preventing that case.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Default Values are not appearing when the Dynamo language is German (deutsch) 

### Reviewers

@QilongTang 

### FYIs

