### PR TITLE
DYN-7671: pm client crash fix - version parsing

### DIFF
--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -302,7 +302,7 @@ namespace Dynamo.PackageManager
             // Use the optional parameters for Testing purposes
             if (dynamoVersion == null)
             {
-                Version.TryParse(DynamoModel.Version, out dynamoVersion);
+                dynamoVersion = VersionUtilities.Parse(DynamoModel.Version);
             }
 
             if (hostVersion == null)
@@ -353,8 +353,8 @@ namespace Dynamo.PackageManager
                 else
                 {
                     // Check within min and max range
-                    isWithinMinMax = (dynamoCompatibility.min == null || dynamoVersion >= VersionUtilities.ParseVersionSafely(dynamoCompatibility.min)) &&
-                                     (dynamoCompatibility.max == null || dynamoVersion <= VersionUtilities.ParseVersionSafely(dynamoCompatibility.max));
+                    isWithinMinMax = (dynamoCompatibility.min == null || dynamoVersion >= VersionUtilities.Parse(dynamoCompatibility.min)) &&
+                                     (dynamoCompatibility.max == null || dynamoVersion <= VersionUtilities.Parse(dynamoCompatibility.max));
                 }
 
                 // If neither listed nor within min/max, return false (incompatible)
@@ -380,8 +380,8 @@ namespace Dynamo.PackageManager
                     }
 
                     // Check if the host version falls within the min/max range
-                    isHostWithinMinMax = (hostCompatibility.min == null || hostVersion >= VersionUtilities.ParseVersionSafely(hostCompatibility.min)) &&
-                                         (hostCompatibility.max == null || hostVersion <= VersionUtilities.ParseVersionSafely(hostCompatibility.max));
+                    isHostWithinMinMax = (hostCompatibility.min == null || hostVersion >= VersionUtilities.Parse(hostCompatibility.min)) &&
+                                         (hostCompatibility.max == null || hostVersion <= VersionUtilities.Parse(hostCompatibility.max));
                     
                     // If the host version is neither listed nor within the min/max range, it's incompatible
                     if (!isHostListedInVersions && !isHostWithinMinMax)

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -393,7 +393,7 @@ namespace Dynamo.PackageManager
 
             // If we passed all the checks, the version is compatible
             return true;
-        }        
+        }
 
         // Method to find Dynamo compatibility based on other hosts in the compatibilityMatrix
         internal static Greg.Responses.Compatibility GetDynamoCompatibilityFromHost(List<Greg.Responses.Compatibility> compatibilityMatrix, Dictionary<string, Dictionary<string, string>> map = null)

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -297,6 +297,7 @@ namespace Dynamo.PackageManager
         /// <returns></returns>
         internal static bool? CalculateCompatibility(List<Greg.Responses.Compatibility> compatibilityMatrix, Version dynamoVersion = null, Dictionary<string, Dictionary<string, string>> map = null, Version hostVersion = null, string host = null)
         {
+
             // Parse Dynamo and Host versions/name from the model
             // Use the optional parameters for Testing purposes
             if (dynamoVersion == null)
@@ -352,8 +353,8 @@ namespace Dynamo.PackageManager
                 else
                 {
                     // Check within min and max range
-                    isWithinMinMax = (dynamoCompatibility.min == null || dynamoVersion >= Version.Parse(dynamoCompatibility.min)) &&
-                                     (dynamoCompatibility.max == null || dynamoVersion <= Version.Parse(dynamoCompatibility.max));
+                    isWithinMinMax = (dynamoCompatibility.min == null || dynamoVersion >= VersionUtilities.ParseVersionSafely(dynamoCompatibility.min)) &&
+                                     (dynamoCompatibility.max == null || dynamoVersion <= VersionUtilities.ParseVersionSafely(dynamoCompatibility.max));
                 }
 
                 // If neither listed nor within min/max, return false (incompatible)
@@ -379,12 +380,9 @@ namespace Dynamo.PackageManager
                     }
 
                     // Check if the host version falls within the min/max range
