### PR TITLE
DYN-7523: editwindow fix

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -52,6 +52,7 @@ namespace Dynamo.UI.Prompts
             this.ContentRendered += OnContentRendered;
         }
 
+        // Centralize the window correctly after it is rendered
         private void OnContentRendered(object sender, EventArgs e)
         {
             // Unsubscribe immediately, we only call this once on initialization
@@ -61,6 +62,7 @@ namespace Dynamo.UI.Prompts
             editText.Focus(); 
         }
 
+        // Centralize the window relative to another Window
         private void CenterWindowRelativeToOwner()
         {
             if (Owner != null)


### PR DESCRIPTION
### Purpose

This is a follow up on https://github.com/DynamoDS/Dynamo/pull/15583 which was recently merged. I am addressing potential leak introduced in the previous PR by introducing anonymous event subscription. The fix is mainly making these explicit, and unsubscribing immediately after the first call. This should ensure no unsubscribed events remain after the window is closed. 

Also, removed a small bit of unnecessary test code that was accidentally left over. 

Tagging this PR with the old Jira issue.

### UI Changes
![DynamoSandbox_EW2dZXsRDJ](https://github.com/user-attachments/assets/515757b4-0c4e-47fb-a670-c416a6a1f76c)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- removed anonymous subscription
- immediately unsubscribe after calling the event to prevent leaking
- removed redundant test code

### Reviewers

@reddyashish 
@zeusongit 
@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
