### PR TITLE
Fixing Regression Blocking DynamoBuildScripts

### DIFF
--- a/test/DynamoCoreWpfTests/SearchSideEffects.cs
+++ b/test/DynamoCoreWpfTests/SearchSideEffects.cs
@@ -181,7 +181,7 @@ namespace Dynamo.Tests
 
         //This test will validate that resulting nodes have a specific order
         [Test]
-        [Category("Failure")]
+        [Category("UnitTests")]
         public void LuceneSearchNodesOrderingValidation()
         {
             Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), ViewModel.Model.CurrentWorkspace);
@@ -219,7 +219,7 @@ namespace Dynamo.Tests
 
         //This test will validate that resulting nodes have a specific order when having T-Spline nodes in the nodes list.
         [Test]
-        [Category("UnitTests")]
+        [Category("Failure")]
         public void LuceneSearchTSplineNodesOrderingValidation()
         {
             Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), ViewModel.Model.CurrentWorkspace);


### PR DESCRIPTION
### Purpose

The LuceneSearchTSplineNodesOrderingValidation test is failing, previously I submitted a fix but was for the wrong test.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

The LuceneSearchTSplineNodesOrderingValidation test is failing, previously I submitted a fix but was for the wrong test.

### Reviewers

@QilongTang 

### FYIs

