### PR TITLE
use windows temp folder

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoViewTests.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewTests.cs
@@ -166,7 +166,8 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, (obj["Bindings"] as IEnumerable<object>).Count());
 
             var saveAsPathInTestDir = @"core\callsite\trace_test2.dyn";
-            var saveAsPath = Path.Combine(GetTestDirectory(ExecutingDirectory), saveAsPathInTestDir);
+            var saveAsPath = Path.Combine(TempFolder, saveAsPathInTestDir);
+            Directory.CreateDirectory(Path.GetDirectoryName(saveAsPath));
 
             // SaveAs current workspace, close workspace.
             ViewModel.SaveAsCommand.Execute(saveAsPath);

--- a/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -759,7 +759,7 @@ namespace DynamoCoreWpfTests
             //we somehow need use single threaded sync context to force webview2 async initalization on this thread.
             //unfortunately it passes locally but then still fails on master-15.
             var testDirectory = GetTestDirectory(ExecutingDirectory);
-            var tempDynDirectory = Path.Combine(testDirectory, "Temp Test Path");
+            var tempDynDirectory = Path.Combine(TempFolder, "Temp Test Path");
             var dynFileName = Path.Combine(testDirectory, @"UI\BasicAddition.dyn");
             var insertDynFilePath = Path.Combine(tempDynDirectory, @"BasicAddition.dyn");
 

--- a/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
@@ -47,7 +47,9 @@ namespace Dynamo.Tests
             ViewModel.Model.EvaluationCompleted -= testXmlEvent;
 
             // Save to json in temp location
-            string tempPath = Path.Combine(Dynamo.UnitTestBase.TestDirectory, @"core\serialization\serialization_temp.dyn");
+            string tempPath = Path.Combine(TempFolder, @"core\serialization\serialization_temp.dyn");
+            Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
+            
             ViewModel.SaveAsCommand.Execute(tempPath);
             
             // Close workspace


### PR DESCRIPTION
### Purpose

Attempt to stabilize some test by moving temp dyn file out of the dynamo test folder to the windows temp folder

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
