### PR TITLE
DYN-7535 Record python engine package information in graphs when using engines served from them

### DIFF
--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -35,6 +35,8 @@ namespace PythonNodeModels
     public abstract class PythonNodeBase : VariableInputNode
     {
         private string engine = string.Empty;
+        private string enginePackageName = string.Empty;
+        private string enginePackageVersion = string.Empty;
 
         // Set the default EngineName value to IronPython2 so that older graphs can show the migration warnings.
         [DefaultValue("IronPython2")]
@@ -58,7 +60,46 @@ namespace PythonNodeModels
                 if (engine != value)
                 {
                     engine = value;
+                    SetEnginePackageInfo(engine);
                     RaisePropertyChanged(nameof(EngineName));
+                }
+            }
+        }
+
+        [JsonProperty("EnginePackageName")]
+        /// <summary>
+        /// Return the package name of the selected python engine, if it was loaded from an extenal package.
+        /// </summary>
+        public string EnginePackageName
+        {
+            get
+            {
+                return enginePackageName;
+            }
+            set
+            {
+                if (enginePackageName != value)
+                {
+                    enginePackageName = value;
+                }
+            }
+        }
+
+        [JsonProperty("EnginePackageVersion")]
+        /// <summary>
+        /// Return the package version of the selected python engine, if it was loaded from an extenal package.
+        /// </summary>
+        public string EnginePackageVersion
+        {
+            get
+            {
+                return enginePackageVersion;
+            }
+            set
+            {
+                if (enginePackageVersion != value)
+                {
+                    enginePackageVersion = value;
                 }
             }
         }
@@ -82,6 +123,16 @@ namespace PythonNodeModels
             {
                 // Use CPython as default
                 engine = PythonEngineManager.CPython3EngineName;
+            }
+            SetEnginePackageInfo(engine);
+        }
+        private void SetEnginePackageInfo(string engine)
+        {
+            var pkgDetails = PythonEngineManager.TryGetPythonEnginePackage(engine);
+            if (pkgDetails != null)
+            {
+                enginePackageName = pkgDetails.Item1;
+                enginePackageVersion = pkgDetails.Item2;
             }
         }
 


### PR DESCRIPTION
### Purpose

The PR adds package information to dynamo graphs consisting of python nodes using the latest engine.
When a python engine is served from a package, the package name and version information is lost, due to which we were unable to display dependency mismatch in workspace references. This PR will preserve package name and version information as part of the python node that uses a python engine served from a package.

Following steps are performed to populate a map of python engine and it's respective package name and version:
- Get all package paths
- Get all dlls/binaries from all package paths
- Use MLC to inspect all binaries found in those paths and select the one whose Assembly and namespace names are same as the `PythonEngine`.
- Based on that assembly inspected by the MLC that has the engine, get the loaded assembly from the AppDomain
- Cast type to PythonEngine to get engine name, and validate if that engine was added to Dynamo.
- Using the path to that binary, get the package path.
- Extract the package name and version and populate the PackageEngineMap with the engine name and package info.
- When Python Node engine is updated, update engine package and version as well.

(Note: I know variable name are a bit vague, will update them as the review goes on)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Record python engine package information in graphs when using engines served from them

### Reviewers

@DynamoDS/dynamo 
