### PR TITLE
DYN-7759: hover fix

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -74,7 +74,10 @@
 
             <!--  DataTemplate for ComboBox items  -->
             <DataTemplate x:Key="VersionInfoTemplate">
-                <StackPanel MinWidth="111" Orientation="Horizontal">
+                <StackPanel MinWidth="111"
+                            HorizontalAlignment="Stretch"
+                            Background="Transparent"
+                            Orientation="Horizontal">
                     <!--  Compatibility Icon  -->
                     <Button Width="18"
                             Height="18"
@@ -446,6 +449,7 @@
                                             Orientation="Vertical">
                                     <ComboBox x:Name="VersionComboBox"
                                               HorizontalAlignment="Left"
+                                              HorizontalContentAlignment="Stretch"
                                               ItemTemplate="{StaticResource VersionInfoTemplate}"
                                               ItemsSource="{Binding Path=ReversedVersionInformationList, UpdateSourceTrigger=PropertyChanged}"
                                               SelectedItem="{Binding Path=SelectedVersion, UpdateSourceTrigger=PropertyChanged}">


### PR DESCRIPTION
### Purpose

Enable hover on the full width of version picker in Package Manager

### Changes
![7ZvS0Fvetl](https://github.com/user-attachments/assets/305af5cb-09a1-45cc-809a-e7747ab2f197)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now hover activates on the whole row

### Reviewers

@zeusongit 

### FYIs

@reddyashish 
