### PR TITLE
DYN-7728 Add Wild Card Syntax

### DIFF
--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -366,8 +366,14 @@ namespace Dynamo.PackageManager
             bool isWithinMinMax = true;
             if (!string.IsNullOrEmpty(compatibility.min) || !string.IsNullOrEmpty(compatibility.max))
             {
-                Version minVersion = compatibility.min != null ? VersionUtilities.Parse(compatibility.min) : null;
-                Version maxVersion = compatibility.max != null ? VersionUtilities.Parse(compatibility.max) : null;
+                Version minVersion = VersionUtilities.Parse(compatibility.min);
+                Version maxVersion = VersionUtilities.Parse(compatibility.max);
+
+                // if max is null, try to parse based on wildcard symantics
+                if(maxVersion == null)
+                {
+                    maxVersion = VersionUtilities.WildCardParse(compatibility.max);
+                }
 
                 // If max is specified without min, return false as max-only ranges are unsupported
                 if (minVersion == null && maxVersion != null)

--- a/src/DynamoUtilities/PublicAPI.Unshipped.txt
+++ b/src/DynamoUtilities/PublicAPI.Unshipped.txt
@@ -215,6 +215,7 @@ static Dynamo.Utilities.TypeExtensions.GetInstance<TArg>(this System.Type type, 
 static Dynamo.Utilities.TypeExtensions.ImplementsGeneric(System.Type generic, System.Type toCheck) -> bool
 static Dynamo.Utilities.VersionUtilities.Parse(string version) -> System.Version
 static Dynamo.Utilities.VersionUtilities.PartialParse(string versionString, int numberOfFields = 3) -> System.Version
+static Dynamo.Utilities.VersionUtilities.WildCardParse(string version) -> System.Version
 static DynamoUtilities.CertificateVerification.CheckAssemblyForValidCertificate(string assemblyPath) -> bool
 static DynamoUtilities.PathHelper.CreateFolderIfNotExist(string folderPath) -> System.Exception
 static DynamoUtilities.PathHelper.ExtractAndSaveEmbeddedFont(string resourcePath, string outputPath, string outputFileName, System.Reflection.Assembly assembly) -> void

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -67,7 +67,7 @@ namespace Dynamo.Utilities
         /// <summary>
         /// The maximum version we check against when substituting a wildcard
         /// </summary>
-        private const string WILDCARD_MAX_VERSION = "99999";
+        private const string WILDCARD_MAX_VERSION = "65535";
 
         /// <summary>
         /// Parse the first n fields of a version string. Delegates to

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -67,7 +67,7 @@ namespace Dynamo.Utilities
         /// <summary>
         /// The maximum version we check against when substituting a wildcard
         /// </summary>
-        private const string WILDCARD_MAX_VERSION = "65535";
+        private const string WILDCARD_MAX_VERSION = "2147483647";
 
         /// <summary>
         /// Parse the first n fields of a version string. Delegates to

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -67,7 +67,7 @@ namespace Dynamo.Utilities
         /// <summary>
         /// The maximum version we check against when substituting a wildcard
         /// </summary>
-        private const string WILDCARD_MAX_VERSION = "1000";
+        private const string WILDCARD_MAX_VERSION = "99999";
 
         /// <summary>
         /// Parse the first n fields of a version string. Delegates to

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -62,5 +62,67 @@ namespace Dynamo.Utilities
             // Now it should be safe to parse
             return Version.Parse(version);
         }
+
+        /// <summary>
+        /// Parse the first n fields of a version string.  Delegates to
+        /// Version.Parse.
+        /// </summary>
+        public static Version WildCardParse(string version)
+        {
+            // If the version string is null or empty, return null
+            if (string.IsNullOrEmpty(version))
+            {
+                return null;
+            }
+
+            // Check if the version string ends with a wild card.
+            if (!version.EndsWith(".*"))
+            {
+                return null;
+            }
+
+            var splitVersion = version.Split('.');
+
+            //CHeck that there are not more then 3 version items specified
+            if (splitVersion.Length > 3)
+            {
+                return null;
+            }
+
+            // Check that the first number is a valid number
+            if (!int.TryParse(splitVersion[0], out _))
+            {
+                return null;
+            }
+
+            if (splitVersion.Length == 2)
+            {
+                var newVersion = splitVersion[0] + ".1000.0";
+                if (Version.TryParse(newVersion, out Version parsedVersion))
+                {
+                    return parsedVersion;
+                }
+
+                return null;
+            }
+
+            if(splitVersion.Length == 3)
+            {
+                if (!int.TryParse(splitVersion[1], out _))
+                {
+                    return null;
+                }
+
+                var newVersion = splitVersion[0] + "." + splitVersion[1] + ".1000";
+                if (Version.TryParse(newVersion, out Version parsedVersion))
+                {
+                    return parsedVersion;
+                }
+
+                return null;
+            }
+
+            return null;
+        }
     }
 }

