### PR TITLE
DYN-7521 : fix output value for bool type

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -556,7 +556,9 @@ sys.stdout = DynamoStdOut({0})
                                 }
                             }
                             // Special case for big long values: decode them as BigInteger
-                            if (PyInt.IsIntType(pyObj))
+
+                            var unmarshalled = pyObj.AsManagedObject(typeof(object));
+                            if (unmarshalled is PyInt)
                             {
                                 using (var pyLong = PyInt.AsInt(pyObj))
                                 {
@@ -570,8 +572,8 @@ sys.stdout = DynamoStdOut({0})
                                     }
                                 }
                             }
+
                             // Default handling for other Python objects
-                            var unmarshalled = pyObj.AsManagedObject(typeof(object));
                             if (unmarshalled is PyObject)
                             {
                                 using (unmarshalled as PyObject)


### PR DESCRIPTION
### Purpose
While we were trying to marshal the output value from python into C# we were incorrectly converting a Boolean type into an int. That was happening because the check PyInt.IsIntType also considers internally in python that Bool is a sub-type of Int.

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Reviewers
@twastvedt 
