### PR TITLE
DYN-7821:pm-compatibility-fix-test-coverage

### DIFF
--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -312,6 +312,12 @@ namespace Dynamo.PackageManager
                     return null;
                 }
 
+                // If there is any mal-formed data, we reject
+                if (compatibilityMatrix.Any(x => string.IsNullOrEmpty(x.name)))
+                {
+                    return null;
+                }
+
                 Greg.Responses.Compatibility compatibility = null;
 
                 // Determine compatibility
@@ -323,6 +329,12 @@ namespace Dynamo.PackageManager
                     // Check for host-specific compatibility
                     compatibility = compatibilityMatrix.FirstOrDefault(c => c.name?.ToLowerInvariant() == host?.ToLowerInvariant())
                                     ?? compatibilityMatrix.FirstOrDefault(c => c.name?.ToLowerInvariant() == "dynamo");
+
+                    //If we have no compatibility that means didn't match the supported cases 
+                    if (compatibility == null)
+                    {
+                        return false;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
### Purpose

Based on https://github.com/DynamoDS/Dynamo/compare/master...saintentropy:Dynamo:FailureCase#diff-a7975ce1cd3828b7bc9a238f4ae9e0e5352d4ab6fba2071899a423ffdf2286ffR320 by @saintentropy 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- craig proposed fixes implemented
- additional test coverage for -- complex matrices with multiple hosts
-- fill matrices with min, max and single versions -- precise single version testing (question to devs)

### Reviewers

@saintentropy 
@QilongTang 

### FYIs

@achintyabhat 
@avidit 
