### PR TITLE
DYN-7861:pm change compatibility border color

### DIFF
--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -66,7 +66,7 @@
             <Style x:Key="TextLinkStyle" TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
                 <Setter Property="FontSize" Value="14px" />
-                <Setter Property="Foreground" Value="{StaticResource Blue300Brush}" />  
+                <Setter Property="Foreground" Value="{StaticResource Blue300Brush}" />
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Foreground" Value="{StaticResource Blue400Brush}" />

--- a/src/PackageDetailsViewExtension/PackageDetailsView.xaml
+++ b/src/PackageDetailsViewExtension/PackageDetailsView.xaml
@@ -66,7 +66,7 @@
             <Style x:Key="TextLinkStyle" TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
                 <Setter Property="FontSize" Value="14px" />
-                <Setter Property="Foreground" Value="{StaticResource Blue300Brush}" />
+                <Setter Property="Foreground" Value="{StaticResource Blue300Brush}" />  
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Foreground" Value="{StaticResource Blue400Brush}" />
@@ -433,7 +433,7 @@
                                         <Style.Triggers>
                                             <!--  Trigger for IsCompatible == true (compatible)  -->
                                             <DataTrigger Binding="{Binding IsCompatible}" Value="True">
-                                                <Setter Property="BorderBrush" Value="{StaticResource PMHeaderBackgroundColorBrush}" />
+                                                <Setter Property="BorderBrush" Value="{StaticResource PMVersionCompatibleColorBrush}" />
                                             </DataTrigger>
 
                                             <!--  Trigger for IsCompatible == false (not compatible)  -->


### PR DESCRIPTION
### Purpose

A small PR to change the color of the detail package item border for compatible packages.

### UI Changes

![image](https://github.com/user-attachments/assets/36f6ada9-ede6-4d02-bdab-67b369a21a0a)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- now colors the border of the detail item with the default (green) compatibility color

### Reviewers

@achintyabhat 
@hwahlstrom 
@reddyashish 

### FYIs

@QilongTang 