### PR TITLE
DYN-7341 Package compatibility calculation rework

### DIFF
--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -297,102 +297,104 @@ namespace Dynamo.PackageManager
         /// <returns></returns>
         internal static bool? CalculateCompatibility(List<Greg.Responses.Compatibility> compatibilityMatrix, Version dynamoVersion = null, Dictionary<string, Dictionary<string, string>> map = null, Version hostVersion = null, string host = null)
         {
-
-            // Parse Dynamo and Host versions/name from the model
-            // Use the optional parameters for Testing purposes
-            if (dynamoVersion == null)
+            try
             {
-                dynamoVersion = VersionUtilities.Parse(DynamoModel.Version);
-            }
+                // Set the defaults if parameters are not provided (for testing)
+                dynamoVersion ??= VersionUtilities.Parse(DynamoModel.Version);
+                hostVersion ??= DynamoModel.HostAnalyticsInfo.HostProductVersion;
+                host ??= DynamoModel.HostAnalyticsInfo.HostProductName;
+                host = host?.ToLowerInvariant();
 
-            if (hostVersion == null)
-            {
-                hostVersion = DynamoModel.HostAnalyticsInfo.HostProductVersion;
-            }
-
-            if (host == null)
-            {
-                host = DynamoModel.HostAnalyticsInfo.HostProductName;
-            }
-
-            // If there is no compatibility matrix, we cannot determine anything
-            if (compatibilityMatrix == null || compatibilityMatrix.Count == 0)
-            {
-                return null; 
-            }
-
-            // Step 1: Check Dynamo version compatibility
-            var dynamoCompatibility = compatibilityMatrix.FirstOrDefault(c => c.name == "Dynamo");
-
-            // If no Dynamo compatibility is found, check if host compatibility exists and use the compatibility map
-            if (dynamoCompatibility == null)
-            {
-                dynamoCompatibility = GetDynamoCompatibilityFromHost(compatibilityMatrix, map);
-
-                // If dynamoVersion is still null, return null (indeterminate)
-                if (dynamoCompatibility == null)
+                // If there is no compatibility matrix, we cannot determine anything
+                if (compatibilityMatrix == null || compatibilityMatrix.Count == 0)
                 {
-                    return null; // No way to determine compatibility
+                    return null; 
                 }
-            }
 
-            // Now, with a dynamoVersion, check the Dynamo compatibility
-            if (dynamoCompatibility != null)
-            {
-                // Check if the Dynamo version is explicitly listed in 'versions'
-                bool isListedInVersions = dynamoCompatibility.versions != null && dynamoCompatibility.versions.Contains(dynamoVersion.ToString());
+                Greg.Responses.Compatibility compatibility = null;
 
-                // Check if the Dynamo version falls within the min/max range
-                bool isWithinMinMax = true;
-
-                // Check if both min and max are null; if so, it's not valid
-                if (string.IsNullOrEmpty(dynamoCompatibility.min) && string.IsNullOrEmpty(dynamoCompatibility.max))
+                // Determine compatibility based on presence of host
+                // We only care about 2 conditions:
+                // 1. If we are under host, we first look at that host compatibility. If that's missing, we still check for Dynamo-only compatibility
+                // 2. If we are not under host, we only care about Dynamo compatibility
+                // ! The opposite to 1. is not true - if there is Host compatibility information, then we NEED to be compatible with the host
+                // (this is to say, we cannot just flip the conditions around to declare 'if Dynamo is compatible, we are already compatible')
+                if (!string.IsNullOrEmpty(host))
                 {
-                    isWithinMinMax = false;  // No version bounds means no compatibility
+                    // Attempt to retrieve compatibility specific to the host
+                    compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == host.ToLowerInvariant());
+
+                    // If host compatibility is missing, fallback to Dynamo compatibility
+                    if (compatibility == null)
+                    {
+                        compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
+                    }
                 }
                 else
                 {
-                    // Check within min and max range
-                    isWithinMinMax = (dynamoCompatibility.min == null || dynamoVersion >= VersionUtilities.Parse(dynamoCompatibility.min)) &&
-                                     (dynamoCompatibility.max == null || dynamoVersion <= VersionUtilities.Parse(dynamoCompatibility.max));
+                    // No host specified, so we only check for Dynamo compatibility
+                    compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
                 }
 
-                // If neither listed nor within min/max, return false (incompatible)
-                if (!isListedInVersions && !isWithinMinMax)
+                // If no relevant compatibility info is found, return indeterminate
+                if (compatibility == null)
+                {
+                    return null;
+                }
+
+                // Step 2: Check compatibility based on min/max ranges or specific versions
+                var versionToCheck = (compatibility.name.ToLowerInvariant() == "dynamo") ? dynamoVersion : hostVersion;
+                return versionToCheck != null && IsVersionCompatible(compatibility, versionToCheck);
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine(ex.Message.ToString());
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Helper function to validate version compatibility using min, max, and versions array.
+        /// Supports min-only ranges, (in the future: max with asterisk), and schema validation rules.
+        /// </summary>
+        internal static bool IsVersionCompatible(Greg.Responses.Compatibility compatibility, Version version)
+        {
+            // Check if the version is explicitly listed
+            bool isListedInVersions = compatibility.versions?.Contains(version.ToString()) ?? false;
+
+            // Parse min and max values, if provided, and check for valid range
+            bool isWithinMinMax = true;
+            if (!string.IsNullOrEmpty(compatibility.min) || !string.IsNullOrEmpty(compatibility.max))
+            {
+                Version minVersion = compatibility.min != null ? VersionUtilities.Parse(compatibility.min) : null;
+                Version maxVersion = compatibility.max != null ? VersionUtilities.Parse(compatibility.max) : null;
+
+                // If max is specified without min, return false as max-only ranges are unsupported
+                if (minVersion == null && maxVersion != null)
                 {
                     return false;
                 }
-            }
 
-            // Step 2: Check Host version compatibility (if available)
-            if (!string.IsNullOrEmpty(host))
-            {
-                var hostCompatibility = compatibilityMatrix.FirstOrDefault(c => c.name == host);
-                if (hostCompatibility != null)
+                // Validate that min is less than or equal to max if both are specified
+                if (minVersion != null && maxVersion != null && minVersion > maxVersion)
                 {
-                    bool isHostListedInVersions = false;
-                    bool isHostWithinMinMax = false;
+                    throw new ArgumentException("Min version cannot be greater than max version.");
+                }
 
-                    // Check if the host version is explicitly listed in 'versions'
-                    if (hostCompatibility.versions != null && hostCompatibility.versions.Contains(hostVersion.ToString()))
-                    {
-                        isHostListedInVersions = true;
-                    }
-
-                    // Check if the host version falls within the min/max range
-                    isHostWithinMinMax = (hostCompatibility.min == null || hostVersion >= VersionUtilities.Parse(hostCompatibility.min)) &&
-                                         (hostCompatibility.max == null || hostVersion <= VersionUtilities.Parse(hostCompatibility.max));
-                    
-                    // If the host version is neither listed nor within the min/max range, it's incompatible
-                    if (!isHostListedInVersions && !isHostWithinMinMax)
-                    {
-                        return false;
-                    }
+                // Check min-only case: compatibility only extends to the same major version
+                if (minVersion != null && maxVersion == null)
+                {
+                    isWithinMinMax = version >= minVersion && version.Major == minVersion.Major;
+                }
+                else
+                {
+                    // Check within min and max bounds for cases where both are specified
+                    isWithinMinMax = (minVersion == null || version >= minVersion) &&
+                                     (maxVersion == null || version <= maxVersion);
                 }
             }
 
-            // If we passed all the checks, the version is compatible
-            return true;
+            return isListedInVersions || isWithinMinMax;
         }
 
         // Method to find Dynamo compatibility based on other hosts in the compatibilityMatrix

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -935,74 +935,86 @@ namespace Dynamo.PackageManager.Wpf.Tests
         [Test]
         public void TestComputeIncompatibleVersionCompatibility()
         {
-            //Arrange
-            var compatibilityMatrixIncompatibleDynamo = new List<Greg.Responses.Compatibility>
+            // Arrange
+            var compatibilityMatrix_IncompatibleDynamo = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "Dynamo", min = "3.0", max = "3.5" },
-                new Greg.Responses.Compatibility { name = "Host", min = "2020.0", max = "2025.0" }
+                new Greg.Responses.Compatibility { name = "dynamo", min = "3.0", max = "3.5" },
+                new Greg.Responses.Compatibility { name = "host", min = "2020.0", max = "2025.0" }
             };
 
