### PR TITLE
7525: DYN-7252: note edit textbox fix

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:ui="clr-namespace:Dynamo.UI"
         Title="{x:Static p:Resources.EditWindowTitle}"
         Width="400"
-        Height="250"
+        Height="200"
         MinWidth="300"
         MinHeight="170"
         MaxWidth="{x:Static SystemParameters.PrimaryScreenWidth}"
@@ -125,7 +125,6 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
-                    <RowDefinition Height="auto" />
                 </Grid.RowDefinitions>
 
                 <!--  Title Bar + Close Button  -->
@@ -170,27 +169,12 @@
 
                 <TextBox Name="editText"
                          Grid.Row="1"
-                         Margin="15,1,15,10"
+                         Margin="15,1,15,15"
                          HorizontalAlignment="Stretch"
                          x:FieldModifier="private"
                          IsHitTestVisible="True"
                          PreviewKeyDown="OnEditWindowPreviewKeyDown"
                          Style="{DynamicResource InputStyle}" />
-
-
-                <StackPanel Grid.Row="2"
-                            FlowDirection="RightToLeft"
-                            Orientation="Horizontal">
-                    <Button MinWidth="90"
-                            Margin="11,0,0,12"
-                            Background="#0696D7"
-                            BorderBrush="#0696D7"
-                            Click="OkClick"
-                            Content="{x:Static p:Resources.EditWindowAcceptButton}"
-                            Foreground="White"
-                            Style="{StaticResource CtaButtonStyle}" />
-                </StackPanel>
-
             </Grid>
         </Border>
     </Grid>

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
@@ -1,15 +1,17 @@
 <Window x:Class="Dynamo.UI.Prompts.EditWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
-        Title="{x:Static p:Resources.EditWindowTitle}" 
-        MaxHeight="{x:Static SystemParameters.PrimaryScreenHeight}"
+        xmlns:ui="clr-namespace:Dynamo.UI"
+        Title="{x:Static p:Resources.EditWindowTitle}"
+        Width="400"
+        Height="250"
+        MinWidth="300"
+        MinHeight="170"
         MaxWidth="{x:Static SystemParameters.PrimaryScreenWidth}"
-        MinHeight="170" MinWidth="300"
-        Height="250" Width="400"
-        Style="{DynamicResource DynamoWindowStyle}"
+        MaxHeight="{x:Static SystemParameters.PrimaryScreenHeight}"
         AllowsTransparency="True"
+        Style="{DynamicResource DynamoWindowStyle}"
         WindowStyle="None">
 
     <Window.Background>
