### PR TITLE
DYN-6218 Turning off "Show Connectors" doesn't keep them off when file is reopened

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -1263,8 +1263,8 @@ namespace Dynamo.Graph.Workspaces
             var startId = obj["Start"].Value<string>();
             var endId = obj["End"].Value<string>();
             var isHiddenExists = obj[nameof(ConnectorModel.IsHidden)];
-
-            var isHidden = isHiddenExists != null && obj[nameof(ConnectorModel.IsHidden)].Value<bool>();
+            // final connector visibility would respect current setting first, if visible then fallback to serialized value
+            var isHidden = !PreferenceSettings.Instance.ShowConnector || isHiddenExists != null && obj[nameof(ConnectorModel.IsHidden)].Value<bool>();
 
             var resolver = (IdReferenceResolver)serializer.ReferenceResolver;
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -1,12 +1,11 @@
-﻿using System.Linq;
+using System;
+using System.IO;
+using System.Linq;
 using Dynamo.Selection;
-using NUnit.Framework;
-using static Dynamo.Models.DynamoModel;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
-using System;
-using System.Xml;
-using System.IO;
+using NUnit.Framework;
+using static Dynamo.Models.DynamoModel;
 
 namespace DynamoCoreWpfTests
 {
@@ -14,6 +13,23 @@ namespace DynamoCoreWpfTests
     {
 
         #region Regular Connector Tests
+        /// <summary>
+        /// Check to see if a connector is visible after in session preferences is set to hide connectors
+        /// </summary>
+        [Test]
+        public void ConnectorVisibilityWithPrefrencesTest()
+        {
+            Model.PreferenceSettings.ShowConnector = false;
+
+            Open(@"UI/ConnectorPinTests.dyn");
+
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
+
+            // Although default IsHidden state should be false when opening legacy graph,
+            // if current preferences are set to hide connectors, the connector should be hidden
+            Assert.AreEqual(connectorViewModel.IsHidden, true);
+        }
+
         /// <summary>
         /// Check to see if a connector is visible after pre 2.13 graph open
         /// </summary>


### PR DESCRIPTION
### Purpose

Per DYN-6218, Turning off "Show Connectors" doesn't keep them off when file is reopened, update logic to default connector visibility after graph open to include the current setting.

![DefaultConnectorVisibility](https://github.com/user-attachments/assets/22c9ccf1-36aa-4f5e-af97-1ae93c40ca0e)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Turning off "Show Connectors" doesn't keep them off when file is reopened, update logic to default connector visibility after graph open to include the current setting.

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