-            var compatibilityMatrixIncompatibleHost = new List<Greg.Responses.Compatibility>
+            var compatibilityMatrix_IncompatibleHost = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "Dynamo", min = "2.0", max = "3.5" },
-                new Greg.Responses.Compatibility { name = "Host", min = "2020.0", max = "2022.0" }
+                new Greg.Responses.Compatibility { name = "dynamo", min = "2.0", max = "3.5" },
+                new Greg.Responses.Compatibility { name = "host", min = "2020.0", max = "2022.0" }
             };
 
-            var customDynamoVersion = new Version("2.9");
-            var customHostVersion = new Version("2023.0");
-            var customHostName = "Host";
+            var dynamoVersion = new Version("2.9");
+            var hostVersion = new Version("2023.0");
+            var hostName = "host";
 
             // Act
-            var resultIncompatibleDynamo = PackageManagerSearchElement.CalculateCompatibility(compatibilityMatrixIncompatibleDynamo, customDynamoVersion, compatibilityMap, customHostVersion, customHostName);
-            var resultIncompatibleHost = PackageManagerSearchElement.CalculateCompatibility(compatibilityMatrixIncompatibleHost, customDynamoVersion, compatibilityMap, customHostVersion, customHostName);
+            var resultIncompatibleDynamo = PackageManagerSearchElement.CalculateCompatibility(
+                compatibilityMatrix_IncompatibleDynamo, dynamoVersion, compatibilityMap, hostVersion, hostName);
+            var resultIncompatibleHost = PackageManagerSearchElement.CalculateCompatibility(
+                compatibilityMatrix_IncompatibleHost, dynamoVersion, compatibilityMap, hostVersion, hostName);
 
             // Assert
