### PR TITLE
DYN-7826: pm compatibility bug fix

### DIFF
--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -369,13 +369,13 @@ namespace Dynamo.PackageManager
             bool isListedInVersions = compatibility.versions?.Contains(version.ToString()) ?? false;
 
             // Parse min and max values, if provided, and check for valid range
-            bool isWithinMinMax = true;
+            bool isWithinMinMax = false;
             if (!string.IsNullOrEmpty(compatibility.min) || !string.IsNullOrEmpty(compatibility.max))
             {
                 Version minVersion = VersionUtilities.Parse(compatibility.min);
                 Version maxVersion = VersionUtilities.Parse(compatibility.max);
 
-                // if max is null, try to parse based on wildcard symantics
+                // if max is null, try to parse based on wildcard semantics
                 if(maxVersion == null)
                 {
                     maxVersion = VersionUtilities.WildCardParse(compatibility.max);

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1028,6 +1028,32 @@ namespace Dynamo.PackageManager.Wpf.Tests
         }
 
         [Test]
+        public void TestComputeVersionSingleCompatibility()
+        {
+            // Arrange
+            var hostOnlyCompatibilityMatrix = new List<Greg.Responses.Compatibility>
+            {
+                new Greg.Responses.Compatibility { name = "dynamo", versions = new List<string> { "3.2.2" } }
+            };
+
+            var compatibleDynamoVersion = new Version("3.2.2");  // Compatible with Dynamo 3.2.2
+            var incompatibleDynamoVersion = new Version("3.4.0");  // Incompatible with Dynamo 3.4.0
+
+            // Act
+            // Case 1: Single Dynamo version, compatible
+            var resultDynamoCompatibility = PackageManagerSearchElement.CalculateCompatibility(
+                hostOnlyCompatibilityMatrix, compatibleDynamoVersion, compatibilityMap);
+
+            // Case 2: Single Dynamo version, incompatible
+            var resultNoDynamoCompatibility = PackageManagerSearchElement.CalculateCompatibility(
+                hostOnlyCompatibilityMatrix, incompatibleDynamoVersion, compatibilityMap);
+
+            // Assert
+            Assert.IsTrue(resultDynamoCompatibility, "Expected compatible with matching Dynamo versions.");
+            Assert.IsFalse(resultNoDynamoCompatibility, "Expected incompatible with mismatched Dynamo versions.");
+        }
+
+        [Test]
         public void HostCompatibilityFiltersExclusivity()
         {
             var mockGreg = new Mock<IGregClient>();
@@ -1160,6 +1186,20 @@ namespace Dynamo.PackageManager.Wpf.Tests
             bool result = PackageManagerSearchElement.IsVersionCompatible(compatibility, version);
 
             Assert.IsTrue(result, "Expected compatibility to be true when version is in the list.");
+        }
+
+        [Test]
+        public void IsVersionCompatible_NoCompatibleVersion_ReturnsFalse()
+        {
+            var compatibility = new Greg.Responses.Compatibility
+            {
+                versions = new List<string> { "2.1.0", "2.3.0" }
+            };
+            Version version = new Version("2.2.0");
+
+            bool result = PackageManagerSearchElement.IsVersionCompatible(compatibility, version);
+
+            Assert.IsFalse(result, "Expected compatibility to be false when version is not in the list.");
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Bugfix - returning `True` when no compatibility single version was found. For reference [jira issue]([DYN-7826](https://jira.autodesk.com/browse/DYN-7826))

![image](https://github.com/user-attachments/assets/fa84dcf0-a127-4b5d-94bb-edf0865f682e)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- flipped `isWithinMinMax` initial bool value to `False` 
- added Tests to cover this case

### Reviewers

@achintyabhat 
@zeusongit 
@saintentropy 
@QilongTang 

### FYIs

@reddyashish 