### PR TITLE
DYN-7256 dynamo home tab

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -41,7 +41,9 @@
     <SolidColorBrush x:Key="PrimaryCharcoal300Brush" Color="{StaticResource PrimaryCharcoal300}" />
     <SolidColorBrush x:Key="LightGreyBrush" Color="{StaticResource LightGrey}" />
     <SolidColorBrush x:Key="LightMidGreyBrush" Color="{StaticResource LightMidGrey}" />
-    <SolidColorBrush x:Key="LightMidGreyOpacityBrush" Color="{StaticResource LightMidGrey}" Opacity="0.2" />
+    <SolidColorBrush x:Key="LightMidGreyOpacityBrush"
+                     Opacity="0.2"
+                     Color="{StaticResource LightMidGrey}" />
     <SolidColorBrush x:Key="MidGreyBrush" Color="{StaticResource MidGrey}" />
     <SolidColorBrush x:Key="DarkMidGreyBrush" Color="{StaticResource DarkMidGrey}" />
     <SolidColorBrush x:Key="DarkGreyBrush" Color="{StaticResource DarkGrey}" />
@@ -82,8 +84,8 @@
     <SolidColorBrush x:Key="NodeInfoColor" Color="{StaticResource Blue300}" />
     <SolidColorBrush x:Key="NodeWarningColor" Color="{StaticResource YellowOrange500}" />
     <SolidColorBrush x:Key="NodeErrorColor" Color="{StaticResource Red500}" />
-    <SolidColorBrush x:Key="NodePreviewColor" Color="#BBBBBB"/>
-    <SolidColorBrush x:Key="NodeCustomColor" Color="#B385F2"/>
+    <SolidColorBrush x:Key="NodePreviewColor" Color="#BBBBBB" />
+    <SolidColorBrush x:Key="NodeCustomColor" Color="#B385F2" />
 
     <SolidColorBrush x:Key="NodeOptionsButtonBackground" Color="#282828" />
     <SolidColorBrush x:Key="NodeDismissedWarningsGlyphForeground" Color="#4B4B4B" />
@@ -95,24 +97,19 @@
     <SolidColorBrush x:Key="NodeContextMenuBackgroundHighlight" Color="#808080" />
     <SolidColorBrush x:Key="NodeContextMenuSeparatorColor" Color="#AFAFAF" />
 
-    <SolidColorBrush x:Key="NodeSelectionTextColor" Color="#6ac0e7"/>
+    <SolidColorBrush x:Key="NodeSelectionTextColor" Color="#6ac0e7" />
 
     <!--  Node colors in selected state  -->
     <SolidColorBrush x:Key="outerBorderSelection" Color="#4192d9" />
 
-    <!-- NodeLabel colors -->
-    <SolidColorBrush x:Key="stringLabelBackground"
-                     Color="#E0A86F" />
-    <SolidColorBrush x:Key="numberLabelBackground"
-                     Color="#6AC0E7" />
-    <SolidColorBrush x:Key="objectLabelBackground"
-                     Color="#EEEEEE" />
-    <SolidColorBrush x:Key="boolLabelBackground"
-                     Color="#F9F9A5" />
-    <SolidColorBrush x:Key="nullLabelBackground"
-                     Color="#F9F9A5" />
+    <!--  NodeLabel colors  -->
+    <SolidColorBrush x:Key="stringLabelBackground" Color="#E0A86F" />
+    <SolidColorBrush x:Key="numberLabelBackground" Color="#6AC0E7" />
+    <SolidColorBrush x:Key="objectLabelBackground" Color="#EEEEEE" />
+    <SolidColorBrush x:Key="boolLabelBackground" Color="#F9F9A5" />
+    <SolidColorBrush x:Key="nullLabelBackground" Color="#F9F9A5" />
 
-    <!-- Node Autocomplete -->
+    <!--  Node Autocomplete  -->
     <SolidColorBrush x:Key="autocompletionWindow" Color="#535353" />
     <SolidColorBrush x:Key="AutocompletionWindowFontColor" Color="#F5F5F5" />
 
@@ -131,7 +128,7 @@
     <SolidColorBrush x:Key="HighlightedBrush" Color="#424242" />
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="#949494" />
 
-<!--  Extensions Sidebar  -->
+    <!--  Extensions Sidebar  -->
     <SolidColorBrush x:Key="BorderBrushWhite" Color="#FF3F4040" />
     <SolidColorBrush x:Key="FeedbackSectionBackground" Color="#4192D9" />
     <SolidColorBrush x:Key="ExtensionBackgroundColor" Color="#353535" />
@@ -184,7 +181,7 @@
     <!--  Connector  -->
     <SolidColorBrush x:Key="ConnectorHoverStateColor" Color="#808080" />
 
-    <!-- Modal Pattern -->
+    <!--  Modal Pattern  -->
 
     <!--  TextBlock Link  -->
     <SolidColorBrush x:Key="TextBlockLinkForegroundColor" Color="{StaticResource Blue350}" />
@@ -192,10 +189,10 @@
     <!--  TextBlock Link Dark  -->
     <SolidColorBrush x:Key="TextBlockLinkForegroundColorDark" Color="{StaticResource Blue450}" />
 
-    <!--  TextBlock ToolTip color -->
+    <!--  TextBlock ToolTip color  -->
     <SolidColorBrush x:Key="TextBlockToolTipDescriptionColor" Color="{StaticResource DarkerGrey}" />
 
-    <!--  TextEditor brush color -->
+    <!--  TextEditor brush color  -->
     <SolidColorBrush x:Key="TextEditorBrush" Color="#353535" />
     
     <!--  Custom ToolTip border color  -->

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1,39 +1,40 @@
 <Window x:Class="Dynamo.Controls.DynamoView"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore"
         xmlns:controls="clr-namespace:Dynamo.Controls"
-        xmlns:workspaces="clr-namespace:Dynamo.Graph.Workspaces;assembly=DynamoCore"
-        xmlns:ui="clr-namespace:Dynamo.UI"
-        xmlns:uiviews="clr-namespace:Dynamo.UI.Views"
-        xmlns:uictrls="clr-namespace:Dynamo.UI.Controls"
+        xmlns:controls1="clr-namespace:Dynamo.Wpf.Controls"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
         xmlns:service="clr-namespace:Dynamo.Services"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:ui="clr-namespace:Dynamo.UI"
+        xmlns:uictrls="clr-namespace:Dynamo.UI.Controls"
+        xmlns:uiviews="clr-namespace:Dynamo.UI.Views"
         xmlns:viewModels="clr-namespace:Dynamo.ViewModels"
         xmlns:views="clr-namespace:Dynamo.Views"
-        xmlns:controls1="clr-namespace:Dynamo.Wpf.Controls"
-        xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-        xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        d:DataContext="{d:DesignInstance viewModels:DynamoViewModel, IsDesignTimeCreatable=False}"
-        mc:Ignorable="d"
+        xmlns:workspaces="clr-namespace:Dynamo.Graph.Workspaces;assembly=DynamoCore"
         x:Name="_this"
-        Height="768"
         Width="1024"
-        Closing="WindowClosing"
-        Closed="WindowClosed"
-        MinHeight="600"
+        Height="768"
         MinWidth="800"
+        MinHeight="600"
+        d:DataContext="{d:DesignInstance viewModels:DynamoViewModel,
+                                         IsDesignTimeCreatable=False}"
+        Activated="DynamoView_Activated"
         AllowsTransparency="False"
+        Background="#3C3C3C"
+        Closed="WindowClosed"
+        Closing="WindowClosing"
+        Deactivated="DynamoView_Deactivated"
         KeyDown="DynamoView_KeyDown"
         KeyUp="DynamoView_KeyUp"
-        Background="#3C3C3C"
-        SnapsToDevicePixels="True"
         ResizeMode="CanResizeWithGrip"
+        SnapsToDevicePixels="True"
+        Style="{DynamicResource DynamoWindowStyle}"
         UseLayoutRounding="True"
-        Activated="DynamoView_Activated"
-        Deactivated="DynamoView_Deactivated"
-        Style="{DynamicResource DynamoWindowStyle}">
+        mc:Ignorable="d">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -48,210 +49,206 @@
 
     <Window.InputBindings>
 
