### PR TITLE
Revert "DYN-7736 Bump splash screen version to 1.0.21"

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -23,7 +23,7 @@
 
   <Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
       <PropertyGroup>
-          <PackageVersion>1.0.21</PackageVersion>
+          <PackageVersion>1.0.20</PackageVersion>
           <PackageName>SplashScreen</PackageName>
       </PropertyGroup>
       <Exec Command="$(PowerShellCommand) -ExecutionPolicy Bypass -File &quot;$(SolutionDir)pkgexist.ps1&quot; &quot;$(PackageName)&quot; &quot;$(PackageVersion)&quot;" ConsoleToMSBuild="true">


### PR DESCRIPTION
Reverts DynamoDS/Dynamo#15607

Splash screen image too large?
![Screenshot 2024-11-05 at 5 30 29 PM](https://github.com/user-attachments/assets/787be30a-e4c0-4262-8e33-6b525673df91)
