### PR TITLE
DYN-7472: Add a host condition when setting UI culture.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -685,7 +685,14 @@ namespace Dynamo.Models
 
             if (PreferenceSettings != null)
             {
-                SetUICulture(PreferenceSettings.Locale);
+                // Setting the locale for Dynamo from loaded Preferences only when
+                // In a non-in-process integration case (when HostAnalyticsInfo.HostName is unspecified)
+                // Language is specified, otherwise Default setting means following host locale
+                if (string.IsNullOrEmpty(HostAnalyticsInfo.HostName) || !PreferenceSettings.Locale.Equals(Configuration.Configurations.SupportedLocaleList.First()))
+                {
+                    SetUICulture(PreferenceSettings.Locale);
+                }
+
                 PreferenceSettings.PropertyChanged += PreferenceSettings_PropertyChanged;
                 PreferenceSettings.MessageLogged += LogMessage;
             }


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-7472

Adding back the host check condition when setting the UIculture.

@QilongTang This was causing the locale to not be set in Revit locale when Dynamo is closed. We need to set this only when there is no host. Correct me if I am wrong here. I haven't tested in 2025 revit as I am running into build issues. So opening this as draft for discussion.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers
@QilongTang 