--- a/test/DynamoCoreTests/VersionUtilitiesTests.cs
+++ b/test/DynamoCoreTests/VersionUtilitiesTests.cs
@@ -63,6 +63,20 @@ namespace Dynamo.Tests
             Assert.IsNull(result, "Expected null when input is an invalid version string.");
         }
 
+
+        [Test]
+        public void ParseVersionSafely_TooManyComponents_ReturnsNull()
+        {
+            // Arrange
+            string version = "1.2.3.4.5";
+
+            // Act
+            Version result = VersionUtilities.Parse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input has too many components '1.2.3.4.5'.");
+        }
+
         [Test]
         public void ParseVersionSafely_ShortVersion_ReturnsPaddedVersion()
         {
@@ -90,6 +104,19 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void ParseVersionSafely_LongVersion_ReturnsParsedVersion()
+        {
+            // Arrange
+            string version = "2019.1.2.0";
+
+            // Act
+            Version result = VersionUtilities.Parse(version);
+
+            // Assert
+            Assert.AreEqual(new Version(2019, 1, 2, 0), result, "Expected version '2019.1.2.0' when input is '2019.1.2.0'.");
+        }
+
+        [Test]
         public void ParseWildCard_ValidVersion_ReturnsNull()
         {
             // Arrange
@@ -99,11 +126,11 @@ namespace Dynamo.Tests
             Version result = VersionUtilities.WildCardParse(version);
 
             // Assert
-            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+            Assert.IsNull(result, "Expected null when input does not end with a wildcard symbol.");
         }
 
         [Test]
-        public void ParseWildCard_InvalidWildcarVersion1_ReturnsNull()
+        public void ParseWildCard_InvalidWildcardVersion1_ReturnsNull()
         {
             // Arrange
             string version = "2019.1.2.*";
@@ -116,7 +143,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void ParseWildCard_InvalidWildcarVersion2_ReturnsNull()
+        public void ParseWildCard_InvalidWildcardVersion2_ReturnsNull()
         {
             // Arrange
             string version = "2019.1*";
@@ -129,7 +156,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void ParseWildCard_InvalidWildcarVersion3_ReturnsNull()
+        public void ParseWildCard_InvalidWildcardVersion3_ReturnsNull()
         {
             // Arrange
             string version = "2019.*.1";
@@ -142,7 +169,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void ParseWildCard_Invalidcharacters1_ReturnsNull()
+        public void ParseWildCard_InvalidCharacters1_ReturnsNull()
         {
             // Arrange
             string version = "a.*";
@@ -155,7 +182,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void ParseWildCard_Invalidcharacters2_ReturnsNull()
+        public void ParseWildCard_InvalidCharacters2_ReturnsNull()
         {
             // Arrange
             string version = "a.1.*";
@@ -168,7 +195,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void ParseWildCard_Invalidcharacters3_ReturnsNull()
+        public void ParseWildCard_InvalidCharacters3_ReturnsNull()
         {
             // Arrange
             string version = "2016.a.*";
@@ -204,6 +231,31 @@ namespace Dynamo.Tests
 
             // Assert
             Assert.AreEqual(new Version(2019, 1000, 0), result, "Expected version '2019.1000.0' when input is '2019.*'.");
+        }
+
+        [Test]
+        public void ParseWildCard_TwoAndThreePartVersionConsistency_ReturnsParsedVersions()
+        {
+            // Arrange & Act
+            Version twoPartResult = VersionUtilities.WildCardParse("2021.*");
+            Version threePartResult = VersionUtilities.WildCardParse("2021.2.*");
+
+            // Assert
+            Assert.AreEqual(new Version(2021, 1000, 0), twoPartResult, "Expected version '2021.1000.0' for input '2021.*'.");
+            Assert.AreEqual(new Version(2021, 2, 1000), threePartResult, "Expected version '2021.2.1000' for input '2021.2.*'.");
+        }
+
+        [Test]
+        public void ParseWildCard_TooManyComponents_ReturnsNull()
+        {
+            // Arrange
+            string version = "1.2.3.4.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input has too many components '1.2.3.4.*'.");
         }
 
     }

--- a/test/DynamoCoreTests/VersionUtilitiesTests.cs
+++ b/test/DynamoCoreTests/VersionUtilitiesTests.cs
@@ -217,7 +217,7 @@ namespace Dynamo.Tests
             Version result = VersionUtilities.WildCardParse(version);
 
             // Assert
-            Assert.AreEqual(new Version(2019, 1, 1000), result, "Expected version '2019.1.1000' when input is '2019.1.*'.");
+            Assert.AreEqual(new Version(2019, 1, 2147483647), result, "Expected version '2019.1.2147483647' when input is '2019.1.*'.");
         }
 
         [Test]
@@ -230,7 +230,7 @@ namespace Dynamo.Tests
             Version result = VersionUtilities.WildCardParse(version);
 
             // Assert
-            Assert.AreEqual(new Version(2019, 1000, 0), result, "Expected version '2019.1000.0' when input is '2019.*'.");
+            Assert.AreEqual(new Version(2019, 2147483647, 0), result, "Expected version '2019.2147483647.0' when input is '2019.*'.");
         }
 
         [Test]
@@ -241,8 +241,8 @@ namespace Dynamo.Tests
             Version threePartResult = VersionUtilities.WildCardParse("2021.2.*");
 
             // Assert
-            Assert.AreEqual(new Version(2021, 1000, 0), twoPartResult, "Expected version '2021.1000.0' for input '2021.*'.");
-            Assert.AreEqual(new Version(2021, 2, 1000), threePartResult, "Expected version '2021.2.1000' for input '2021.2.*'.");
+            Assert.AreEqual(new Version(2021, 2147483647, 0), twoPartResult, "Expected version '2021.2147483647.0' for input '2021.*'.");
+            Assert.AreEqual(new Version(2021, 2, 2147483647), threePartResult, "Expected version '2021.2.2147483647' for input '2021.2.*'.");
         }
 
         [Test]

--- a/test/DynamoCoreTests/VersionUtilitiesTests.cs
+++ b/test/DynamoCoreTests/VersionUtilitiesTests.cs
@@ -89,6 +89,123 @@ namespace Dynamo.Tests
             Assert.AreEqual(new Version(2019, 1, 2), result, "Expected version '2019.1.2' when input is '2019.1.2'.");
         }
 
