### PR TITLE
Regressions Extra Node Info

### DIFF
--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -169,6 +169,7 @@ namespace DynamoCoreWpfTests
             // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
             var nodeNamesResultList = searchViewModel.FilteredResults.Select(x => x.Name).ToList();
+
             Assert.AreEqual(expectedNodes.Count(), nodeNamesResultList.Count(),string.Format("Missing nodes: {0} ", string.Join(", ",expectedNodes.Except(nodeNamesResultList))));
         }
         [Test]

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -169,7 +169,6 @@ namespace DynamoCoreWpfTests
             // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
             var nodeNamesResultList = searchViewModel.FilteredResults.Select(x => x.Name).ToList();
-
             Assert.AreEqual(expectedNodes.Count(), nodeNamesResultList.Count(),string.Format("Missing nodes: {0} ", string.Join(", ",expectedNodes.Except(nodeNamesResultList))));
         }
         [Test]

--- a/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
+++ b/test/DynamoCoreWpfTests/NodeAutoCompleteSearchTests.cs
@@ -18,6 +18,8 @@ namespace DynamoCoreWpfTests
     class NodeAutoCompleteSearchTests : DynamoTestUIBase
     {
 
+        private readonly List<string> expectedNodes = new List<string> { "ByFillet", "ByFilletTangentToCurve", "ByGeometry", "ByMinimumVolume", "ByBlendBetweenCurves", "ByTangency", "ByLineAndPoint", "ByJoinedCurves", "ByThickeningCurveNormal", "ByLoft", "ByLoft", "ByLoftGuides", "BySweep", "ByLoft", "ByLoft", "ByRevolve", "BySweep", "BySweep2Rails", "ByLoft", "ByLoft", "ByPatch", "ByRevolve", "ByRuledLoft", "BySweep", "BySweep2Rails", "BuildFromLines", "BuildPipes", "ByExtrude", "ByPlaneLineAndPoint", "ByRevolve", "BySweep", "DoesIntersect", "IsAlmostEqualTo", "DistanceTo", "Intersect", "IntersectAll", "Project", "Project", "ProjectInputOnto", "ProjectInputOnto", "Split", "Trim", "SerializeAsSAB", "ClosestPointTo", "Join", "ByGroupedCurves", "SweepAsSolid", "ExportToSAT", "SweepAsSurface", "LocateSurfacesByLine", "BridgeEdgesToEdges", "BridgeEdgesToFaces", "BridgeFacesToEdges", "BridgeFacesToFaces", "CreateMatch", "ExtrudeEdgesAlongCurve", "ExtrudeFacesAlongCurve", "PullVertices" };
+
         [NodeDescription("This is test node with multiple output ports and types specified.")]
         [NodeName("node with multi type outputs")]
         [InPortNames("input1", "input2")]
@@ -166,7 +168,9 @@ namespace DynamoCoreWpfTests
 
             // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(58, searchViewModel.FilteredResults.Count());
+            var nodeNamesResultList = searchViewModel.FilteredResults.Select(x => x.Name).ToList();
+
+            Assert.AreEqual(expectedNodes.Count(), nodeNamesResultList.Count(),string.Format("Missing nodes: {0} ", string.Join(", ",expectedNodes.Except(nodeNamesResultList))));
         }
         [Test]
         public void NodeSuggestions_CanAutoCompleteOnCustomNodesOutPort_WithWhiteSpaceStartingPortName()
@@ -186,7 +190,9 @@ namespace DynamoCoreWpfTests
 
             // Results will be nodes that accept Line as parameter.
             searchViewModel.PopulateAutoCompleteCandidates();
-            Assert.AreEqual(58, searchViewModel.FilteredResults.Count());
+            var nodeNamesResultList = searchViewModel.FilteredResults.Select(x => x.Name).ToList();
+
+            Assert.AreEqual(expectedNodes.Count(), nodeNamesResultList.Count(), string.Format("Missing nodes: {0} ", string.Join(", ", expectedNodes.Except(nodeNamesResultList))));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Adding code for getting extra info and fix flaky regressions
Instead of using a hard-coded value like 58 got the list of expected nodes names in a variable and then if the test fails log the missing nodes.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Adding code for getting extra info and fix flaky regressions

### Reviewers

@QilongTang @mjkkirschner 

### FYIs


