### PR TITLE
DYN-7394 Retire two feature flags used for DynamoHome and TSpline nodes

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1200,14 +1200,11 @@ namespace Dynamo.Configuration
         /// </summary>
         internal void UpdateNamespacesToExcludeFromLibrary()
         {
-            // When the experiment toggle is disabled by feature flag, include the TSpline namespace from the library OOTB.
-            if (!DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false)
-            {
-                NamespacesToExcludeFromLibrary.Remove(
-                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
-                );
-                return;
-            }
+            // Include the TSpline namespace from the library OOTB.
+            NamespacesToExcludeFromLibrary.Remove(
+                "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
+            );
+            return;
         }
 
         //migrate old path token to new path token

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1164,12 +1164,13 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// Controls if the TSpline nodes experiment toggle is visible from feature flag
+        /// TODO: remove this public property in Dynamo 4.0 and archive the feature flag
         /// </summary>
         public bool IsTSplineNodesExperimentToggleVisible
         {
             get
             {
-                return DynamoModel.FeatureFlags?.CheckFeatureFlag("IsTSplineNodesExperimentToggleVisible", false) ?? false;
+                return false;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1417,7 +1417,7 @@ namespace Dynamo.Controls
             }
 
             // Load the new HomePage
-            if (IsNewAppHomeEnabled) LoadHomePage();
+            LoadHomePage();
 
             loaded = true;
         }
@@ -2696,13 +2696,14 @@ namespace Dynamo.Controls
         }
 
         /// <summary>
-        /// A feature flag controlling the appearance of the Dynamo home navigation page
+        /// A bool controlling the appearance of the Dynamo home navigation page
+        /// TODO: remove this public property and archive the feature flag in Dynamo 4.0
         /// </summary>
         public bool IsNewAppHomeEnabled
         {
             get
             {
-                return DynamoModel.FeatureFlags?.CheckFeatureFlag("IsDynamoAppHomeEnabled", false) ?? false;
+                return true;
             }
         }
 


### PR DESCRIPTION
### Purpose

Remove the feature flag usage from https://github.com/DynamoDS/Dynamo/pull/14923 and https://github.com/DynamoDS/Dynamo/pull/14879

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Retire two feature flags used for DynamoHome and TSpline nodes

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
