### PR TITLE
DYN-7442 Search Nodes with Special Characters

### DIFF
--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -2256,7 +2256,7 @@ Dynamo.Selection.ISelectable.IsSelected.set -> void
 Dynamo.Selection.ISelectable.Select() -> void
 Dynamo.Updates.BinaryVersion
 Dynamo.Utilities.LuceneCustomAnalyzer
-Dynamo.Utilities.LuceneCustomAnalyzer.LuceneCustomAnalyzer(Lucene.Net.Util.LuceneVersion matchVersion) -> void
+Dynamo.Utilities.LuceneCustomAnalyzer.LuceneCustomAnalyzer(Lucene.Net.Util.LuceneVersion matchVersion, string language) -> void
 Dynamo.Visualization.DefaultRenderPackage
 Dynamo.Visualization.DefaultRenderPackage.AddLineStripVertex(double x, double y, double z) -> void
 Dynamo.Visualization.DefaultRenderPackage.AddLineStripVertexColor(byte red, byte green, byte blue, byte alpha) -> void

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -552,34 +552,7 @@ namespace Dynamo.Utilities
         /// <returns></returns>
         internal Analyzer CreateAnalyzerByLanguage(string language)
         {
-            switch (language)
-            {
-                case "en-US":
-                    return new LuceneCustomAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "cs-CZ":
-                    return new CzechAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "de-DE":
-                    return new GermanAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "es-ES":
-                    return new SpanishAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "fr-FR":
-                    return new FrenchAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "it-IT":
-                    return new ItalianAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "ja-JP":
-                case "ko-KR":
-                case "zh-CN":
-                case "zh-TW":
-                    return new CJKAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "pl-PL":
-                    return new LuceneCustomAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "pt-BR":
-                    return new BrazilianAnalyzer(LuceneConfig.LuceneNetVersion);
-                case "ru-RU":
-                    return new RussianAnalyzer(LuceneConfig.LuceneNetVersion);
-                default:
-                    return new LuceneCustomAnalyzer(LuceneConfig.LuceneNetVersion);
-            }
+            return new LuceneCustomAnalyzer(LuceneConfig.LuceneNetVersion, language);
         }
 
         /// <summary>
@@ -663,10 +636,12 @@ namespace Dynamo.Utilities
     public class LuceneCustomAnalyzer : Analyzer
     {
         private readonly LuceneVersion luceneVersion;
+        private readonly string analyzerLanguage;
 
-        public LuceneCustomAnalyzer(LuceneVersion matchVersion)
+        public LuceneCustomAnalyzer(LuceneVersion matchVersion, string language)
         {
             luceneVersion = matchVersion;
+            analyzerLanguage = language ?? "en-US";
         }
 
         protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
@@ -681,10 +656,51 @@ namespace Dynamo.Utilities
             //Lowercase all the text
             tok = new LowerCaseFilter(luceneVersion, tok);
 
+            CharArraySet languageSet = StopAnalyzer.ENGLISH_STOP_WORDS_SET;
+
+
+            switch (analyzerLanguage)
+            {
+                case "cs-CZ":
+                    languageSet = CzechAnalyzer.DefaultStopSet;
+                    break;
+                case "de-DE":
+                    languageSet = GermanAnalyzer.DefaultStopSet;
+                    break;
+                case "es-ES":
+                    languageSet = SpanishAnalyzer.DefaultStopSet;
+                    break;
+                case "fr-FR":
+                    languageSet = FrenchAnalyzer.DefaultStopSet;
+                    break;
+                case "it-IT":
+                    languageSet = ItalianAnalyzer.DefaultStopSet;
+                    break;
+                case "ja-JP":
+                case "ko-KR":
+                case "zh-CN":
+                case "zh-TW":
+                    languageSet = CJKAnalyzer.DefaultStopSet;
+                    break;
+                case "pl-PL":
+                    languageSet = StopAnalyzer.ENGLISH_STOP_WORDS_SET;
+                    break;
+                case "pt-BR":                   
+                    languageSet = BrazilianAnalyzer.DefaultStopSet;
+                    break;
+                case "ru-RU":
+                    languageSet = RussianAnalyzer.DefaultStopSet;
+                    break;
+                default:
+                    languageSet = StopAnalyzer.ENGLISH_STOP_WORDS_SET;
+                    break;
+
+            }
+
             //List of stopwords that will be removed by the StopFilter like "a", "an", "and", "are", "as", "at", "be", "but", "by"
             CharArraySet stopWords = new CharArraySet(luceneVersion, 1, true)
             {
-                StopAnalyzer.ENGLISH_STOP_WORDS_SET,
+                languageSet
             };
 
             tok = new StopFilter(LuceneConfig.LuceneNetVersion, tok, stopWords);


### PR DESCRIPTION
### Purpose

Fixing Search bug that is happening when searching nodes in which the name contain special characters.
When Searching nodes with special characters in the Name when Dynamo is in a different language than English was not getting the expected results, the problem was related to the Analyzer being used. In this fix I'm using the CustomAnalyzer providing the Dynamo language as a parameter, this will allow using the expected character set.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Search bug that is happening when searching nodes in which the name contain special characters.

### Reviewers

@QilongTang 

### FYIs

