### PR TITLE
DYN-7343: Pm search compatibility filters update

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -696,6 +696,10 @@ Dynamo.Controls.TreeViewVLineMarginConverter
 Dynamo.Controls.TreeViewVLineMarginConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.TreeViewVLineMarginConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.TreeViewVLineMarginConverter.TreeViewVLineMarginConverter() -> void
+Dynamo.Controls.VersionStringAsteriskToXConverter
+Dynamo.Controls.VersionStringAsteriskToXConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
+Dynamo.Controls.VersionStringAsteriskToXConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
+Dynamo.Controls.VersionStringAsteriskToXConverter.VersionStringAsteriskToXConverter() -> void
 Dynamo.Controls.ViewButtonClipRectConverter
 Dynamo.Controls.ViewButtonClipRectConverter.Convert(object[] values, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.ViewButtonClipRectConverter.ConvertBack(object value, System.Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture) -> object[]

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -4029,4 +4029,29 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
+    /// Returns "2019.10.x" from "2019.10.*" input
+    /// </summary>
+    public class VersionStringAsteriskToXConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string version && !string.IsNullOrEmpty(version))
+            {
+                return version.Replace("*", "x");
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string version && !string.IsNullOrEmpty(version))
+            {
+                return version.Replace("x", "*");
+            }
+
+            return value;
+        }
+    }
 }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -203,6 +203,7 @@
     <Color x:Key="PMBorderColor">#5F5F5F</Color>
     <Color x:Key="PMHeaderBackgroundColor">#3f3f3f</Color>
     <Color x:Key="PMDataGridBackgroundColor">#474747</Color>
+    <Color x:Key="PMDataAltBackgroundColor">#535353</Color>
     <Color x:Key="PMVersionCompatibleColor">#87B340</Color>
     <Color x:Key="PMVersionUncompatibleColor">#EB5555</Color>
     <Color x:Key="PMVersionUnknownColor">#73C5FF</Color>
@@ -211,6 +212,7 @@
     <SolidColorBrush x:Key="PMBorderColorBrush" Color="{StaticResource PMBorderColor}" />
     <SolidColorBrush x:Key="PMHeaderBackgroundColorBrush" Color="{StaticResource PMHeaderBackgroundColor}" />
     <SolidColorBrush x:Key="PMDataGridBackgroundColorBrush" Color="{StaticResource PMDataGridBackgroundColor}" />
+    <SolidColorBrush x:Key="PMDataAltBackgroundColorBrush" Color="{StaticResource PMDataAltBackgroundColor}" />
     <SolidColorBrush x:Key="PMVersionCompatibleColorBrush" Color="{StaticResource PMVersionCompatibleColor}" />
     <SolidColorBrush x:Key="PMVersionUncompatibleColorBrush" Color="{StaticResource PMVersionUncompatibleColor}" />
     <SolidColorBrush x:Key="PMVersionUnknownColorBrush" Color="{StaticResource PMVersionUnknownColor}" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -207,6 +207,7 @@
     <Color x:Key="PMVersionCompatibleColor">#87B340</Color>
     <Color x:Key="PMVersionUncompatibleColor">#EB5555</Color>
     <Color x:Key="PMVersionUnknownColor">#73C5FF</Color>
+    <Color x:Key="PMInnerVerticleLineColor">#646464</Color>
 
     <SolidColorBrush x:Key="PMForegroundColorBrush" Color="{StaticResource PMForegroundColor}" />
     <SolidColorBrush x:Key="PMBorderColorBrush" Color="{StaticResource PMBorderColor}" />
@@ -216,4 +217,5 @@
     <SolidColorBrush x:Key="PMVersionCompatibleColorBrush" Color="{StaticResource PMVersionCompatibleColor}" />
     <SolidColorBrush x:Key="PMVersionUncompatibleColorBrush" Color="{StaticResource PMVersionUncompatibleColor}" />
     <SolidColorBrush x:Key="PMVersionUnknownColorBrush" Color="{StaticResource PMVersionUnknownColor}" />