-        <KeyBinding Key="Tab"
-                    Command="{Binding Path=DataContext.SelectNeighborsCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <KeyBinding Key="Tab" Command="{Binding Path=DataContext.SelectNeighborsCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
 
-        <KeyBinding Key="Delete"
-                    Command="{Binding Path=DataContext.DeleteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <KeyBinding Key="Delete" Command="{Binding Path=DataContext.DeleteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="N"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.NewHomeWorkspaceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.NewHomeWorkspaceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="N"
-                    Modifiers="Control+Shift"
-                    Command="{Binding Path=DataContext.ShowNewFunctionDialogCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ShowNewFunctionDialogCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control+Shift" />
         <KeyBinding Key="R"
-                    Modifiers="Control+Shift"
-                    Command="{Binding Path=DataContext.SaveRecordedCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.SaveRecordedCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control+Shift" />
         <KeyBinding Key="Q"
-                    Modifiers="Control+Shift"
-                    Command="{Binding Path=DataContext.InsertPausePlaybackCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.InsertPausePlaybackCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control+Shift" />
         <KeyBinding Key="L"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.GraphAutoLayoutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.GraphAutoLayoutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="I"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.BackgroundPreviewViewModel.ToggleIsolationModeCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
-        <KeyBinding Key="Tab"
-                    Command="{Binding Path=DataContext.SelectNeighborsCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.BackgroundPreviewViewModel.ToggleIsolationModeCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
+        <KeyBinding Key="Tab" Command="{Binding Path=DataContext.SelectNeighborsCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
 
         <KeyBinding Key="C"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="Z"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.UndoCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.UndoCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="Y"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.RedoCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.RedoCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="A"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.SelectAllCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.SelectAllCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="K"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.UnpinAllPreviewBubblesCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.UnpinAllPreviewBubblesCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="D"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.NodeFromSelectionCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.NodeFromSelectionCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="V"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.PasteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.PasteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
 
         <KeyBinding Key="B"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
 
         <KeyBinding Key="W"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.AddNoteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.AddNoteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="V"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.PasteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.PasteCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="S"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.ShowSaveDialogIfNeededAndSaveResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ShowSaveDialogIfNeededAndSaveResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="S"
-                    Modifiers="Control+Shift"
-                    Command="{Binding Path=DataContext.ShowSaveDialogAndSaveResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ShowSaveDialogAndSaveResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control+Shift" />
         <KeyBinding Key="O"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.ShowOpenDialogAndOpenResultAsyncCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ShowOpenDialogAndOpenResultAsyncCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="T"
-                    Modifiers="Control"
                     Command="{Binding Path=DataContext.ShowOpenTemplateDialogAsyncCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                    CommandParameter="Template"/>
+                    CommandParameter="Template"
+                    Modifiers="Control" />
         <KeyBinding Key="I"
-                    Modifiers="Control+Shift"
-                    Command="{Binding Path=DataContext.ShowInsertDialogAndInsertResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ShowInsertDialogAndInsertResultCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control+Shift" />
         <KeyBinding Key="H"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.HomeCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.HomeCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="Up"
-                    Modifiers="Control+Shift"
-                    Command="{Binding Path=DataContext.ToggleConsoleShowingCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ToggleConsoleShowingCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control+Shift" />
         <KeyBinding Key="F4"
-                    Modifiers="Alt"
-                    Command="{Binding Path=DataContext.ExitCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ExitCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Alt" />
         <KeyBinding Key="D"
-                    Modifiers="Ctrl+Alt"
-                    Command="{Binding Path=DataContext.DumpLibraryToXmlCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.DumpLibraryToXmlCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl+Alt" />
         <KeyBinding Key="G"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.AddAnnotationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.AddAnnotationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="U"
-                    Modifiers="Control"
-                    Command="{Binding Path=DataContext.UngroupAnnotationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.UngroupAnnotationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Control" />
         <KeyBinding Key="Left"
-                    Modifiers="Ctrl+Alt"
+                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                     CommandParameter="Left"
-                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Modifiers="Ctrl+Alt" />
         <KeyBinding Key="Right"
-                    Modifiers="Ctrl+Alt"
+                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                     CommandParameter="Right"
-                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Modifiers="Ctrl+Alt" />
         <KeyBinding Key="Up"
-                    Modifiers="Ctrl+Alt"
+                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                     CommandParameter="Up"
-                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Modifiers="Ctrl+Alt" />
         <KeyBinding Key="Down"
-                    Modifiers="Ctrl+Alt"
+                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                     CommandParameter="Down"
-                    Command="{Binding Path=DataContext.PanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Modifiers="Ctrl+Alt" />
         <KeyBinding Key="OemPlus"
-                    Modifiers="Ctrl"
-                    Command="{Binding Path=DataContext.ZoomInCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ZoomInCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl" />
         <KeyBinding Key="OemMinus"
-                    Modifiers="Ctrl"
-                    Command="{Binding Path=DataContext.ZoomOutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ZoomOutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl" />
         <KeyBinding Key="Add"
-                    Modifiers="Ctrl"
-                    Command="{Binding Path=DataContext.ZoomInCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ZoomInCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl" />
         <KeyBinding Key="Subtract"
-                    Modifiers="Ctrl"
-                    Command="{Binding Path=DataContext.ZoomOutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.ZoomOutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl" />
         <KeyBinding Key="D0"
-                    Modifiers="Ctrl"
-                    Command="{Binding Path=DataContext.FitViewCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.FitViewCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl" />
         <KeyBinding Key="P"
-                    Modifiers="Ctrl"
-                    Command="{Binding Path=DataContext.BackgroundPreviewViewModel.TogglePanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.BackgroundPreviewViewModel.TogglePanCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Ctrl" />
 
         <KeyBinding Key="F5"
-                    Modifiers="Shift"
-                    Command="{Binding Path=DataContext.HomeSpaceViewModel.RunSettingsViewModel.CancelRunCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+                    Command="{Binding Path=DataContext.HomeSpaceViewModel.RunSettingsViewModel.CancelRunCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                    Modifiers="Shift" />
         <KeyBinding Key="F5"
                     Command="{Binding Path=DataContext.HomeSpaceViewModel.RunSettingsViewModel.RunExpressionCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
                     CommandParameter="{Binding Path=DataContext.HomeSpaceViewModel.RunSettingsViewModel.RunInDebug, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
-        <MouseBinding Gesture="Shift+LeftDoubleClick"
-                      Command="{Binding Path=DataContext.HomeSpaceViewModel.ShowInCanvasSearchCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                      CommandParameter="{x:Static viewModels:ShowHideFlags.Show}"/>
-        <KeyBinding Key="F1"
-                    Command="{Binding Path=DataContext.ShowNodeDocumentationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <MouseBinding Command="{Binding Path=DataContext.HomeSpaceViewModel.ShowInCanvasSearchCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                      CommandParameter="{x:Static viewModels:ShowHideFlags.Show}"
+                      Gesture="Shift+LeftDoubleClick" />
+        <KeyBinding Key="F1" Command="{Binding Path=DataContext.ShowNodeDocumentationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
     </Window.InputBindings>
 
     <Grid Name="mainGrid"
           FocusManager.IsFocusScope="True"
           PreviewMouseDown="Window_PreviewMouseDown"
-          PreviewMouseUp="Window_PreviewMouseUp"
-          PreviewMouseLeftButtonUp="Window_PreviewMouseLeftButtonUp">
+          PreviewMouseLeftButtonUp="Window_PreviewMouseLeftButtonUp"
+          PreviewMouseUp="Window_PreviewMouseUp">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="37px" />
             <RowDefinition Height="40px" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Name="consoleRow"
-                           Height="{Binding ConsoleHeight, Mode=TwoWay, Converter={StaticResource ConsoleHeightConverter}}" />
+            <RowDefinition Name="consoleRow" Height="{Binding ConsoleHeight, Mode=TwoWay, Converter={StaticResource ConsoleHeightConverter}}" />
             <RowDefinition Height="48" />
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition MaxWidth="500"
+            <ColumnDefinition Name="LeftExtensionsViewColumn"
                               MinWidth="1"
-                              Name="LeftExtensionsViewColumn">
+                              MaxWidth="500">
                 <ColumnDefinition.Width>
-                    <Binding Path="LibraryWidth"
+                    <Binding Converter="{StaticResource ConsoleHeightConverter}"
                              Mode="TwoWay"
-                             Converter="{StaticResource ConsoleHeightConverter}" />
+                             Path="LibraryWidth" />
                 </ColumnDefinition.Width>
             </ColumnDefinition>
-            <!--MinWidth fix for GridSplitter dragging in frameless window-->
+            <!--  MinWidth fix for GridSplitter dragging in frameless window  -->
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5*" MinWidth="200" Name="CanvasColumn" />
+            <ColumnDefinition Name="CanvasColumn"
+                              Width="5*"
+                              MinWidth="200" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="0"
-                              MinWidth="1"
-                              Name="RightExtensionsViewColumn">
-            </ColumnDefinition>
+            <ColumnDefinition Name="RightExtensionsViewColumn"
+                              Width="0"
+                              MinWidth="1" />
         </Grid.ColumnDefinitions>
 
-        <!--Titlebar-->
-        <Border Grid.Row="0"
+        <!--  Titlebar  -->
+        <Border Name="titleBar"
+                Grid.Row="0"
                 Grid.Column="0"
-                Grid.ColumnSpan="5"
-                Name="titleBar">
+                Grid.ColumnSpan="5">
             <Grid Name="titleBarGrid" VerticalAlignment="Center">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <!--Menu-->
-                <Menu IsMainMenu="True"
-                      Name="menu1"
+                <!--  Menu  -->
+                <Menu Name="menu1"
+                      IsMainMenu="True"
                       Style="{StaticResource MainMenu}">
-                    <!--Accessor key = false. This is to include underscore in header(only for SubMenuItem-->
+                    <!--  Accessor key = false. This is to include underscore in header(only for SubMenuItem  -->
                     <Menu.Resources>
                         <Style x:Key="SubMenuItemOverride"
-                            BasedOn="{StaticResource MenuItemStyle}"
-                            TargetType="{x:Type MenuItem}">
+                               BasedOn="{StaticResource MenuItemStyle}"
+                               TargetType="{x:Type MenuItem}">
 
                             <Style.Resources>
                                 <!--  SubmenuItem  -->
-                                <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}"
-                                                          TargetType="MenuItem">
+                                <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="MenuItem">
 
                                     <Border Name="Border"
-                                            Height="25" Background="Transparent">
+                                            Height="25"
+                                            Background="Transparent">
                                         <Grid MinWidth="200">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto" />
@@ -259,525 +256,490 @@
                                             </Grid.ColumnDefinitions>
                                             <ContentPresenter Name="HeaderHost"
                                                               Grid.Column="0"
-                                                              TextBlock.FontSize="14px"
-                                                              TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
-                                                              TextBlock.Foreground="{StaticResource NormalForegroundBrush}"
                                                               Margin="5,0,0,0"
                                                               HorizontalAlignment="Stretch"
                                                               VerticalAlignment="Center"
                                                               ContentSource="Header"
-                                                              RecognizesAccessKey="False" />
+                                                              RecognizesAccessKey="False"
+                                                              TextBlock.FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                              TextBlock.FontSize="14px"
+                                                              TextBlock.Foreground="{StaticResource NormalForegroundBrush}" />
                                         </Grid>
                                     </Border>
                                     <ControlTemplate.Triggers>
-                                        <Trigger Property="IsHighlighted"
-                                                           Value="true">
-                                            <Setter TargetName="Border"
-                                                              Property="Background"
-                                                              Value="{StaticResource HighlightedBrush}" />
-                                            <Setter TargetName="HeaderHost"
-                                                               Property="TextBlock.Foreground"
-                                                               Value="{StaticResource ActiveForegroundBrush}" />
-                                            <Setter TargetName="Border"
-                                                                Property="BorderBrush"
-                                                                Value="Transparent" />
+                                        <Trigger Property="IsHighlighted" Value="true">
+                                            <Setter TargetName="Border" Property="Background" Value="{StaticResource HighlightedBrush}" />
+                                            <Setter TargetName="HeaderHost" Property="TextBlock.Foreground" Value="{StaticResource ActiveForegroundBrush}" />
+                                            <Setter TargetName="Border" Property="BorderBrush" Value="Transparent" />
                                         </Trigger>
-                                        <Trigger Property="IsEnabled"
-                                                                Value="false">
-                                            <Setter Property="Foreground"
-                                                                 Value="{StaticResource DisabledForegroundBrush}" />
+                                        <Trigger Property="IsEnabled" Value="false">
+                                            <Setter Property="Foreground" Value="{StaticResource DisabledForegroundBrush}" />
                                         </Trigger>
                                     </ControlTemplate.Triggers>
                                 </ControlTemplate>
                             </Style.Resources>
                             <Style.Triggers>
-                                <Trigger Property="Role"
-                                    Value="SubmenuItem">
-                                    <Setter Property="Template"
-                                      Value="{StaticResource {x:Static MenuItem.SubmenuItemTemplateKey}}" />
+                                <Trigger Property="Role" Value="SubmenuItem">
+                                    <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuItemTemplateKey}}" />
                                 </Trigger>
                             </Style.Triggers>
                         </Style>
                     </Menu.Resources>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewDynamoMenu}"
-                              Name="dynamoMenu"
-                              Focusable="False">
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewDynamoMenuAbout}"
-                                  Command="{Binding ShowAboutWindowCommand}"/>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewSettingMenuShowDataReportingDialog}"
-                                  Name="ToggleIsAnalyticsReportingApprovedCommand"
-                                  Command="{Binding Path=ToggleIsAnalyticsReportingApprovedCommand, Source={x:Static service:UsageReportingManager.Instance} }"
-                                  CommandParameter="{Binding  RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Visibility="{Binding HideReportOptions, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}">
-                        </MenuItem>
-                            <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewDynamoMenuPreferences}"
+                    <MenuItem Name="dynamoMenu"
+                              Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewDynamoMenu}">
+                        <MenuItem Command="{Binding ShowAboutWindowCommand}" Header="{x:Static p:Resources.DynamoViewDynamoMenuAbout}" />
+                        <MenuItem Name="ToggleIsAnalyticsReportingApprovedCommand"
+                                  Command="{Binding Path=ToggleIsAnalyticsReportingApprovedCommand, Source={x:Static service:UsageReportingManager.Instance}}"
+                                  CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
+                                  Header="{x:Static p:Resources.DynamoViewSettingMenuShowDataReportingDialog}"
+                                  Visibility="{Binding HideReportOptions, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+                        <Separator />
+                        <MenuItem Name="preferencesOption"
                                   Click="OnPreferencesWindowClick"
-                                  Name="preferencesOption"/>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewDynamoMenuExit}"
+                                  Header="{x:Static p:Resources.DynamoViewDynamoMenuPreferences}" />
+                        <MenuItem Name="exit"
                                   Command="{Binding ExitCommand}"
-                                  Name="exit"
-                                  InputGestureText="Alt + F4"/>
+                                  Header="{x:Static p:Resources.DynamoViewDynamoMenuExit}"
+                                  InputGestureText="Alt + F4" />
                     </MenuItem>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenu}"
-                              Name="fileMenu"
-                              Focusable="False">
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuNew}"
-                                  Name="newMenu">
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuNewHomeWorkSpace}"
+                    <MenuItem Name="fileMenu"
+                              Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewFileMenu}">
+                        <MenuItem Name="newMenu" Header="{x:Static p:Resources.DynamoViewFileMenuNew}">
+                            <MenuItem Name="newHomeWorkspace"
                                       Command="{Binding NewHomeWorkspaceCommand}"
-                                      Name="newHomeWorkspace"
-                                      InputGestureText="Ctrl + N">
-                            </MenuItem>
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuNewCustomNode}"
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuNewHomeWorkSpace}"
+                                      InputGestureText="Ctrl + N" />
+                            <MenuItem Name="newFuncButton"
                                       Command="{Binding ShowNewFunctionDialogCommand}"
-                                      Name="newFuncButton"
-                                      InputGestureText="Ctrl + Shift + N">
-                            </MenuItem>
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuNewCustomNode}"
+                                      InputGestureText="Ctrl + Shift + N" />
                         </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuOpen}"
-                                  Name="openButton">
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuOpenFile}"
-                                      Name="openFileMenuItem"
+                        <MenuItem Name="openButton" Header="{x:Static p:Resources.DynamoViewFileMenuOpen}">
+                            <MenuItem Name="openFileMenuItem"
                                       Command="{Binding ShowOpenDialogAndOpenResultCommand}"
-                                      InputGestureText="Ctrl + O">
-                            </MenuItem>
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuOpenTemplate}"
-                                      Name="openTemplateMenuItem"
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuOpenFile}"
+                                      InputGestureText="Ctrl + O" />
+                            <MenuItem Name="openTemplateMenuItem"
                                       Command="{Binding ShowOpenTemplateDialogCommand}"
                                       CommandParameter="Template"
-                                      InputGestureText="Ctrl + T">
-                            </MenuItem>
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuOpenTemplate}"
+                                      InputGestureText="Ctrl + T" />
                         </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuInsert}"
+                        <MenuItem Name="insertButton"
                                   Command="{Binding ShowInsertDialogAndInsertResultCommand}"
-                                  Name="insertButton"
-                                  InputGestureText="Ctrl + Shift + I">
-                        </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuRecentFiles}"
-                                  ItemsSource="{Binding RecentFiles}">
-                            <MenuItem.ItemContainerStyle>   
+                                  Header="{x:Static p:Resources.DynamoViewFileMenuInsert}"
+                                  InputGestureText="Ctrl + Shift + I" />
+                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuRecentFiles}" ItemsSource="{Binding RecentFiles}">
+                            <MenuItem.ItemContainerStyle>
                                 <Style TargetType="MenuItem">
-                                    <Setter Property="Header"
-                                            Value="{Binding Converter={StaticResource FilePathDisplayConverter}}" />
-                                    <Setter Property="Command"
-                                            Value="{Binding DataContext.OpenRecentCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type MenuItem}, AncestorLevel=1}}" />
-                                    <Setter Property="CommandParameter"
-                                            Value="{Binding}" />
+                                    <Setter Property="Header" Value="{Binding Converter={StaticResource FilePathDisplayConverter}}" />
+                                    <Setter Property="Command" Value="{Binding DataContext.OpenRecentCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type MenuItem}, AncestorLevel=1}}" />
+                                    <Setter Property="CommandParameter" Value="{Binding}" />
                                 </Style>
                             </MenuItem.ItemContainerStyle>
                         </MenuItem>
                         <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuSave}"
+                        <MenuItem Name="saveThisButton"
                                   Command="{Binding ShowSaveDialogIfNeededAndSaveResultCommand}"
-                                  Name="saveThisButton"
+                                  Header="{x:Static p:Resources.DynamoViewFileMenuSave}"
                                   InputGestureText="Ctrl + S"
-                                  IsEnabled="False">
-                        </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuSaveAs}"
+                                  IsEnabled="False" />
+                        <MenuItem Name="saveButton"
                                   Command="{Binding ShowSaveDialogAndSaveResultCommand}"
-                                  Name="saveButton"
+                                  Header="{x:Static p:Resources.DynamoViewFileMenuSaveAs}"
                                   InputGestureText="Ctrl + Shift + S"
-                                  IsEnabled="False">
-                        </MenuItem>
+                                  IsEnabled="False" />
                         <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuImport}"
+                        <MenuItem Name="importLibrary"
                                   Command="{Binding Path=DataContext.ImportLibraryCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Name="importLibrary" />
+                                  Header="{x:Static p:Resources.DynamoViewFileMenuImport}" />
                         <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuExport}"
-                                  Name="exportMenu"
-                                  Tag="NoDownArrow"
-                                  IsEnabled="False">
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuExportAsImage}"
-                                      Command="{Binding ValidateWorkSpaceBeforeToExportAsImageCommand }"
-                                      Name="saveImage">
-                            </MenuItem>
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuExport3DAsImage}"
-                                      Command="{Binding ValidateWorkSpaceBeforeToExportAsImageCommand }"
+                        <MenuItem Name="exportMenu"
+                                  Header="{x:Static p:Resources.DynamoViewFileMenuExport}"
+                                  IsEnabled="False"
+                                  Tag="NoDownArrow">
+                            <MenuItem Name="saveImage"
+                                      Command="{Binding ValidateWorkSpaceBeforeToExportAsImageCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuExportAsImage}" />
+                            <MenuItem Name="save3DImage"
+                                      Command="{Binding ValidateWorkSpaceBeforeToExportAsImageCommand}"
                                       CommandParameter="{x:Static p:Resources.ScreenShotFrom3DParameter}"
