### PR TITLE
DYN-7427 Add missing node help docs for color palette node

### DIFF
--- a/doc/distrib/NodeHelpFiles/CoreNodeModels.Input.ColorPalette.dyn
+++ b/doc/distrib/NodeHelpFiles/CoreNodeModels.Input.ColorPalette.dyn
@@ -1,0 +1,361 @@
+{
+  "Uuid": "a2ce429c-eb89-45ae-8018-5f3ae7cf8a4b",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "CoreNodeModels.Input.ColorPalette",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.ColorPalette, CoreNodeModels",
+      "InputValue": {
+        "R": 0,
+        "G": 204,
+        "B": 204,
+        "A": 255
+      },
+      "Id": "2368b3bba4574510b7944d0bee831dbd",
+      "NodeType": "ColorInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a2c97e14e00245949ca74c6cdcf13a71",
+          "Name": "Color",
+          "Description": "Selected Color.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Color from the palette"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "0fdd523c73ef4aa7a350d90c5cda3cf6",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "ea0400311c194b7f80f2bcea0ce39346",
+          "Name": "color",
+          "Description": "A color object\n\nColor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f6a39c777a81443cb6d3100cb4b14d70",
+          "Name": "alpha",
+          "Description": "Alpha value, int between 0 and 255 inclusive.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ccd4c2423042499096fc2b180e104cb6",
+          "Name": "red",
+          "Description": "Red value for RGB color model, int between 0 and 255 inclusive.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "367d6a1141a94d68bbec036f1c263272",
+          "Name": "green",
+          "Description": "Green value for RGB color model, int between 0 and 255 inclusive.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "763241133ecc46288d63335174ea28cb",
+          "Name": "blue",
+          "Description": "Blue value for RGB color model, int between 0 and 255 inclusive.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "DSCore.Color.Components@DSCore.Color",
+      "Replication": "Auto",
+      "Description": "Lists the components for the color in the order: alpha, red, green, blue.\n\nColor.Components (color: Color): var[]..[]"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 42.5,
+      "WatchHeight": 38.0,
+      "Id": "c5aaffd3f4b64ee694568969d6a95201",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "a3f1b67a242447728b685e679b782400",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4e35c55a605f4ba99b4f7041c73693c4",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 27.5,
+      "WatchHeight": 38.0,
+      "Id": "c9c4441cd7ff4b8e943c86e5f42905ef",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "037c7b14beb24bd09b4e20c507f25e5e",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f7da5c287f7d4cc79ff61649918fc13c",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 42.5,
+      "WatchHeight": 38.0,
+      "Id": "4a45a51fa26542a78436270d63ab41e9",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "fb4465ad8b56477d8e421177d05496eb",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a1c12631922548e7aaa22d1156475f1d",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 42.5,
+      "WatchHeight": 38.0,
+      "Id": "5bc9cf594db3436fbf9ec60ae64fd801",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "40186e8ef02b45df90e3bc01b23f86f7",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c1be6f903f1941ad82d454acce94fb34",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "a2c97e14e00245949ca74c6cdcf13a71",
+      "End": "ea0400311c194b7f80f2bcea0ce39346",
+      "Id": "766c77ef51184ee6a31f993482890ecb",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f6a39c777a81443cb6d3100cb4b14d70",
+      "End": "a3f1b67a242447728b685e679b782400",
+      "Id": "2b1ec511614647e28d4fce5cee890abd",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "ccd4c2423042499096fc2b180e104cb6",
+      "End": "037c7b14beb24bd09b4e20c507f25e5e",
+      "Id": "cca5bb9a987042149deb352f3a173077",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "367d6a1141a94d68bbec036f1c263272",
+      "End": "fb4465ad8b56477d8e421177d05496eb",
+      "Id": "95b480397d7e44d0b83421a00cf8b985",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "763241133ecc46288d63335174ea28cb",
+      "End": "40186e8ef02b45df90e3bc01b23f86f7",
+      "Id": "59e4e8b3c1804346968809d5fa70ebac",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": null,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.5",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.5.0.6812",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "2368b3bba4574510b7944d0bee831dbd",
+        "Name": "Color Palette",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 248.5,
+        "Y": 302.0
+      },
+      {
+        "Id": "0fdd523c73ef4aa7a350d90c5cda3cf6",
+        "Name": "Color.Components",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 549.5,
+        "Y": 301.0
+      },
+      {
+        "Id": "c5aaffd3f4b64ee694568969d6a95201",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 857.375,
+        "Y": 291.0
+      },
+      {
+        "Id": "c9c4441cd7ff4b8e943c86e5f42905ef",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 854.875,
+        "Y": 162.0
+      },
+      {
+        "Id": "4a45a51fa26542a78436270d63ab41e9",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 857.875,
+        "Y": 420.5
+      },
+      {
+        "Id": "5bc9cf594db3436fbf9ec60ae64fd801",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 858.875,
+        "Y": 553.5
+      }
+    ],
+    "Annotations": [],
+    "X": -27.0,
+    "Y": -64.5,
+    "Zoom": 1.0
+  }
+}

