### PR TITLE
DYN-7214 Info Messages Bug

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2007,7 +2007,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         internal bool HasInfos
         {
-            get { return Nodes.Any(n => n.State == ElementState.Info); }
+            get { return Nodes.Any(n => n.State == ElementState.Info || n.State == ElementState.PersistentInfo); }
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Fixing Info messages bug when updating the graph.
When having several nodes with info messages if the one of the nodes connected is fixed then all the messages are cleared (when the other info message should still appear).
There is still a weird behavior when a graph (which previously had info messages) is opened the info messages are not present, I noticed this behavior when creating this PR then I will continue working on this.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Info messages bug when updating the graph.

### Reviewers

@QilongTang 

### FYIs