-                                      Name="save3DImage">
-                            </MenuItem>
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewFileMenuExportToSTL}"
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuExport3DAsImage}" />
+                            <MenuItem Name="saveSTL"
                                       Command="{Binding ExportToSTLCommand}"
-                                      Name="saveSTL">
-                            </MenuItem>
+                                      Header="{x:Static p:Resources.DynamoViewFileMenuExportToSTL}" />
                         </MenuItem>
                     </MenuItem>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenu}"
-                              Name="editMenu"
-                              Focusable="False">
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuUndo}"
+                    <MenuItem Name="editMenu"
+                              Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewEditMenu}">
+                        <MenuItem Name="undo"
                                   Command="{Binding UndoCommand}"
-                                  Name="undo"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuUndo}"
                                   InputGestureText="Ctrl + Z" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuRedo}"
+                        <MenuItem Name="redo"
                                   Command="{Binding RedoCommand}"
-                                  Name="redo"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuRedo}"
                                   InputGestureText="Ctrl + Y" />
                         <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuCopy}"
+                        <MenuItem Name="copy"
                                   Command="{Binding CopyCommand}"
-                                  Name="copy"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuCopy}"
                                   InputGestureText="Ctrl + C" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuPaste}"
+                        <MenuItem Name="paste"
                                   Command="{Binding PasteCommand}"
-                                  Name="paste"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuPaste}"
                                   InputGestureText="Ctrl + V" />
                         <Separator />
 
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuCreateNote}"
+                        <MenuItem Name="noteMenuItem"
                                   Command="{Binding AddNoteCommand}"
-                                  Name="noteMenuItem"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuCreateNote}"
                                   InputGestureText="Ctrl + W" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuCreateGroup}"
+                        <MenuItem Name="noteMenuAnnotation"
                                   Command="{Binding AddAnnotationCommand}"
-                                  Name="noteMenuAnnotation"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuCreateGroup}"
                                   InputGestureText="Ctrl + G" />
-                        <MenuItem Header="{x:Static p:Resources.GroupContextMenuUngroup}"
+                        <MenuItem Name="ungroupGroup"
                                   Command="{Binding UngroupAnnotationCommand}"
-                                  Name="ungroupGroup"
+                                  Header="{x:Static p:Resources.GroupContextMenuUngroup}"
                                   InputGestureText="Ctrl + U" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuCreateCustomNode}"
+                        <MenuItem Name="nodeFromSelection"
                                   Command="{Binding Path=NodeFromSelectionCommand}"
-                                  Name="nodeFromSelection"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuCreateCustomNode}"
                                   InputGestureText="Ctrl + D" />
 
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuSelectAll}"
+                        <MenuItem Name="selectAll"
                                   Command="{Binding SelectAllCommand}"
-                                  Name="selectAll"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuSelectAll}"
                                   InputGestureText="Ctrl + A" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuUnpinAllPreviewBubbles}"
+                        <MenuItem Name="unpinPB"
                                   Command="{Binding UnpinAllPreviewBubblesCommand}"
-                                  Name="unpinPB"
-                                  InputGestureText="Ctrl + K"/>                        
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuDeleteSelected}"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuUnpinAllPreviewBubbles}"
+                                  InputGestureText="Ctrl + K" />
+                        <MenuItem Name="deleteSelected"
                                   Command="{Binding DeleteCommand}"
-                                  Name="deleteSelected"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuDeleteSelected}"
                                   InputGestureText="Delete" />
                         <!--<MenuItem Focusable="False" Header="{x:Static p:Resources.DynamoViewEditMenuSelectNeighbours}" Command="{Binding Path=ExpandSelectionCommand}"  Name="expandSelect" InputGestureText="Tab"/>-->
-                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignSelection}"
-                                   Name="Align">
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="HorizontalCenter">
+                        <MenuItem Name="Align" Header="{x:Static p:Resources.DynamoViewEditMenuAlignSelection}">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="HorizontalCenter">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_x_average.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignXAverage}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_x_average.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignXAverage}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="HorizontalLeft">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="HorizontalLeft">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_left.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignLeft}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_left.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignLeft}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="HorizontalRight">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="HorizontalRight">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_right.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignRight}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_right.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignRight}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="VerticalCenter">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="VerticalCenter">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_y_average.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignYAverage}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_y_average.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignYAverage}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="VerticalTop">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="VerticalTop">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_top.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignTop}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_top.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignTop}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="VerticalBottom">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="VerticalBottom">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_bottom.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlighBottom}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_bottom.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlighBottom}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="VerticalDistribute">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="VerticalDistribute">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_y_distribute.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignYDistribute}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_y_distribute.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignYDistribute}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem Command="{Binding AlignSelectedCommand}"
-                                  CommandParameter="HorizontalDistribute">
+                            <MenuItem Command="{Binding AlignSelectedCommand}" CommandParameter="HorizontalDistribute">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
-                                        <Image Width="14" Height="14" Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_X_distribute.png" />
-                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignXDistribute}" Foreground="White"/>
+                                        <Image Width="14"
+                                               Height="14"
+                                               Source="/DynamoCoreWpf;component/UI/Images/Alignment/align_X_distribute.png" />
+                                        <Label Content="{x:Static p:Resources.DynamoViewEditMenuAlignXDistribute}" Foreground="White" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
                         </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.UpdateAllPythonEngineMainMenuHeader}"
-                              Name="PythonEngineMenu" />
+                        <MenuItem Name="PythonEngineMenu" Header="{x:Static p:Resources.UpdateAllPythonEngineMainMenuHeader}" />
                         <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewEditMenuCleanupLayout}"
+                        <MenuItem Name="GraphAutoLayout"
                                   Command="{Binding GraphAutoLayoutCommand}"
-                                  Name="GraphAutoLayout"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuCleanupLayout}"
                                   InputGestureText="Ctrl + L" />
                     </MenuItem>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenu}"
-                              Name="viewMenu"
-                              Focusable="False">
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuZoom}"
-                                  Name="zoomMenu">
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewViewMenuZoomIn}"
-                                       Command="{Binding ZoomInCommand}"
-                                       InputGestureText="Ctrl + =" />
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewViewMenuZoomOut}"
-                                       Command="{Binding ZoomOutCommand}"
-                                       InputGestureText="Ctrl + -" />
+                    <MenuItem Name="viewMenu"
+                              Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewViewMenu}">
+                        <MenuItem Name="zoomMenu" Header="{x:Static p:Resources.DynamoViewViewMenuZoom}">
+                            <MenuItem Command="{Binding ZoomInCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuZoomIn}"
+                                      InputGestureText="Ctrl + =" />
+                            <MenuItem Command="{Binding ZoomOutCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuZoomOut}"
+                                      InputGestureText="Ctrl + -" />
                         </MenuItem>
 
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuPan}"
-                                  Name="panMenu">
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewViewMenuPanLeft}"
-                                       Command="{Binding PanCommand}"
-                                       CommandParameter="Left"
-                                       InputGestureText="Ctrl + Alt + Left" />
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewViewMenuPanRight}"
-                                       Command="{Binding PanCommand}"
-                                       CommandParameter="Right"
-                                       InputGestureText="Ctrl + Alt + Right" />
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewViewMenuPanUp}"
-                                       Command="{Binding PanCommand}"
-                                       CommandParameter="Up"
-                                       InputGestureText="Ctrl + Alt + Up" />
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewViewMenuPanDown}"
-                                       Command="{Binding PanCommand}"
-                                       CommandParameter="Down"
-                                       InputGestureText="Ctrl + Alt + Down" />
+                        <MenuItem Name="panMenu" Header="{x:Static p:Resources.DynamoViewViewMenuPan}">
+                            <MenuItem Command="{Binding PanCommand}"
+                                      CommandParameter="Left"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuPanLeft}"
+                                      InputGestureText="Ctrl + Alt + Left" />
+                            <MenuItem Command="{Binding PanCommand}"
+                                      CommandParameter="Right"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuPanRight}"
+                                      InputGestureText="Ctrl + Alt + Right" />
+                            <MenuItem Command="{Binding PanCommand}"
+                                      CommandParameter="Up"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuPanUp}"
+                                      InputGestureText="Ctrl + Alt + Up" />
+                            <MenuItem Command="{Binding PanCommand}"
+                                      CommandParameter="Down"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuPanDown}"
+                                      InputGestureText="Ctrl + Alt + Down" />
                         </MenuItem>
 
-                        <MenuItem IsCheckable="True"
-                                  IsChecked="{Binding Path=ConsoleHeight, Converter={StaticResource ConsoleHeightToBoolConverter},Mode=TwoWay}"
+                        <MenuItem Command="{Binding ToggleConsoleShowingCommand}"
                                   Header="{x:Static p:Resources.DynamoViewViewMenuShowConsole}"
-                                  Command="{Binding ToggleConsoleShowingCommand}"
-                                  InputGestureText="Ctrl + Shift + Up" />
+                                  InputGestureText="Ctrl + Shift + Up"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding Path=ConsoleHeight, Converter={StaticResource ConsoleHeightToBoolConverter}, Mode=TwoWay}" />
 
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuConnector}"
-                                  Name="connectorMenu">
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuShowConnectors}"
+                        <MenuItem Name="connectorMenu" Header="{x:Static p:Resources.DynamoViewViewMenuConnector}">
+                            <MenuItem Name="ShowHideConnectorsMenuItem"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuShowConnectors}"
                                       IsCheckable="True"
-                                      Name="ShowHideConnectorsMenuItem"
-                                      IsChecked="{Binding Path=IsShowingConnectors}"/>
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuConnectorShowTooltip}"
+                                      IsChecked="{Binding Path=IsShowingConnectors}" />
+                            <MenuItem Name="ShowHideConnectorTooltipMenuItem"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuConnectorShowTooltip}"
                                       IsCheckable="True"
-                                      Name="ShowHideConnectorTooltipMenuItem"
-                                      IsChecked="{Binding Path=IsShowingConnectorTooltip}"/>
+                                      IsChecked="{Binding Path=IsShowingConnectorTooltip}" />
                         </MenuItem>
 
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenu3DPreview}"
-                                  Name="background3dMenu">
+                        <MenuItem Name="background3dMenu" Header="{x:Static p:Resources.DynamoViewViewMenu3DPreview}">
 
                             <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuAvailablePreviews}" ItemsSource="{Binding Watch3DViewModels}">
                                 <MenuItem.ItemContainerStyle>
                                     <Style TargetType="MenuItem">
-                                        <Setter Property="Header" Value="{Binding Name}"/>
-                                        <Setter Property="IsCheckable" Value="True"/>
-                                        <Setter Property="IsChecked" Value="{Binding Active}"/>
-                                        <Setter Property="IsEnabled" Value="{Binding CanBeActivated}"/>
+                                        <Setter Property="Header" Value="{Binding Name}" />
+                                        <Setter Property="IsCheckable" Value="True" />
+                                        <Setter Property="IsChecked" Value="{Binding Active}" />
+                                        <Setter Property="IsEnabled" Value="{Binding CanBeActivated}" />
                                     </Style>
                                 </MenuItem.ItemContainerStyle>
                             </MenuItem>
 
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuShowGrid}"
-                                      IsEnabled="True"
+                            <MenuItem Command="{Binding ToggleBackgroundGridVisibilityCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuShowGrid}"
                                       IsChecked="{Binding PreferenceSettings.IsBackgroundGridVisible}"
-                                      Command="{Binding ToggleBackgroundGridVisibilityCommand}" />
+                                      IsEnabled="True" />
 
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewViewMenuPreviewNavigate}"
-                                      IsEnabled="{Binding BackgroundPreviewActive}"
-                                      IsChecked="{Binding Path=BackgroundPreviewViewModel.CanNavigateBackground}"
+                            <MenuItem Command="{Binding Path=BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewViewMenuPreviewNavigate}"
                                       InputGestureText="Ctrl + B"
-                                      Command="{Binding Path=BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand}" />
+                                      IsChecked="{Binding Path=BackgroundPreviewViewModel.CanNavigateBackground}"
+                                      IsEnabled="{Binding BackgroundPreviewActive}" />
                         </MenuItem>
                     </MenuItem>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewPackageMenu}"
-                              Name="PackageManagerMenu"
+                    <MenuItem Name="PackageManagerMenu"
                               Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewPackageMenu}"
                               IsEnabled="True">
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewPackageMenuPublishNodes}"
+                        <MenuItem Name="publishSelected"
                                   Command="{Binding Path=DataContext.PublishSelectedNodesCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Name="publishSelected" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewPackageMenuPublishWorkspace}"
+                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPublishNodes}" />
+                        <MenuItem Name="publishCurrent"
                                   Command="{Binding Path=DataContext.PublishCurrentWorkspaceCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Name="publishCurrent" />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewPackageMenuPackageManager}"
+                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPublishWorkspace}" />
+                        <MenuItem Name="showPM"
                                   Command="{Binding Path=DataContext.ShowPackageManagerCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}"
-                                  Name="showPM" />
+                                  Header="{x:Static p:Resources.DynamoViewPackageMenuPackageManager}" />
                     </MenuItem>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenu}"
-                              Name="HelpMenu"
-                              Focusable="False">
-                        <MenuItem Header="{x:Static p:Resources.InteractiveGuides}"
-                                  x:Name="InteractiveGuidesMenuItem"
-                                  Command="{Binding DisplayInteractiveGuideCommand}">
-                            <MenuItem x:Name="GetStartedMenuItem"
-                                      Header="{x:Static p:Resources.GetStartedGuide}"
-                                      Click="GetStartedMenuItem_Click">
-                            </MenuItem>
-                            <MenuItem x:Name="OnBoardingMenuGuide"
-                                      Header="{x:Static p:Resources.OnboardingGuide}"
-                                      Command="{Binding GettingStartedGuideCommand}">
-                            </MenuItem>
-                            <MenuItem x:Name="PackagesMenuGuide"
-                                      Header="{x:Static p:Resources.PackagesGuide}"
-                                      Click="PackagesMenuGuide_Click">
-                            </MenuItem>                            
-                        </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHepMenuSamples}"
-                                  Name="SamplesMenu"
-                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunEnabled}">
-                        </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpDictionary}"
-                                  Name="ViewDictionary"
-                                  Command="{Binding GoToDictionaryCommand}">
-                        </MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuGotoWebsite}"
-                                  Command="{Binding GoToWebsiteCommand}"
-                                  Name="ViewDynamoWebsite"/>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuGotoRepo}"
-                                  Command="{Binding GoToSourceCodeCommand}"
-                                  Name="ViewDynamoRepo"/>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuGotoWiki}"
-                                  Command="{Binding GoToWikiCommand}"
-                                  Name="ViewDynamoWiki"/>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuDisplayStartPage}"
-                                  Command="{Binding DisplayStartPageCommand}"
-                                  Name="DisplayStartupPage"/>
-                        <Separator />
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenuReportBug}"
-                                  Command="{Binding ReportABugCommand}"
-                                  Name="ReportBug"/>
-                    </MenuItem>
-
-                    <!--The menu will be enabled when at least one MenuItem is added-->
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewExtensionsMenu}"
-                              Style="{StaticResource ExtensionsStyle}"
-                              Name="ExtensionsMenu"
+                    <MenuItem Name="HelpMenu"
                               Focusable="False"