@@ -23,18 +25,100 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
+            <Style x:Key="InputStyle" TargetType="TextBox">
+                <Setter Property="Margin" Value="0,0,0,12" />
+                <Setter Property="MinWidth" Value="62px" />
+                <Setter Property="Cursor" Value="IBeam" />
+                <Setter Property="Background" Value="{StaticResource DarkThemeInputBoxBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="CaretBrush" Value="{StaticResource Blue300Brush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource DarkMidGreyBrush}" />
+                <Setter Property="BorderThickness" Value="0,0,0,1" />
+                <Setter Property="Padding" Value="8,10" />
+
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TextBox">
+                            <Border Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}">
+                                <Grid>
+                                    <!--  Main content  -->
+                                    <ScrollViewer x:Name="PART_ContentHost" />
+
+                                    <!--  Underline and Shadow  -->
+                                    <StackPanel Height="4px" VerticalAlignment="Bottom">
+                                        <Rectangle x:Name="Underline"
+                                                   Height="1px"
+                                                   Fill="#9B9B9B"
+                                                   Opacity="0" />
+                                        <Rectangle x:Name="UnderlineShadow"
+                                                   Height="3px"
+                                                   Fill="#6E6E6E"
+                                                   Opacity="0" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+
+                            <!--  ControlTemplate Triggers  -->
+                            <ControlTemplate.Triggers>
+                                <!--  MouseOver Trigger: Fade in underline and change border  -->
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Trigger.EnterActions>
+                                        <BeginStoryboard>
+                                            <Storyboard SpeedRatio="10">
+                                                <DoubleAnimation Storyboard.TargetName="Underline"
+                                                                 Storyboard.TargetProperty="Opacity"
+                                                                 To="0.75"
+                                                                 Duration="0:0:1" />
+                                                <DoubleAnimation Storyboard.TargetName="UnderlineShadow"
+                                                                 Storyboard.TargetProperty="Opacity"
+                                                                 To="0.75"
+                                                                 Duration="0:0:1" />
+                                            </Storyboard>
+                                        </BeginStoryboard>
+                                    </Trigger.EnterActions>
+                                    <Trigger.ExitActions>
+                                        <BeginStoryboard>
+                                            <Storyboard SpeedRatio="2">
+                                                <DoubleAnimation Storyboard.TargetName="Underline"
+                                                                 Storyboard.TargetProperty="Opacity"
+                                                                 To="0"
+                                                                 Duration="0:0:1" />
+                                                <DoubleAnimation Storyboard.TargetName="UnderlineShadow"
+                                                                 Storyboard.TargetProperty="Opacity"
+                                                                 To="0"
+                                                                 Duration="0:0:1" />
+                                            </Storyboard>
+                                        </BeginStoryboard>
+                                    </Trigger.ExitActions>
+                                </Trigger>
+                                <!--  IsFocused Trigger  -->
+                                <Trigger Property="IsFocused" Value="True">
+                                    <Setter TargetName="Underline" Property="Fill" Value="{StaticResource Blue300Brush}" />
+                                    <Setter TargetName="UnderlineShadow" Property="Fill" Value="#497386" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
     <Window.CommandBindings>
         <CommandBinding Command="Close" Executed="OnCloseExecuted" />
     </Window.CommandBindings>
     <Window.InputBindings>
-        <KeyBinding Command="Close" Key="Esc"/>
+        <KeyBinding Key="Esc" Command="Close" />
     </Window.InputBindings>
 
 
     <Grid Background="Transparent" MouseDown="UIElement_OnMouseDown">
-        <Border Name="MainBorder" Style="{StaticResource NoStyleWindowBorderStyle}" Background="#535353">
+        <Border Name="MainBorder"
+                Background="#535353"
+                Style="{StaticResource NoStyleWindowBorderStyle}">
 
             <Grid Margin="0">
 
@@ -46,13 +130,13 @@
 
                 <!--  Title Bar + Close Button  -->
                 <DockPanel Grid.Row="0"
-                           Margin="15 15 14 30"
+                           Margin="15,15,14,30"
                            HorizontalAlignment="Stretch">
 
                     <Button Name="CloseButton"
+                            Margin="25,0,0,0"
                             Click="CloseButton_OnClick"
                             DockPanel.Dock="Right"
-                            Margin="25 0 0 0"
                             Style="{StaticResource CloseButtonDarkStyle}" />
 
                     <Button Name="MaximizeButton"
@@ -63,11 +147,11 @@
                     <Button Name="NormalizeButton"
                             Click="MaximizeButton_OnClick"
                             DockPanel.Dock="Right"
-                            Visibility="Collapsed"
-                            Style="{StaticResource RestoreButtonDarkStyle}" />
+                            Style="{StaticResource RestoreButtonDarkStyle}"
+                            Visibility="Collapsed" />
 
                     <Button Name="MinimizeButton"
-                            Margin="0 0 25 0"
+                            Margin="0,0,25,0"
                             Click="MinimizeButton_OnClick"
                             DockPanel.Dock="Right"
                             Style="{StaticResource MinimizeButtonDarkStyle}" />
@@ -78,33 +162,33 @@
                                FontFamily="{StaticResource ArtifaktElementRegular}"
                                FontSize="20px"
                                Foreground="{StaticResource DarkThemeBodyMediumBrush}"