+        [Test]
+        public void ParseWildCard_ValidVersion_ReturnsNull()
+        {
+            // Arrange
+            string version = "2019.1.2";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_InvalidWildcarVersion1_ReturnsNull()
+        {
+            // Arrange
+            string version = "2019.1.2.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_InvalidWildcarVersion2_ReturnsNull()
+        {
+            // Arrange
+            string version = "2019.1*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_InvalidWildcarVersion3_ReturnsNull()
+        {
+            // Arrange
+            string version = "2019.*.1";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_Invalidcharacters1_ReturnsNull()
+        {
+            // Arrange
+            string version = "a.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_Invalidcharacters2_ReturnsNull()
+        {
+            // Arrange
+            string version = "a.1.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_Invalidcharacters3_ReturnsNull()
+        {
+            // Arrange
+            string version = "2016.a.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.IsNull(result, "Expected null when input is an invalid version string.");
+        }
+
+        [Test]
+        public void ParseWildCard_ValidString1_ReturnsParsedVersion()
+        {
+            // Arrange
+            string version = "2019.1.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.AreEqual(new Version(2019, 1, 1000), result, "Expected version '2019.1.1000' when input is '2019.1.*'.");
+        }
+
+        [Test]
+        public void ParseWildCard_ValidString2_ReturnsParsedVersion()
+        {
+            // Arrange
+            string version = "2019.*";
+
+            // Act
+            Version result = VersionUtilities.WildCardParse(version);
+
+            // Assert
+            Assert.AreEqual(new Version(2019, 1000, 0), result, "Expected version '2019.1000.0' when input is '2019.*'.");
+        }
+
     }
 
 }

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1217,8 +1217,8 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 min = "2.3.0",
                 max = "2.*"
             };
-            Version compatibleVersion = new Version("2.99999.0");
-            Version incompatibleVersion = new Version("2.99999.1");
+            Version compatibleVersion = new Version("2.65535.0");
+            Version incompatibleVersion = new Version("2.65535.1");
 
             Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion),
                           "Expected compatibility to be true when version is within the min and max wildcard range.");

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1210,6 +1210,24 @@ namespace Dynamo.PackageManager.Wpf.Tests
         }
 
         [Test]
