### PR TITLE
DYN-7466: padding factor

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -56,7 +56,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Const used for zoom-to-fit calculations for nodes and groups in the workspace.
         /// </summary>
-        public const double ZoomToFitPaddingFactor = 3.5;
+        public static readonly double ZoomToFitPaddingFactor = 3.5;
 
         #endregion
 

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -53,6 +53,11 @@ namespace Dynamo.Configuration
         /// </summary>
         public static readonly string DynamoNodeHelpDocs = "NodeHelpSharedDocs";
 
+        /// <summary>
+        /// Const used for zoom-to-fit calculations for nodes and groups in the workspace.
+        /// </summary>
+        public const double ZoomToFitPaddingFactor = 3.5;
+
         #endregion
 
         #region Usage Reporting Error Message

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -3015,6 +3015,7 @@ static readonly Dynamo.Configuration.Configurations.TabDefaultWidth -> int
 static readonly Dynamo.Configuration.Configurations.ZoomDirectEditThreshold -> double
 static readonly Dynamo.Configuration.Configurations.ZoomIncrement -> double
 static readonly Dynamo.Configuration.Configurations.ZoomThreshold -> double
+static readonly Dynamo.Configuration.Configurations.ZoomToFitPaddingFactor -> double
 static readonly Dynamo.Configuration.PreferenceSettings.DynamoDefaultTime -> System.DateTime
 virtual Dynamo.Core.CustomNodeManager.OnCustomNodeRemoved(System.Guid functionId) -> void
 virtual Dynamo.Core.CustomNodeManager.OnDefinitionUpdated(Dynamo.CustomNodeDefinition obj) -> void

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1548,7 +1548,7 @@ namespace Dynamo.ViewModels
             }
 
             // Add padding to the calculated bounding box for better visibility
-            double paddingFactor = 1.5;
+            double paddingFactor = 3.5;
 
             double focusWidth = (maxX - minX) * paddingFactor;
             double focusHeight = (maxY - minY) * paddingFactor;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1547,9 +1547,16 @@ namespace Dynamo.ViewModels
                 
             }
 
-            var offset = new Point2D(minX, minY);
-            double focusWidth = maxX - minX;
-            double focusHeight = maxY - minY;
+            // Add padding to the calculated bounding box for better visibility
+            double paddingFactor = 1.5;
+
+            double focusWidth = (maxX - minX) * paddingFactor;
+            double focusHeight = (maxY - minY) * paddingFactor;
+
+            // Adjust offset to ensure the view is centered with the padding
+            double offsetX = minX - (focusWidth - (maxX - minX)) / 2.0;
+            double offsetY = minY - (focusHeight - (maxY - minY)) / 2.0;
+            var offset = new Point2D(offsetX, offsetY);
 
             ZoomEventArgs zoomArgs;
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1548,10 +1548,8 @@ namespace Dynamo.ViewModels
             }
 
             // Add padding to the calculated bounding box for better visibility
-            double paddingFactor = 3.5;
-
-            double focusWidth = (maxX - minX) * paddingFactor;
-            double focusHeight = (maxY - minY) * paddingFactor;
+            double focusWidth = (maxX - minX) * Configurations.ZoomToFitPaddingFactor;
+            double focusHeight = (maxY - minY) * Configurations.ZoomToFitPaddingFactor;
 
             // Adjust offset to ensure the view is centered with the padding
             double offsetX = minX - (focusWidth - (maxX - minX)) / 2.0;


### PR DESCRIPTION
### Purpose

Small PR related to [DYN-7466](https://jira.autodesk.com/browse/DYN-7466) and feedback from the last Archilizer Check-in regarding nodes/groups appearing too large when zoom-to-fit is applied.

I've added a `paddingFactor` of 1.5 to `WorkspaceViewModel.FitViewInternal`. This adjustment affects zoom-to-fit behavior for node or group selections in TuneUp and Graph Node Manager, as well as for the Zoom to Fit button in workspace.

I think keeping `paddingFactor` as a local variable is appropriate, and the value of 1.5 seems reasonable. However, please let me know if this should be changed.

**_Before   ---> ---> --->    After_**

![Zoom-Node](https://github.com/user-attachments/assets/be8ef51e-9d68-45c1-b5df-a8b48b13db36)

![Zoom-Group](https://github.com/user-attachments/assets/2aae270c-b2a7-444a-932a-799f11caf099)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Padding factor added to zoom-to-fit, affecting TuneUp, Graph Node Manager, and the Zoom to Fit button.

### Reviewers
@reddyashish 
@QilongTang 

### FYIs
@dnenov 
@Amoursol 