--- a/doc/distrib/NodeHelpFiles/DynamoUnits.Utilities.ConvertByUnits.dyn
+++ b/doc/distrib/NodeHelpFiles/DynamoUnits.Utilities.ConvertByUnits.dyn
@@ -1,0 +1,281 @@
+{
+  "Uuid": "e8bda09f-70de-4d9f-af2c-573a192fea1c",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "DynamoUnits.Utilities.ConvertByUnits",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "b31034bd8a6647a2a34a805ac0110574",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "820d25520c2c43bf901d89717bb4449a",
+          "Name": "value",
+          "Description": "Value to convert\n\ndouble",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a0ef2c27c12845d4a6ba8db8a8aa82d7",
+          "Name": "fromUnit",
+          "Description": "Unit object\n\nUnit",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "70a2be62799c4478bf832df406399be5",
+          "Name": "toUnit",
+          "Description": "Unit object\n\nUnit",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3d506f13921f421d88040371077915e7",
+          "Name": "double",
+          "Description": "Converted value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "DynamoUnits.Utilities.ConvertByUnits@double,DynamoUnits.Unit,DynamoUnits.Unit",
+      "Replication": "Auto",
+      "Description": "Converts a value from one Unit System to another Unit System\n\nUtilities.ConvertByUnits (value: double, fromUnit: Unit, toUnit: Unit): double"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NumberType": "Double",
+      "Id": "fb2a765e332e4fa4854a38a315656064",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f01978ee48c74bf2a2f8abad1ad2ed27",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number",
+      "InputValue": 5.5
+    },
+    {
+      "ConcreteType": "UnitsUI.Units, UnitsNodeModels",
+      "SelectedIndex": 77,
+      "SelectedString": "Feet",
+      "Id": "789ba591a7354579b97e43effb0c4a8c",
+      "NodeType": "ExtensionNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "55a2f95af09742cead063199ab2debf5",
+          "Name": "Unit",
+          "Description": "The selected Unit",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Unit type"
+    },
+    {
+      "ConcreteType": "UnitsUI.Units, UnitsNodeModels",
+      "SelectedIndex": 211,
+      "SelectedString": "Meters",
+      "Id": "f6acc007aff84b0b95ff748b122a3ba1",
+      "NodeType": "ExtensionNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4764fdb701994f9d81f139c9d113ee91",
+          "Name": "Unit",
+          "Description": "The selected Unit",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Unit type"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 155.0,
+      "WatchHeight": 38.0,
+      "Id": "b631402b019e4e4ebb4fc77e4a55ca86",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "8e8682ab8baa4c50a3b4036de0419392",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cb2893c1c422453c82e9d7163eaf3f90",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "3d506f13921f421d88040371077915e7",
+      "End": "8e8682ab8baa4c50a3b4036de0419392",
+      "Id": "cd51087ad7eb43b4a885cac29a2f805e",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "f01978ee48c74bf2a2f8abad1ad2ed27",
+      "End": "820d25520c2c43bf901d89717bb4449a",
+      "Id": "01b441959d844df6bd52129bb275d0f1",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "55a2f95af09742cead063199ab2debf5",
+      "End": "a0ef2c27c12845d4a6ba8db8a8aa82d7",
+      "Id": "26f00b3bc82f4426872fdf2d7c6d5eac",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "4764fdb701994f9d81f139c9d113ee91",
+      "End": "70a2be62799c4478bf832df406399be5",
+      "Id": "9c6522d1ff614465b39445a536bf4d87",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": true,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.5",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.5.0.6812",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "b31034bd8a6647a2a34a805ac0110574",
+        "Name": "Utilities.ConvertByUnits",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 413.0,
+        "Y": 216.0
+      },
+      {
+        "Id": "fb2a765e332e4fa4854a38a315656064",
+        "Name": "Number",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 145.0,
+        "Y": 109.0
+      },
+      {
+        "Id": "789ba591a7354579b97e43effb0c4a8c",
+        "Name": "Units",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 116.5,
+        "Y": 250.0
+      },
+      {
+        "Id": "f6acc007aff84b0b95ff748b122a3ba1",
+        "Name": "Units",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 117.0,
+        "Y": 383.5
+      },
+      {
+        "Id": "b631402b019e4e4ebb4fc77e4a55ca86",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 724.5,
+        "Y": 242.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/doc/distrib/NodeHelpFiles/LMVGRWYVOONMRPCSD3NCYVD776V33DFYWXC2F5S3KREHPOX5A2FA.dyn
+++ b/doc/distrib/NodeHelpFiles/LMVGRWYVOONMRPCSD3NCYVD776V33DFYWXC2F5S3KREHPOX5A2FA.dyn
@@ -1,0 +1,445 @@
+{
+  "Uuid": "2e5385d9-99ed-4748-bdfa-55fdebe34099",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "LMVGRWYVOONMRPCSD3NCYVD776V33DFYWXC2F5S3KREHPOX5A2FA",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Autodesk.DesignScript.Geometry.Vector": {
+        "Key": "Autodesk.DesignScript.Geometry.Vector",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [
+    {
+      "Id": "da68fd354c2a430299c17732c1732b18",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "10",
+      "MaximumValue": 10.0,
+      "MinimumValue": 1.0,
+      "StepValue": 0.1,
+      "NumberType": "Double",
+      "Description": "Produces numeric values"
+    },
+    {
+      "Id": "b656d002ffe54c8a8ebb56ef899a2dab",
+      "Name": "Number Slider",
+      "Type": "number",
+      "Type2": "number",
+      "Value": "15",
+      "MaximumValue": 15.0,
+      "MinimumValue": 1.0,
+      "StepValue": 0.1,
+      "NumberType": "Double",
+      "Description": "Produces numeric values"
+    }
+  ],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NumberType": "Double",
+      "MaximumValue": 10.0,
+      "MinimumValue": 1.0,
+      "StepValue": 0.1,
+      "Id": "da68fd354c2a430299c17732c1732b18",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a3b27e266dfd410faefcf9ef75eab910",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Produces numeric values",
+      "InputValue": 10.0
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NumberType": "Double",
+      "MaximumValue": 15.0,
+      "MinimumValue": 1.0,
+      "StepValue": 0.1,
+      "Id": "b656d002ffe54c8a8ebb56ef899a2dab",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5813011ef0b14998bd6e120b2ae74b7b",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Produces numeric values",
+      "InputValue": 15.0
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "b6a4f0ab1f414ec7bc3515f3389da552",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "65238ef7d46e4bcfa2015b1b79299ebb",
+          "Name": "coordinateSystem",
+          "Description": "Coordinate system of rectangle (center of rectangle)\n\nCoordinateSystem\nDefault value : Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0)",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5458ea218f234a3496e763b0679e8333",
+          "Name": "width",
+          "Description": "Width of rectangle\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c9578dd8006249979be3229a002dc13c",
+          "Name": "length",
+          "Description": "Length of rectangle\n\ndouble\nDefault value : 1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "2976a3c6d0404f0d85babd194d6deba8",
+          "Name": "Rectangle",
+          "Description": "Rectangle created from width and length",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double",
+      "Replication": "Auto",
+      "Description": "Create a Rectangle centered at the input origin in the CoordinateSystem XY Plane, with specified width (X Axis length), and length (Y Axis length).\n\nRectangle.ByWidthLength (coordinateSystem: CoordinateSystem = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0), width: double = 1, length: double = 1): Rectangle"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "Id": "048bac1ef715432b94305a49b70d2319",
+      "NodeType": "FunctionNode",
+      "Inputs": [
+        {
+          "Id": "9cc559768ef8433cb22ffc579b2f082d",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "aa76c7fb20d2432fad0cdcd467ddad26",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "04f74c5bcd514369a7f1d54a3cd5574c",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c80645569d0d45da83e115658e493e94",
+          "Name": "CoordinateSystem",
+          "Description": "CoordinateSystem",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin@double,double,double",
+      "Replication": "Auto",
+      "Description": "Create a CoordinateSystem with origin at X, Y, and Z locations, with X and Y Axes set as WCS X and Y Axes.\n\nCoordinateSystem.ByOrigin (x: double = 0, y: double = 0, z: double = 0): CoordinateSystem"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleSlider, CoreNodeModels",
+      "NumberType": "Double",
+      "MaximumValue": 100.0,
+      "MinimumValue": 0.0,
+      "StepValue": 0.1,
+      "Id": "530e75162e5d46248b56e37b6bc1e360",
+      "NodeType": "NumberInputNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d6f0b96c7c4f4b0780128ce0a684bd6b",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Produces numeric values",
+      "InputValue": 3.0
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 332.5,
+      "WatchHeight": 97.0,
+      "Id": "63bb51b403ac46e882a868d308da44bd",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "f97b8d2e7fb14a8fb76be78b4c191ef7",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "db6ca2f5bc5c4fc095d535dc13ea4238",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    },
+    {
+      "ConcreteType": "Watch3DNodeModels.Watch3D, Watch3DNodeModels",
+      "WatchWidth": 200.0,
+      "WatchHeight": 200.0,
+      "WasExecuted": true,
+      "Camera": {
+        "Name": "3030eb2d-4cb0-45ad-b3a8-a3ed02f1b413 Preview",
+        "EyeX": -17.0,
+        "EyeY": 24.0,
+        "EyeZ": 50.0,
+        "LookX": 12.0,
+        "LookY": -13.0,
+        "LookZ": -58.0,
+        "UpX": 0.0,
+        "UpY": 1.0,
+        "UpZ": 0.0
+      },
+      "VariableInputPorts": true,
+      "Id": "568a80f523f040378306bdfbbdaa23c5",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "4d9733b0e00a476e8e1c29879dc2f99a",
+          "Name": "",
+          "Description": "Incoming geometry objects.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d4f334b2d79148a896c6769419ff5786",
+          "Name": "",
+          "Description": "Incoming geometry objects.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Shows a dynamic preview of geometry"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "a3b27e266dfd410faefcf9ef75eab910",
+      "End": "5458ea218f234a3496e763b0679e8333",
+      "Id": "9cf5d5f4c99e485a97c59f864605cea3",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "5813011ef0b14998bd6e120b2ae74b7b",
+      "End": "c9578dd8006249979be3229a002dc13c",
+      "Id": "80b0d0ac080249fe9917066060da354f",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2976a3c6d0404f0d85babd194d6deba8",
+      "End": "4d9733b0e00a476e8e1c29879dc2f99a",
+      "Id": "ab038143bb434525b671bbbaf1c3bf5a",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "2976a3c6d0404f0d85babd194d6deba8",
+      "End": "f97b8d2e7fb14a8fb76be78b4c191ef7",
+      "Id": "dbc63bf840f84d3fb39c236aea7509af",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "c80645569d0d45da83e115658e493e94",
+      "End": "65238ef7d46e4bcfa2015b1b79299ebb",
+      "Id": "ff8346f3ea784a7b832dd2e44806ac9c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "d6f0b96c7c4f4b0780128ce0a684bd6b",
+      "End": "04f74c5bcd514369a7f1d54a3cd5574c",
+      "Id": "139aaae5c73b45ae8a9043501c947567",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": true,
+  "Thumbnail": null,
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.5",
+      "Data": {}
+    }
+  ],
+  "Author": "None provided",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.5.0.6812",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -3.759126663208008,
+      "EyeY": 3.1215903759002686,
+      "EyeZ": 3.2547216415405273,
+      "LookX": 3.282925844192505,
+      "LookY": -2.345578908920288,
+      "LookZ": -3.261296510696411,
+      "UpX": 0.17762959003448486,
+      "UpY": 0.9681476354598999,
+      "UpZ": -0.17645928263664246
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "da68fd354c2a430299c17732c1732b18",
+        "Name": "Number Slider",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -645.9986447230651,
+        "Y": -109.54675832816861
+      },
+      {
+        "Id": "b656d002ffe54c8a8ebb56ef899a2dab",
+        "Name": "Number Slider",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -645.9986447230651,
+        "Y": 37.45324167183139
+      },
+      {
+        "Id": "b6a4f0ab1f414ec7bc3515f3389da552",
+        "Name": "Rectangle.ByWidthLength",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -167.3196282861618,
+        "Y": -243.2873800142769
+      },
+      {
+        "Id": "048bac1ef715432b94305a49b70d2319",
+        "Name": "CoordinateSystem.ByOrigin",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -645.9986447230651,
+        "Y": -322.5467583281686
+      },
+      {
+        "Id": "530e75162e5d46248b56e37b6bc1e360",
+        "Name": "Number Slider",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": -1133.5079236202018,
+        "Y": -258.0338010110956
+      },
+      {
+        "Id": "63bb51b403ac46e882a868d308da44bd",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 240.23737065339333,
+        "Y": -281.5730374904167
+      },
+      {
+        "Id": "568a80f523f040378306bdfbbdaa23c5",
+        "Name": "Watch 3D",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 250.117540324655,
+        "Y": -65.44432593156216
+      }
+    ],
+    "Annotations": [],
+    "X": 521.2395768912097,
+    "Y": 295.49522350690694,
+    "Zoom": 0.40485134700010733
+  }
+}


### PR DESCRIPTION
## Purpose

Add missing node help docs for couple nodes:
- Color Palette
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/91a6f4f2-18d0-4504-ad9e-0a104706ab58">

- Rectangle.ByWidthLength
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/d0901cc6-ef3b-4092-9af0-5bd44fbbf32d">


- Utilities.ConvertByUnits
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/ff45198f-31f0-4010-ac63-77da43919c19">


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add missing node help docs for couple nodes.

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
