### PR TITLE
simplify file size string

### DIFF
--- a/src/DynamoUtilities/PublicAPI.Unshipped.txt
+++ b/src/DynamoUtilities/PublicAPI.Unshipped.txt
@@ -234,6 +234,7 @@ static DynamoUtilities.PathHelper.IsValidPath(string filePath) -> bool
 static DynamoUtilities.PathHelper.isValidXML(string path, out System.Xml.XmlDocument xmlDoc, out System.Exception ex) -> bool
 static DynamoUtilities.PathHelper.LoadEmbeddedResourceAsString(string resourcePath, System.Reflection.Assembly assembly) -> string
 static DynamoUtilities.StringUtilities.CapitalizeFirstLetter(string word) -> string
+static DynamoUtilities.StringUtilities.SimplifyFileSizeUnit(string size) -> string
 static DynamoUtilities.TypeSwitch.Case<T>(System.Action action) -> DynamoUtilities.TypeSwitch.CaseInfo
 static DynamoUtilities.TypeSwitch.Case<T>(System.Action<T> action) -> DynamoUtilities.TypeSwitch.CaseInfo
 static DynamoUtilities.TypeSwitch.Default(System.Action action) -> DynamoUtilities.TypeSwitch.CaseInfo

--- a/src/DynamoUtilities/StringUtilities.cs
+++ b/src/DynamoUtilities/StringUtilities.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace DynamoUtilities
 {
     /// <summary>
@@ -22,6 +16,21 @@ namespace DynamoUtilities
                 return word;
 
             return char.ToUpper(word[0]) + word.Substring(1);
+        }
+
+        /// <summary>
+        /// Replaces 'i' in a file size string
+        /// </summary>
+        /// <param name="size">The file size string</param>
+        /// <returns></returns>
+        public static string SimplifyFileSizeUnit(string size)
+        {
+            if (string.IsNullOrEmpty(size))
+            {
+                return size;
+            }
+
+            return size.Replace("i", "");
         }
     }
 }

--- a/src/PackageDetailsViewExtension/PackageDetailItem.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailItem.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Dynamo.Core;
 using Dynamo.PackageManager;
 using Dynamo.PythonServices;
+using DynamoUtilities;
 using Greg.Responses;
 
 namespace Dynamo.PackageDetails
@@ -283,7 +284,7 @@ namespace Dynamo.PackageDetails
             this.CopyRightYear = PackageVersion.copyright_year;
             this.CanInstall = canInstall;
             this.IsEnabledForInstall = isEnabledForInstall && canInstall;
-            this.PackageSize = string.IsNullOrEmpty(PackageVersion.size) ? "--" : PackageVersion.size;
+            this.PackageSize = string.IsNullOrEmpty(PackageVersion.size) ? "--" : StringUtilities.SimplifyFileSizeUnit (PackageVersion.size);
             this.Created = GetFormattedDate(PackageVersion.created);
             this.VersionInformation = GetFlattenedCompatibilityInformation(packageVersion.compatibility_matrix);
             this.ReleaseNotes = PackageVersion.release_notes_url;
@@ -315,7 +316,7 @@ namespace Dynamo.PackageDetails
             this.CopyRightYear = PackageVersion.copyright_year;
             this.CanInstall = canInstall;
             this.IsEnabledForInstall = isEnabledForInstall && canInstall;
-            this.PackageSize = string.IsNullOrEmpty(PackageVersion.size) ? "--" : PackageVersion.size;
+            this.PackageSize = string.IsNullOrEmpty(PackageVersion.size) ? "--" : StringUtilities.SimplifyFileSizeUnit (PackageVersion.size);
             this.Created = GetFormattedDate(PackageVersion.created);
             this.VersionInformation = GetFlattenedCompatibilityInformation(packageVersion.compatibility_matrix);
             this.IsCompatible = PackageManager.VersionInformation.GetVersionCompatibility(versionDetails, PackageVersionNumber);

--- a/test/DynamoCoreTests/StringUtilitiesTest.cs
+++ b/test/DynamoCoreTests/StringUtilitiesTest.cs
@@ -1,0 +1,49 @@
+using DynamoUtilities;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    [TestFixture]
+    class StringUtilitiesTest
+    {
+        [TestCase("512 MiB", ExpectedResult = "512 MB")]
+        [TestCase("1 GiB", ExpectedResult = "1 GB")]
+        [TestCase("128 KiB", ExpectedResult = "128 KB")]
+        [TestCase("2 TiB", ExpectedResult = "2 TB")]
+        [TestCase("0 PiB", ExpectedResult = "0 PB")]
+        [TestCase("1024 EiB", ExpectedResult = "1024 EB")]
+        public string ConvertToSIFileSize_StandardUnitsWithI_RemovesI(string input)
+        {
+            return StringUtilities.SimplifyFileSizeUnit (input);
+        }
+
+        [TestCase("512 MB", ExpectedResult = "512 MB")]
+        [TestCase("1 GB", ExpectedResult = "1 GB")]
+        [TestCase("128 KB", ExpectedResult = "128 KB")]
+        public string ConvertToSIFileSize_StandardUnitsWithoutI_Unchanged(string input)
+        {
+            return StringUtilities.SimplifyFileSizeUnit (input);
+        }
+
+        [TestCase("Random Text", ExpectedResult = "Random Text")]
+        [TestCase("128", ExpectedResult = "128")]
+        [TestCase("", ExpectedResult = "")]
+        [TestCase(null, ExpectedResult = null)]
+        public string ConvertToSIFileSize_NonStandardInputs_Unchanged(string input)
+        {
+            return StringUtilities.SimplifyFileSizeUnit (input);
+        }
+
+        [Test]
+        public void ConvertToSIFileSize_NullInput_ReturnsNull()
+        {
+            Assert.IsNull(StringUtilities.SimplifyFileSizeUnit (null));
+        }
+
+        [Test]
+        public void ConvertToSIFileSize_EmptyString_ReturnsEmptyString()
+        {
+            Assert.AreEqual("", StringUtilities.SimplifyFileSizeUnit (""));
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Addresses this [jira issue](https://jira.autodesk.com/browse/DYN-7753) (removes 'i' in the middle of file size string 'KiB, MiB')

![image](https://github.com/user-attachments/assets/e6aabe9a-8734-4b5b-ac72-e5f256758a25)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- added utility function to remove lowercase 'i' inside filesize string
- test coverage

### Reviewers

@reddyashish 

### FYIs

@achintyabhat 
@QilongTang 