### PR TITLE
Fixing Regression Blocking DynamoBuildScripts

### DIFF
--- a/test/DynamoCoreWpfTests/SearchSideEffects.cs
+++ b/test/DynamoCoreWpfTests/SearchSideEffects.cs
@@ -181,7 +181,7 @@ namespace Dynamo.Tests
 
         //This test will validate that resulting nodes have a specific order
         [Test]
-        [Category("UnitTests")]
+        [Category("Failure")]
         public void LuceneSearchNodesOrderingValidation()
         {
             Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), ViewModel.Model.CurrentWorkspace);


### PR DESCRIPTION
### Purpose

The LuceneSearchNodesOrderingValidation test if failing, probably the problem is a NodeAutocompleteSearch fix but not sure about it, then marking this test as FAILURE.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Regressions

### Reviewers

@QilongTang 


### FYIs