-            Assert.IsFalse(resultIncompatibleDynamo);
-            Assert.IsFalse(resultIncompatibleHost);
+            Assert.IsTrue(resultIncompatibleDynamo, "Expected compatibility to be true as under host we don't care about Dynamo version.");
+            Assert.IsFalse(resultIncompatibleHost, "Expected compatibility to be false due to incompatible host version.");
         }
 
         [Test]
         public void TestComputeVersionNoDynamoCompatibility()
         {
-            //Arrange
-            var compatibilityMatrix = new List<Greg.Responses.Compatibility>
+            // Arrange
+            var hostOnlyCompatibilityMatrix = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "Revit", min = "2020", max = "2025" }
+                new Greg.Responses.Compatibility { name = "revit", min = "2020", max = "2025" }
             };
 
-            var minValueCompatibilityMatrix = new List<Greg.Responses.Compatibility>
+            var minOnlyCompatibilityMatrix = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "Revit", min = "2020",  }
+                new Greg.Responses.Compatibility { name = "revit", min = "2023" }
             };
-
 
             var incompleteCompatibilityMatrix = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "Revit" }
+                new Greg.Responses.Compatibility { name = "revit" }
             };
 
-            var customIncompatibleDynamoVersion = new Version("2.0.2"); // Matches Revit 2019
-            var customCompatibleDynamoVersion = new Version("2.13.1");  // Dynamo 2.13.1 matches Revit 2023.0
-            var customHostVersion = new Version("2023.0");  // Revit 2023.0 matches Dynamo 2.13.1 
-            var hostName = "Revit";
+            var compatibleDynamoVersion = new Version("2.13.1");  // Compatible within Revit 2023.0
+            var incompatibleDynamoVersion = new Version("2.0.2"); // Incompatible version matching Revit 2019
+            var hostVersion = new Version("2023.1");
+            var hostName = "revit";
 
             // Act
