### PR TITLE
DYN-7778 Package details compatible version tooltip  

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Dynamo.Wpf.Properties
 {
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -7461,6 +7461,15 @@ namespace Dynamo.Wpf.Properties
         public static string PackageUseOlderDynamoMessageBoxTitle {
             get {
                 return ResourceManager.GetString("PackageUseOlderDynamoMessageBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Versions marked with .x include all versions in the specified major release.
+        /// </summary>
+        public static string PackageVersionTooltip {
+            get {
+                return ResourceManager.GetString("PackageVersionTooltip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4102,4 +4102,7 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PackageIncompatibleFilterTooltip" xml:space="preserve">
     <value>Versions maybe incompatible with the current setup</value>
   </data>
+  <data name="PackageVersionTooltip" xml:space="preserve">
+    <value>Versions marked with .x include all versions in the specified major release</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4089,4 +4089,7 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PackageIncompatibleFilterTooltip" xml:space="preserve">
     <value>Versions maybe incompatible with the current setup</value>
   </data>
+  <data name="PackageVersionTooltip" xml:space="preserve">
+    <value>Versions marked with .x include all versions in the specified major release</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -5389,6 +5389,7 @@ static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageHostDependencyTo
 static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageKeywords.get -> string
 static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageKeywordsTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageName.get -> string
+static Dynamo.Wpf.Properties.Resources.PackageVersionTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageNameTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageNameWatermark.get -> string
 static Dynamo.Wpf.Properties.Resources.PublishPackageViewPackageVersion.get -> string

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -475,7 +475,7 @@
                                                                 <Binding Path="CopyRightHolder" />
                                                                 <Binding Path="CopyRightYear" />
                                                             </MultiBinding>
-                                                       </ToolTip.Content>
+                                                        </ToolTip.Content>
                                                     </ToolTip>
                                                 </Viewbox.ToolTip>
                                             </Viewbox>
@@ -733,25 +733,42 @@
                                                       FontFamily="{StaticResource ArtifaktElementRegular}"
                                                       Foreground="#ffffff"
                                                       HeadersVisibility="Column"
-                                                      IsHitTestVisible="False"
+                                                      IsHitTestVisible="True"
                                                       IsReadOnly="True"
                                                       IsSynchronizedWithCurrentItem="True"
                                                       ItemsSource="{Binding VersionInformation}"
+                                                      PreviewMouseDown="DataGrid_PreviewMouseDown"
                                                       RowBackground="{StaticResource PMDataGridBackgroundColorBrush}"
                                                       RowDetailsVisibilityMode="Collapsed"
                                                       ScrollViewer.CanContentScroll="True"
                                                       ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
                                                       Style="{StaticResource DataGridStyle1}"
+                                                      ToolTipService.IsEnabled="True"
                                                       VirtualizingStackPanel.IsVirtualizing="True"
                                                       VirtualizingStackPanel.VirtualizationMode="Recycling">
                                                 <DataGrid.Columns>
                                                     <DataGridTextColumn Width="*"
                                                                         Binding="{Binding CompatibilityName}"
-                                                                        Header="" />
-                                                    <DataGridTextColumn Width="3*"
-                                                                        Binding="{Binding Versions, Converter={StaticResource VersionStringAsteriskToXConverter}}"
-                                                                        Header="{x:Static p:Resources.PublishPackageViewPackageVersion}" />
+                                                                        Header="{x:Static p:Resources.PublishPackageViewPackageName}" />
+                                                    <DataGridTextColumn Width="3*" Binding="{Binding Versions, Converter={StaticResource VersionStringAsteriskToXConverter}}">
+                                                        <DataGridTextColumn.HeaderTemplate>
+                                                            <DataTemplate>
+                                                                <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                                                                    <TextBlock VerticalAlignment="Center" Text="{x:Static p:Resources.PublishPackageViewPackageVersion}" />
+                                                                    <Image Width="14"
+                                                                           Height="14"
+                                                                           Margin="10,0,0,0"
+                                                                           VerticalAlignment="Center"
+                                                                           Source="pack://application:,,,/DynamoCoreWpf;component/UI/Images/whiteinfotab.png">
+                                                                        <Image.ToolTip>
+                                                                            <ToolTip Content="{x:Static p:Resources.PackageVersionTooltip}" />
+                                                                        </Image.ToolTip>
+                                                                    </Image>
+                                                                </StackPanel>
+                                                            </DataTemplate>
+                                                        </DataGridTextColumn.HeaderTemplate>
+                                                    </DataGridTextColumn>
                                                 </DataGrid.Columns>
                                             </DataGrid>
                                         </StackPanel>

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml.cs
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml.cs
@@ -71,6 +71,12 @@ namespace Dynamo.PackageDetails
         {
             Closed?.Invoke(this, EventArgs.Empty);
         }
+
+        // Disables DataGrid interactions on mousedown (selection)
+        private void DataGrid_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            e.Handled = true;
+        }
     }
     
 }


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7778

Adding a tooltip info for the compatible versions shown in package details viewextension

<img width="482" alt="Screenshot 2024-11-12 at 1 23 59 PM" src="https://github.com/user-attachments/assets/732c1485-b616-4493-a518-5a27b50031e8">


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
DYN-7778 Package details compatible version tooltip  

### Reviewers
@zeusongit @dnenov @hwahlstrom 

