### PR TITLE
add new debug service core runtime nuspec with portable symbols

### DIFF
--- a/src/Config/CS_SDK.props
+++ b/src/Config/CS_SDK.props
@@ -36,7 +36,7 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
     <PropertyGroup>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' ">
     <Optimize>false</Optimize>

--- a/src/Config/CS_SDK.props
+++ b/src/Config/CS_SDK.props
@@ -35,8 +35,12 @@
     <DebugSymbols>true</DebugSymbols>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
-    <PropertyGroup>
-    <DebugType>portable</DebugType>
+    <!--generate windows pdbs on windows and portable pdbs for linux builds - CER currently does not support portable-->
+    <PropertyGroup Condition="!$(Platform.Contains('Linux'))">
+        <DebugType>full</DebugType>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Platform.Contains('Linux'))" >
+        <DebugType>portable</DebugType>
     </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' ">
     <Optimize>false</Optimize>

--- a/tools/NuGet/template-service-core/DynamoVisualProgramming.ServiceCoreRuntime-debug.nuspec
+++ b/tools/NuGet/template-service-core/DynamoVisualProgramming.ServiceCoreRuntime-debug.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>DynamoVisualProgramming.ServiceCoreRuntime-debug</id>
+        <version>$Version$</version>
+        <authors>Autodesk</authors>
+        <owners>Autodesk</owners>
+        <license type="expression">Apache-2.0</license>
+        <projectUrl>https://github.com/DynamoDS/Dynamo</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Assemblies required to start a DynamoModel and execute DesignScript code bundled along with their dependencies.
+            Built targeting linux. </description>
+        <copyright>Copyright Autodesk 2023</copyright>
+ <dependencies>
+            <group targetFramework="$TargetFramework$">
+            </group>
+        </dependencies>
+        <repository type ="git" url="https://github.com/DynamoDS/Dynamo.git" commit="$gitcommitid$"></repository>
+    </metadata>
+    <files>
+              <file src="**"
+              target="lib\$TargetFramework$\"
+              exclude="**\*.txt;**\*.rtf;en-US\fallback_docs\*;NodeHelpSharedDocs\*;Open Source Licenses\*;samples\** "/>
+    </files>
+</package>


### PR DESCRIPTION
create portable symbols so debugging linux builds of dynamo core requires less manual steps.

- [x] DNM until we see if CER supports this format - if not we'll have to do this conditionally for linux builds.
- [x] support single nuspec file in buildpackages.bat to support @pinzart90's changes in linux build job.
- [x] set commit info on the package using git commit 
<img width="615" alt="nuget pic" src="https://github.com/user-attachments/assets/09585493-d67a-4aa7-87a8-cafbfc285cd2">