-            // True - No dynamo compatibility provided, we extract Dynamo versions from Host and check against the current Dynamo Version
-            var resultNoDynamoCompatibilityUnderDynamo = PackageManagerSearchElement.CalculateCompatibility(compatibilityMatrix, customCompatibleDynamoVersion, compatibilityMap);
-            // True - No dynamo compatibility provided, but we are under a Host
-            var resultNoDynamoCompatibilityUnderHost = PackageManagerSearchElement.CalculateCompatibility(compatibilityMatrix, customCompatibleDynamoVersion, compatibilityMap, customHostVersion, hostName);
-            // True - We will assume that, if we have 'min' value but no 'max' value, anything above that is OK
-            var resultMinValue = PackageManagerSearchElement.CalculateCompatibility(minValueCompatibilityMatrix, customCompatibleDynamoVersion, compatibilityMap);
-            // False - looking for support for Dynamo 2.0.2 (matching Revit 2019), but the min Revit version is 2020
-            var resultIncompatible = PackageManagerSearchElement.CalculateCompatibility(compatibilityMatrix, customIncompatibleDynamoVersion, compatibilityMap);
-            // Null - Not enough information provided to extract DynamoCompatibility, we return 'null' for unknown compatibility
-            var resultIncomplete = PackageManagerSearchElement.CalculateCompatibility(incompleteCompatibilityMatrix, customIncompatibleDynamoVersion, compatibilityMap);
+            // Case 1: No Dynamo-specific compatibility, expect null (no fallback)
+            var resultNoDynamoCompatibility = PackageManagerSearchElement.CalculateCompatibility(
+                hostOnlyCompatibilityMatrix, compatibleDynamoVersion, compatibilityMap);
+
+            // Case 2: No Dynamo-specific compatibility but host compatibility is provided
+            var resultWithHostCompatibility = PackageManagerSearchElement.CalculateCompatibility(
+                hostOnlyCompatibilityMatrix, compatibleDynamoVersion, compatibilityMap, hostVersion, hostName);
+
+            // Case 3: Min-only range for compatibility within major version (Dynamo context)
+            var resultMinOnlyCompatibility = PackageManagerSearchElement.CalculateCompatibility(
+                minOnlyCompatibilityMatrix, compatibleDynamoVersion, compatibilityMap, hostVersion, hostName);
+
+            // Case 4: Incomplete compatibility information, expect indeterminate result
+            var resultIncompleteCompatibilityInfo = PackageManagerSearchElement.CalculateCompatibility(
+                incompleteCompatibilityMatrix, incompatibleDynamoVersion, compatibilityMap);
+
+            // Case 5: Under host context, but host compatibility is not provided, fall back to Dynamo
+            var resultFallbackToDynamo = PackageManagerSearchElement.CalculateCompatibility(
+                new List<Greg.Responses.Compatibility> { new Greg.Responses.Compatibility { name = "dynamo", min = "2.10", max = "2.13.1" } },
+                compatibleDynamoVersion, compatibilityMap, null, hostName);
 
             // Assert
-            Assert.IsTrue(resultNoDynamoCompatibilityUnderDynamo);
-            Assert.IsTrue(resultNoDynamoCompatibilityUnderHost);
-            Assert.IsTrue(resultMinValue);
-            Assert.IsFalse(resultIncompatible);
+            Assert.IsNull(resultNoDynamoCompatibility, "Expected compatibility to be null when no Dynamo-specific compatibility exists and no fallback is allowed.");
+            Assert.IsTrue(resultWithHostCompatibility, "Expected compatibility to be true when no Dynamo-specific compatibility exists but host compatibility matches.");
+            Assert.IsTrue(resultMinOnlyCompatibility, "Expected compatibility to be true for min-only range within major version.");
+            Assert.IsNull(resultIncompleteCompatibilityInfo, "Expected compatibility to be indeterminate (null) when information is incomplete.");
+            Assert.IsTrue(resultFallbackToDynamo, "Expected compatibility to be true when under host but only Dynamo compatibility is provided.");
         }
 
         [Test]
@@ -1047,6 +1059,140 @@ namespace Dynamo.PackageManager.Wpf.Tests
 
             // Assert the exception message if needed
             Assert.AreEqual("The compatibility map is not initialized.", exception.Message);
