### PR TITLE
DYN-7821:changed compatibility calculation algorithm

### DIFF
--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -266,6 +266,7 @@ namespace Dynamo.PackageManager
         {
             var versionInformation = new List<VersionInformation>();
             if (header.versions == null) return versionInformation;
+            var name = header.name;
 
             // Iterate through each version entry in the header
             foreach (var versionEntry in header.versions)
@@ -299,7 +300,7 @@ namespace Dynamo.PackageManager
         {
             try
             {
-                // Set the defaults if parameters are not provided (for testing)
+                // Set defaults if parameters are not provided
                 dynamoVersion ??= VersionUtilities.Parse(DynamoModel.Version);
                 hostVersion ??= DynamoModel.HostAnalyticsInfo.HostProductVersion;
                 host ??= DynamoModel.HostAnalyticsInfo.HostProductName;
@@ -308,45 +309,50 @@ namespace Dynamo.PackageManager
                 // If there is no compatibility matrix, we cannot determine anything
                 if (compatibilityMatrix == null || compatibilityMatrix.Count == 0)
                 {
-                    return null; 
+                    return null;
                 }
 
                 Greg.Responses.Compatibility compatibility = null;
 
-                // Determine compatibility based on presence of host
-                // We only care about 2 conditions:
+                // Determine compatibility
                 // 1. If we are under host, we first look at that host compatibility. If that's missing, we still check for Dynamo-only compatibility
-                // 2. If we are not under host, we only care about Dynamo compatibility
-                // ! The opposite to 1. is not true - if there is Host compatibility information, then we NEED to be compatible with the host
-                // (this is to say, we cannot just flip the conditions around to declare 'if Dynamo is compatible, we are already compatible')
+                // 2. If we are not under host, we care about Dynamo compatibility first and foremost. However, we use fallback to Host compatibility if no Dynamo compatibility is found. In this case, we mark as Incompatible
+                // 3. Only if no compatibility information is found, then we mark as 'Unknown Compatibility'
                 if (!string.IsNullOrEmpty(host))
                 {
-                    // Attempt to retrieve compatibility specific to the host
-                    compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == host.ToLowerInvariant());
-
-                    // If host compatibility is missing, fallback to Dynamo compatibility
-                    if (compatibility == null)
-                    {
-                        compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
-                    }
+                    // Check for host-specific compatibility
+                    compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == host.ToLowerInvariant())
+                                    ?? compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
                 }
                 else
                 {
-                    // No host specified, so we only check for Dynamo compatibility
+                    // No host specified (DynamoCore only)
+                    // Check Dynamo compatibility first; if missing, check for host compatibility
                     compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
+
+                    if (compatibility == null)
+                    {
+                        // No Dynamo compatibility, fallback to any host compatibility if present
+                        var hostCompatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() != "dynamo");
+                        if (hostCompatibility != null)
+                        {
+                            // Mark as incompatible if host compatibility is present without Dynamo info
+                            return false;
+                        }
+                    }
                 }
 
-                // If no relevant compatibility info is found, return indeterminate
+                // If no compatibility information is found for both Dynamo and host, return unknown (null)
                 if (compatibility == null)
                 {
                     return null;
                 }
 
-                // Step 2: Check compatibility based on min/max ranges or specific versions
+                // Check compatibility based on min/max ranges or specific versions
                 var versionToCheck = (compatibility.name.ToLowerInvariant() == "dynamo") ? dynamoVersion : hostVersion;
                 return versionToCheck != null && IsVersionCompatible(compatibility, versionToCheck);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Console.WriteLine(ex.Message.ToString());
                 return null;

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -298,65 +298,59 @@ namespace Dynamo.PackageManager
         /// <returns></returns>
         internal static bool? CalculateCompatibility(List<Greg.Responses.Compatibility> compatibilityMatrix, Version dynamoVersion = null, Dictionary<string, Dictionary<string, string>> map = null, Version hostVersion = null, string host = null)
         {
-            try
+            
+            // Set defaults if parameters are not provided
+            dynamoVersion ??= VersionUtilities.Parse(DynamoModel.Version);
+            hostVersion ??= DynamoModel.HostAnalyticsInfo.HostProductVersion;
+            host ??= DynamoModel.HostAnalyticsInfo.HostProductName;
+            host = host?.ToLowerInvariant();
+
+            // If there is no compatibility matrix, we cannot determine anything
+            if (compatibilityMatrix == null || compatibilityMatrix.Count == 0)
             {
-                // Set defaults if parameters are not provided
-                dynamoVersion ??= VersionUtilities.Parse(DynamoModel.Version);
-                hostVersion ??= DynamoModel.HostAnalyticsInfo.HostProductVersion;
-                host ??= DynamoModel.HostAnalyticsInfo.HostProductName;
-                host = host?.ToLowerInvariant();
-
-                // If there is no compatibility matrix, we cannot determine anything
-                if (compatibilityMatrix == null || compatibilityMatrix.Count == 0)
-                {
-                    return null;
-                }
-
-                Greg.Responses.Compatibility compatibility = null;
-
-                // Determine compatibility
-                // 1. If we are under host, we first look at that host compatibility. If that's missing, we still check for Dynamo-only compatibility
-                // 2. If we are not under host, we care about Dynamo compatibility first and foremost. However, we use fallback to Host compatibility if no Dynamo compatibility is found. In this case, we mark as Incompatible
-                // 3. Only if no compatibility information is found, then we mark as 'Unknown Compatibility'
-                if (!string.IsNullOrEmpty(host))
-                {
-                    // Check for host-specific compatibility
-                    compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == host.ToLowerInvariant())
-                                    ?? compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
-                }
-                else
-                {
-                    // No host specified (DynamoCore only)
-                    // Check Dynamo compatibility first; if missing, check for host compatibility
-                    compatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() == "dynamo");
-
-                    if (compatibility == null)
-                    {
-                        // No Dynamo compatibility, fallback to any host compatibility if present
-                        var hostCompatibility = compatibilityMatrix.FirstOrDefault(c => c.name.ToLowerInvariant() != "dynamo");
-                        if (hostCompatibility != null)
-                        {
-                            // Mark as incompatible if host compatibility is present without Dynamo info
-                            return false;
-                        }
-                    }
-                }
-
-                // If no compatibility information is found for both Dynamo and host, return unknown (null)
-                if (compatibility == null)
-                {
-                    return null;
-                }
-
-                // Check compatibility based on min/max ranges or specific versions
-                var versionToCheck = (compatibility.name.ToLowerInvariant() == "dynamo") ? dynamoVersion : hostVersion;
-                return versionToCheck != null && IsVersionCompatible(compatibility, versionToCheck);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message.ToString());
                 return null;
             }
