### PR TITLE
DYN-7138 Save as and Save buttons should be enabled after closing a graph while editing a custom node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -3196,8 +3196,11 @@ namespace Dynamo.ViewModels
                 // If after closing the HOME workspace, and there are no other custom 
                 // workspaces opened at the time, then we should show the start page.
                 this.ShowStartPage = (Model.Workspaces.Count() <= 1);
+                if (this.ShowStartPage)
+                {
+                    OnEnableShortcutBarItems(false);
+                }
                 RunSettings.ForceBlockRun = false;
-                OnEnableShortcutBarItems(false);
                 OnRequestCloseHomeWorkSpace();
             }
         }

--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -113,6 +113,34 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void TestHomeWorkspaceClosedBeforeCustomNode()
+        {
+            Open(@"core\CustomNodes\TestAdd.dyn");
+
+            Open(@"core\CustomNodes\add.dyf");
+
+            ViewModel.UIDispatcher.Invoke(new Action(() =>
+            {
+                DynamoModel.SwitchTabCommand switchCommand =
+                    new DynamoModel.SwitchTabCommand(0);
+
+                ViewModel.ExecuteCommand(switchCommand);
+            }));
+            Assert.AreEqual(ViewModel.Model.Workspaces.Count(), 2);
+
+            DynamoModel.IsTestMode = false;
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+            DynamoModel.IsTestMode = true;  
+
+            //the workspace count is still 2, since the homeworkspace was replaced by default workspace,
+            //and second is custom workspace that is still open.
+            Assert.AreEqual(ViewModel.Model.Workspaces.Count(), 2);
+
+            //assert that save button is still enabled
+            Assert.IsTrue(View.saveButton.IsEnabled);
+        }
+
+        [Test]
         public void ElementBinding_SaveAs()
         {
             var prebindingPathInTestDir = @"core\callsite\trace_test-prebinding.dyn";


### PR DESCRIPTION
### Purpose

When a Graph(dyn) and a Custom Node(dyf) is open in Dynamo, and the  HomeWorkspace(dyn) is closed, the toolbar becomes disabled, this PR fixes this behavior, and does not disable the toolbar when there is a custom node workspace still open.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Save as and Save buttons should be enabled after closing a graph while editing a custom node

### Reviewers

@DynamoDS/dynamo 