+        }
+
+
+        [Test]
+        public void TestLowerCaseCompatibilityMap()
+        {
+            // Arrange
+            var compatibilityMatrix = new List<Greg.Responses.Compatibility>
+            {
+                new Greg.Responses.Compatibility { name = "revit", min = "2020", max = "2025", versions = new List<string>() { "2016", "2018" } }
+            };
+
+            var expectedDynamoCompatibility = new Compatibility()
+            {
+                name = "Dynamo",
+                min = "2.1.0",
+                max = "3.0.3",
+                versions = new List<string>() { "1.3.2", "2.0.2" }
+            };
+
+            var result = PackageManagerSearchElement.GetDynamoCompatibilityFromHost(compatibilityMatrix, compatibilityMap);
+
+            Assert.That(result.name, Is.EqualTo(expectedDynamoCompatibility.name));
+            Assert.That(result.min, Is.EqualTo(expectedDynamoCompatibility.min));
+            Assert.That(result.max, Is.EqualTo(expectedDynamoCompatibility.max));
+            Assert.That(result.versions, Is.EqualTo(expectedDynamoCompatibility.versions));
+        }
+
+        [Test]
+        public void IsVersionCompatible_ExactVersionInList_ReturnsTrue()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                versions = new List<string> { "2.1.0", "2.2.0", "2.3.0" }
+            };
+            Version version = new Version("2.2.0");
+
+            bool result = PackageManagerSearchElement.IsVersionCompatible(compatibility, version);
+
+            Assert.IsTrue(result, "Expected compatibility to be true when version is in the list.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_MinOnly_ReturnsTrueForCompatibleVersion()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.1.0"
+            };
+            Version compatibleVersion = new Version("2.1.5");
+            Version incompatibleVersion = new Version("2.0.9");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion),
+                          "Expected compatibility to be true when version is greater than or equal to min.");
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, incompatibleVersion),
+                           "Expected compatibility to be false when version is less than min.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_MinOnlyWithinSameMajorVersion_ReturnsTrue()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.1.0"
+            };
+            Version compatibleVersion = new Version("2.1.5"); // Same major version (2.x)
+
+            bool result = PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion);
+
+            Assert.IsTrue(result, "Expected compatibility to be true when version is within the same major version and greater than or equal to min.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_MinOnlyBeyondMajorVersion_ReturnsFalse()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.1.0"
+            };
+            Version incompatibleVersion = new Version("3.0.0"); // Higher major version (3.x)
+
+            bool result = PackageManagerSearchElement.IsVersionCompatible(compatibility, incompatibleVersion);
+
+            Assert.IsFalse(result, "Expected compatibility to be false when version is in a higher major version than min.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_MaxOnly_ReturnsFalse()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                max = "2.3.0"
+            };
+            Version compatibleVersion = new Version("2.2.5");
+            Version incompatibleVersion = new Version("2.4.0");
+
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion),
+                           "Expected compatibility to be false when only max is specified, regardless of version.");
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, incompatibleVersion),
+                           "Expected compatibility to be false when only max is specified, regardless of version.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_MinAndMax_ReturnsTrueForVersionWithinRange()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.1.0",
+                max = "2.3.0"
+            };
+            Version inRangeVersion = new Version("2.2.0");
+            Version belowRangeVersion = new Version("2.0.9");
+            Version aboveRangeVersion = new Version("2.4.0");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, inRangeVersion),
+                          "Expected compatibility to be true when version is within the min and max range.");
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, belowRangeVersion),
+                           "Expected compatibility to be false when version is below min.");
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, aboveRangeVersion),
+                           "Expected compatibility to be false when version is above max.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_InvalidMinMaxRange_ThrowsArgumentException()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2.1.0"
+            };
+            Version version = new Version("2.2.0");
+
+            Assert.Throws<ArgumentException>(() => PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected an ArgumentException when min version is greater than max version.");
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR follows on the recent changes to the PM Search functionality. Following an in-depth discussion with the wider design team regarding how Compatibility should be calculated, this PR contains the changes on the PM Client side.

Current rules affecting the compatibility calculation:

1. Fall back to Dynamo Sandbox computability version will follow the below rules:
•	In Revit look for Revit specific compatibility version. If it is there, use Revit version data and stop.
•	In Revit look for Revit specific compatibility version. If Revit specific compatibility info is not present, look if only Dynamo host exists and then use it.
•	In C3D look for C3D specific compatibility version. If it is there use C3D version data and stop.
•	In C3D look for C3D specific compatibility version. If C3D specific compatibility info is not present, look if only Dynamo host exists and then use it.
•	In Sandbox only ever look for Dynamo host. If you find it use it and stop.

2. Do we support Minimum only range? Yes
•	If you only put a Minium, we assume that it is compatible with all point versions of this major version.
•	We limit it Major version.
Example Scenario: Min = 2025.0, Max Left Black
Assumption.  This will be implemented as any version above 2025.0 and above this (Limited by major version) package works.  In 2026 this package will be labeled as incompatible.
For Dynamo we limit to Major versions (2.x, 3.X and so on)

4. Do we support Maximum only range? No
5. Min cannot be greater than the max

7. Version field is a String (not a number)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- following a discussion with the wider design team, we are implementing changes to the compatibility calculation
- changes to compatibility calculations
- additional helper method introduced to specifically calculate version compatibility based on the new ruleset
- test cover and test update

### Reviewers

@zeusongit 
@QilongTang 

### FYIs

@achintyabhat 