### PR TITLE
Build fix: Allow paths with spaces

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -155,7 +155,7 @@
     <Copy SourceFiles="@(LibGProtoGeometryXml)" DestinationFolder="$(OutputPath)\$(UICulture)" />
     <Copy SourceFiles="@(LibGProtoGeometryUICulture)" DestinationFolder="$(OutputPath)\$(UICulture)" />
     <Copy SourceFiles="@(LibG231Deps)" DestinationFolder="$(OutputPath)libg_231_0_0\asm_deps\" />
-    <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command Copy-Item -Path $(LibGProtoGeometryLibGLocale) -Destination $(OutputPath) -Recurse -Force" />
+    <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command Copy-Item -Path '$(LibGProtoGeometryLibGLocale)' -Destination '$(OutputPath)' -Recurse -Force" />
     <Copy SourceFiles="@(LibG230)" DestinationFolder="$(OutputPath)libg_230_0_0\" />
     <Copy SourceFiles="@(LibG231)" DestinationFolder="$(OutputPath)libg_231_0_0\" />
     <Copy SourceFiles="@(SampleFiles)" DestinationFolder="$(OutputPath)samples\%(RecursiveDir)" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -26,12 +26,12 @@
           <PackageVersion>1.0.19</PackageVersion>
           <PackageName>SplashScreen</PackageName>
       </PropertyGroup>
-      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+      <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">
           <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
       </Exec>
       <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high" />
       <!--This command updates the npm registry configuration if necessary-->
-      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" Condition="$(ShouldInstall)" />
+      <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)setnpmreg.ps1&quot;" Condition="$(ShouldInstall)" />
       <!--This command gets a specific splash screen build from npm-->
       <Exec Command="npm pack @dynamods/splash-screen@$(PackageVersion)" Condition="$(ShouldInstall)" />
   </Target>
@@ -50,7 +50,7 @@
         <MakeDir Directories="Packages/SplashScreen" />
 
         <!--Extracts the file to /package-->
-        <Exec Command="tar -xzf $(MSBuildProjectDirectory)\$(Last).tgz --strip-components=1 --directory=Packages/SplashScreen"></Exec>
+        <Exec Command="tar -xzf &quot;$(MSBuildProjectDirectory)\$(Last).tgz&quot; --strip-components=1 --directory=&quot;Packages/SplashScreen&quot;" />
 
         <!--Deletes the tgz file-->
         <Delete Files="$(MSBuildProjectDirectory)\$(Last).tgz" />
@@ -62,12 +62,12 @@
             <PackageVersion>1.0.20</PackageVersion>
             <PackageName>DynamoHome</PackageName>
         </PropertyGroup>
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">
             <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
         </Exec>
         <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1" Condition="$(ShouldInstall)" />
+        <Exec Command="&quot;$(PowerShellCommand)&quot; -ExecutionPolicy ByPass -Command &quot;&amp; '$(SolutionDir)setnpmreg.ps1'&quot;" Condition="$(ShouldInstall)" />
         <!--Download a specific build of the Dynamo Home package from npm-->
         <Exec Command="npm pack @dynamods/dynamo-home@$(PackageVersion)" Condition="$(ShouldInstall)" />
     </Target>
@@ -86,7 +86,7 @@
         <MakeDir Directories="Packages/DynamoHome" />
 
         <!--Extract the file to the specified directory-->
-        <Exec Command="tar -xzf $(MSBuildProjectDirectory)\$(Last).tgz --strip-components=1 --directory=Packages/DynamoHome"></Exec>
+        <Exec Command="tar -xzf &quot;$(MSBuildProjectDirectory)\$(Last).tgz&quot; --strip-components=1 --directory=&quot;Packages/DynamoHome&quot;" />
 
         <!--Delete the tgz file-->
         <Delete Files="$(MSBuildProjectDirectory)\$(Last).tgz" />

--- a/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
+++ b/src/LibraryViewExtensionWebView2/LibraryViewExtensionWebView2.csproj
@@ -20,13 +20,13 @@
           <PackageVersion>1.0.5</PackageVersion>
           <PackageName>LibrarieJS</PackageName>
       </PropertyGroup>
-      <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+      <Exec Command="&quot;$(PowerShellCommand)&quot; -ExecutionPolicy ByPass -Command &quot;&amp; '$(SolutionDir)pkgexist.ps1' '$(PackageName)' '$(PackageVersion)'&quot;" ConsoleToMSBuild="true">
           <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
       </Exec>
       <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
