### PR TITLE
DYN-7820 Fix regression

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -186,7 +186,7 @@ namespace Dynamo.PackageManager
                     Dynamo.Logging.Analytics.TrackEvent(
                         Actions.Filter,
                         Categories.PackageManagerOperations,
-                        pmSearchViewModel.CompatibilityFilter.FirstOrDefault(x=>x.OnChecked).FilterName);
+                        pmSearchViewModel.CompatibilityFilter.FirstOrDefault(x=>x.OnChecked)?.FilterName);
                 }
                 pmSearchViewModel.SearchAndUpdateResults();
                 return;

--- a/src/LibraryViewExtensionWebView2/ViewExtension.cs
+++ b/src/LibraryViewExtensionWebView2/ViewExtension.cs
@@ -43,8 +43,8 @@ namespace Dynamo.LibraryViewExtensionWebView2
                 viewParams = viewLoadedParams;
                 controller = new LibraryViewController(viewLoadedParams.DynamoWindow, viewLoadedParams.CommandExecutive, customization);
                 (viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).PropertyChanged += handleDynamoViewPropertyChanges;
+                viewParams.CurrentWorkspaceChanged += ViewParams_CurrentWorkspaceChanged;
             }
-            viewParams.CurrentWorkspaceChanged += ViewParams_CurrentWorkspaceChanged;
         }
 
         private void ViewParams_CurrentWorkspaceChanged(IWorkspaceModel workspace)


### PR DESCRIPTION
### Purpose

Follow up of https://github.com/DynamoDS/Dynamo/pull/15660, fix an issue that on Test UIless mode, the filter element `OnChecked()` linq statement would return null causing a null exception. This is somehow missed from my previous PR.

Also included a change that causing null exception seems from [here](https://github.com/DynamoDS/Dynamo/commit/2b36e1fc93a94968f6a3f738e87000a9887a479d#diff-abf7d5091e6fead4372c07412928ada4ab2664a9018e07716f311e6980993339R47) FYI: @mjkkirschner 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers



### FYIs

@DynamoDS/dynamo 