+    <SolidColorBrush x:Key="PMInnerVerticleLineColorBrush" Color="{StaticResource PMInnerVerticleLineColor}" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -6480,7 +6480,7 @@
         <Setter Property="BorderBrush" Value="{StaticResource DarkMidGreyBrush}" />
         <Setter Property="ColumnWidth" Value="Auto" />
         <Setter Property="GridLinesVisibility" Value="Vertical" />
-        <Setter Property="VerticalGridLinesBrush" Value="{StaticResource DarkMidGreyBrush}" />
+        <Setter Property="VerticalGridLinesBrush" Value="#646464" />
         <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
     </Style>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -6480,7 +6480,7 @@
         <Setter Property="BorderBrush" Value="{StaticResource DarkMidGreyBrush}" />
         <Setter Property="ColumnWidth" Value="Auto" />
         <Setter Property="GridLinesVisibility" Value="Vertical" />
-        <Setter Property="VerticalGridLinesBrush" Value="#646464" />
+        <Setter Property="VerticalGridLinesBrush" Value="{StaticResource PMInnerVerticleLineColorBrush}" />
         <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
     </Style>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -825,6 +825,24 @@ namespace Dynamo.PackageManager
                     negateFilter.OnChecked = false;
                     break;
 
+                // Mutually exclusive case for Compatible and Incompatible
+                case var name when name.Equals(Resources.PackageCompatible):
+                    if (!filter.OnChecked)
+                        break;
+                    var incompatibleFilter = CompatibilityFilter.First(x => x.FilterName.Equals(Resources.PackageIncompatible));
+                    if (!incompatibleFilter.OnChecked)
+                        break;
+                    incompatibleFilter.OnChecked = false;
+                    break;
+
+                case var name when name.Equals(Resources.PackageIncompatible):
+                    if (!filter.OnChecked)
+                        break;
+                    var compatibleFilter = CompatibilityFilter.First(x => x.FilterName.Equals(Resources.PackageCompatible));
+                    if (!compatibleFilter.OnChecked)
+                        break;
+                    compatibleFilter.OnChecked = false;
+                    break;
             }
         }
 

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -709,6 +709,7 @@
                                                       IsReadOnly="True"
                                                       IsSynchronizedWithCurrentItem="True"
                                                       ItemsSource="{Binding VersionInformation}"
+                                                      RowBackground="{StaticResource DarkMidGreyBrush}"
                                                       RowDetailsVisibilityMode="Collapsed"
                                                       ScrollViewer.CanContentScroll="True"
                                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -29,6 +29,7 @@
             <controls:InverseEmptyListToVisibilityConverter x:Key="InverseEmptyListToVisibilityConverter" />
             <controls:CopyrightInfoTooltipConverter x:Key="CopyrightInfoTooltipConverter" />
             <controls:PackageDetailsLinkCollapseOnEmpty x:Key="PackageDetailsLinkCollapseOnEmpty" />
+            <controls:VersionStringAsteriskToXConverter x:Key="VersionStringAsteriskToXConverter" />
             <SolidColorBrush x:Key="ForegroundGrayBrush" Color="#D8D8D8" />
             <SolidColorBrush x:Key="HoverBorderGrayBrush" Color="#6d6d6d" />
             <SolidColorBrush x:Key="PressedBorderGrayBrush" Color="#7e7e7e" />
@@ -693,7 +694,7 @@
                                             <TextBlock Margin="0,5" Text="{x:Static p:Resources.PackageDetailsCompatibilityWithSetup}" />
                                             <DataGrid x:Name="VersionCompatibilityDataGrid"
                                                       Margin="0,0,20,20"
-                                                      AlternatingRowBackground="{StaticResource PMDataGridBackgroundColorBrush}"
+                                                      AlternatingRowBackground="{StaticResource PMDataAltBackgroundColorBrush}"
                                                       AlternationCount="2"
                                                       AutoGenerateColumns="False"
                                                       Background="{StaticResource ExtensionBackgroundColor}"