-                              IsEnabled="True">
+                              Header="{x:Static p:Resources.DynamoViewHelpMenu}">
+                        <MenuItem x:Name="InteractiveGuidesMenuItem"
+                                  Command="{Binding DisplayInteractiveGuideCommand}"
+                                  Header="{x:Static p:Resources.InteractiveGuides}">
+                            <MenuItem x:Name="GetStartedMenuItem"
+                                      Click="GetStartedMenuItem_Click"
+                                      Header="{x:Static p:Resources.GetStartedGuide}" />
+                            <MenuItem x:Name="OnBoardingMenuGuide"
+                                      Command="{Binding GettingStartedGuideCommand}"
+                                      Header="{x:Static p:Resources.OnboardingGuide}" />
+                            <MenuItem x:Name="PackagesMenuGuide"
+                                      Click="PackagesMenuGuide_Click"
+                                      Header="{x:Static p:Resources.PackagesGuide}" />
+                        </MenuItem>
+                        <MenuItem Name="SamplesMenu"
+                                  Header="{x:Static p:Resources.DynamoViewHepMenuSamples}"
+                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunEnabled}" />
+                        <MenuItem Name="ViewDictionary"
+                                  Command="{Binding GoToDictionaryCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewHelpDictionary}" />
+                        <MenuItem Name="ViewDynamoWebsite"
+                                  Command="{Binding GoToWebsiteCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewHelpMenuGotoWebsite}" />
+                        <MenuItem Name="ViewDynamoRepo"
+                                  Command="{Binding GoToSourceCodeCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewHelpMenuGotoRepo}" />
+                        <MenuItem Name="ViewDynamoWiki"
+                                  Command="{Binding GoToWikiCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewHelpMenuGotoWiki}" />
+                        <MenuItem Name="DisplayStartupPage"
+                                  Command="{Binding DisplayStartPageCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewHelpMenuDisplayStartPage}" />
+                        <Separator />
+                        <MenuItem Name="ReportBug"
+                                  Command="{Binding ReportABugCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewHelpMenuReportBug}" />
+                    </MenuItem>
+
+                    <!--  The menu will be enabled when at least one MenuItem is added  -->
+                    <MenuItem Name="ExtensionsMenu"
+                              Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewExtensionsMenu}"
+                              IsEnabled="True"
+                              Style="{StaticResource ExtensionsStyle}">
                         <MenuItem.Icon>
-                            <Image Source="/DynamoCoreWpf;component/UI/Images/pin.png"
-                                   Width="14"
-                                   Height="14"/>
+                            <Image Width="14"
+                                   Height="14"
+                                   Source="/DynamoCoreWpf;component/UI/Images/pin.png" />
                         </MenuItem.Icon>
                     </MenuItem>
 
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewDebugMenu}"
-                              Focusable="False"
+                    <MenuItem Focusable="False"
+                              Header="{x:Static p:Resources.DynamoViewDebugMenu}"
                               Visibility="{Binding IsDebugBuild, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                         <MenuItem Name="VerboseLogging"
+                                  Header="{x:Static p:Resources.DynamoViewDebugMenuVerboseLogging}"
                                   IsCheckable="True"
-                                  IsChecked="{Binding VerboseLogging}"
-                                  Header="{x:Static p:Resources.DynamoViewDebugMenuVerboseLogging}" />
+                                  IsChecked="{Binding VerboseLogging}" />
                         <MenuItem Name="ShowDebugASTs"
-                                  IsCheckable="True"
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuShowDebugAST}"
-                                  IsChecked="{Binding ShowDebugASTs}"></MenuItem>
+                                  IsCheckable="True"
+                                  IsChecked="{Binding ShowDebugASTs}" />
                         <MenuItem Name="ForceReexec"
-                                  Header="{x:Static p:Resources.DynamoViewDebugMenuForceReExecute}"
                                   Command="{Binding ForceRunExpressionCommand}"
                                   CommandParameter="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunInDebug}"
-                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}"></MenuItem>
+                                  Header="{x:Static p:Resources.DynamoViewDebugMenuForceReExecute}"
+                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}" />
                         <MenuItem Name="MutateTest"
-                                  Header="{x:Static p:Resources.DynamoViewDebugMenuRunMutationTest}"
                                   Command="{Binding MutateTestDelegateCommand}"
                                   CommandParameter="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunInDebug}"
-                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}"></MenuItem>
-                        <MenuItem Header="{x:Static p:Resources.DynamoViewDebugMenuDumpData}"
-                                  Name="dumpDataMenuMenu">
-                            <MenuItem Header="{x:Static p:Resources.DynamoViewDebugMenuDumpLibrary}"
-                                      Command="{Binding DumpLibraryToXmlCommand}"
+                                  Header="{x:Static p:Resources.DynamoViewDebugMenuRunMutationTest}"
+                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}" />
+                        <MenuItem Name="dumpDataMenuMenu" Header="{x:Static p:Resources.DynamoViewDebugMenuDumpData}">
+                            <MenuItem Command="{Binding DumpLibraryToXmlCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewDebugMenuDumpLibrary}"
                                       IsEnabled="True" />
-                            <MenuItem  Header="{x:Static p:Resources.DynamoViewDebugMenuDumpNodeHelpData}"
-                                       Command="{Binding DumpNodeHelpDataCommand}" IsEnabled="True"/>
+                            <MenuItem Command="{Binding DumpNodeHelpDataCommand}"
+                                      Header="{x:Static p:Resources.DynamoViewDebugMenuDumpNodeHelpData}"
+                                      IsEnabled="True" />
                         </MenuItem>
                         <MenuItem Name="DebugModes"
-                                  Header="{x:Static p:Resources.DynamoViewDebugMenuDebugModes}"
                                   Click="OnDebugModesClick"
+                                  Header="{x:Static p:Resources.DynamoViewDebugMenuDebugModes}"
                                   IsCheckable="False" />
                         <MenuItem Name="FileTrustWarning"
-                                  Header="{x:Static p:Resources.DynamoShowFileTrustWarning}"
                                   Click="FileTrustWarning_Click"
+                                  Header="{x:Static p:Resources.DynamoShowFileTrustWarning}"
                                   IsCheckable="False" />
                         <MenuItem Name="UpdateNodeIcons"
-                                  Header="{x:Static p:Resources.UpdateNodeIconsDebugMenu}"
                                   Click="UpdateNodeIcons_Click"
+                                  Header="{x:Static p:Resources.UpdateNodeIconsDebugMenu}"
                                   IsCheckable="False" />
                     </MenuItem>
                 </Menu>
 
-                <!--Titlebar buttons-->
-                <Grid Name="titleBarButtonsGrid"
-                      Grid.Column="1">
-                </Grid>
+                <!--  Titlebar buttons  -->
+                <Grid Name="titleBarButtonsGrid" Grid.Column="1" />
 
             </Grid>
         </Border>
 
-        <!--Shortcuts Toolbar-->
-        <Grid Grid.Row="1"
+        <!--  Shortcuts Toolbar  -->
+        <Grid Name="shortcutsBarGrid"
+              Grid.Row="1"
               Grid.Column="0"
-              Canvas.ZIndex="1"
-              VerticalAlignment="Top"
               Grid.ColumnSpan="5"
-              Name="shortcutsBarGrid">
+              VerticalAlignment="Top"
+              Canvas.ZIndex="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"></ColumnDefinition>
-                <ColumnDefinition Width="Auto"></ColumnDefinition>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
             <Border Name="shortcutBarBorder"
-                    BorderThickness="0"
-                    HorizontalAlignment="Stretch"
-                    Margin="0,-1"
                     Grid.Row="0"
-                Grid.Column="0">
-                <Grid Name="shortcutBarGrid">
-                </Grid>
+                    Grid.Column="0"
+                    Margin="0,-1"
+                    HorizontalAlignment="Stretch"
+                    BorderThickness="0">
+                <Grid Name="shortcutBarGrid" />
             </Border>
 
         </Grid>
 
-        <!--Canvas-->
-        <Grid HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch"
+        <!--  Canvas  -->
+        <Grid Name="background_grid"
               Grid.Row="2"
-              Grid.Column="2"
               Grid.RowSpan="3"
+              Grid.Column="2"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch"
               Background="#232323"
-              Name="background_grid"
               IsHitTestVisible="{Binding BackgroundPreviewViewModel.CanNavigateBackground}">
             <Canvas Name="backgroundCanvas"
                     Margin="0,0,0,0"
@@ -787,7 +749,7 @@
                 </Canvas.Background>
             </Canvas>
 
-            <!-- The BackgroundPreview is now created in the DynamoView_Loaded method.-->
+            <!--  The BackgroundPreview is now created in the DynamoView_Loaded method.  -->
 
         </Grid>
 
@@ -797,30 +759,29 @@
             Please ensure that mouse events will be able to pass through this layer,
             when Navigate Background 3D Preview is set to true.
         -->
-        <!--Workspace-->
-        <Border Margin="0"
-                BorderBrush="Black"
-                BorderThickness="0"
-                Name="border"
+        <!--  Workspace  -->
+        <Border Name="border"
                 Grid.Row="1"
                 Grid.RowSpan="2"
                 Grid.Column="2"
+                Margin="0"
+                BorderBrush="Black"
+                BorderThickness="0"
                 SizeChanged="Workspace_SizeChanged">
-            <Grid AllowDrop="True"
-                  Drop="DynamoView_OnDrop" Margin="0,0,0,0">
-                <TabControl ItemsSource="{Binding Path=Workspaces, NotifyOnTargetUpdated=True}"
-                            Name="WorkspaceTabs"
-                            SelectedIndex="{Binding CurrentWorkspaceIndex}"
+            <Grid Margin="0,0,0,0"
+                  AllowDrop="True"
+                  Drop="DynamoView_OnDrop">
+                <TabControl Name="WorkspaceTabs"
                             Padding="0"
-                            TargetUpdated="WorkspaceTabs_TargetUpdated"
+                            ItemsSource="{Binding Path=Workspaces, NotifyOnTargetUpdated=True}"
+                            SelectedIndex="{Binding CurrentWorkspaceIndex}"
                             SelectionChanged="WorkspaceTabs_SelectionChanged"
-                            SizeChanged="WorkspaceTabs_SizeChanged">
+                            SizeChanged="WorkspaceTabs_SizeChanged"
+                            TargetUpdated="WorkspaceTabs_TargetUpdated">
                     <TabControl.Resources>
                         <Style TargetType="{x:Type TabControl}">
-                            <Setter Property="OverridesDefaultStyle"
-                                    Value="True" />
-                            <Setter Property="SnapsToDevicePixels"
-                                    Value="True" />
+                            <Setter Property="OverridesDefaultStyle" Value="True" />
+                            <Setter Property="SnapsToDevicePixels" Value="True" />
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="{x:Type TabControl}">
@@ -829,52 +790,89 @@
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="*" />
                                             </Grid.RowDefinitions>
-                                            <Border Background="Transparent" Grid.Row="0">
+                                            <Border Grid.Row="0" Background="Transparent">
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*" />
-                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="Auto   " />
                                                     </Grid.ColumnDefinitions>
                                                     <ScrollViewer Grid.Column="0"
                                                                   Margin="0,0,150,0"
                                                                   HorizontalScrollBarVisibility="Auto"
                                                                   VerticalScrollBarVisibility="Disabled">
-                                                        <TabPanel x:Name="HeaderPanel"
-                                                                  IsItemsHost="True"
-                                                                  KeyboardNavigation.TabIndex="1"
-                                                                  Background="Transparent" />
+                                                        <StackPanel Orientation="Horizontal">
+
+                                                            <!--  HomeButton  -->
+                                                            <Button Name="HomeButton"
+                                                                    Width="42"
+                                                                    Height="42"
+                                                                    Click="HomeButton_Click"
+                                                                    BorderThickness="0"
+                                                                    Cursor="Hand">
+                                                                <Button.Template>
+                                                                    <ControlTemplate TargetType="Button">
+                                                                        <Border Name="HomeButtomBorder"
+                                                                                VerticalAlignment="Stretch"
+                                                                                Background="Transparent">
+                                                                            <Viewbox Width="16"
+                                                                                     Height="16"
+                                                                                     HorizontalAlignment="Center"
+                                                                                     VerticalAlignment="Center"
+                                                                                     Stretch="Uniform">
+                                                                                <Path x:Name="HomeIcon"
+                                                                                      Margin="0,0,5,5"
+                                                                                      Data="M39.5,43h-9c-1.381,0-2.5-1.119-2.5-2.5v-9c0-1.105-0.895-2-2-2h-4c-1.105,0-2,0.895-2,2v9c0,1.381-1.119,2.5-2.5,2.5h-9 C7.119,43,6,41.881,6,40.5V21.413c0-2.299,1.054-4.471,2.859-5.893L23.071,4.321c0.545-0.428,1.313-0.428,1.857,0L39.142,15.52 C40.947,16.942,42,19.113,42,21.411V40.5C42,41.881,40.881,43,39.5,43z"
+                                                                                      Fill="{StaticResource LightGrayBrush}"
+                                                                                      StrokeThickness="0" />
+                                                                            </Viewbox>
+                                                                        </Border>
+                                                                        <ControlTemplate.Triggers>
+                                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                                <Setter TargetName="HomeIcon" Property="Fill" Value="{StaticResource TextColorBrush}" />
+                                                                            </Trigger>
+                                                                            <DataTrigger Binding="{Binding DataContext.ShowStartPage, RelativeSource={RelativeSource AncestorType={x:Type controls:DynamoView}}}" Value="True">
+                                                                                <Setter TargetName="HomeButtomBorder" Property="Background" Value="#535353" />
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding DataContext.ShowStartPage, RelativeSource={RelativeSource AncestorType={x:Type controls:DynamoView}}}" Value="False">
+                                                                                <Setter TargetName="HomeButtomBorder" Property="Background" Value="Transparent" />
+                                                                            </DataTrigger>
+                                                                        </ControlTemplate.Triggers>
+                                                                    </ControlTemplate>
+                                                                </Button.Template>
+                                                            </Button>
+
+                                                            <TabPanel x:Name="HeaderPanel"
+                                                                      Background="Transparent"
+                                                                      IsItemsHost="True"
+                                                                      KeyboardNavigation.TabIndex="1" />
+                                                        </StackPanel>
                                                     </ScrollViewer>
                                                     <Menu x:Name="TabControlMenu"
                                                           Grid.Column="1"