+        public void IsVersionCompatible_ValidMaxWildCardRange1_ReturnsTrueForVersionWithinDomainRange()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2.*"
+            };
+            Version compatibleVersion = new Version("2.1000.0");
+            Version incompatibleVersion = new Version("2.1000.1");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion),
+                          "Expected compatibility to be true when version is within the min and max wildcard range.");
+
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, incompatibleVersion),
+                          "Expected compatibility to be true when version is within the min and max wildcard range.");
+        }
+
+        [Test]
         public void IsVersionCompatible_ValidMaxWildCardRange2_ReturnsTrueForVersionWithinRange()
         {
             var compatibility = new Greg.Responses.Compatibility

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1217,8 +1217,8 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 min = "2.3.0",
                 max = "2.*"
             };
-            Version compatibleVersion = new Version("2.65535.0");
-            Version incompatibleVersion = new Version("2.65535.1");
+            Version compatibleVersion = new Version("2.2147483647.0");
+            Version incompatibleVersion = new Version("2.2147483647.1");
 
             Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion),
                           "Expected compatibility to be true when version is within the min and max wildcard range.");

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1194,5 +1194,118 @@ namespace Dynamo.PackageManager.Wpf.Tests
             Assert.Throws<ArgumentException>(() => PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
                           "Expected an ArgumentException when min version is greater than max version.");
         }
+
+        [Test]
+        public void IsVersionCompatible_ValidMaxWildCardRange1_ReturnsTrueForVersionWithinRange()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2.*"
+            };
+            Version version = new Version("2.4.0");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be true when version is within the min and max wildcard range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_ValidMaxWildCardRange2_ReturnsTrueForVersionWithinRange()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2.5.*"
+            };
+            Version version = new Version("2.5.1");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be true when version is within the min and max wildcard range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_ValidMaxWildCardRange_ReturnsFalseForVersionOutsideMajorVersionRange()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2.*"
+            };
+            Version version = new Version("3.1.0");
+
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be false when version is outside the min and max wildcard range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_ValidMaxWildCardRange_ReturnsFalseForVersionOutsideMinorVersionRange()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2.5.*"
+            };
+            Version version = new Version("2.6.0");
+
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be false when version is outside the min and max wildcard range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_InValidMaxWildCardRange_ReturnsFalseForVersionOutsideOfMajorVersion()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2*"
+            };
+            Version version = new Version("3.5.1");
+
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be false when major version is same as Max major version and there is an invalid max range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_InValidMaxWildCardRange_ReturnsTrueForVersionInsideOfMajorVersion()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "2*"
+            };
+            Version version = new Version("2.5.1");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be true when major version is greater than Max major version and there is an invalid max range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_InValidMaxRange_ReturnsFalseForVersionOutsideOfMajorVersion()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "asdfasdfa"
+            };
+            Version version = new Version("3.5.1");
+
+            Assert.IsFalse(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be false when major version is same as Max major version and there is an invalid max range.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_InValidMaxRange_ReturnsTrueForVersionInsideOfMajorVersion()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                min = "2.3.0",
+                max = "asdfasdfa"
+            };
+            Version version = new Version("2.5.1");
+
+            Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
+                          "Expected compatibility to be true when major version is greater than Max major version and there is an invalid max range.");
+        }
+
     }
 }

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1217,8 +1217,8 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 min = "2.3.0",
                 max = "2.*"
             };
-            Version compatibleVersion = new Version("2.1000.0");
-            Version incompatibleVersion = new Version("2.1000.1");
+            Version compatibleVersion = new Version("2.99999.0");
+            Version incompatibleVersion = new Version("2.99999.1");
 
             Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, compatibleVersion),
                           "Expected compatibility to be true when version is within the min and max wildcard range.");


### PR DESCRIPTION
### Purpose

This PR adds `wildcard` support for version compatibility calculation. Based on the [current scheme explained here](https://wiki.autodesk.com/pages/viewpage.action?spaceKey=GEN&title=Dynamo+Package+Compatibility+Schema#:~:text=with%20Dynamo%20sandbox.-,Schema%20Validation%20Rules,-List%20Level%20Validation).


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Asterisk(*) support 
- new `WildCardParse` method
- test coverage

### Reviewers

@zeusongit 
@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
