### PR TITLE
DYN-7837: Fix zoom to fit in workspace.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1501,9 +1501,9 @@ namespace Dynamo.ViewModels
         /// <summary>
         ///     Zoom around current selection
         ///     _fitViewActualZoomToggle is used internally to toggle
-        /// between the default 1.0 zoom level and the intended zoom around selection
+        ///     between the default 1.0 zoom level and the intended zoom around selection
         ///     The optional toggle boolean is introduced to avoid this behavior and only zoom around the selection
-        /// no matter how many times the operation is performed
+        ///     no matter how many times the operation is performed.
         /// </summary>
         /// <param name="toggle"></param>
         internal void FitViewInternal(bool toggle = true)
@@ -1543,13 +1543,26 @@ namespace Dynamo.ViewModels
                     maxX = Math.Max(model.X + model.Width, maxX);
                     minY = Math.Min(model.Y, minY);
                     maxY = Math.Max(model.Y + model.Height, maxY);
-                }
-                
+                }   
             }
 
-            // Add padding to the calculated bounding box for better visibility
-            double focusWidth = (maxX - minX) * Configurations.ZoomToFitPaddingFactor;
-            double focusHeight = (maxY - minY) * Configurations.ZoomToFitPaddingFactor;
+            double focusWidth;
+            double focusHeight;
+
+            //  If toggle is true, zoom to fit in the whole workspace view,
+            //  else zoom around the selected element by adding a padding factor.
+            if (toggle)
+            {
+                focusWidth = maxX - minX;
+                focusHeight = maxY - minY;
+            }
+            else
+            {
+                // Add padding to the calculated bounding box for better visibility
+                focusWidth = (maxX - minX) * Configurations.ZoomToFitPaddingFactor;
+                focusHeight = (maxY - minY) * Configurations.ZoomToFitPaddingFactor;
+
+            }
 
             // Adjust offset to ensure the view is centered with the padding
             double offsetX = minX - (focusWidth - (maxX - minX)) / 2.0;

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Dynamo.Models;
 using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
-
+using DynamoServices;
 using Greg.Responses;
 
 namespace Dynamo.PackageManager
@@ -354,7 +354,7 @@ namespace Dynamo.PackageManager
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.ToString());
+                DynamoConsoleLogger.OnLogMessageToDynamoConsole(ex.ToString());
                 return null;
             }
         }


### PR DESCRIPTION
### Purpose

Fixes https://jira.autodesk.com/browse/DYN-7837.

For zoomtofit in workspace, we don't want to use any padding factor. It is only used for cases where we zoom to the selected element.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
DYN-7837: Fix zoom to fit in workspace.

### Reviewers
@QilongTang @ivaylo-matov 