-                                                          VerticalAlignment="Center"
                                                           Margin="10,0,0,0"
+                                                          VerticalAlignment="Center"
                                                           Background="Transparent"
                                                           SnapsToDevicePixels="True">
                                                         <Menu.Resources>
                                                             <sys:Double x:Key="ButtonWidthAndHeight">19</sys:Double>
-                                                            <Style x:Key="TabMenuButtonStyle"
-                                                                   TargetType="{x:Type MenuItem}">
-                                                                <Setter Property="Focusable"
-                                                                        Value="False" />
-                                                                <Setter Property="Height"
-                                                                        Value="{StaticResource ButtonWidthAndHeight}" />
-                                                                <Setter Property="Width"
-                                                                        Value="{StaticResource ButtonWidthAndHeight}" />
+                                                            <Style x:Key="TabMenuButtonStyle" TargetType="{x:Type MenuItem}">
+                                                                <Setter Property="Focusable" Value="False" />
+                                                                <Setter Property="Height" Value="{StaticResource ButtonWidthAndHeight}" />
+                                                                <Setter Property="Width" Value="{StaticResource ButtonWidthAndHeight}" />
                                                                 <Setter Property="Template">
                                                                     <Setter.Value>
                                                                         <ControlTemplate TargetType="{x:Type MenuItem}">
                                                                             <Border Name="ButtonBorder"
                                                                                     Margin="0"
-                                                                                    Background="Transparent"
-                                                                                    BorderThickness="0"
-                                                                                    VerticalAlignment="Center"
+                                                                                    Padding="0"
                                                                                     HorizontalAlignment="Center"
-                                                                                    Padding="0">
-                                                                                <Grid VerticalAlignment="Center"
-                                                                                      HorizontalAlignment="Center">
-                                                                                    <ContentPresenter ContentSource="Header"
-                                                                                                      HorizontalAlignment="Center"
-                                                                                                      VerticalAlignment="Center" />
+                                                                                    VerticalAlignment="Center"
+                                                                                    Background="Transparent"
+                                                                                    BorderThickness="0">
+                                                                                <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                                                    <ContentPresenter HorizontalAlignment="Center"
+                                                                                                      VerticalAlignment="Center"
+                                                                                                      ContentSource="Header" />
                                                                                 </Grid>
                                                                             </Border>
                                                                         </ControlTemplate>
@@ -882,21 +880,18 @@
                                                                 </Setter>
                                                             </Style>
 
-                                                            <!-- The style for MenuItems that represent TabItems -->
+                                                            <!--  The style for MenuItems that represent TabItems  -->
                                                             <Style x:Key="TabMenuItem"
                                                                    BasedOn="{StaticResource MenuItemStyle}"
                                                                    TargetType="{x:Type MenuItem}">
 
                                                                 <Style.Resources>
                                                                     <!--  SubmenuHeader  -->
-                                                                    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuHeaderTemplateKey}"
-                                                                                     TargetType="MenuItem">
-                                                                        <Border Name="Border"
-                                                                                Height="25">
+                                                                    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuHeaderTemplateKey}" TargetType="MenuItem">
+                                                                        <Border Name="Border" Height="25">
                                                                             <Grid>
                                                                                 <Grid.ColumnDefinitions>
-                                                                                    <ColumnDefinition Width="*"
-                                                                                                      MinWidth="100" />
+                                                                                    <ColumnDefinition Width="*" MinWidth="100" />
                                                                                 </Grid.ColumnDefinitions>
                                                                                 <ContentPresenter Name="HeaderHost"
                                                                                                   Grid.Column="0"
@@ -913,13 +908,12 @@
                                                                                        Placement="Right"
                                                                                        PopupAnimation="Fade">
                                                                                     <Border Name="SubmenuBorder"
-                                                                                            Margin="0 0 5 5"
+                                                                                            Margin="0,0,5,5"
                                                                                             Background="{StaticResource NormalBackgroundBrush}"
                                                                                             BorderBrush="{StaticResource NormalBorderBrush}"
                                                                                             BorderThickness="1"
                                                                                             SnapsToDevicePixels="True">
-                                                                                        <StackPanel IsItemsHost="True"
-                                                                                                    KeyboardNavigation.DirectionalNavigation="Cycle" />
+                                                                                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                                                                                         <Border.Effect>
                                                                                             <DropShadowEffect BlurRadius="5"
                                                                                                               Opacity="0.4"
@@ -930,31 +924,20 @@
                                                                             </Grid>
                                                                         </Border>
                                                                         <ControlTemplate.Triggers>
-                                                                            <Trigger Property="IsHighlighted"
-                                                                                     Value="true">
-                                                                                <Setter TargetName="Border"
-                                                                                        Property="Background"
-                                                                                        Value="{StaticResource HighlightedBrush}" />
-                                                                                <Setter TargetName="HeaderHost"
-                                                                                        Property="TextBlock.Foreground"
-                                                                                        Value="{StaticResource ActiveForegroundBrush}" />
-                                                                                <Setter TargetName="Border"
-                                                                                        Property="BorderBrush"
-                                                                                        Value="Transparent" />
+                                                                            <Trigger Property="IsHighlighted" Value="true">
+                                                                                <Setter TargetName="Border" Property="Background" Value="{StaticResource HighlightedBrush}" />
+                                                                                <Setter TargetName="HeaderHost" Property="TextBlock.Foreground" Value="{StaticResource ActiveForegroundBrush}" />
+                                                                                <Setter TargetName="Border" Property="BorderBrush" Value="Transparent" />
                                                                             </Trigger>
-                                                                            <Trigger Property="IsEnabled"
-                                                                                     Value="false">
-                                                                                <Setter Property="Foreground"
-                                                                                        Value="{StaticResource DisabledForegroundBrush}" />
+                                                                            <Trigger Property="IsEnabled" Value="false">
+                                                                                <Setter Property="Foreground" Value="{StaticResource DisabledForegroundBrush}" />
                                                                             </Trigger>
                                                                         </ControlTemplate.Triggers>
                                                                     </ControlTemplate>
 
                                                                     <!--  SubmenuItem  -->
-                                                                    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}"
-                                                                                     TargetType="MenuItem">
-                                                                        <Border Name="Border"
-                                                                                Height="25">
+                                                                    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="MenuItem">
+                                                                        <Border Name="Border" Height="25">
                                                                             <Grid MinWidth="200">
                                                                                 <Grid.ColumnDefinitions>
                                                                                     <ColumnDefinition Width="Auto" />
@@ -977,71 +960,48 @@
                                                                             </Grid>
                                                                         </Border>
                                                                         <ControlTemplate.Triggers>
-                                                                            <Trigger Property="IsHighlighted"
-                                                                                     Value="true">
-                                                                                <Setter TargetName="Border"
-                                                                                        Property="Background"
-                                                                                        Value="{StaticResource HighlightedBrush}" />
-                                                                                <Setter TargetName="HeaderHost"
-                                                                                        Property="TextBlock.Foreground"
-                                                                                        Value="{StaticResource ActiveForegroundBrush}" />
-                                                                                <Setter TargetName="Border"
-                                                                                        Property="BorderBrush"
-                                                                                        Value="Transparent" />
+                                                                            <Trigger Property="IsHighlighted" Value="true">
+                                                                                <Setter TargetName="Border" Property="Background" Value="{StaticResource HighlightedBrush}" />
+                                                                                <Setter TargetName="HeaderHost" Property="TextBlock.Foreground" Value="{StaticResource ActiveForegroundBrush}" />
+                                                                                <Setter TargetName="Border" Property="BorderBrush" Value="Transparent" />
                                                                             </Trigger>
-                                                                            <Trigger Property="IsEnabled"
-                                                                                     Value="false">
-                                                                                <Setter Property="Foreground"
-                                                                                        Value="{StaticResource DisabledForegroundBrush}" />
+                                                                            <Trigger Property="IsEnabled" Value="false">
+                                                                                <Setter Property="Foreground" Value="{StaticResource DisabledForegroundBrush}" />
                                                                             </Trigger>
                                                                         </ControlTemplate.Triggers>
                                                                     </ControlTemplate>
                                                                 </Style.Resources>
 
-                                                                <EventSetter Event="Click"
-                                                                             Handler="TabControlMenuItem_Click" />
+                                                                <EventSetter Event="Click" Handler="TabControlMenuItem_Click" />
 
                                                                 <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
-                                                                                 Value="Unsaved">
-                                                                        <Setter Property="Header"
-                                                                                Value="{Binding Name}" />
+                                                                    <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Unsaved">
+                                                                        <Setter Property="Header" Value="{Binding Name}" />
                                                                     </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
-                                                                                 Value="Saved">
-                                                                        <Setter Property="Header"
-                                                                                Value="{Binding FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                                    <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Saved">
+                                                                        <Setter Property="Header" Value="{Binding FileName, Converter={StaticResource PathToFileNameConverter}}" />
                                                                     </DataTrigger>
 
-                                                                    <DataTrigger Binding="{Binding HasUnsavedChanges}"
-                                                                                 Value="True">
-                                                                        <Setter Property="Tag"
-                                                                                Value="*" />
+                                                                    <DataTrigger Binding="{Binding HasUnsavedChanges}" Value="True">
+                                                                        <Setter Property="Tag" Value="*" />
                                                                     </DataTrigger>
 
-                                                                    <DataTrigger Binding="{Binding HasUnsavedChanges}"
-                                                                                 Value="False">
-                                                                        <Setter Property="Tag"
-                                                                                Value="" />
+                                                                    <DataTrigger Binding="{Binding HasUnsavedChanges}" Value="False">
+                                                                        <Setter Property="Tag" Value="" />
                                                                     </DataTrigger>
 
-                                                                    <Trigger Property="Role"
-                                                                             Value="SubmenuHeader">
-                                                                        <Setter Property="Template"
-                                                                                Value="{StaticResource {x:Static MenuItem.SubmenuHeaderTemplateKey}}" />
+                                                                    <Trigger Property="Role" Value="SubmenuHeader">
+                                                                        <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuHeaderTemplateKey}}" />
                                                                     </Trigger>
-                                                                    <Trigger Property="Role"
-                                                                             Value="SubmenuItem">
-                                                                        <Setter Property="Template"
-                                                                                Value="{StaticResource {x:Static MenuItem.SubmenuItemTemplateKey}}" />
+                                                                    <Trigger Property="Role" Value="SubmenuItem">
+                                                                        <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuItemTemplateKey}}" />
                                                                     </Trigger>
                                                                 </Style.Triggers>
                                                             </Style>
                                                         </Menu.Resources>
-                                                        <MenuItem Style="{StaticResource TabMenuButtonStyle}"
-                                                                  ItemsSource="{Binding RelativeSource={RelativeSource FindAncestor,AncestorType={x:Type TabControl}},Path=Items}"
-                                                                  ItemContainerStyle="{StaticResource TabMenuItem}">
-                                                        </MenuItem>
+                                                        <MenuItem ItemContainerStyle="{StaticResource TabMenuItem}"
+                                                                  ItemsSource="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=Items}"
+                                                                  Style="{StaticResource TabMenuButtonStyle}" />
                                                     </Menu>
                                                 </Grid>
                                             </Border>
@@ -1049,32 +1009,22 @@
                                                     Grid.Row="1"
                                                     BorderBrush="{Binding Path=ViewingHomespace, Converter={StaticResource WorkspaceBackgroundBrushConverter}}"
                                                     BorderThickness="0,0,0,0">
-                                                <ContentPresenter x:Name="PART_SelectedContentHost"
-                                                                  ContentSource="SelectedContent" />
+                                                <ContentPresenter x:Name="PART_SelectedContentHost" ContentSource="SelectedContent" />
                                             </Border>
                                         </Grid>
                                     </ControlTemplate>
                                 </Setter.Value>
                             </Setter>
                         </Style>
-                        <Style TargetType="{x:Type Button}"
-                               x:Key="CloseButtonStyle">
-                            <Setter Property="OverridesDefaultStyle"
-                                    Value="True" />
-                            <Setter Property="SnapsToDevicePixels"
-                                    Value="true" />
-                            <Setter Property="VerticalAlignment"
-                                    Value="Center" />
-                            <Setter Property="HorizontalAlignment"
-                                    Value="Center" />
-                            <Setter Property="Margin"
-                                    Value="0,0,10,0" />
-                            <Setter Property="Background"
-                                    Value="Transparent" />
-                            <Setter Property="BorderThickness"
-                                    Value="0" />
-                            <Setter Property="Padding"
-                                    Value="0" />
+                        <Style x:Key="CloseButtonStyle" TargetType="{x:Type Button}">
+                            <Setter Property="OverridesDefaultStyle" Value="True" />
+                            <Setter Property="SnapsToDevicePixels" Value="true" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                            <Setter Property="HorizontalAlignment" Value="Center" />
+                            <Setter Property="Margin" Value="0,0,10,0" />
+                            <Setter Property="Background" Value="Transparent" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Padding" Value="0" />
                             <!--<EventSetter Event="Click"
                                          Handler="TabCloseButton_Click" />-->
                             <Setter Property="Template">
@@ -1082,16 +1032,16 @@
                                     <ControlTemplate TargetType="Button">
                                         <Border x:Name="Border"
                                                 Background="Transparent"
