### PR TITLE
DYN-7647 Search PackageManager EmptySpace

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -591,7 +591,7 @@ namespace Dynamo.PackageManager
         {
             if (LuceneUtility.addedFields == null) return;
 
-            LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), package.Name);
+            LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Name), package.Name.Trim().Replace(" ", string.Empty));
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Description), package.Description);
             LuceneUtility.SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Author), package.Maintainers);
 
@@ -1495,7 +1495,7 @@ namespace Dynamo.PackageManager
         /// <returns></returns>
         private PackageManagerSearchElementViewModel GetViewModelForPackageSearchElement(string packageName)
         {
-            var result = PackageManagerClientViewModel.CachedPackageList.Where(e => e.Name.Equals(packageName));
+            var result = PackageManagerClientViewModel.CachedPackageList.Where(e => e.Name.Replace(" ", string.Empty).Equals(packageName));
 
             if (!result.Any())
             {

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -729,7 +729,6 @@ namespace Dynamo.PackageManager.Wpf.Tests
         [Test]
         public void PackageSearchWithWhitespaceInName()
         {
-            var packageToBeSearched = "Dynamo Samples";
             var packagesListNames =  new List<string> { "Dynamo Samples", "archi-lab.net", "LunchBox for Dynamo", "DynamoSap", "TuneUp" };
             string packageId = "c5ecd20a-d41c-4e0c-8e11-8ddfb953d77f";
             string packageVersionNumber = "1.0.0.0";
@@ -781,12 +780,12 @@ namespace Dynamo.PackageManager.Wpf.Tests
 
             packageManagerSearchVM.LuceneUtility.CommitWriterChanges();
 
-            var packagesSearchResult = packageManagerSearchVM.Search(packageToBeSearched, true);
+            var packagesSearchResult = packageManagerSearchVM.Search("Dynamo Samples", true);
 
             //Validates that the Search returned results and that the first one is "Dynamo Samples"
             Assert.IsTrue(packagesSearchResult != null, "The Search didn't return any results");
             Assert.IsTrue(packagesSearchResult.Count() >= 1, string.Format("The number of results returned by search are: {0}", packagesSearchResult.Count()));
-            Assert.IsTrue(packagesSearchResult.FirstOrDefault().Name == packageToBeSearched, string.Format("The first search result {0} doesn't match with the expected: {1}: ", packagesSearchResult.FirstOrDefault().Name, packageToBeSearched));
+            Assert.IsTrue(packagesSearchResult.FirstOrDefault().Name == "Dynamo Samples", string.Format("The first search result {0} doesn't match with the expected: {1}: ", packagesSearchResult.FirstOrDefault().Name, "Dynamo Samples"));
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -739,8 +739,8 @@ namespace Dynamo.PackageManager.Wpf.Tests
             List<PackageHeader> packageHeaders = new List<PackageHeader>();
             var mockGreg = new Mock<IGregClient>();
 
-            var clientmock = new Mock<PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
-            var pmCVM = new Mock<PackageManagerClientViewModel>(ViewModel, clientmock.Object) { CallBase = true };
+            var clientMock = new Mock<PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
+            var pmCVM = new Mock<PackageManagerClientViewModel>(ViewModel, clientMock.Object) { CallBase = true };
             List<PackageManagerSearchElement> cachedPackages = new List<PackageManagerSearchElement>();
             foreach (var packageName in packagesListNames)
             {

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -730,10 +730,11 @@ namespace Dynamo.PackageManager.Wpf.Tests
         public void PackageSearchWithWhitespaceInName()
         {
             var packageToBeSearched = "Dynamo Samples";
-            var packagesListNames =  new List<string> { packageToBeSearched, "archi-lab.net", "LunchBox for Dynamo", "DynamoSap", "TuneUp" };
+            var packagesListNames =  new List<string> { "Dynamo Samples", "archi-lab.net", "LunchBox for Dynamo", "DynamoSap", "TuneUp" };
             string packageId = "c5ecd20a-d41c-4e0c-8e11-8ddfb953d77f";
             string packageVersionNumber = "1.0.0.0";
-            string packageCreatedDateString = "2024 - 10 - 02T13:13:20.135000 + 00:00";
+            string packageCreatedDateString = "2016 - 10 - 02T13:13:20.135000 + 00:00";
+            string formItFilterName = "FormIt";
             var packageMaintainer = new User() { username = "DynamoTest", _id = "90-63-17" };
 
             List<PackageHeader> packageHeaders = new List<PackageHeader>();
@@ -744,7 +745,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
             List<PackageManagerSearchElement> cachedPackages = new List<PackageManagerSearchElement>();
             foreach (var packageName in packagesListNames)
             {
-                var tmpPackageVersion = new PackageVersion { version = packageVersionNumber, host_dependencies = new List<string> { "FormIt" }, created = packageCreatedDateString };
+                var tmpPackageVersion = new PackageVersion { version = packageVersionNumber, host_dependencies = new List<string> { formItFilterName }, created = packageCreatedDateString };
                 cachedPackages.Add(new PackageManagerSearchElement(new PackageHeader() { name = packageName, versions = new List<PackageVersion> { tmpPackageVersion } }));
             }
             pmCVM.SetupProperty(p => p.CachedPackageList, cachedPackages);
@@ -758,6 +759,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 var tmpPackageVersion = new PackageVersion
                 {
                     version = packageVersionNumber,
+                    host_dependencies = new List<string> { formItFilterName },
                     created = packageCreatedDateString
                 };
                 var tmpPackage = new PackageManagerSearchElementViewModel(new PackageManagerSearchElement(new PackageHeader()
@@ -765,6 +767,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
                     _id = packageId,
                     name = package,
                     versions = new List<PackageVersion> { tmpPackageVersion },
+                    host_dependencies = new List<string> { formItFilterName },
                     maintainers = new List<User> { packageMaintainer },
                 }), false);
                 packageManagerSearchVM.AddToSearchResults(tmpPackage);

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -781,9 +781,9 @@ namespace Dynamo.PackageManager.Wpf.Tests
             var packagesSearchResult = packageManagerSearchVM.Search(packageToBeSearched, true);
 
             //Validates that the Search returned results and that the first one is "Dynamo Samples"
-            Assert.IsTrue(packagesSearchResult != null);
-            Assert.IsTrue(packagesSearchResult.Count() == 1);
-            Assert.IsTrue(packagesSearchResult.FirstOrDefault().Name == packageToBeSearched);
+            Assert.IsTrue(packagesSearchResult != null, "The Search didn't return any results");
+            Assert.IsTrue(packagesSearchResult.Count() >= 1, string.Format("The number of results returned by search are: {0}", packagesSearchResult.Count()));
+            Assert.IsTrue(packagesSearchResult.FirstOrDefault().Name == packageToBeSearched, string.Format("The first search result {0} doesn't match with the expected: {1}: ", packagesSearchResult.FirstOrDefault().Name, packageToBeSearched));
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Dynamo.Controls;
 using Dynamo.PackageManager.ViewModels;
+using Dynamo.Search;
 using Dynamo.Tests;
 using Dynamo.ViewModels;
 using Greg;
@@ -730,7 +731,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
         public void PackageSearchWithWhitespaceInName()
         {
             var packagesListNames =  new List<string> { "Dynamo Samples", "archi-lab.net", "LunchBox for Dynamo", "DynamoSap", "TuneUp" };
-            string packageId = "c5ecd20a-d41c-4e0c-8e11-8ddfb953d77f";
+            string packageId = Guid.NewGuid().ToString();
             string packageVersionNumber = "1.0.0.0";
             string packageCreatedDateString = "2016 - 10 - 02T13:13:20.135000 + 00:00";
             string formItFilterName = "FormIt";
@@ -749,6 +750,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
             }
             pmCVM.SetupProperty(p => p.CachedPackageList, cachedPackages);
 
+            LuceneSearch.LuceneUtilityPackageManager = null;
             var packageManagerSearchVM = new PackageManagerSearchViewModel(pmCVM.Object);
             packageManagerSearchVM.RegisterTransientHandlers();
 


### PR DESCRIPTION
### Purpose

Fixing Search for packages with empty space in the Package.Name
For searching nodes a fix was implemented for removing empty space in node names when indexing/searching/fetching, then the same fix needs to be applied to Packages name (otherwise if the package being search has empty space in the name, won't be found),


### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Search for packages with empty space in the Package.Name

### Reviewers

@QilongTang

### FYIs

@reddyashish @zeusongit 
