### PR TITLE
Exclude mapping in case the host name is Dynamo

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -382,6 +382,7 @@ namespace Dynamo.PackageManager
                     foreach (var property in host.Properties())
                     {
                         string hostName = property.Name;
+                        if (hostName.ToLower().Equals("dynamo")) continue;
                         var versionMapping = property.Value.ToObject<Dictionary<string, string>>();
 
                         if (!compatibilityMap.ContainsKey(hostName))


### PR DESCRIPTION
### Purpose

After adding Dynamo versions to /host_map, make an exception for Dynamo, and not map it into a Dictionary as it provides a flat list of versions.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

After adding Dynamo versions to /host_map, make an exception for Dynamo, and not map it into a Dictionary as it provides a flat list of versions.

### Reviewers

@reddyashish 
