### PR TITLE
DYN-7754: filter exclusivity

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -874,6 +874,8 @@ Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.FilterName.get -
 Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.FilterName.set -> void
 Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.GroupName.get -> string
 Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.GroupName.set -> void
+Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.IsEnabled.get -> bool
+Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.IsEnabled.set -> void
 Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.OnChecked.get -> bool
 Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.OnChecked.set -> void
 Dynamo.PackageManager.PackageManagerSearchViewModel.FilterEntry.Tooltip.get -> string

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -87,6 +87,22 @@ namespace Dynamo.PackageManager
             public string Tooltip { get; set; }
 
             /// <summary>
+            /// Controls the IsEnabled status of the filter
+            /// </summary>
+            private bool isEnabled = true;
+
+            public bool IsEnabled
+            {
+                get { return isEnabled; }
+                set
+                {
+                    isEnabled = value;
+                    RaisePropertyChanged(nameof(IsEnabled));
+                }
+            }
+
+
+            /// <summary>
             /// Filter entry click command, notice this is a dynamic command
             /// with command param set to FilterName so that the code is robust
             /// in a way UI could handle as many hosts as possible
@@ -410,6 +426,33 @@ namespace Dynamo.PackageManager
         private void SetFilterChange()
         {
             IsAnyFilterOn = HostFilter.Any(f => f.OnChecked) || NonHostFilter.Any(f => f.OnChecked) || CompatibilityFilter.Any(f => f.OnChecked);
+            ApplyFilterRules();
+        }
+
+        /// <summary>
+        /// Executes any additional logic on the filters
+        /// </summary>
+        internal void ApplyFilterRules()
+        {
+            // Enable/disable Compatibility filters if any HostFilter is on
+            if (CompatibilityFilter.Any(f => f.OnChecked))
+            {
+                HostFilter.ForEach(x => x.IsEnabled = false);   
+            }
+            else
+            {
+                HostFilter.ForEach(x => x.IsEnabled = true);
+            }
+
+            // Enable/disable Host filters if any CompatibilityFilter is on
+            if (HostFilter.Any(f => f.OnChecked))
+            {
+                CompatibilityFilter.ForEach(x => x.IsEnabled = false);
+            }
+            else
+            {
+                CompatibilityFilter.ForEach(x => x.IsEnabled = true);
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerSearchControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerSearchControl.xaml
@@ -262,6 +262,7 @@
                                         <Setter Property="Command" Value="{Binding FilterCommand}" />
                                         <Setter Property="CommandParameter" Value="{Binding FilterName}" />
                                         <Setter Property="IsChecked" Value="{Binding OnChecked, UpdateSourceTrigger=PropertyChanged}" />
+                                        <Setter Property="IsEnabled" Value="{Binding IsEnabled, UpdateSourceTrigger=PropertyChanged}" />
                                         <Setter Property="ToolTip">
                                             <Setter.Value>
                                                 <ToolTip Content="{Binding Tooltip}" Style="{StaticResource GenericToolTipLight}" />

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1380,5 +1380,7 @@ namespace Dynamo.PackageManager.Wpf.Tests
                           "Expected compatibility to be true when major version is greater than Max major version and there is an invalid max range.");
         }
 
+        #endregion
+
     }
 }

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1022,6 +1022,57 @@ namespace Dynamo.PackageManager.Wpf.Tests
         }
 
         [Test]
+        public void HostCompatibilityFiltersExclusivity()
+        {
+            var mockGreg = new Mock<IGregClient>();
+
+            var clientMock = new Mock<PackageManagerClient>(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
+            var pmCVM = new Mock<PackageManagerClientViewModel>(ViewModel, clientMock.Object) { CallBase = true };
+            var pmSVM = new PackageManagerSearchViewModel(pmCVM.Object);
+            pmSVM.RegisterTransientHandlers();
+
+            pmSVM.HostFilter = new List<FilterEntry>
+            {
+                new FilterEntry("host", "group", "tooltip", pmSVM) { OnChecked = false },
+            };
+
+            pmSVM.CompatibilityFilter = new List<FilterEntry>
+            {
+                new FilterEntry("compatibility", "group", "tooltip", pmSVM) { OnChecked = false },
+            };
+
+            pmSVM.HostFilter.ForEach(f => f.PropertyChanged += pmSVM.filter_PropertyChanged);
+            pmSVM.CompatibilityFilter.ForEach(f => f.PropertyChanged += pmSVM.filter_PropertyChanged);
+
+            Assert.IsTrue(pmSVM.HostFilter.All(x => x.IsEnabled), "Expect starting filter state to be enabled");
+            Assert.IsTrue(pmSVM.CompatibilityFilter.All(x => x.IsEnabled), "Expect starting filter state to be enabled");
+
+            // Act/Assert Host -> Compatibility
+            pmSVM.HostFilter.First().OnChecked = true;
+            pmSVM.ApplyFilterRules();
+
+            Assert.IsFalse(pmSVM.CompatibilityFilter.All(x => x.IsEnabled), "Filter groups should be mutually exclusive");
+
+            pmSVM.HostFilter.First().OnChecked = false;
+            pmSVM.ApplyFilterRules();
+
+            Assert.IsTrue(pmSVM.CompatibilityFilter.All(x => x.IsEnabled), "Filter groups should be mutually exclusive");
+
+            // Act/Assert Compatibility -> Host
+            pmSVM.CompatibilityFilter.First().OnChecked = true;
+            pmSVM.ApplyFilterRules();
+
+            Assert.IsFalse(pmSVM.HostFilter.All(x => x.IsEnabled), "Filter groups should be mutually exclusive");
+
+            pmSVM.CompatibilityFilter.First().OnChecked = false;
+            pmSVM.ApplyFilterRules();
+
+            Assert.IsTrue(pmSVM.HostFilter.All(x => x.IsEnabled), "Filter groups should be mutually exclusive");
+        }
+
+        #region Compatibility Tests
+
+        [Test]
         public void TestReverseDynamoCompatibilityFromHost()
         {
             //Arrange


### PR DESCRIPTION
### Purpose

Adding mutual exclusivity for filters in the `Host` and `Compatibility` groups. This change will make it so using filters from one of the groups will **disable** all filters from the other group, and vice verse.
 
### UI Changes

![EhcEZ64lKs](https://github.com/user-attachments/assets/3970ff10-7d99-4e5c-87ab-450a97c486c3)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- host and compatibility filters are now exclusive
- enables/disables filters from the opposing group
- tests coverage

### Reviewers

@achintyabhat 
@zeusongit 
@reddyashish 

### FYIs

@QilongTang 