-                                                BorderThickness="0 0 0 0">
-                                            <ContentPresenter Margin="0 1 0 0" />
+                                                BorderThickness="0,0,0,0">
+                                            <ContentPresenter Margin="0,1,0,0" />
                                         </Border>
                                     </ControlTemplate>
                                 </Setter.Value>
                             </Setter>
 
-                            <!-- The close button for workspace is no longer hidden on the HOME 
+                            <!-- The close button for workspace is no longer hidden on the HOME
                                  tab page, since it is used to bring up the Start Page when pressed.
-                            
+
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
                                              Value="{x:Type models:HomeWorkspaceModel}">
@@ -1103,18 +1053,14 @@
 
                         </Style>
                         <Style TargetType="{x:Type TabItem}">
-                            <Setter Property="MaxWidth"
-                                    Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
-                            <Setter Property="MinWidth"
-                                    Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
+                            <Setter Property="MaxWidth" Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
+                            <Setter Property="MinWidth" Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
                             <Setter Property="Width">
                                 <Setter.Value>
                                     <MultiBinding Converter="{StaticResource TabSizeConverter}">
                                         <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}" />
-                                        <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}"
-                                                 Path="ActualWidth" />
-                                        <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}"
-                                                 Path="Items.Count" />
+                                        <Binding Path="ActualWidth" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}" />
+                                        <Binding Path="Items.Count" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}" />
                                         <!--<Binding Path="Visibility" />-->
                                     </MultiBinding>
                                 </Setter.Value>
@@ -1127,8 +1073,11 @@
                                                 CornerRadius="0,0,0,0">
                                             <Border.ToolTip>
                                                 <uictrls:DynamoToolTip AttachmentSide="Bottom" Style="{DynamicResource ResourceKey=SLightToolTip}">
-                                                    <StackPanel Margin="5" MaxWidth="250">
-                                                        <TextBlock x:Name="FileName" Margin="0,0,0,5"  Text="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" TextWrapping="Wrap"/>
+                                                    <StackPanel MaxWidth="250" Margin="5">
+                                                        <TextBlock x:Name="FileName"
+                                                                   Margin="0,0,0,5"
+                                                                   Text="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}"
+                                                                   TextWrapping="Wrap" />
                                                         <TextBlock x:Name="topMessage"
                                                                    FontFamily="{StaticResource ArtifaktElementBold}"
                                                                    FontSize="11px"
@@ -1137,27 +1086,27 @@
                                                                 <Style TargetType="TextBlock">
                                                                     <Style.Triggers>
                                                                         <DataTrigger Binding="{Binding Path=HasUnsavedChanges}" Value="True">
-                                                                            <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabSavingNecessary}"/>
+                                                                            <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabSavingNecessary}" />
                                                                         </DataTrigger>
                                                                         <DataTrigger Binding="{Binding Path=HasUnsavedChanges}" Value="False">
-                                                                            <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabSavingUnnecessary}"/>
+                                                                            <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabSavingUnnecessary}" />
                                                                         </DataTrigger>
                                                                         <MultiDataTrigger>
                                                                             <MultiDataTrigger.Conditions>
-                                                                                <Condition Binding="{Binding Path=FileName}" Value=""/>
-                                                                                <Condition Binding="{Binding Path=HasUnsavedChanges}" Value="True"/>
+                                                                                <Condition Binding="{Binding Path=FileName}" Value="" />
+                                                                                <Condition Binding="{Binding Path=HasUnsavedChanges}" Value="True" />
                                                                             </MultiDataTrigger.Conditions>
                                                                             <MultiDataTrigger.Setters>
-                                                                                <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabNotSavedYet}"/>
+                                                                                <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabNotSavedYet}" />
                                                                             </MultiDataTrigger.Setters>
                                                                         </MultiDataTrigger>
                                                                         <MultiDataTrigger>
                                                                             <MultiDataTrigger.Conditions>
-                                                                                <Condition Binding="{Binding Path=FileName}" Value=""/>
-                                                                                <Condition Binding="{Binding Path=HasUnsavedChanges}" Value="False"/>
+                                                                                <Condition Binding="{Binding Path=FileName}" Value="" />
+                                                                                <Condition Binding="{Binding Path=HasUnsavedChanges}" Value="False" />
                                                                             </MultiDataTrigger.Conditions>
                                                                             <MultiDataTrigger.Setters>
-                                                                                <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabSavingBrandNewFile}"/>
+                                                                                <Setter Property="Text" Value="{x:Static p:Resources.WorkspaceTabSavingBrandNewFile}" />
                                                                             </MultiDataTrigger.Setters>
                                                                         </MultiDataTrigger>
                                                                     </Style.Triggers>
@@ -1168,16 +1117,16 @@
                                                                    FontFamily="{StaticResource ArtifaktElementRegular}"
                                                                    FontSize="11px"
                                                                    Foreground="Black">
-                                                            <Run Text="{x:Static p:Resources.PreferencesViewSavedChangesTooltip}"/>
-                                                            <Run Text="{Binding DynamoViewModel.HomeSpace.LastSaved}"/>
+                                                            <Run Text="{x:Static p:Resources.PreferencesViewSavedChangesTooltip}" />
+                                                            <Run Text="{Binding DynamoViewModel.HomeSpace.LastSaved}" />
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
                                                                     <Style.Triggers>
                                                                         <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Unsaved">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            <Setter Property="Visibility" Value="Collapsed" />
                                                                         </DataTrigger>
                                                                         <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Saved">
-                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                            <Setter Property="Visibility" Value="Visible" />
                                                                         </DataTrigger>
                                                                     </Style.Triggers>
                                                                 </Style>
@@ -1188,25 +1137,17 @@
                                             </Border.ToolTip>
                                             <Border.Style>
                                                 <Style TargetType="Border">
-                                                    <Setter Property="BorderBrush" Value="{StaticResource BorderBrushWhite}"/>
+                                                    <Setter Property="BorderBrush" Value="{StaticResource BorderBrushWhite}" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}"
-                                                                     Value="False">
-                                                            <Setter Property="Background"
-                                                                    Value="{StaticResource WorkspaceTabBorderSelectedFalse}" />
-                                                            <Setter Property="BorderBrush"
-                                                                    Value="{StaticResource BorderBrushWhite}" />
-                                                            <Setter Property="Margin"
-                                                                    Value="0,0,0,-1" />
+                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="False">
+                                                            <Setter Property="Background" Value="{StaticResource WorkspaceTabBorderSelectedFalse}" />
+                                                            <Setter Property="BorderBrush" Value="{StaticResource BorderBrushWhite}" />
+                                                            <Setter Property="Margin" Value="0,0,0,-1" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}"
-                                                                     Value="True">
-                                                            <Setter Property="Background"
-                                                                    Value="{StaticResource WorkspaceTabBorderSelectedTrue}" />
-                                                            <Setter Property="BorderBrush"
-                                                                    Value="#ADE4DE" />
-                                                            <Setter Property="Margin"
-                                                                    Value="0" />
+                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="True">
+                                                            <Setter Property="Background" Value="{StaticResource WorkspaceTabBorderSelectedTrue}" />
+                                                            <Setter Property="BorderBrush" Value="#ADE4DE" />
+                                                            <Setter Property="Margin" Value="0" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -1220,26 +1161,22 @@
                                                                   Grid.Column="0"
                                                                   VerticalAlignment="Center"
                                                                   ContentSource="Header" />
-                                                <Button Style="{StaticResource CloseButtonStyle}"
+                                                <Button Grid.Column="1"
+                                                        Margin="0"
                                                         Command="{Binding HideCommand}"
                                                         Cursor="Hand"
-                                                        Margin="0"
-                                                        Grid.Column="1">
+                                                        Style="{StaticResource CloseButtonStyle}">
                                                     <Image Width="16"
-                                                           Margin="0,0,10,0"
-                                                           Height="16">
+                                                           Height="16"
+                                                           Margin="0,0,10,0">
                                                         <Image.Style>
                                                             <Style TargetType="{x:Type Image}">
                                                                 <Style.Triggers>
-                                                                    <Trigger Property="IsMouseOver"
-                                                                             Value="False">
-                                                                        <Setter Property="Source"
-                                                                            Value="/DynamoCoreWpf;component/UI/Images/closetab_normal.png" />
+                                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                                        <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/closetab_normal.png" />
                                                                     </Trigger>
-                                                                    <Trigger Property="IsMouseOver"
-                                                                             Value="True">
-                                                                        <Setter Property="Source"
-                                                                            Value="/DynamoCoreWpf;component/UI/Images/closetab_hover.png" />
+                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                        <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/closetab_hover.png" />
                                                                     </Trigger>
                                                                 </Style.Triggers>
                                                             </Style>
@@ -1259,7 +1196,7 @@
                         <DataTemplate>
                             <Grid Height="35" Margin="12,0,5,0">
                                 <Grid.RowDefinitions>
-                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="*" />
                                     <RowDefinition Height="5" />
                                 </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
@@ -1270,40 +1207,40 @@
                                 </Grid.ColumnDefinitions>
                                 <Ellipse Name="UnsavedChangesIcon"
                                          Grid.Column="0"
-                                         Margin="0,5,5,0"
-                                         Height="9"
                                          Width="9"
-                                         Fill="{StaticResource YellowOrange500Brush}"
-                                         VerticalAlignment="Center">
+                                         Height="9"
+                                         Margin="0,5,5,0"
+                                         VerticalAlignment="Center"
+                                         Fill="{StaticResource YellowOrange500Brush}">
                                     <Ellipse.Style>
                                         <Style TargetType="Ellipse">
                                             <Style.Triggers>
-                                                <DataTrigger Binding="{Binding HasUnsavedChanges}"
-                                                                 Value="True">
-                                                    <Setter Property="Visibility"
-                                                                Value="Visible" />
+                                                <DataTrigger Binding="{Binding HasUnsavedChanges}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
                                                 </DataTrigger>
-                                                <DataTrigger Binding="{Binding HasUnsavedChanges}"
-                                                                 Value="False">
-                                                    <Setter Property="Visibility"
-                                                                Value="Collapsed" />
+                                                <DataTrigger Binding="{Binding HasUnsavedChanges}" Value="False">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
                                     </Ellipse.Style>
                                 </Ellipse>
-                                <Rectangle Grid.Column="1" Width="16" Height="16" Margin="0,5,7,0" VerticalAlignment="Center">
+                                <Rectangle Grid.Column="1"
+                                           Width="16"
+                                           Height="16"
+                                           Margin="0,5,7,0"
+                                           VerticalAlignment="Center">
                                     <Rectangle.Fill>
-                                        <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/custom-node.png"/>
+                                        <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/custom-node.png" />
                                     </Rectangle.Fill>
                                     <Rectangle.Style>
                                         <Style TargetType="Rectangle">
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsHomeSpace}" Value="False">
-                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Setter Property="Visibility" Value="Visible" />
                                                 </DataTrigger>
                                                 <DataTrigger Binding="{Binding IsHomeSpace}" Value="True">
-                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                    <Setter Property="Visibility" Value="Collapsed" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -1314,16 +1251,16 @@
                                            Margin="0,7,0,0"
                                            HorizontalAlignment="Stretch"
                                            VerticalAlignment="Center"
-                                           FontSize="16px"
                                            FontFamily="{StaticResource ArtifaktElementRegular}"
+                                           FontSize="16px"
                                            TextTrimming="CharacterEllipsis">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
                                             <Style.Triggers>
-                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}" Value="True">
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="True">
                                                     <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
                                                 </DataTrigger>
-                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type TabItem}},Path=IsSelected}" Value="False">
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="False">
                                                     <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}" />
                                                 </DataTrigger>
                                                 <MultiDataTrigger>
@@ -1331,7 +1268,8 @@
                                                         <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:HomeWorkspaceModel}" />
                                                         <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}" Value="Unsaved" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Home" />
+                                                    <!--  The value of the unsaved Workspace tab text field  -->
+                                                    <Setter Property="Text" Value="Workspace" />
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
@@ -1365,7 +1303,7 @@
 
                     <TabControl.ContentTemplate>
                         <DataTemplate>
-                            <views:WorkspaceView></views:WorkspaceView>
+                            <views:WorkspaceView />
                         </DataTemplate>
                     </TabControl.ContentTemplate>
 
@@ -1374,59 +1312,53 @@
 
         </Border>
 
-        <!--Collapsed Left Sidebar-->
-        <StackPanel Grid.Row="2"
+        <!--  Collapsed Left Sidebar  -->
+        <StackPanel Name="collapsedLibrarySidebar"
+                    Grid.Row="2"
                     Grid.Column="2"
-                    Orientation="Vertical"
-                    Name="collapsedLibrarySidebar"
                     Width="Auto"
                     Height="Auto"
-                    Background="{StaticResource HighlightedBrush}"
+                    Margin="0,400,0,0"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
-                    Margin="0,400,0,0">
-            <Grid Background="#353535"
-                  Width="Auto"
+                    Background="{StaticResource HighlightedBrush}"
+                    Orientation="Vertical">
+            <Grid Width="Auto"
+                  Background="#353535"
                   Cursor="Hand">
-                <Button Click="OnCollapsedLeftSidebarClick"
-                        Template="{DynamicResource BackgroundButton}">
+                <Button Click="OnCollapsedLeftSidebarClick" Template="{DynamicResource BackgroundButton}">
                     <Button.Resources>
-                        <ControlTemplate x:Key="BackgroundButton"
-                                         TargetType="Button">
+                        <ControlTemplate x:Key="BackgroundButton" TargetType="Button">
                             <Border Name="border"
-                                    BorderThickness="0"
-                                    BorderBrush="Black"
+                                    Padding="5,0,5,0"
                                     VerticalAlignment="Stretch"
-                                    Padding="5,0,5,0">
-                                <ContentPresenter HorizontalAlignment="Stretch"
-                                                  VerticalAlignment="Stretch" />
+                                    BorderBrush="Black"
+                                    BorderThickness="0">
+                                <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
                             </Border>
                         </ControlTemplate>
                     </Button.Resources>
