### PR TITLE
Add analytics for python engine switch from context menus

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1438,6 +1438,8 @@ namespace Dynamo.ViewModels
                     new DynamoModel.UpdateModelValueCommand(
                         workspaceGUID, pythonNode.GUID, nameof(pythonNode.EngineName), engine));
                 pythonNode.OnNodeModified();
+                Analytics.TrackEvent(Actions.Switch, Categories.PythonOperations, engine);
+                Model.Logger.Log("Updated python node(" + pythonNode.GUID.ToString() + ") engine to use " + engine, LogLevel.Console);
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
### Purpose

Added analytics logs for when the engine is changed for python nodes using context menu options.
Also added a console log when this happens, that will log the node GUID and the selected engine.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add analytics for python engine switch from context menus

### Reviewers


