### PR TITLE
[DYN-7436] Dynamo crashes upon exporting results if the destination file is

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4562,6 +4562,17 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file is currently in use by another application.
+        ///	
+        ///Please close the file before trying to overwrite it..
+        /// </summary>
+        public static string MessageFileInUseByApplication {
+            get {
+                return ResourceManager.GetString("MessageFileInUseByApplication", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package {0} has one or more dependencies that conflict with the following packages that are in use in the workspace: {1}. Dependency conflicts could cause unintended behavior to occur.
         ///    
         ///Do you wish to continue installing it while keeping the packages that are already installed?
@@ -9954,6 +9965,15 @@ namespace Dynamo.Wpf.Properties {
         public static string TermsOfUseViewTitle {
             get {
                 return ResourceManager.GetString("TermsOfUseViewTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File in use.
+        /// </summary>
+        public static string TitleFileInUse {
+            get {
+                return ResourceManager.GetString("TitleFileInUse", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1267,6 +1267,14 @@ Would you like to save your changes?</value>
 
 Would you like to save your changes?</value>
   </data>
+  <data name="MessageFileInUseByApplication" xml:space="preserve">
+    <value>The file is currently in use by another application.
+	
+Please close the file before trying to overwrite it.</value>
+  </data>
+  <data name="TitleFileInUse" xml:space="preserve">
+    <value>File in use</value>
+  </data>
   <data name="MessageConfirmToSaveNamedHomeWorkSpace" xml:space="preserve">
     <value>You have unsaved changes to {0}.
 

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -935,6 +935,14 @@ Would you like to save your changes?</value>
 
 Would you like to save your changes?</value>
   </data>
+  <data name="MessageFileInUseByApplication" xml:space="preserve">
+    <value>The file is currently in use by another application.
+	
+Please close the file before trying to overwrite it.</value>
+  </data>
+  <data name="TitleFileInUse" xml:space="preserve">
+    <value>File in use</value>
+  </data>
   <data name="MessageConfirmToSaveNamedHomeWorkSpace" xml:space="preserve">
     <value>You have unsaved changes to {0}.
 

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4866,6 +4866,7 @@ static Dynamo.Wpf.Properties.Resources.MessageFailedToOpenCorruptedFile.get -> s
 static Dynamo.Wpf.Properties.Resources.MessageFailedToSaveAsImage.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailedToUnload.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageFailToUninstallPackage.get -> string
+static Dynamo.Wpf.Properties.Resources.MessageFileInUseByApplication.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageForceInstallOrUninstallToContinue.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageForceInstallOrUninstallUponRestart.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageGettingNodeError.get -> string
@@ -5460,6 +5461,7 @@ static Dynamo.Wpf.Properties.Resources.TabFileNameReadOnlyPrefix.get -> string
 static Dynamo.Wpf.Properties.Resources.TermsOfUseAcceptButton.get -> string
 static Dynamo.Wpf.Properties.Resources.TermsOfUseDeclineButton.get -> string
 static Dynamo.Wpf.Properties.Resources.TermsOfUseViewTitle.get -> string
+static Dynamo.Wpf.Properties.Resources.TitleFileInUse.get -> string
 static Dynamo.Wpf.Properties.Resources.TitlePackageTargetOtherHost.get -> string
 static Dynamo.Wpf.Properties.Resources.TooltipCurrentIndex.get -> string
 static Dynamo.Wpf.Properties.Resources.TourLabelProgressText.get -> string

--- a/src/GraphNodeManagerViewExtension/Utilities/Utilities.cs
+++ b/src/GraphNodeManagerViewExtension/Utilities/Utilities.cs
@@ -2,8 +2,11 @@ using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Linq;
+using System.Windows;
 using System.Windows.Forms;
 using System.Xml;
+using Dynamo.Wpf.Utilities;
+using Dynamo.Wpf.Properties;
 using Newtonsoft.Json;
 
 namespace Dynamo.GraphNodeManager.Utilities
@@ -30,6 +33,17 @@ namespace Dynamo.GraphNodeManager.Utilities
 
                 if (saveFileDialog.ShowDialog() == DialogResult.OK)
                 {
+                    if (IsFileLocked(new FileInfo(saveFileDialog.FileName)))
+                    {
+                        MessageBoxService.Show(
+                            Resources.MessageFileInUseByApplication,
+                            Resources.TitleFileInUse,
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+
+                        return;
+                    }
+
                     string output = JsonConvert.SerializeObject(exportObject);
 
                     var csv = jsonToCSV(output);
@@ -106,6 +120,31 @@ namespace Dynamo.GraphNodeManager.Utilities
 
             lines.AddRange(valueLines);
             return lines;
+        }
+
+        /// <summary>
+        /// Checks if the specified file is locked by another process or application.
+        /// </summary>
+        private static bool IsFileLocked(FileInfo file)
+        {
+            if (!file.Exists) return false;
+
+            FileStream stream = null;
+
+            try
+            {
+                stream = file.Open(FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException)
+            {
+                return true;
+            }
+            finally
+            {
+                stream?.Close();
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
### Purpose

PR aims to address [DYN-7436](https://jira.autodesk.com/browse/DYN-7436).

When a user tries to export a .csv from the Graph Node Manager, the code now checks if the file is locked by another application. If the file is in use, a warning message is displayed, and the export is canceled. This behavior mirrors the implementation in TuneUp and PR #66.

The warning message and title have been added as resources to Dynamo.Wpf for localization support.

![DYN-7436-Dynamo](https://github.com/user-attachments/assets/35313eaa-cced-4ab3-8c0b-7a9ca3cdc0e3)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

When a user tries to export a .csv from the Graph Node Manager, the code now checks if the file is locked by another application. If the file is in use, a warning message is displayed, and the export is canceled.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@Amoursol
