### PR TITLE
DYN-7332: improvements after comments

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml.cs
@@ -94,6 +94,22 @@ namespace Dynamo.Nodes
         private void OnPinRightMouseButtonDown(object sender, MouseButtonEventArgs e)
         {
             ViewModel.IsHoveredOver = true;
+
+            if (!ViewModel.Model.IsSelected)
+            {
+                if (!Keyboard.IsKeyDown(Key.LeftShift) && !Keyboard.IsKeyDown(Key.RightShift))
+                {
+                    DynamoSelection.Instance.ClearSelection();
+                }
+                DynamoSelection.Instance.Selection.AddUnique(ViewModel.Model);
+            }
+            else
+            {
+                if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+                {
+                    DynamoSelection.Instance.Selection.Remove(ViewModel.Model);
+                }
+            }
         }
 
         private void OnPinRightMouseButtonUp(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
 ### Purpose

PR to address [DYN-7332](https://jira.autodesk.com/browse/DYN-7332) and [this Slack thread](https://autodesk.slack.com/archives/CPJ5UQW0Z/p1728400702047819) .

- Pins are now automatically added to a group when created, if both the start and end nodes are in the same group.
- Pins are selected when right-clicked, making it easier to interact with them.
- The "Remove from Group" option is now updated correctly, so it becomes greyed out when the pin is no longer in a group, without needing to deselect and reselect the pin.

![DYN-7332-After_comments](https://github.com/user-attachments/assets/9283c37c-1146-4a81-bbd0-1d11d60240bb)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Pins can now be added or removed from groups.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@Amoursol 