### PR TITLE
filter analytics crash fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -186,7 +186,7 @@ namespace Dynamo.PackageManager
                     Dynamo.Logging.Analytics.TrackEvent(
                         Actions.Filter,
                         Categories.PackageManagerOperations,
-                        pmSearchViewModel.CompatibilityFilter.FirstOrDefault(x=>x.OnChecked)?.FilterName);
+                        pmSearchViewModel.CompatibilityFilter.FirstOrDefault(x=>x.OnChecked)?.FilterName ?? "No filter selected.");
                 }
                 pmSearchViewModel.SearchAndUpdateResults();
                 return;


### PR DESCRIPTION
### Purpose

A small PR that contains a small fix to a dynamo crash when deselecting filters. 

### Before
![DynamoSandbox_IvsvAznMUm](https://github.com/user-attachments/assets/73aa3ea1-e037-4768-8e4f-44d535780592)

###After
![DynamoSandbox_VoN88wsSmh](https://github.com/user-attachments/assets/c11e3183-bfe3-4517-8be5-c303786b114f)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- catching the case where on filter deselect no filter result will be queried for FilterName resulting in a crush

### Reviewers

@QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