@@ -709,7 +710,7 @@
                                                       IsReadOnly="True"
                                                       IsSynchronizedWithCurrentItem="True"
                                                       ItemsSource="{Binding VersionInformation}"
-                                                      RowBackground="{StaticResource DarkMidGreyBrush}"
+                                                      RowBackground="{StaticResource PMDataGridBackgroundColorBrush}"
                                                       RowDetailsVisibilityMode="Collapsed"
                                                       ScrollViewer.CanContentScroll="True"
                                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"
@@ -722,7 +723,7 @@
                                                                         Binding="{Binding CompatibilityName}"
                                                                         Header="" />
                                                     <DataGridTextColumn Width="3*"
-                                                                        Binding="{Binding Versions}"
+                                                                        Binding="{Binding Versions, Converter={StaticResource VersionStringAsteriskToXConverter}}"
                                                                         Header="{x:Static p:Resources.PublishPackageViewPackageVersion}" />
                                                 </DataGrid.Columns>
                                             </DataGrid>

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -593,6 +593,8 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 new FilterEntry(unknownCompatibilityFilterName, "Filter by compatibility", "Unknown Compatibility Packages", packageManagerSearchViewModel) { OnChecked = false },
             };
 
+            packageManagerSearchViewModel.CompatibilityFilter.ForEach(f => f.PropertyChanged += packageManagerSearchViewModel.filter_PropertyChanged);
+
             // Adding compatible packages
             foreach (var package in compatiblePackagesName)
             {
@@ -654,17 +656,19 @@ namespace Dynamo.PackageManager.Wpf.Tests
             Assert.IsNotNull(packageManagerSearchViewModel.SearchResults, "No results found");
             Assert.That(packageManagerSearchViewModel.SearchResults.Count == compatiblePackagesName.Count, "Filtered results do not match the compatible packages");
 
-            // Reset (Filters are not mutually exclusive)
-            packageManagerSearchViewModel.CompatibilityFilter[0].OnChecked = false;
-
             // Check the Incompatible filter
             packageManagerSearchViewModel.CompatibilityFilter[1].OnChecked = true;
             packageManagerSearchViewModel.CompatibilityFilter[1].FilterCommand.Execute(string.Empty);
             Assert.IsNotNull(packageManagerSearchViewModel.SearchResults, "No results found");
             Assert.That(packageManagerSearchViewModel.SearchResults.Count == incompatiblePackagesName.Count, "Filtered results do not match the incompatible packages");
 
-            // Reset (Filters are not mutually exclusive)
-            packageManagerSearchViewModel.CompatibilityFilter[1].OnChecked = false;
+            // Asserts that Compatible and Incompatible filters are mutually exclusive
+            Assert.IsFalse(packageManagerSearchViewModel.CompatibilityFilter[0].OnChecked, "Compatible and Incompatible filters should be mutually exclusive");
+            packageManagerSearchViewModel.CompatibilityFilter[0].OnChecked = true;
+            Assert.IsFalse(packageManagerSearchViewModel.CompatibilityFilter[1].OnChecked, "Compatible and Incompatible filters should be mutually exclusive");
+
+            // Reset (These filters are not mutually exclusive)
+            packageManagerSearchViewModel.CompatibilityFilter[0].OnChecked = false;
 
             // Check the Unknown Compatibility filter
             packageManagerSearchViewModel.CompatibilityFilter[2].OnChecked = true;


### PR DESCRIPTION
### Purpose

A few minor issues/alignments to push before 3.4. 

### UI Changes 

![image](https://github.com/user-attachments/assets/a9cf6b16-4366-4ffd-81a3-df147871a9ef)

![i9Pxc7kVEg](https://github.com/user-attachments/assets/110477b2-e54e-4ea0-a4ae-56bffea2c0dd)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- `Compatible` and `Incompatible` filters are now exclusive @QilongTang @hwahlstrom 
- `*` to `x` conversion for the UI 
- minor color fix for alternating row colors for the `compatibility matrix`

### Reviewers

@zeusongit 
@QilongTang 

### FYIs

@reddyashish 