+
+            Greg.Responses.Compatibility compatibility = null;
+
+            // Determine compatibility
+            // 1. If we are under host, we first look at that host compatibility. If that's missing, we still check for Dynamo-only compatibility
+            // 2. If we are not under host, we care about Dynamo compatibility first and foremost. However, we use fallback to Host compatibility if no Dynamo compatibility is found. In this case, we mark as Incompatible
+            // 3. Only if no compatibility information is found, then we mark as 'Unknown Compatibility'
+            if (!string.IsNullOrEmpty(host))
+            {
+                // Check for host-specific compatibility
+                compatibility = compatibilityMatrix.FirstOrDefault(c => c.name?.ToLowerInvariant() == host?.ToLowerInvariant())
+                                ?? compatibilityMatrix.FirstOrDefault(c => c.name?.ToLowerInvariant() == "dynamo");
+            }
+            else
+            {
+                // No host specified (DynamoCore only)
+                // Check Dynamo compatibility first; if missing, check for host compatibility
+                compatibility = compatibilityMatrix.FirstOrDefault(c => c.name?.ToLowerInvariant() == "dynamo");
+
+                if (compatibility == null)
+                {
+                    // No Dynamo compatibility, fallback to any host compatibility if present
+                    var hostCompatibility = compatibilityMatrix.FirstOrDefault(c => c.name?.ToLowerInvariant() != "dynamo");
+                    if (hostCompatibility != null)
+                    {
+                        // Mark as incompatible if host compatibility is present without Dynamo info
+                        return false;
+                    }
+                }
+            }
+
+            // If no compatibility information is found for both Dynamo and host, return unknown (null)
+            if (compatibility == null)
+            {
+                return null;
+            }
+
+            // Check compatibility based on min/max ranges or specific versions
+            var versionToCheck = (compatibility.name.ToLowerInvariant() == "dynamo") ? dynamoVersion : hostVersion;
+            return versionToCheck != null && IsVersionCompatible(compatibility, versionToCheck);
+            
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1013,12 +1013,18 @@ namespace Dynamo.PackageManager.Wpf.Tests
                 new List<Greg.Responses.Compatibility> { new Greg.Responses.Compatibility { name = "dynamo", min = "2.10", max = "2.13.1" } },
                 compatibleDynamoVersion, compatibilityMap, null, hostName);
 
+            // Case 6: No compatibility information is provided
+            var resultNoCompatibility = PackageManagerSearchElement.CalculateCompatibility(
+                new List<Greg.Responses.Compatibility> { new Greg.Responses.Compatibility() },
+                compatibleDynamoVersion, compatibilityMap, null, hostName);
+
             // Assert
-            Assert.IsNull(resultNoDynamoCompatibility, "Expected compatibility to be null when no Dynamo-specific compatibility exists and no fallback is allowed.");
+            Assert.IsFalse(resultNoDynamoCompatibility, "Expected compatibility to be incompatible (false) when no Dynamo-specific compatibility exists and we fallback to host.");
             Assert.IsTrue(resultWithHostCompatibility, "Expected compatibility to be true when no Dynamo-specific compatibility exists but host compatibility matches.");
             Assert.IsTrue(resultMinOnlyCompatibility, "Expected compatibility to be true for min-only range within major version.");
-            Assert.IsNull(resultIncompleteCompatibilityInfo, "Expected compatibility to be indeterminate (null) when information is incomplete.");
+            Assert.IsFalse(resultIncompleteCompatibilityInfo, "Expected compatibility to be incompatible (false) when no dynamo information is provided, but any information for host is present.");
             Assert.IsTrue(resultFallbackToDynamo, "Expected compatibility to be true when under host but only Dynamo compatibility is provided.");
+            Assert.IsNull(resultNoCompatibility, "Expected unknown compatibility (null) when no compatibility information is provided.");
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Change to how package version `Compatibility` is calculated. The main changes are that:
- now only flags as 'Unknown Compatibility' if no information is provided
- under DynamoSandbox, if Dynamo comp not provided, refer to host. If host comp exist, mark as 'Incompatible'

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now only flags as 'Unknown Compatibility' if no information is provided
- under DynamoSandbox, if Dynamo comp not provided, refer to host. If host comp exist, mark as 'Incompatible'

### Reviewers

@achintyabhat 
@reddyashish 
@zeusongit 
@QilongTang 

### FYIs

@saintentropy 
