### PR TITLE
DYN-7400 : handle host data marshaler dependent on python runtime

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -451,12 +451,11 @@ sys.stdout = DynamoStdOut({0})
         /// Add additional data marshalers to handle host data.
         /// </summary>
         [SupressImportIntoVM]
-        public override void RegisterHostDataMarshalers(object dataMarshaler)
+        internal override void RegisterHostDataMarshalers()
         {
-            DataMarshaler dataMarshalerToUse = dataMarshaler as DataMarshaler;
+            DataMarshaler dataMarshalerToUse = HostDataMarshaler as DataMarshaler;
             dataMarshalerToUse?.RegisterMarshaler((PyObject pyObj) =>
             {
-                IntPtr gs = PythonEngine.AcquireLock();
                 try
                 {
                     using (Py.GIL())
@@ -484,10 +483,6 @@ sys.stdout = DynamoStdOut({0})
                 {
                     DynamoLogger?.Log($"error marshaling python object {pyObj.Handle} {e.Message}");                    
                     return pyObj;
-                }
-                finally
-                {
-                    PythonEngine.ReleaseLock(gs);
                 }
             });
         }

--- a/src/NodeServices/Properties/AssemblyInfo.cs
+++ b/src/NodeServices/Properties/AssemblyInfo.cs
@@ -44,3 +44,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamoApplications")]
 [assembly: InternalsVisibleTo("DynamoUnits")]
 [assembly: InternalsVisibleTo("DSPythonNet3")]
+[assembly: InternalsVisibleTo("DynamoRevitDS")]

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -93,6 +93,14 @@ namespace Dynamo.PythonServices
         public abstract object Evaluate(string code,
                         IList bindingNames,
                         [ArbitraryDimensionArrayImport] IList bindingValues);
+
+        /// <summary>
+        /// Add additional data marshalers to handle host data.
+        /// While some data marshalers are specific to the host application,
+        /// they must be implemented at the Dynamo Core level in order to
+        /// avoid host dependencies on the Python runtime.
+        /// </summary>
+        public virtual void RegisterHostDataMarshalers(object dataMarshaler) { }
     }
 
     /// <summary>

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -68,7 +68,7 @@ namespace Dynamo.PythonServices
         /// This can be implemented differently across various Python engines due to
         /// factors such as differing PythonNet APIs or other specific requirements.
         /// </summary>
-        public object HostDataMarshaler { get; set; }
+        internal object HostDataMarshaler { get; set; }
 
         /// <summary>
         /// Name of the Python engine
@@ -107,7 +107,7 @@ namespace Dynamo.PythonServices
         /// they must be implemented at the Dynamo Core level in order to
         /// avoid host dependencies on the Python runtime.
         /// </summary>
-        public virtual void RegisterHostDataMarshalers(object dataMarshaler) { }
+        internal virtual void RegisterHostDataMarshalers() { }
     }
 
     /// <summary>

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -64,6 +64,13 @@ namespace Dynamo.PythonServices
         }
 
         /// <summary>
+        /// Data marshaler for host data used during the execution of a Python node.
+        /// This can be implemented differently across various Python engines due to
+        /// factors such as differing PythonNet APIs or other specific requirements.
+        /// </summary>
+        public object HostDataMarshaler { get; set; }
+
+        /// <summary>
         /// Name of the Python engine
         /// </summary>
         public abstract string Name


### PR DESCRIPTION
### Purpose
We want to remove dependency on Python.Runtime in D4R ( see [this pr](https://github.com/DynamoDS/DynamoRevit/pull/3102) ) in order to easily handle multiple python engines.
So we need to bring this data marshaler ( which is needed in D4R ) here since it depends on Python.Runtime.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
Added API to allow Python engines to add data marshalers without a direct dependency on Python.Runtime.

### Reviewers
@twastvedt @QilongTang 