-                               Text="{x:Static p:Resources.EditNodeWindowTitle}" 
+                               Text="{x:Static p:Resources.EditNodeWindowTitle}"
                                TextWrapping="Wrap" />
                 </DockPanel>
 
-                <Rectangle Style="{StaticResource DividerRectangleStyle}" Grid.Row="0" />
+                <Rectangle Grid.Row="0" Style="{StaticResource DividerRectangleStyle}" />
 
-                <TextBox 
-                        PreviewKeyDown="OnEditWindowPreviewKeyDown"
-                        x:FieldModifier="private" 
-                        Grid.Row="1"
-                        Margin="15 1 15 10" 
-                        HorizontalAlignment="Stretch" 
-                        Name="editText" 
-                        IsHitTestVisible="True"
-                        Style="{StaticResource HintingInputStyle}"/>
+                <TextBox Name="editText"
+                         Grid.Row="1"
+                         Margin="15,1,15,10"
+                         HorizontalAlignment="Stretch"
+                         x:FieldModifier="private"
+                         IsHitTestVisible="True"
+                         PreviewKeyDown="OnEditWindowPreviewKeyDown"
+                         Style="{DynamicResource InputStyle}" />
 
 
-                <StackPanel Grid.Row="2" Orientation="Horizontal" FlowDirection="RightToLeft">
-                    <Button 
-                        Content="{x:Static p:Resources.EditWindowAcceptButton}" 
-                        Margin="11 0 0 12"
-                        MinWidth="90"
-                        BorderBrush="#0696D7"
-                        Foreground="White"
-                        Background="#0696D7"
-                        Style="{StaticResource CtaButtonStyle}" 
-                        Click="OkClick" />
+                <StackPanel Grid.Row="2"
+                            FlowDirection="RightToLeft"
+                            Orientation="Horizontal">
+                    <Button MinWidth="90"
+                            Margin="11,0,0,12"
+                            Background="#0696D7"
+                            BorderBrush="#0696D7"
+                            Click="OkClick"
+                            Content="{x:Static p:Resources.EditWindowAcceptButton}"
+                            Foreground="White"
+                            Style="{StaticResource CtaButtonStyle}" />
                 </StackPanel>
 
             </Grid>

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -33,9 +33,17 @@ namespace Dynamo.UI.Prompts
             InitializeComponent();
             this.dynamoViewModel = dynamoViewModel;
 
-            this.WindowStartupLocation = WindowStartupLocation.CenterOwner;          
-            this.editText.Focus();
-            
+            Owner = dynamoViewModel.Owner;
+            this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            this.Loaded += (sender, e) => this.editText.Focus();
+
+            // Center the window again once rendering is complete
+            this.ContentRendered += (sender, e) =>
+            {
+                this.Left = Owner.Left + (Owner.Width - this.ActualWidth) / 2;
+                this.Top = Owner.Top + (Owner.Height - this.ActualHeight) / 2;
+            };
+
             // do not accept value if user closes 
             this.Closing += (sender, args) => this.DialogResult = false;
             if (false != updateSourceOnTextChange)
@@ -97,6 +105,9 @@ namespace Dynamo.UI.Prompts
 
         private void EditText_PreviewKeyDown(object sender, KeyEventArgs e)
         {
+            var textBox = sender as TextBox;
+            var caretIndex = textBox.CaretIndex;
+
             EditTextBoxPreviewKeyDown?.Invoke(sender, e);
         }
 


### PR DESCRIPTION
### Purpose

Addressing issues with Edit Text window of the Note when zoomed out. Documented jira issue https://jira.autodesk.com/browse/DYN-7252?filter=-1

### UI Changes

![DynamoSandbox_zJEikJGy8M](https://github.com/user-attachments/assets/7282e0a5-0875-4785-bc1b-813f663684d6)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [x] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- fixing the caret positioning issue causing all the observed issues
- restyling the window without overriding the textbox control template fixed the issue
- also fixed the starting location of the window
- the Accept button was not used (the text is being edited real-time), removing

### Reviewers

@reddyashish 

### FYIs

@QilongTang 