### PR TITLE
DYN-7535 Record package information in graphs(NodeLibraryDependencies) when using engines loaded from them

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -81,6 +81,7 @@ namespace Dynamo.Graph.Nodes
         private ElementState state;
         private readonly ObservableHashSet<Info> infos = new ObservableHashSet<Info>();
         private string description;
+        private bool isPython = false;
 
 
         ///A flag indicating whether the node has been explicitly frozen.
@@ -360,6 +361,26 @@ namespace Dynamo.Graph.Nodes
                 {
                     isSetAsOutput = value;
                     RaisePropertyChanged(nameof(IsSetAsOutput));
+                }
+            }
+        }
+
+        /// <summary>
+        /// This property defines if the node is a PythonNode
+        /// </summary>
+        [JsonIgnore]
+        internal bool IsPython
+        {
+            get
+            {
+                return isPython;
+            }
+
+            set
+            {
+                if (isPython != value)
+                {
+                    isPython = value;
                 }
             }
         }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -594,6 +594,12 @@ namespace Dynamo.Graph.Workspaces
         internal event Func<AssemblyName, PackageInfo> CollectingNodePackageDependencies;
 
         /// <summary>
+        /// Event that is fired when the workspace is collecting node package dependencies for a python node
+        /// that may be using an python engine provided by a dynamo package.
+        /// </summary>
+        internal event Func<NodeModel, PackageInfo> CollectingPythonEnginePackageDependencies;
+
+        /// <summary>
         /// This handler handles the workspaceModel's request to populate a JSON with view data.
         /// This is used to construct a full workspace for instrumentation.
         /// </summary>
@@ -2173,6 +2179,11 @@ namespace Dynamo.Graph.Workspaces
                     {
                         throw new Exception("There are multiple subscribers to Workspace.CollectingNodePackageDependencies. " +
                             "Only PackageManagerExtension should subscribe to this event.");
+                    }
+                    //in case of python node, return python engine dependency
+                    if (node.IsPython && CollectingPythonEnginePackageDependencies != null)
+                    {
+                        return CollectingPythonEnginePackageDependencies(node);
                     }
                     var assemblyName = GetNameOfAssemblyReferencedByNode(node);
                     if (assemblyName != null)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1174,7 +1174,7 @@ namespace Dynamo.Models
         /// <returns>List of available unique python engines</returns>
         private List<string> GetEngineList()
         {
-            return PythonServices.PythonEngineManager.Instance.AvailableEngines.GroupBy(x => x.Name).Select(g => g.FirstOrDefault().Name).ToList();
+            return PythonServices.PythonEngineManager.Instance.AvailableEngines.Select(e => e.Name).Distinct().ToList();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -879,7 +879,7 @@ namespace Dynamo.ViewModels
 
         private PackageInfo GetPythonEnginePackageDependenciesFromName(NodeModel node)
         {
-            var eng = ((PythonNode)node).EngineName;
+            var eng = ((PythonNodeBase)node).EngineName;
             if (Model.PythonEngineExtensionMap?.TryGetValue(eng, out var relatedExt) ?? false)
             {
                 if (relatedExt != null)

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -89,6 +89,7 @@ namespace PythonNodeModels
         {
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("OUT", Properties.Resources.PythonNodePortDataOutputToolTip)));
             ArgumentLacing = LacingStrategy.Disabled;
+            IsPython = true;
         }
 
         /// <summary>
@@ -99,6 +100,7 @@ namespace PythonNodeModels
         protected PythonNodeBase(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             ArgumentLacing = LacingStrategy.Disabled;
+            IsPython = true;
         }
 
         protected override string GetInputName(int index)


### PR DESCRIPTION
### Purpose

The PR adds package information if a python engine loaded from them is used inside a dynamo graph. Leveraging `NodeLibraryDependencies` which is also used to record nodes which are dependent on packages.

When a python engine is served from a package, the package name and version information is lost, due to which we were unable to display dependency mismatch in workspace references. This PR will preserve package name and version information as part of the NodeLibraryDependencies in the graph.

Implementation Notes:
- A map is added to maintain a list of all extensions and the respective Python engine they added, if any
- A map is added to maintain a list of all extensions and the Dynamo Package that loaded that extension.
- This gives us a way to link a package to python engine, since loading of an extension is decoupled from package loading process, this seemed necessary. Also saves us from assembly mining and reflection.

Possible cases to look into:
- One extension loading multiple python engines? possible? Should we guard against that, only consider the last one?
- Multiple python engines with same name? Update engine names to a more qualified name. (like @pinzart mentioned attaching the PackageName and Version to it.)

**Opening a graph with PythonEngine not loaded in Dynamo:**

![DynamoSandbox_0MUnzezPDs](https://github.com/user-attachments/assets/812bc4ff-f79e-47d4-9900-1a9f9dd7f1e1)


**Opening a graph with PythonEngine loaded in Dynamo, but with a version mis-match:**

https://github.com/user-attachments/assets/40508671-d940-4866-be77-feda4341313b


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Record package information in graphs(NodeLibraryDependencies) when using engines loaded from them

### Reviewers

@DynamoDS/dynamo 
