### PR TITLE
[DYN-7466] Follow up - Zoom to fit to nodes/groups selected in TuneUP and GraphNodeManager

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2771,6 +2771,7 @@ namespace Dynamo.ViewModels
             }
             // Center the view on the model
             this.CurrentSpaceViewModel.OnRequestCenterViewOnElement(this, new ModelEventArgs(e));
+            FitView(false);
         }
 
         private void CancelActiveState(NodeModel node)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1156,7 +1156,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMinX()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.X)
                            .Min();
@@ -1164,7 +1164,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMinY()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.Y)
                            .Min();
@@ -1172,7 +1172,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMaxX()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.X + x.Width)
                            .Max();
@@ -1188,7 +1188,7 @@ namespace Dynamo.ViewModels
 
         public double GetSelectionMaxY()
         {
-            return DynamoSelection.Instance.Selection.Where((x) => !(x is AnnotationModel) && x is ILocatable)
+            return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
                            .Cast<ILocatable>()
                            .Select((x) => x.Y + x.Height)
                            .Max();


### PR DESCRIPTION
### Purpose

This PR is related to [DYN-4766](https://jira.autodesk.com/browse/DYN-7466) and is a follow up to [this thread](https://autodesk.slack.com/archives/CPJ5UQW0Z/p1726605504746209) and point 4 of [this Mural](https://app.mural.co/t/autodesk2145/m/autodesk2145/1726671147065/f22bbd9296463ee3376ffd3c5be0a9e68028b323?sender=u63a4c10277115ad8dc555082).

Now, clicking on a node or group in TuneUp or GraphNodeManager will trigger a zoom-to-fit action for the selected node or group. Previously, the behavior only centered on the selected node.

Additionally, I have removed the `x is AnnotationModel` check from the `    public partial class WorkspaceViewModel : ViewModelBase
.GetSelectionMinX()`, `GetSelectionMinY()`, `GetSelectionMaxX()`, and `GetSelectionMaxY()` methods. This change allows the functionality to work with groups, and I couldn't find any reason for keeping that check in place.

**_Before:_**

![DYN-7466_Before](https://github.com/user-attachments/assets/b6ace582-ab99-4e31-b45b-1e88d9fbb93d)

**_Afrer:_**

![DYN-7466_After](https://github.com/user-attachments/assets/4262d00d-6160-4217-a87b-d294155f52bb)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Adds zoom-to-fit functionality for nodes or groups selected in TuneUp and GraphNodeManager.

### Reviewers
@reddyashish 
@QilongTang 

### FYIs
@dnenov 
@Amoursol 
