### PR TITLE
[DYN-7362] bugfix: prevent dynamo workspace paste execution when out of focus

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -915,6 +915,11 @@ namespace Dynamo.Controls
 
         private void OnRequestPaste()
         {
+            // When focus is at webview2 component Keyboard.FocusedElement returns null so we interrupt the execution
+            // with an early return
+            var FocuseElement = Keyboard.FocusedElement;
+            if (FocuseElement == null) return;
+
             var clipBoard = dynamoViewModel.Model.ClipBoard;
 
             var locatableModels = clipBoard.Where(item => item is NoteModel || item is NodeModel);

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -239,7 +239,6 @@ namespace Dynamo.LibraryViewExtensionWebView2
         /// <param name="text">text to be added to clipboard</param>
         internal void OnCopyToClipboard(string text)
         {
-            dynamoViewModel.Model.ClipBoard.Clear();
             Clipboard.SetText(text);
         }
 


### PR DESCRIPTION

![oXo3IwY07c](https://github.com/user-attachments/assets/d8194969-eb37-405b-9d95-c206f960f4ab)


### Purpose

ref.:  [[7362]](https://jira.autodesk.com/browse/DYN-7362)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Include an early return within DynamoView `OnRequestPaste` interrupting the execution when workspace is out of focus.

### Reviewers
@RobertGlobant20 
@QilongTang 

