### PR TITLE
DYN-6526 Converter Culture Bug Swedish

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -62,6 +62,7 @@ namespace CoreNodeModelsWpf.Nodes
             {
                 Mode = BindingMode.TwoWay,
                 Converter = new DoubleInputDisplay(),
+                ConverterCulture = CultureInfo.InvariantCulture,
                 NotifyOnValidationError = false,
                 Source = nodeModel,
                 UpdateSourceTrigger = UpdateSourceTrigger.Explicit


### PR DESCRIPTION
### Purpose

Fixing Culture in Converter used in the Number node.
In Civil3D when loading a dyn file that contains a Number with value 0.25 the converter was converting the value to 25.00 showing this value in the Number node (due that the CurrentCulture is "sv-FI"). For fixing this I just set the InvariantCulture in the Converter.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Culture in Converter used in the Number node.

### Reviewers

@QilongTang 

### FYIs