-        <!--This command gets a specific build of the notifcation center from npm-->
+      <Exec Command="&quot;$(PowerShellCommand)&quot; -ExecutionPolicy ByPass -Command &quot;&amp; '$(SolutionDir)setnpmreg.ps1'&quot;" Condition="$(ShouldInstall)" />
+      <!--This command gets a specific build of the notifcation center from npm-->
         <Exec Command="npm pack @dynamods/librariejs@$(PackageVersion)"  Condition="$(ShouldInstall)"/>
     </Target>
 
@@ -42,7 +42,7 @@
         </PropertyGroup>
 
         <!--Extracts the file to /package-->
-        <Exec Command="tar -xzf $(MSBuildProjectDirectory)\$(Last).tgz --strip-components=1 --directory=Packages/LibrarieJS"></Exec>
+        <Exec Command="tar -xzf &quot;$(MSBuildProjectDirectory)\$(Last).tgz&quot; --strip-components=1 --directory=&quot;Packages/LibrarieJS&quot;" />
 
         <!--Deletes the tgz file-->
         <Delete Files=" $(MSBuildProjectDirectory)\$(Last).tgz" />

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -19,13 +19,13 @@
             <PackageVersion>0.0.29</PackageVersion>
             <PackageName>NotificationCenter</PackageName>
         </PropertyGroup>
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command echo ($(SolutionDir)\pkgexist.ps1 $(PackageName) $(PackageVersion))" ConsoleToMSBuild="true">
+        <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">
             <Output TaskParameter="ConsoleOutput" PropertyName="ShouldInstall" />
         </Exec>
         <Message Text="Skipping Install for $(PackageName) $(PackageVersion), package up to date." Condition="!$(ShouldInstall)" Importance="high"></Message>
         
         <!--This command updates the npm registry configuration if necessary-->
-        <Exec Command="$(PowerShellCommand) -ExecutionPolicy ByPass -Command $(SolutionDir)\setnpmreg.ps1"  Condition="$(ShouldInstall)"/>
+        <Exec Command="&quot;$(PowerShellCommand)&quot; -ExecutionPolicy ByPass -Command &quot;&amp; '$(SolutionDir)setnpmreg.ps1'&quot;" Condition="$(ShouldInstall)" />
         <!--This command gets a specific build of the notifcation center from npm-->
         <Exec Command="npm pack @dynamods/notifications-center@$(PackageVersion)"  Condition="$(ShouldInstall)"/>
     </Target>
@@ -45,7 +45,7 @@
         <MakeDir Directories="Packages/NotificationCenter" />
 
         <!--Extracts the file to /package-->
-        <Exec Command="tar -xzf $(MSBuildProjectDirectory)\$(Last).tgz --strip-components=1 --directory=Packages/NotificationCenter"></Exec>
+        <Exec Command="tar -xzf &quot;$(MSBuildProjectDirectory)\$(Last).tgz&quot; --strip-components=1 --directory=&quot;Packages/NotificationCenter&quot;" />
 
         <!--Deletes the tgz file-->
         <Delete Files=" $(MSBuildProjectDirectory)\$(Last).tgz" />

--- a/src/Tools/Md2Html/Md2Html.csproj
+++ b/src/Tools/Md2Html/Md2Html.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
     <Target Name="Publish dotnet" Condition="'$([MSBuild]::IsOSPlatform(`Windows`))' == 'True' " AfterTargets="Build">
         <CallTarget Targets="Publish" />
-        <Exec Command="if not exist $(SharedOutputPath) mkdir $(SharedOutputPath)"/>
+        <Exec Command="if not exist &quot;$(SharedOutputPath)&quot; mkdir &quot;$(SharedOutputPath)&quot;"/>
         <Copy Condition=" $(RuntimeIdentifier.Contains('win')) " SourceFiles="$(OutputPath)$(RuntimeIdentifier)\publish\Md2Html.exe" DestinationFolder="$(SharedOutputPath)" />
         <Copy Condition=" $(RuntimeIdentifier.Contains('win')) " SourceFiles="$(OutputPath)\Md2Html.runtimeconfig.json" DestinationFolder="$(SharedOutputPath)" />
         <Copy Condition=" $(RuntimeIdentifier.Contains('linux')) " SourceFiles="$(OutputPath)$(RuntimeIdentifier)\publish\Md2Html" DestinationFolder="$(SharedOutputPath)" />


### PR DESCRIPTION
### Purpose

Dynamo now properly builds when the Windows username contains spaces. 
(Example: `C:\Users\John Doe\Documents\GitHub\Dynamo\src`)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Dynamo now properly builds when the Windows username contains spaces.

### Reviewers

@QilongTang 
@zeusongit 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