-                    if ((hostCompatibility.min == null || hostVersion >= Version.Parse(NormalizeVersionString(hostCompatibility.min))) &&
-                        (hostCompatibility.max == null || hostVersion <= Version.Parse(NormalizeVersionString(hostCompatibility.max))))
-                    {
-                        isHostWithinMinMax = true;
-                    }
-
+                    isHostWithinMinMax = (hostCompatibility.min == null || hostVersion >= VersionUtilities.ParseVersionSafely(hostCompatibility.min)) &&
+                                         (hostCompatibility.max == null || hostVersion <= VersionUtilities.ParseVersionSafely(hostCompatibility.max));
+                    
                     // If the host version is neither listed nor within the min/max range, it's incompatible
                     if (!isHostListedInVersions && !isHostWithinMinMax)
                     {
@@ -395,7 +393,7 @@ namespace Dynamo.PackageManager
 
             // If we passed all the checks, the version is compatible
             return true;
-        }
+        }        
 
         // Method to find Dynamo compatibility based on other hosts in the compatibilityMatrix
         internal static Greg.Responses.Compatibility GetDynamoCompatibilityFromHost(List<Greg.Responses.Compatibility> compatibilityMatrix, Dictionary<string, Dictionary<string, string>> map = null)
@@ -465,13 +463,6 @@ namespace Dynamo.PackageManager
             // Return null if no matching host or Dynamo versions were found
             return null;
         }
-
-        // Normalize the version strings before parsing to ensure they are valid for Version.Parse()
-        private static string NormalizeVersionString(string version)
-        {
-            return version.Contains('.') ? version : version + ".0";
-        }
-
 
         private VersionInformation GetLatestCompatibleVersion()
         {

--- a/src/DynamoUtilities/PublicAPI.Unshipped.txt
+++ b/src/DynamoUtilities/PublicAPI.Unshipped.txt
@@ -211,6 +211,7 @@ static Dynamo.Utilities.TypeExtensions.GetInstance<TArg1, TArg2, TArg3>(this Sys
 static Dynamo.Utilities.TypeExtensions.GetInstance<TArg1, TArg2>(this System.Type type, TArg1 argument1, TArg2 argument2) -> object
 static Dynamo.Utilities.TypeExtensions.GetInstance<TArg>(this System.Type type, TArg argument) -> object
 static Dynamo.Utilities.TypeExtensions.ImplementsGeneric(System.Type generic, System.Type toCheck) -> bool
+static Dynamo.Utilities.VersionUtilities.ParseVersionSafely(string version) -> System.Version
 static Dynamo.Utilities.VersionUtilities.PartialParse(string versionString, int numberOfFields = 3) -> System.Version
 static DynamoUtilities.CertificateVerification.CheckAssemblyForValidCertificate(string assemblyPath) -> bool
 static DynamoUtilities.PathHelper.CreateFolderIfNotExist(string folderPath) -> System.Exception

--- a/src/DynamoUtilities/PublicAPI.Unshipped.txt
+++ b/src/DynamoUtilities/PublicAPI.Unshipped.txt
@@ -211,7 +211,7 @@ static Dynamo.Utilities.TypeExtensions.GetInstance<TArg1, TArg2, TArg3>(this Sys
 static Dynamo.Utilities.TypeExtensions.GetInstance<TArg1, TArg2>(this System.Type type, TArg1 argument1, TArg2 argument2) -> object
 static Dynamo.Utilities.TypeExtensions.GetInstance<TArg>(this System.Type type, TArg argument) -> object
 static Dynamo.Utilities.TypeExtensions.ImplementsGeneric(System.Type generic, System.Type toCheck) -> bool
-static Dynamo.Utilities.VersionUtilities.ParseVersionSafely(string version) -> System.Version
+static Dynamo.Utilities.VersionUtilities.Parse(string version) -> System.Version
 static Dynamo.Utilities.VersionUtilities.PartialParse(string versionString, int numberOfFields = 3) -> System.Version
 static DynamoUtilities.CertificateVerification.CheckAssemblyForValidCertificate(string assemblyPath) -> bool
 static DynamoUtilities.PathHelper.CreateFolderIfNotExist(string folderPath) -> System.Exception

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace Dynamo.Utilities
@@ -18,6 +18,49 @@ namespace Dynamo.Utilities
             var rejoinedVersion = string.Join(".", splitVersion.Take(numberOfFields));
 
             return Version.Parse(rejoinedVersion);
+        }
+
+        /// <summary>
+        /// A utility method accepting any string input and trying to return a valid Version from it
+        /// If the initial input is not valid, returns null
+        /// </summary>
+        /// <param name="version">The string representation of the version to be parsed.</param>
+        /// <returns></returns>
+        public static Version ParseVersionSafely(string version)
+        {
+            // If the version string is null or empty, return null
+            if (string.IsNullOrEmpty(version))
+            {
+                return null;
+            }
+
+            // Split the version by periods
+            var versionParts = version.Split('.');
+
+            // Ensure each part is numeric; if not, return null
+            foreach (var part in versionParts)
+            {
+                if (!int.TryParse(part, out _))
+                {
+                    return null;
+                }
+            }
+
+            // Try parsing directly; if successful, return the parsed version
+            if (Version.TryParse(version, out Version parsedVersion))
+            {
+                return parsedVersion;
+            }
+
+            // If parsing failed, pad the version string
+            while (versionParts.Length < 3)
+            {
+                version += ".0";
+                versionParts = version.Split('.');
+            }
+
+            // Now it should be safe to parse
+            return Version.Parse(version);
         }
     }
 }

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -26,7 +26,7 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="version">The string representation of the version to be parsed.</param>
         /// <returns></returns>
