### PR TITLE
[DYN-4361] Enable Ctrl + C to copy selected data out of preview bubbles/watch nodes

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml
@@ -164,12 +164,22 @@
                                                                             <ColumnDefinition Width="30" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <!--  Displays the warning message  -->
-                                                                        <TextBlock LineHeight="14px" TextWrapping="Wrap">
-                                                                            <TextBlock.Inlines>
-                                                                                <Run FontFamily="{StaticResource ArtifaktElementBold}" Text="{Binding MessageNumber, UpdateSourceTrigger=PropertyChanged}" />
-                                                                                <Run Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
-                                                                            </TextBlock.Inlines>
-                                                                        </TextBlock>
+                                                                        <Grid>
+                                                                            <!-- TextBox for the numbering -->
+                                                                            <TextBox Text="{Binding MessageNumber, UpdateSourceTrigger=PropertyChanged}"
+                                                                                     FontFamily="{StaticResource ArtifaktElementBold}"
+                                                                                     IsReadOnly="True"
+                                                                                     Background="Transparent"
+                                                                                     BorderThickness="0"/>
+                                                                            <!-- TextBox for the message description -->
+                                                                            <TextBox Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}"
+                                                                                     FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                                                     TextWrapping="Wrap"
+                                                                                     IsReadOnly="True"
+                                                                                     Background="Transparent"
+                                                                                     BorderThickness="0"
+                                                                                     Margin="30,0,0,0"/>
+                                                                        </Grid>
                                                                     </Grid>
                                                                     <Button Name="LearnMoreErrorsButton"
                                                                             Margin="-2,4,0,0"
@@ -221,11 +231,11 @@
                                                                             <ColumnDefinition Width="30" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <!--  Displays the warning message  -->
-                                                                        <TextBlock LineHeight="14px" TextWrapping="Wrap">
-                                                                            <TextBlock.Inlines>
-                                                                                <Run Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
-                                                                            </TextBlock.Inlines>
-                                                                        </TextBlock>
+                                                                        <TextBox IsReadOnly="True"
+                                                                                 Background="Transparent"
+                                                                                 BorderThickness="0"
+                                                                                 TextWrapping="Wrap"
+                                                                                 Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
                                                                     </Grid>
                                                                     <Button Name="LearnMoreErrorsButton"
                                                                             Margin="-2,4,0,0"
@@ -394,12 +404,22 @@
                                                                             <ColumnDefinition Width="30" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <!--  Displays the warning message  -->
-                                                                        <TextBlock LineHeight="14px" TextWrapping="Wrap">
-                                                                            <TextBlock.Inlines>
-                                                                                <Run FontFamily="{StaticResource ArtifaktElementBold}" Text="{Binding MessageNumber, UpdateSourceTrigger=PropertyChanged}" />
-                                                                                <Run Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
-                                                                            </TextBlock.Inlines>
-                                                                        </TextBlock>
+                                                                        <Grid>
+                                                                            <!-- TextBox for the numbering -->
+                                                                            <TextBox Text="{Binding MessageNumber, UpdateSourceTrigger=PropertyChanged}"
+                                                                                     FontFamily="{StaticResource ArtifaktElementBold}"
+                                                                                     IsReadOnly="True"
+                                                                                     Background="Transparent"
+                                                                                     BorderThickness="0"/>
+                                                                            <!-- TextBox for the message description -->
+                                                                            <TextBox Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}"
+                                                                                     FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                                                     TextWrapping="Wrap"
+                                                                                     IsReadOnly="True"
+                                                                                     Background="Transparent"
+                                                                                     BorderThickness="0"
+                                                                                     Margin="30,0,0,0"/>
+                                                                        </Grid>
                                                                         <Button Name="DismissMessageButton"
                                                                                 Grid.Column="1"
                                                                                 Width="13"
@@ -466,11 +486,11 @@
                                                                             <ColumnDefinition Width="30" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <!--  Displays the warning message  -->
-                                                                        <TextBlock LineHeight="14px" TextWrapping="Wrap">
-                                                                            <TextBlock.Inlines>
-                                                                                <Run Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
-                                                                            </TextBlock.Inlines>
-                                                                        </TextBlock>
+                                                                        <TextBox IsReadOnly="True"
+                                                                                 Background="Transparent"
+                                                                                 BorderThickness="0"
+                                                                                 TextWrapping="Wrap"
+                                                                                 Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
                                                                         <Button Name="DismissMessageButton"
                                                                                 Grid.Column="1"
                                                                                 Width="13"
@@ -669,12 +689,22 @@
                                                                             <ColumnDefinition Width="30" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <!--  Displays the warning message  -->
-                                                                        <TextBlock LineHeight="14px" TextWrapping="Wrap">
-                                                                            <TextBlock.Inlines>
-                                                                                <Run FontFamily="{StaticResource ArtifaktElementBold}" Text="{Binding MessageNumber, UpdateSourceTrigger=PropertyChanged}" />
-                                                                                <Run Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
-                                                                            </TextBlock.Inlines>
-                                                                        </TextBlock>
+                                                                        <Grid>
+                                                                            <!-- TextBox for the numbering -->
+                                                                            <TextBox Text="{Binding MessageNumber, UpdateSourceTrigger=PropertyChanged}"
+                                                                                     FontFamily="{StaticResource ArtifaktElementBold}"
+                                                                                     IsReadOnly="True"
+                                                                                     Background="Transparent"
+                                                                                     BorderThickness="0"/>
+                                                                            <!-- TextBox for the message description -->
+                                                                            <TextBox Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}"
+                                                                                     FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                                                     TextWrapping="Wrap"
+                                                                                     IsReadOnly="True"
+                                                                                     Background="Transparent"
+                                                                                     BorderThickness="0"
+                                                                                     Margin="30,0,0,0"/>
+                                                                        </Grid>
                                                                         <Button Name="DismissMessageButton"
                                                                                 Grid.Column="1"
                                                                                 Width="13"
