### PR TITLE
DYN-7494 feature: integrated the latest npm packages

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -23,7 +23,7 @@
 
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
       <PropertyGroup>
-          <PackageVersion>1.0.19</PackageVersion>
+          <PackageVersion>1.0.20</PackageVersion>
           <PackageName>SplashScreen</PackageName>
       </PropertyGroup>
       <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">

--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -17,7 +17,7 @@
   
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
       <PropertyGroup>
-          <PackageVersion>1.0.5</PackageVersion>
+          <PackageVersion>1.0.6</PackageVersion>
           <PackageName>LibrarieJS</PackageName>
       </PropertyGroup>
       <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -16,7 +16,7 @@
 
     <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
         <PropertyGroup>
-            <PackageVersion>0.0.29</PackageVersion>
+            <PackageVersion>0.0.31</PackageVersion>
             <PackageName>NotificationCenter</PackageName>
         </PropertyGroup>
         <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">


### PR DESCRIPTION
### Purpose

This PR is integrating the latest versions of librarieJS, NotificationsCenter and SplashScreen as part of [DYN-7494](https://jira.autodesk.com/browse/DYN-7494)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB


### Reviewers

@QilongTang 