-                    <Grid Mouse.MouseEnter="LibraryHandle_MouseEnter"
-                          Mouse.MouseLeave="LibraryHandle_MouseLeave">
+                    <Grid Mouse.MouseEnter="LibraryHandle_MouseEnter" Mouse.MouseLeave="LibraryHandle_MouseLeave">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <StackPanel Orientation="Horizontal" 
-                                    HorizontalAlignment="Center">
-                            <TextBlock Grid.Column="0"
-                                   Name="LibrarySidebarText"
-                                   VerticalAlignment="Center"
-                                   Foreground="#aaaaaa"
-                                   FontWeight="Normal"
-                                   Margin="5,0,0,5"
-                                   Text="{x:Static p:Resources.LibraryViewTitle}">
-                            </TextBlock>
-                            <Image Grid.Column="0"
-                               Name="LibrarySidebarIcon"
-                               Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
-                               Visibility="Visible"
-                               Width="10"
-                               Height="10"
-                               Margin="5,5,5,5"
-                               RenderTransformOrigin="0.5, 0.5">
+                        <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                            <TextBlock Name="LibrarySidebarText"
+                                       Grid.Column="0"
+                                       Margin="5,0,0,5"
+                                       VerticalAlignment="Center"
+                                       FontWeight="Normal"
+                                       Foreground="#aaaaaa"
+                                       Text="{x:Static p:Resources.LibraryViewTitle}" />
+                            <Image Name="LibrarySidebarIcon"
+                                   Grid.Column="0"
+                                   Width="10"
+                                   Height="10"
+                                   Margin="5,5,5,5"
+                                   RenderTransformOrigin="0.5, 0.5"
+                                   Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
+                                   Visibility="Visible">
                                 <Image.RenderTransform>
                                     <RotateTransform Angle="-90" />
                                 </Image.RenderTransform>
@@ -1441,66 +1373,61 @@
             </StackPanel.RenderTransform>
         </StackPanel>
 
-        <!--Collapsed right sidebar panel-->
-        <StackPanel Grid.Row="2"
+        <!--  Collapsed right sidebar panel  -->
+        <StackPanel Name="collapsedExtensionSidebar"
+                    Grid.Row="2"
                     Grid.Column="2"
-                    Orientation="Vertical"
-                    Name="collapsedExtensionSidebar"
                     Width="Auto"
                     Height="Auto"
-                    Background="{StaticResource HighlightedBrush}"
+                    Margin="0,400,0,0"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
-                    Margin="0,400,0,0"
+                    Background="{StaticResource HighlightedBrush}"
+                    Orientation="Vertical"
                     RenderTransformOrigin="1,0">
-            <Grid Background="#353535"
-                  Width="Auto"
+            <Grid Width="Auto"
+                  Background="#353535"
                   Cursor="Hand">
-                <Button Click="OnCollapsedRightSidebarClick"
-                        Template="{DynamicResource BackgroundButton}">
+                <Button Click="OnCollapsedRightSidebarClick" Template="{DynamicResource BackgroundButton}">
                     <Button.Resources>
-                        <ControlTemplate x:Key="BackgroundButton"
-                                         TargetType="Button">
+                        <ControlTemplate x:Key="BackgroundButton" TargetType="Button">
                             <Border Name="border"
-                                    BorderThickness="0"
-                                    BorderBrush="Black"
+                                    Padding="5,0,5,0"
                                     VerticalAlignment="Stretch"
-                                    Padding="5,0,5,0">
-                                <ContentPresenter HorizontalAlignment="Stretch"
-                                                  VerticalAlignment="Stretch" />
+                                    BorderBrush="Black"
+                                    BorderThickness="0">
+                                <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
                             </Border>
                         </ControlTemplate>
                     </Button.Resources>
-                    <Grid Mouse.MouseEnter="ExtensionHandle_MouseEnter"
-                          Mouse.MouseLeave="ExtensionHandle_MouseLeave">
+                    <Grid Mouse.MouseEnter="ExtensionHandle_MouseEnter" Mouse.MouseLeave="ExtensionHandle_MouseLeave">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <StackPanel Orientation="Horizontal" 
-                                    HorizontalAlignment="Center">
-                            <Image Grid.Column="0"
-                               Name="ExtensionSidebarIcon"
-                               Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
-                               Visibility="Visible"
-                               Width="10"
-                               Height="10"
-                               Margin="5,5,5,5"
-                               RenderTransformOrigin="0.5, 0.5">
+                        <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                            <Image Name="ExtensionSidebarIcon"
+                                   Grid.Column="0"
+                                   Width="10"
+                                   Height="10"
+                                   Margin="5,5,5,5"
+                                   RenderTransformOrigin="0.5, 0.5"
+                                   Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
+                                   Visibility="Visible">
                                 <Image.RenderTransform>
                                     <RotateTransform Angle="-90" />
                                 </Image.RenderTransform>
                             </Image>
-                            <TextBlock Grid.Column="0"
-                                   Name="ExtensionSidebarText"
-                                   VerticalAlignment="Center"
-                                   Foreground="#aaaaaa"
-                                   FontWeight="Normal"
-                                   Margin="0,5,5,0"
-                                   Text="{x:Static p:Resources.SideBarPanelViewTitle}"
-                                   RenderTransformOrigin="0.5,0.5">
+                            <TextBlock Name="ExtensionSidebarText"
+                                       Grid.Column="0"
+                                       Margin="0,5,5,0"
+                                       VerticalAlignment="Center"
+                                       FontWeight="Normal"
+                                       Foreground="#aaaaaa"
+                                       RenderTransformOrigin="0.5,0.5"
+                                       Text="{x:Static p:Resources.SideBarPanelViewTitle}">
                                 <TextBlock.RenderTransform>
-                                    <RotateTransform Angle="180"/>
+                                    <RotateTransform Angle="180" />
                                 </TextBlock.RenderTransform>
                             </TextBlock>
                         </StackPanel>
@@ -1514,138 +1441,143 @@
             </StackPanel.RenderTransform>
         </StackPanel>
 
-        <!--Console Log Area-->
+        <!--  Console Log Area  -->
         <ScrollViewer Name="LogScroller"
-                      VerticalAlignment="Stretch"
-                      VerticalScrollBarVisibility="Auto"
-                      HorizontalAlignment="Stretch"
-                      HorizontalScrollBarVisibility="Hidden"
-                      Background="Black"
-                      Opacity="1"
-                      Visibility="Visible"
                       Grid.Row="4"
                       Grid.Column="0"
-                      Grid.ColumnSpan="5">
+                      Grid.ColumnSpan="5"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch"
+                      Background="Black"
+                      HorizontalScrollBarVisibility="Hidden"
+                      Opacity="1"
+                      VerticalScrollBarVisibility="Auto"
+                      Visibility="Visible">
 
             <ScrollViewer.ContextMenu>
                 <ContextMenu Style="{StaticResource ContextMenuStyle}">
-                    <MenuItem Header="{x:Static p:Resources.DynamoViewContextMenuClearLog}"
-                              Command="{Binding ClearLogCommand}" />
+                    <MenuItem Command="{Binding ClearLogCommand}" Header="{x:Static p:Resources.DynamoViewContextMenuClearLog}" />
                 </ContextMenu>
             </ScrollViewer.ContextMenu>
 
-            <TextBox Text="{Binding Path=LogText, Mode=OneWay}"
-                     Foreground="#FF888888"
-                     BorderThickness="0"
-                     BorderBrush="#00000000"
+            <TextBox Margin="0"
                      Background="Black"
-                     Margin="0"
-                     TextWrapping="Wrap"
+                     BorderBrush="#00000000"
+                     BorderThickness="0"
+                     FontFamily="Consolas"
+                     Foreground="#FF888888"
                      IsReadOnly="True"
                      IsReadOnlyCaretVisible="True"
-                     IsUndoEnabled="False"
                      IsTabStop="False"
-                     FontFamily="Consolas"
-                     TextChanged="TextBoxBase_OnTextChanged" />
+                     IsUndoEnabled="False"
+                     Text="{Binding Path=LogText, Mode=OneWay}"
+                     TextChanged="TextBoxBase_OnTextChanged"
+                     TextWrapping="Wrap" />
         </ScrollViewer>
 
-        <!--Left Sidebar Library-->
-        <Grid Height="Auto"
-              Width="Auto"
-              HorizontalAlignment="Stretch"
-              Name="sidebarGrid"
-              VerticalAlignment="Stretch"
-              Visibility="Visible"
+        <!--  Left Sidebar Library  -->
+        <Grid Name="sidebarGrid"
               Grid.Row="2"
+              Grid.RowSpan="2"
               Grid.Column="0"
-              Grid.RowSpan="2">
-        </Grid>
-
-        <!--Right Sidebar Panel-->
-        <Grid Height="Auto"
               Width="Auto"
+              Height="Auto"
               HorizontalAlignment="Stretch"
-              Name="sidebarExtensionsGrid"
               VerticalAlignment="Stretch"
-              Visibility="Visible"
+              Visibility="Visible" />
+
+        <!--  Right Sidebar Panel  -->
+        <Grid Name="sidebarExtensionsGrid"
               Grid.Row="2"
+              Grid.RowSpan="2"
               Grid.Column="4"
-              Grid.RowSpan="2">
-            <TabControl Name="tabDynamic" Background="#353535" BorderThickness="0" ItemsSource="{Binding SideBarTabItems, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+              Width="Auto"
+              Height="Auto"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch"
+              Visibility="Visible">
+            <TabControl Name="tabDynamic"
+                        Background="#353535"
+                        BorderThickness="0"
+                        ItemsSource="{Binding SideBarTabItems, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
                 <TabControl.Resources>
-                    <!--Styling for the close button in the tab-->
-                    <Style TargetType="{x:Type Button}"
-                               x:Key="CloseButtonStyle">
-                        <Setter Property="OverridesDefaultStyle"
-                                    Value="True" />
-                        <Setter Property="SnapsToDevicePixels"
-                                    Value="true" />
-                        <Setter Property="VerticalAlignment"
-                                    Value="Center" />
-                        <Setter Property="HorizontalAlignment"
-                                    Value="Right" />
-                        <Setter Property="Background"
-                                    Value="Transparent" />
-                        <Setter Property="BorderThickness"
-                                    Value="0" />
-                        <Setter Property="Padding"
-                                    Value="0" />
+                    <!--  Styling for the close button in the tab  -->
+                    <Style x:Key="CloseButtonStyle" TargetType="{x:Type Button}">
+                        <Setter Property="OverridesDefaultStyle" Value="True" />
+                        <Setter Property="SnapsToDevicePixels" Value="true" />
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                        <Setter Property="HorizontalAlignment" Value="Right" />
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="Padding" Value="0" />
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="Button">
                                     <Border x:Name="Border"
-                                                Background="Transparent"
-                                                BorderThickness="0 0 0 0">
-                                        <ContentPresenter Margin="0 0 0 0" />
+                                            Background="Transparent"
+                                            BorderThickness="0,0,0,0">
+                                        <ContentPresenter Margin="0,0,0,0" />
                                     </Border>
                                 </ControlTemplate>
                             </Setter.Value>
                         </Setter>
                     </Style>
 
-                    <!--Template for tab header in the right side bar-->
+                    <!--  Template for tab header in the right side bar  -->
                     <DataTemplate x:Key="TabHeader" DataType="TabItem">
-                        <DockPanel HorizontalAlignment="Stretch" Name ="TabPanel" MinWidth="{Binding Source={x:Static configuration:Configurations.ExtensionsSideBarTabMinWidth}}">
-                            <TextBlock Text="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Header}"
+                        <DockPanel Name="TabPanel"
+                                   MinWidth="{Binding Source={x:Static configuration:Configurations.ExtensionsSideBarTabMinWidth}}"
+                                   HorizontalAlignment="Stretch">
+                            <TextBlock Margin="5,7,0,0"
+                                       HorizontalAlignment="Stretch"
                                        FontFamily="{StaticResource ArtifaktElementBold}"
                                        FontSize="12"
-                                       Margin="5,7,0,0"
-                                       HorizontalAlignment="Stretch"/>
-                            
-                            <!--Button to close a particular tab-->
-                            <Button Name="CloseButton" Style="{StaticResource CloseButtonStyle}" DockPanel.Dock="Right" Click="OnCloseRightSideBarTab"
-                                    Margin="5,5,5,0" Uid="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Uid}">
-                                <Image Width="18" Height="18" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                       Text="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Header}" />
+
+                            <!--  Button to close a particular tab  -->
+                            <Button Name="CloseButton"
+                                    Uid="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Uid}"
+                                    Margin="5,5,5,0"
+                                    Click="OnCloseRightSideBarTab"
+                                    DockPanel.Dock="Right"
+                                    Style="{StaticResource CloseButtonStyle}">
+                                <Image Width="18"
+                                       Height="18"
+                                       HorizontalAlignment="Right"
+                                       VerticalAlignment="Center">
                                     <Image.Style>
                                         <Style TargetType="{x:Type Image}">
                                             <Style.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="False">
-                                                    <Setter Property="Source"
-                                                            Value="/DynamoCoreWpf;component/UI/Images/closetab_normal.png" />
+                                                    <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/closetab_normal.png" />
                                                 </Trigger>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="Source"
-                                                            Value="/DynamoCoreWpf;component/UI/Images/closetab_hover.png" />
+                                                    <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/closetab_hover.png" />
                                                 </Trigger>
                                             </Style.Triggers>
                                         </Style>
                                     </Image.Style>
                                 </Image>
                             </Button>
-                            <!-- Undock -->
-                            <Button Name="UndockButton" Style="{StaticResource CloseButtonStyle}" DockPanel.Dock="Right" Click="OnUndockRightSideBarTab"
-                                    Margin="8,5,0,0" Uid="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Uid}">
-                                <Image Width="18" Height="18" HorizontalAlignment="Right" VerticalAlignment="Center">
+                            <!--  Undock  -->
+                            <Button Name="UndockButton"
+                                    Uid="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabItem}}, Path=Uid}"
+                                    Margin="8,5,0,0"
+                                    Click="OnUndockRightSideBarTab"
+                                    DockPanel.Dock="Right"
+                                    Style="{StaticResource CloseButtonStyle}">
+                                <Image Width="18"
+                                       Height="18"
+                                       HorizontalAlignment="Right"
+                                       VerticalAlignment="Center">
                                     <Image.Style>
                                         <Style TargetType="{x:Type Image}">
                                             <Style.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="False">
-                                                    <Setter Property="Source"
-                                                            Value="/DynamoCoreWpf;component/UI/Images/undock_normal.png" />
+                                                    <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/undock_normal.png" />
                                                 </Trigger>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="Source"
-                                                            Value="/DynamoCoreWpf;component/UI/Images/undock_hover.png" />
+                                                    <Setter Property="Source" Value="/DynamoCoreWpf;component/UI/Images/undock_hover.png" />
                                                 </Trigger>
                                             </Style.Triggers>
                                         </Style>
