### PR TITLE
Optimize SearchDefaultNodeAutocompleteCandidates to reduce DynamoSandbox startup time

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -714,7 +714,8 @@ namespace Dynamo.ViewModels
             var queries = new List<string>() { "String", "Number Slider", "Integer Slider", "Number", "Boolean", "Watch", "Watch 3D", "Python Script" };
             foreach (var query in queries)
             {
-                var foundNode = tempSearchViewModel.Search(query).Where(n => n.Name.Equals(query)).FirstOrDefault();
+                var nodeSearchElement = tempSearchViewModel.Model.Entries.FirstOrDefault(n => n.Name == query);
+                var foundNode = tempSearchViewModel.MakeNodeSearchElementVM(nodeSearchElement);
                 if (foundNode != null)
                 {
                     DefaultAutocompleteCandidates.Add(foundNode.Name, foundNode);

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -715,6 +715,10 @@ namespace Dynamo.ViewModels
             foreach (var query in queries)
             {
                 var nodeSearchElement = tempSearchViewModel.Model.Entries.FirstOrDefault(n => n.Name == query);
+                if(nodeSearchElement == null)
+                {
+                    continue;
+                }
                 var foundNode = tempSearchViewModel.MakeNodeSearchElementVM(nodeSearchElement);
                 if (foundNode != null)
                 {


### PR DESCRIPTION
### Purpose

Optimize SearchDefaultNodeAutocompleteCandidates to reduce 0.4-1.5s (on common current hardware) off of startup time. It is possible to use the array directly instead of passing through Lucene search.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Reduce DynamoSandbox startup time.

### Reviewers

@DynamoDS/dynamo

### FYIs