@@ -737,11 +767,11 @@
                                                                             <ColumnDefinition Width="30" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <!--  Displays the warning message  -->
-                                                                        <TextBlock LineHeight="14px" TextWrapping="Wrap">
-                                                                            <TextBlock.Inlines>
-                                                                                <Run Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
-                                                                            </TextBlock.Inlines>
-                                                                        </TextBlock>
+                                                                        <TextBox IsReadOnly="True"
+                                                                                 Background="Transparent"
+                                                                                 BorderThickness="0"
+                                                                                 TextWrapping="Wrap"
+                                                                                 Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" />
                                                                         <Button Name="DismissMessageButton"
                                                                                 Grid.Column="1"
                                                                                 Width="13"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -352,19 +352,23 @@
                             </TextBlock.Style>
                         </TextBlock>
 
-                        <TextBlock Width="Auto"
-                                   Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
-                                   VerticalAlignment="Center"                                                                      
-                                   FontFamily="{StaticResource SourceCodePro}"
-                                   Text="{Binding Path=NodeLabel}"
-                                   Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" >
+                        <TextBox Width="Auto"
+                                 Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
+                                 VerticalAlignment="Center"
+                                 FontFamily="{StaticResource SourceCodePro}"
+                                 Text="{Binding Path=NodeLabel}"
+                                 Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}"
+                                 IsReadOnly="True"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 TextWrapping="Wrap">
                             <TextBlock.Foreground>
                                 <MultiBinding Converter="{StaticResource ObjectTypeConverter}">
                                     <Binding Path="ValueType" />
                                     <Binding Path="NodeLabel" />
-                                    </MultiBinding>
+                                </MultiBinding>
                             </TextBlock.Foreground>
-                            </TextBlock>
+                        </TextBox>
 
                         <Button Margin="10,2,2,2"
                                 Padding="4,0,4,0"

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -292,8 +292,12 @@ namespace DynamoCoreWpfTests
             var tree = nodeView.ChildrenOfType<WatchTree>();
             Assert.AreEqual(1, tree.Count());
 
-            var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(8, items.Count());
+            // text block for list indexes
+            var textBlocks = tree.First().treeView1.ChildrenOfType<TextBlock>();
+            Assert.AreEqual(4, textBlocks.Count());
+            // text boxes for list items
+            var textBoxes = tree.First().treeView1.ChildrenOfType<TextBox>();
+            Assert.AreEqual(4, textBoxes.Count());
         }
 
         [Test, Category("DisplayHardwareDependent")]
@@ -437,7 +441,12 @@ namespace DynamoCoreWpfTests
 
             var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
             // watch is computed with cbn and has its value
-            Assert.AreEqual(8, items.Count());
+            // text block for list indexes
+            var textBlocks = tree.First().treeView1.ChildrenOfType<TextBlock>();
+            Assert.AreEqual(4, textBlocks.Count());
+            // text boxes for list items
+            var textBoxes = tree.First().treeView1.ChildrenOfType<TextBox>();
+            Assert.AreEqual(4, textBoxes.Count());
 
             // disconnect watch
             Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
@@ -464,8 +473,10 @@ namespace DynamoCoreWpfTests
             Run();
             DispatcherUtil.DoEvents();
             tree = nodeView.ChildrenOfType<WatchTree>();
-            items = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(8, items.Count());
+            textBlocks = tree.First().treeView1.ChildrenOfType<TextBlock>();
+            Assert.AreEqual(4, textBlocks.Count());
+            textBoxes = tree.First().treeView1.ChildrenOfType<TextBox>();
+            Assert.AreEqual(4, textBoxes.Count());
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

PR aims to address [DYN-4361](https://jira.autodesk.com/browse/DYN-4361).

I have replaced `TextBlock` elements with `TextBox` controls in `InfoBubbleView` and `WatchTree`. Now users can select and copy data using Ctrl+C.
Note that for nodes with multiple warnings, the info bubble text boxes are wrapped in a `Grid`. The visual appearance is slightly different compared to the previous version (see image below). The change is small and helps avoid adding extra logic to the code-behind.

_**Before:**_
<img src="https://github.com/user-attachments/assets/9641e567-74a4-4785-b8a1-73f6366d7c3c" width="300"/>

_**After:**_
<img src="https://github.com/user-attachments/assets/eb5dcaf3-4c46-4fab-b3d5-801ea38ddcc4c" width="300"/>


![DYN-4361-EnableCtrlC](https://github.com/user-attachments/assets/8a369d51-31b6-4acf-b370-8bbe9b49195e)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Users can now select data from info bubbles and Watch nodes and use Ctrl+C to copy.

### Reviewers
@reddyashish 
@QilongTang 

### FYIs
@dnenov 
@Amoursol 