@@ -1655,33 +1587,33 @@
                         </DockPanel>
                     </DataTemplate>
 
-                    <!--Styling for the tab in the right side bar-->
+                    <!--  Styling for the tab in the right side bar  -->
                     <Style TargetType="{x:Type TabItem}">
                         <Setter Property="MinWidth" Value="{Binding Source={x:Static configuration:Configurations.ExtensionsSideBarTabMinWidth}}" />
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="{x:Type TabItem}">
                                     <Grid>
-                                        <Border Name="Border" Margin="0,0,0,0"  BorderThickness="1 0 1 0" 
-                                                        BorderBrush="{StaticResource BorderBrushWhite}">
-                                            <ContentPresenter x:Name="ContentSite" VerticalAlignment="Center"
-                                                     HorizontalAlignment="Stretch"
-                                                     ContentSource="Header" Margin="3,0,0,3"
-                                                     RecognizesAccessKey="True">
-                                            </ContentPresenter>
+                                        <Border Name="Border"
+                                                Margin="0,0,0,0"
+                                                BorderBrush="{StaticResource BorderBrushWhite}"
+                                                BorderThickness="1,0,1,0">
+                                            <ContentPresenter x:Name="ContentSite"
+                                                              Margin="3,0,0,3"
+                                                              HorizontalAlignment="Stretch"
+                                                              VerticalAlignment="Center"
+                                                              ContentSource="Header"
+                                                              RecognizesAccessKey="True" />
                                         </Border>
                                     </Grid>
-                                    <!--Properties for selected and unselected tabs-->
+                                    <!--  Properties for selected and unselected tabs  -->
                                     <ControlTemplate.Triggers>
                                         <Trigger Property="IsSelected" Value="true">
-                                            <Setter Property="Foreground"
-                                                         Value="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
+                                            <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderActiveTextBrush}" />
                                         </Trigger>
                                         <Trigger Property="IsSelected" Value="false">
-                                            <Setter Property="Foreground"
-                                                         Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}" />
-                                            <Setter TargetName="Border" Property="Background"
-                                                         Value="{StaticResource HighlightedBrush}" />
+                                            <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}" />
+                                            <Setter TargetName="Border" Property="Background" Value="{StaticResource HighlightedBrush}" />
                                         </Trigger>
                                     </ControlTemplate.Triggers>
                                 </ControlTemplate>
@@ -1692,31 +1624,31 @@
             </TabControl>
         </Grid>
 
-        <!--Bottom Panel including RunMode etc-->
+        <!--  Bottom Panel including RunMode etc  -->
         <Grid Grid.Row="5"
-              Grid.Column="0"
               Grid.RowSpan="1"
+              Grid.Column="0"
+              Grid.ColumnSpan="5"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"
-              Grid.ColumnSpan="5"
               Background="#3C3C3C">
             <Grid Name="bottomBarGrid"
                   Grid.Row="4"
-                  Grid.Column="0"
                   Grid.RowSpan="1"
+                  Grid.Column="0"
                   Grid.ColumnSpan="5"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"></ColumnDefinition>
-                    <ColumnDefinition Width="*"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <WrapPanel Orientation="Horizontal"
-                           Grid.Row="0"
+                <WrapPanel Grid.Row="0"
                            Grid.Column="0"
                            HorizontalAlignment="Stretch"
                            VerticalAlignment="Stretch"
+                           Orientation="Horizontal"
                            Visibility="{Binding IsAbleToGoHome, Converter={StaticResource InverseBoolToVisibilityConverter}}">
 
                     <controls1:RunSettingsControl x:Name="RunSettingsControl"
@@ -1725,96 +1657,97 @@
                                                   DataContext="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel}" />
                 </WrapPanel>
 
-                <!--NotificationControl for showing run-time notifications-->
+                <!--  NotificationControl for showing run-time notifications  -->
                 <controls1:NotificationsControl Grid.Column="1" />
             </Grid>
         </Grid>
 
-        <!--Split Between Console and Canvas-->
-        <GridSplitter ResizeDirection="Rows"
-                      Grid.Column="2"
-                      Grid.ColumnSpan="1"
+        <!--  Split Between Console and Canvas  -->
+        <GridSplitter Name="horizontalSplitter"
                       Grid.Row="3"
                       Grid.RowSpan="1"
+                      Grid.Column="2"
+                      Grid.ColumnSpan="1"
                       Width="Auto"
                       Height="2"
-                      Name="horizontalSplitter"
+                      Margin="0"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      Margin="0"
                       Background="#999"
-                      Cursor="/DynamoCoreWpf;component/UI/Images/resize_vertical.cur" />
+                      Cursor="/DynamoCoreWpf;component/UI/Images/resize_vertical.cur"
+                      ResizeDirection="Rows" />
 
-        <!--Split Between Library and Canvas-->
-        <GridSplitter ResizeDirection="Auto"
+        <!--  Split Between Library and Canvas  -->
+        <GridSplitter Name="verticalSplitter"
+                      Grid.Row="2"
+                      Grid.RowSpan="2"
                       Grid.Column="1"
-                      Grid.Row="2"
-                      Grid.RowSpan="2"
-                      Height="Auto"
                       Width="3"
-                      Name="verticalSplitter"
+                      Height="Auto"
+                      Margin="0"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      Margin="0"
                       Background="Transparent"
-                      Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur" />
+                      Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur"
+                      ResizeDirection="Auto" />
 
-        <!--Split Between Right Sidebar panel and Canvas-->
-        <GridSplitter ResizeDirection="Auto"
+        <!--  Split Between Right Sidebar panel and Canvas  -->
+        <GridSplitter Name="extensionSplitter"
+                      Grid.Row="2"
+                      Grid.RowSpan="2"
                       Grid.Column="3"
-                      Grid.Row="2"
-                      Grid.RowSpan="2"
-                      Height="Auto"
                       Width="3"
-                      Name="extensionSplitter"
+                      Height="Auto"
+                      Margin="0"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      Margin="0"
                       Background="Transparent"
+                      Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur"
                       DragCompleted="RightExtensionSidebar_DragCompleted"
-                      Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur" />
+                      ResizeDirection="Auto" />
 
-        <!--Start Page-->
+        <!--  Start Page  -->
         <Grid x:Name="oldHomePageContainer"
-              Visibility="{Binding IsNewAppHomeEnabled,
-                                    Converter={StaticResource InverseBoolToVisibilityConverter},
-                                    RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
               Grid.Row="2"
               Grid.RowSpan="4"
               Grid.Column="0"
-              Grid.ColumnSpan="5">
+              Grid.ColumnSpan="5"
+              Visibility="{Binding IsNewAppHomeEnabled, Converter={StaticResource InverseBoolToVisibilityConverter}, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}">
             <ItemsControl Name="startPageItemsControl">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="{x:Type uictrls:StartPageViewModel}">
                         <Grid>
                             <Grid.Height>
-                                <Binding Path="ActualHeight"
-                                         Mode="OneWay"
-                                         RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
-                            </Grid.Height>  
+                                <Binding Mode="OneWay"
+                                         Path="ActualHeight"
+                                         RelativeSource="{RelativeSource FindAncestor,
+                                                                         AncestorType={x:Type ItemsControl}}" />
+                            </Grid.Height>
                             <uictrls:StartPageView />
                         </Grid>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
                 <ItemsControl.Visibility>
-                    <Binding Path="DataContext.ShowStartPage"
+                    <Binding Converter="{StaticResource BooleanToVisibilityConverter}"
                              Mode="OneWay"
-                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}"
-                             Converter="{StaticResource BooleanToVisibilityConverter}"
+                             Path="DataContext.ShowStartPage"
+                             RelativeSource="{RelativeSource FindAncestor,
+                                                             AncestorType={x:Type controls:DynamoView}}"
                              UpdateSourceTrigger="Explicit" />
                 </ItemsControl.Visibility>
             </ItemsControl>
-            </Grid>
-        <!--Do not delete newHomePageContainer grid as it is hosting the HomePage-->
+        </Grid>
+        <!--  Do not delete newHomePageContainer grid as it is hosting the HomePage  -->
         <Grid x:Name="newHomePageContainer"
-              Visibility="{Binding IsNewAppHomeEnabled, 
-                                   Converter={StaticResource BooleanToVisibilityConverter}, 
-                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
               Grid.Row="2"
               Grid.RowSpan="4"
               Grid.Column="0"
-              Grid.ColumnSpan="5"/>
+              Grid.ColumnSpan="5"
+              Visibility="{Binding IsNewAppHomeEnabled, Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" />
 
-        <Grid Name="FocusableGrid" Width="0" Height="0" Focusable="True"/>
+        <Grid Name="FocusableGrid"
+              Width="0"
+              Height="0"
+              Focusable="True" />
     </Grid>
 </Window>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -794,7 +794,7 @@
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*" />
-                                                        <ColumnDefinition Width="Auto   " />
+                                                        <ColumnDefinition Width="Auto" />
                                                     </Grid.ColumnDefinitions>
                                                     <ScrollViewer Grid.Column="0"
                                                                   Margin="0,0,150,0"
@@ -806,8 +806,8 @@
                                                             <Button Name="HomeButton"
                                                                     Width="42"
                                                                     Height="42"
-                                                                    Click="HomeButton_Click"
                                                                     BorderThickness="0"
+                                                                    Click="HomeButton_Click"
                                                                     Cursor="Hand">
                                                                 <Button.Template>
                                                                     <ControlTemplate TargetType="Button">
@@ -1055,6 +1055,7 @@
                         <Style TargetType="{x:Type TabItem}">
                             <Setter Property="MaxWidth" Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
                             <Setter Property="MinWidth" Value="{Binding Source={x:Static configuration:Configurations.TabDefaultWidth}}" />
+                            <EventSetter Event="MouseLeftButtonUp" Handler="TabItem_MouseLeftButtonUp" />
                             <Setter Property="Width">
                                 <Setter.Value>
                                     <MultiBinding Converter="{StaticResource TabSizeConverter}">
@@ -1141,13 +1142,16 @@
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="False">
                                                             <Setter Property="Background" Value="{StaticResource WorkspaceTabBorderSelectedFalse}" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource BorderBrushWhite}" />
-                                                            <Setter Property="Margin" Value="0,0,0,-1" />
+                                                            <Setter Property="BorderBrush" Value="{StaticResource WorkspaceTabBorderSelectedFalse}" />
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="True">
                                                             <Setter Property="Background" Value="{StaticResource WorkspaceTabBorderSelectedTrue}" />
-                                                            <Setter Property="BorderBrush" Value="#ADE4DE" />
-                                                            <Setter Property="Margin" Value="0" />
+                                                            <Setter Property="BorderBrush" Value="{StaticResource WorkspaceTabBorderSelectedTrue}" />
+                                                        </DataTrigger>
+                                                        <!--  Fake deselect when start page is shown  -->
+                                                        <DataTrigger Binding="{Binding DataContext.ShowStartPage, RelativeSource={RelativeSource AncestorType={x:Type controls:DynamoView}}}" Value="True">
+                                                            <Setter Property="Background" Value="{StaticResource WorkspaceTabBorderSelectedFalse}" />
+                                                            <Setter Property="BorderBrush" Value="{StaticResource WorkspaceTabBorderSelectedFalse}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -1263,6 +1267,12 @@
                                                 <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabItem}}, Path=IsSelected}" Value="False">
                                                     <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}" />
                                                 </DataTrigger>
+
+                                                <!--  Fake Deselect when StartPage is shown  -->
+                                                <DataTrigger Binding="{Binding DataContext.ShowStartPage, RelativeSource={RelativeSource AncestorType={x:Type controls:DynamoView}}}" Value="True">
+                                                    <Setter Property="Foreground" Value="{StaticResource WorkspaceTabHeaderInactiveTextBrush}" />
+                                                </DataTrigger>
+
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}" Value="{x:Type workspaces:HomeWorkspaceModel}" />

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -145,7 +145,7 @@ namespace Dynamo.Controls
             _timer = new Stopwatch();
             _timer.Start();
 
-            InitializeComponent();
+            InitializeComponent();  
 
             Loaded += DynamoView_Loaded;
             Unloaded += DynamoView_Unloaded;
@@ -2454,6 +2454,7 @@ namespace Dynamo.Controls
 
         private void ToggleWorkspaceTabVisibility(int tabSelected)
         {
+            // Switch off the start page first
             SlideWindowToIncludeTab(tabSelected);
 
             for (int tabIndex = 1; tabIndex < WorkspaceTabs.Items.Count; tabIndex++)
@@ -3008,7 +3009,10 @@ namespace Dynamo.Controls
 
         private void HomeButton_Click(object sender, RoutedEventArgs e)
         {
-            this.dynamoViewModel.ShowStartPage = true;
+            if (!this.dynamoViewModel.ShowStartPage)
+            {
+                this.dynamoViewModel.ShowStartPage = true;
+            }
         }
 
         /// <summary>
@@ -3065,6 +3069,12 @@ namespace Dynamo.Controls
         {
             if(fileTrustWarningPopup != null)
                 fileTrustWarningPopup.ManagePopupActivation(false);
+        }
+
+        private void TabItem_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (this.dynamoViewModel.ShowStartPage)
+                this.dynamoViewModel.ShowStartPage = false;
         }
 
         public void Dispose()

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -3005,6 +3005,12 @@ namespace Dynamo.Controls
             ShowGetStartedGuidedTour();
         }
 
+
+        private void HomeButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.dynamoViewModel.ShowStartPage = true;
+        }
+
         /// <summary>
         /// This method probably will be modified or deleted in the future when the GuideManager and Guide class are created
         /// For now will be used just for testing/demo purposes since the popups will be created probably in the Guide class.


### PR DESCRIPTION
### Purpose

This PR responds to `As a Dynamo user, I want to switch between current workspace and Dynamo home seamlessly` https://jira.autodesk.com/browse/DYN-7256

### Changes
![DynamoSandbox_sBRTeun5YC](https://github.com/user-attachments/assets/88e709a4-4dd8-4612-917c-e3f894bb5350)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- a new button as part of the tab control
- 'fake' select/deselect tab items interaction
- automatic formatting of the .xaml code of DynamoView.xml because of an extension (I hope it's OK)

### Reviewers

@QilongTang 

### FYIs

@reddyashish 
