### PR TITLE
DYN-7535 Record python engine package information in graphs when using engines served from them

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1223,6 +1223,20 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        /// The method returns the assembly name from which the node originated.
+        /// </summary>
+        /// <returns>Assembly Name</returns>
+        internal virtual AssemblyName GetNameOfAssemblyReferencedByNode()
+        {
+            AssemblyName assemblyName = null;
+            
+            var assembly = this.GetType().Assembly;
+            assemblyName = AssemblyName.GetAssemblyName(assembly.Location);
+            
+            return assemblyName;
+        }
+
+        /// <summary>
         /// Here we try to find the correct port names and tooltips.
         /// ideally we'd use the runtime information to correctly update or localize
         /// the port info, if we can't find it for any of the ports of the current node we fallback to the deserialized data

--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 using Dynamo.Engine;
 using Dynamo.Engine.CodeGeneration;
@@ -74,6 +75,23 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
             {
                 return base.GetAstIdentifierForOutputIndex(outputIndex); 
             }
+        }
+
+        /// <summary>
+        /// The method returns the assembly name from which the node originated.
+        /// </summary>
+        /// <returns>Assembly Name</returns>
+        internal override AssemblyName GetNameOfAssemblyReferencedByNode()
+        {
+            AssemblyName assemblyName = null;
+
+            var descriptor = this.Controller.Definition;
+            if (descriptor.IsPackageMember)
+            {
+                assemblyName = AssemblyName.GetAssemblyName(descriptor.Assembly);
+            }
+
+            return assemblyName;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2174,7 +2174,7 @@ namespace Dynamo.Graph.Workspaces
                         throw new Exception("There are multiple subscribers to Workspace.CollectingNodePackageDependencies. " +
                             "Only PackageManagerExtension should subscribe to this event.");
                     }
-                    var assemblyName = GetNameOfAssemblyReferencedByNode(node);
+                    var assemblyName = node.GetNameOfAssemblyReferencedByNode();
                     if (assemblyName != null)
                     {
                         return CollectingNodePackageDependencies(assemblyName);

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 using System.Xml.Serialization;
 using Autodesk.DesignScript.Runtime;
@@ -59,8 +60,25 @@ namespace PythonNodeModels
                 {
                     engine = value;
                     RaisePropertyChanged(nameof(EngineName));
-                }
+                }   
             }
+        }
+
+        /// <summary>
+        /// The method returns the assembly name from which the node originated.
+        /// </summary>
+        /// <returns>Assembly Name</returns>
+        internal override AssemblyName GetNameOfAssemblyReferencedByNode()
+        {
+            AssemblyName assemblyName = null;
+
+            var pyEng = PythonEngineManager.Instance.AvailableEngines.Where(x => x.Name.Equals(this.EngineName)).FirstOrDefault();
+            if (pyEng != null)
+            {
+                assemblyName = AssemblyName.GetAssemblyName(pyEng.GetType().Assembly.Location);
+            }
+
+            return assemblyName;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

A leaner approach to record package dependency for a python engine, and trigger workspace dependency.

**Opening a graph with PythonEngine not loaded in Dynamo:**

![DynamoSandbox_0MUnzezPDs](https://github.com/user-attachments/assets/812bc4ff-f79e-47d4-9900-1a9f9dd7f1e1)


**Opening a graph with PythonEngine loaded in Dynamo, but with a version mis-match:**

https://github.com/user-attachments/assets/40508671-d940-4866-be77-feda4341313b

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Record python engine package information in graphs when using engines served from them

### Reviewers

@DynamoDS/dynamo 

### FYIs

@pinzart90 