-        public static Version ParseVersionSafely(string version)
+        public static Version Parse(string version)
         {
             // If the version string is null or empty, return null
             if (string.IsNullOrEmpty(version))

--- a/test/DynamoCoreTests/VersionUtilitiesTests.cs
+++ b/test/DynamoCoreTests/VersionUtilitiesTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Dynamo.Utilities;
 
@@ -35,6 +35,58 @@ namespace Dynamo.Tests
             Assert.Throws(typeof(FormatException), () => VersionUtilities.PartialParse("0.0.a"));
             Assert.Throws(typeof(FormatException), () => VersionUtilities.PartialParse("0.0"));
             Assert.Throws(typeof(FormatException), () => VersionUtilities.PartialParse(""));
+        }
+
+        [Test]
+        public void ParseVersionSafely_NullInput_ReturnsNull()
+        {
+            // Arrange
+            string version = null;
+
+            // Act
+            Version result = VersionUtilities.ParseVersionSafely(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is null.");
+        }
+
+        [Test]
+        public void ParseVersionSafely_JibberishInput_ReturnsNull()
+        {
+            // Arrange
+            string version = "not.a.version";
+
+            // Act
+            Version result = VersionUtilities.ParseVersionSafely(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseVersionSafely_ShortVersion_ReturnsPaddedVersion()
+        {
+            // Arrange
+            string version = "2019";
+
+            // Act
+            Version result = VersionUtilities.ParseVersionSafely(version);
+
+            // Assert
+            Assert.AreEqual(new Version(2019, 0, 0), result, "Expected version '2019.0.0' when input is '2019'.");
+        }
+
+        [Test]
+        public void ParseVersionSafely_FullVersion_ReturnsParsedVersion()
+        {
+            // Arrange
+            string version = "2019.1.2";
+
+            // Act
+            Version result = VersionUtilities.ParseVersionSafely(version);
+
+            // Assert
+            Assert.AreEqual(new Version(2019, 1, 2), result, "Expected version '2019.1.2' when input is '2019.1.2'.");
         }
 
     }

--- a/test/DynamoCoreTests/VersionUtilitiesTests.cs
+++ b/test/DynamoCoreTests/VersionUtilitiesTests.cs
@@ -44,7 +44,7 @@ namespace Dynamo.Tests
             string version = null;
 
             // Act
-            Version result = VersionUtilities.ParseVersionSafely(version);
+            Version result = VersionUtilities.Parse(version);
 
             // Assert
             Assert.IsNull(result, "Expected null when input is null.");
@@ -57,7 +57,7 @@ namespace Dynamo.Tests
             string version = "not.a.version";
 
             // Act
-            Version result = VersionUtilities.ParseVersionSafely(version);
+            Version result = VersionUtilities.Parse(version);
 
             // Assert
             Assert.IsNull(result, "Expected null when input is an invalid version string.");
@@ -70,7 +70,7 @@ namespace Dynamo.Tests
             string version = "2019";
 
             // Act
-            Version result = VersionUtilities.ParseVersionSafely(version);
+            Version result = VersionUtilities.Parse(version);
 
             // Assert
             Assert.AreEqual(new Version(2019, 0, 0), result, "Expected version '2019.0.0' when input is '2019'.");
@@ -83,7 +83,7 @@ namespace Dynamo.Tests
             string version = "2019.1.2";
 
             // Act
-            Version result = VersionUtilities.ParseVersionSafely(version);
+            Version result = VersionUtilities.Parse(version);
 
             // Assert
             Assert.AreEqual(new Version(2019, 1, 2), result, "Expected version '2019.1.2' when input is '2019.1.2'.");


### PR DESCRIPTION
### Purpose

Fixes this issue: https://jira.autodesk.com/browse/DYN-7671

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- bug when parsing short versions was causing the pm client to crash
- now safely pares versions
- moved method to VersionsUtility class
- test coverage

### Reviewers

@zeusongit 
@QilongTang 

### FYIs

@jnealb 