### PR TITLE
duplicate names 'bug' fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1519,7 +1519,16 @@ namespace Dynamo.PackageManager
                     out def))
                 {
                     defs.Add(def);
-                    defPreviews[x.Name] = x.Path;
+
+                    // Check if the dictionary already contains the key
+                    if (defPreviews.ContainsKey(x.Name))
+                    {
+                        defPreviews[$"{x.Category}.{x.Name}"] = x.Path;
+                    }
+                    else
+                    {
+                        defPreviews[x.Name] = x.Path;
+                    }
                 }
             }
 


### PR DESCRIPTION
### Purpose

PR contains changes to the Publish process of the PM.

A limitation of the current `Publish` and `Publish version..` workflows were detected where a package containing nodes with identical `Names` will only utilize one of the custom nodes. 

`ByCurve` and `ByClosedCurve` kept with short names, whereas the identical `Forma.Elements.Create.Road.ByCurve` and `Forma.Elements.Create.SiteLimit.ByClosedCurve` are used for preview purposes.

<img width="538" alt="image" src="https://github.com/user-attachments/assets/06bc5fee-a758-432b-8b33-ce7b70a46f15">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- works around a limitation that currently does not allow nodes with identical Names to be published
- in such cases, now uses a combination of node.Category and node.Name for preview purposes (nodes will keep their original naming and so on)
- creating a [Test] was far too complicated because of the way the affected method interacts with the `CustomNodeManager` and the registered in the WS CustomNodeDefinitions. (at least I couldn't figure it out)

### Reviewers

@aparajit-pratap 

### FYIs

@QilongTang 