### PR TITLE
[DYN-7839] Wires & Pins: improve snapping tolerance

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -58,6 +58,11 @@ namespace Dynamo.Configuration
         /// </summary>
         public static readonly double ZoomToFitPaddingFactor = 3.5;
 
+        /// <summary>
+        /// Const used to define the interaction or hit area thickness for connectors in the workspace.
+        /// </summary>
+        public static readonly double ConnectorHitAreaThickness = 60;
+
         #endregion
 
         #region Usage Reporting Error Message

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -58,16 +58,6 @@ namespace Dynamo.Configuration
         /// </summary>
         public static readonly double ZoomToFitPaddingFactor = 3.5;
 
-        /// <summary>
-        /// Const defining the base stroke thickness for connectors.
-        /// </summary>
-        public static readonly double ConnectorBaseThickness = 3;
-
-        /// <summary>
-        /// Const defining the scaling factor for adjusting connector stroke thickness based on zoom level.
-        /// </summary>
-        public const double ConnectorZoomScalingFactor = 2.0;
-
         #endregion
 
         #region Usage Reporting Error Message

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -58,6 +58,16 @@ namespace Dynamo.Configuration
         /// </summary>
         public static readonly double ZoomToFitPaddingFactor = 3.5;
 
+        /// <summary>
+        /// Const used to define the interaction or hit area thickness for connectors in the workspace.
+        /// </summary>
+        public static readonly double ConnectorBaseThickness = 3;
+
+        /// <summary>
+        /// Const defining the scaling factor for adjusting connector stroke thickness based on zoom level.
+        /// </summary>
+        public const double ConnectorZoomScalingFactor = 2.0;
+
         #endregion
 
         #region Usage Reporting Error Message

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -59,9 +59,14 @@ namespace Dynamo.Configuration
         public static readonly double ZoomToFitPaddingFactor = 3.5;
 
         /// <summary>
-        /// Const used to define the interaction or hit area thickness for connectors in the workspace.
+        /// Const defining the base stroke thickness for connectors.
         /// </summary>
-        public static readonly double ConnectorHitAreaThickness = 60;
+        public static readonly double ConnectorBaseThickness = 3;
+
+        /// <summary>
+        /// Const defining the scaling factor for adjusting connector stroke thickness based on zoom level.
+        /// </summary>
+        public const double ConnectorZoomScalingFactor = 2.0;
 
         #endregion
 

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -3017,8 +3017,6 @@ static readonly Dynamo.Configuration.Configurations.ZoomDirectEditThreshold -> d
 static readonly Dynamo.Configuration.Configurations.ZoomIncrement -> double
 static readonly Dynamo.Configuration.Configurations.ZoomThreshold -> double
 static readonly Dynamo.Configuration.Configurations.ZoomToFitPaddingFactor -> double
-static readonly Dynamo.Configuration.Configurations.ConnectorBaseThickness -> double
-static readonly Dynamo.Configuration.Configurations.ConnectorZoomScalingFactor -> double
 static readonly Dynamo.Configuration.PreferenceSettings.DynamoDefaultTime -> System.DateTime
 virtual Dynamo.Core.CustomNodeManager.OnCustomNodeRemoved(System.Guid functionId) -> void
 virtual Dynamo.Core.CustomNodeManager.OnDefinitionUpdated(Dynamo.CustomNodeDefinition obj) -> void

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -3001,6 +3001,8 @@ static readonly Dynamo.Configuration.Configurations.AutodeskAsString -> string
 static readonly Dynamo.Configuration.Configurations.BackupFolderName -> string
 static readonly Dynamo.Configuration.Configurations.CBNMaxPortNameLength -> int
 static readonly Dynamo.Configuration.Configurations.CodeBlockOutputPortHeightInPixels -> double
+static readonly Dynamo.Configuration.Configurations.ConnectorBaseThickness -> double
+static readonly Dynamo.Configuration.Configurations.ConnectorZoomScalingFactor -> double
 static readonly Dynamo.Configuration.Configurations.DoubleSliderTextBoxWidth -> double
 static readonly Dynamo.Configuration.Configurations.DynamoAsString -> string
 static readonly Dynamo.Configuration.Configurations.DynamoNodeHelpDocs -> string

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -3017,6 +3017,7 @@ static readonly Dynamo.Configuration.Configurations.ZoomDirectEditThreshold -> d
 static readonly Dynamo.Configuration.Configurations.ZoomIncrement -> double
 static readonly Dynamo.Configuration.Configurations.ZoomThreshold -> double
 static readonly Dynamo.Configuration.Configurations.ZoomToFitPaddingFactor -> double
+static readonly Dynamo.Configuration.Configurations.ConnectorHitAreaThickness -> double
 static readonly Dynamo.Configuration.PreferenceSettings.DynamoDefaultTime -> System.DateTime
 virtual Dynamo.Core.CustomNodeManager.OnCustomNodeRemoved(System.Guid functionId) -> void
 virtual Dynamo.Core.CustomNodeManager.OnDefinitionUpdated(Dynamo.CustomNodeDefinition obj) -> void

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -36,6 +36,7 @@ abstract Dynamo.Search.SearchElements.SearchElementBase.Type.get -> string
 abstract Dynamo.Search.SearchElements.SearchElementBase.Weight.get -> double
 abstract Dynamo.Search.SearchElements.SearchElementBase.Weight.set -> void
 const Dynamo.Configuration.Configurations.NotificationsDefaultTimeOut = 10000 -> int
+const Dynamo.Configuration.Configurations.ConnectorZoomScalingFactor = 2 -> double
 const Dynamo.Configuration.Context.NONE = "None" -> string
 const Dynamo.Configuration.Context.REVIT_2014 = "Revit 2014" -> string
 const Dynamo.Configuration.Context.REVIT_2015 = "Revit 2015" -> string
@@ -3002,7 +3003,6 @@ static readonly Dynamo.Configuration.Configurations.BackupFolderName -> string
 static readonly Dynamo.Configuration.Configurations.CBNMaxPortNameLength -> int
 static readonly Dynamo.Configuration.Configurations.CodeBlockOutputPortHeightInPixels -> double
 static readonly Dynamo.Configuration.Configurations.ConnectorBaseThickness -> double
-static readonly Dynamo.Configuration.Configurations.ConnectorZoomScalingFactor -> double
 static readonly Dynamo.Configuration.Configurations.DoubleSliderTextBoxWidth -> double
 static readonly Dynamo.Configuration.Configurations.DynamoAsString -> string
 static readonly Dynamo.Configuration.Configurations.DynamoNodeHelpDocs -> string

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -3017,7 +3017,8 @@ static readonly Dynamo.Configuration.Configurations.ZoomDirectEditThreshold -> d
 static readonly Dynamo.Configuration.Configurations.ZoomIncrement -> double
 static readonly Dynamo.Configuration.Configurations.ZoomThreshold -> double
 static readonly Dynamo.Configuration.Configurations.ZoomToFitPaddingFactor -> double
-static readonly Dynamo.Configuration.Configurations.ConnectorHitAreaThickness -> double
+static readonly Dynamo.Configuration.Configurations.ConnectorBaseThickness -> double
+static readonly Dynamo.Configuration.Configurations.ConnectorZoomScalingFactor -> double
 static readonly Dynamo.Configuration.PreferenceSettings.DynamoDefaultTime -> System.DateTime
 virtual Dynamo.Core.CustomNodeManager.OnCustomNodeRemoved(System.Guid functionId) -> void
 virtual Dynamo.Core.CustomNodeManager.OnDefinitionUpdated(Dynamo.CustomNodeDefinition obj) -> void

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1717,6 +1717,7 @@ Dynamo.ViewModels.CompactBubbleViewModel.ValueType.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel
 Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorOffset.get -> double
 Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorSize.get -> double
+Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorSize.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanDisplayIcons.get -> bool
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanDisplayIcons.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanShowTooltip.get -> bool
@@ -1735,6 +1736,7 @@ Dynamo.ViewModels.ConnectorAnchorViewModel.IsTemporarilyDisplayed.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetY.get -> double
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetX.get -> double
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerSize.get -> double
+Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerSize.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinConnectorCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinConnectorCommand.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinIconPreviewOn.get -> bool
@@ -1742,6 +1744,8 @@ Dynamo.ViewModels.ConnectorAnchorViewModel.PinIconPreviewOn.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.PlaceWatchNodeCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.ConnectorAnchorViewModel.PlaceWatchNodeCommand.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.RequestDispose -> System.EventHandler
+Dynamo.ViewModels.ConnectorAnchorViewModel.ScaledAnchorSize.get -> double
+Dynamo.ViewModels.ConnectorAnchorViewModel.ScaledMarkerSize.get -> double
 Dynamo.ViewModels.ConnectorAnchorViewModel.WatchIconPreviewOn.get -> bool
 Dynamo.ViewModels.ConnectorAnchorViewModel.WatchIconPreviewOn.set -> void
 Dynamo.ViewModels.ConnectorContextMenuViewModel

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1716,9 +1716,7 @@ Dynamo.ViewModels.CompactBubbleViewModel.ValueType.get -> string
 Dynamo.ViewModels.CompactBubbleViewModel.ValueType.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel
 Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorOffset.get -> double
-Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorOffset.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorSize.get -> double
-Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorSize.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanDisplayIcons.get -> bool
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanDisplayIcons.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanShowTooltip.get -> bool
@@ -1735,11 +1733,8 @@ Dynamo.ViewModels.ConnectorAnchorViewModel.IsHalftone.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.IsTemporarilyDisplayed.get -> bool
 Dynamo.ViewModels.ConnectorAnchorViewModel.IsTemporarilyDisplayed.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetY.get -> double
-Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetY.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetX.get -> double
-Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetX.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerSize.get -> double
-Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerSize.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinConnectorCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinConnectorCommand.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinIconPreviewOn.get -> bool

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1715,6 +1715,8 @@ Dynamo.ViewModels.CompactBubbleViewModel.ShowNumberOfItems.get -> bool
 Dynamo.ViewModels.CompactBubbleViewModel.ValueType.get -> string
 Dynamo.ViewModels.CompactBubbleViewModel.ValueType.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel
+Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorOffset.get -> double
+Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorOffset.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorSize.get -> double
 Dynamo.ViewModels.ConnectorAnchorViewModel.AnchorSize.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.CanDisplayIcons.get -> bool
@@ -1732,6 +1734,10 @@ Dynamo.ViewModels.ConnectorAnchorViewModel.IsHalftone.get -> bool
 Dynamo.ViewModels.ConnectorAnchorViewModel.IsHalftone.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.IsTemporarilyDisplayed.get -> bool
 Dynamo.ViewModels.ConnectorAnchorViewModel.IsTemporarilyDisplayed.set -> void
+Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetY.get -> double
+Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetY.set -> void
+Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetX.get -> double
+Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerOffsetX.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerSize.get -> double
 Dynamo.ViewModels.ConnectorAnchorViewModel.MarkerSize.set -> void
 Dynamo.ViewModels.ConnectorAnchorViewModel.PinConnectorCommand.get -> Dynamo.UI.Commands.DelegateCommand

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1824,6 +1824,8 @@ Dynamo.ViewModels.ConnectorViewModel.DotLeft.get -> double
 Dynamo.ViewModels.ConnectorViewModel.DotLeft.set -> void
 Dynamo.ViewModels.ConnectorViewModel.DotTop.get -> double
 Dynamo.ViewModels.ConnectorViewModel.DotTop.set -> void
+Dynamo.ViewModels.ConnectorViewModel.DynamicStrokeThickness.get -> double
+Dynamo.ViewModels.ConnectorViewModel.DynamicStrokeThickness.set -> void
 Dynamo.ViewModels.ConnectorViewModel.EndDotSize.get -> double
 Dynamo.ViewModels.ConnectorViewModel.EndDotSize.set -> void
 Dynamo.ViewModels.ConnectorViewModel.GoToEndNodeCommand.get -> Dynamo.UI.Commands.DelegateCommand

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -127,14 +127,13 @@
             </Canvas>
 
             <!--Bezier Path-->
-            <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
+            <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="{Binding Source={x:Static configuration:Configurations.ConnectorBaseThickness}}"
               Name="connector"
               Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" 
               Style="{StaticResource SConnector}" Canvas.ZIndex="-2" 
                   Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
             </Path>
-            <Path Stroke="Transparent"
-                  StrokeThickness="{Binding Source={x:Static configuration:Configurations.ConnectorHitAreaThickness}}"
+            <Path Stroke="Transparent" StrokeThickness="{Binding DynamicStrokeThickness}"
                   Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"
                   Style="{StaticResource SConnector}" Canvas.ZIndex="-1"
                   Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -5,7 +5,8 @@
                       xmlns:i="clr-namespace:Dynamo.Microsoft.Xaml.Behaviors;assembly=Dynamo.Microsoft.Xaml.Behaviors"
                       xmlns:views="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
                       xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"
-                      xmlns:mouse="clr-namespace:Dynamo.Wpf.UI;assembly=DynamoCoreWpf">
+                      xmlns:mouse="clr-namespace:Dynamo.Wpf.UI;assembly=DynamoCoreWpf"
+                      xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore">
 
     <ResourceDictionary.MergedDictionaries>
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
@@ -126,7 +127,7 @@
             </Canvas>
 
             <!--Bezier Path-->
-            <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
+            <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="{Binding Source={x:Static configuration:Configurations.ConnectorBaseThickness}}"
               Name="connector"
               Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" 
               Style="{StaticResource SConnector}" Canvas.ZIndex="-2" 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -5,7 +5,8 @@
                       xmlns:i="clr-namespace:Dynamo.Microsoft.Xaml.Behaviors;assembly=Dynamo.Microsoft.Xaml.Behaviors"
                       xmlns:views="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
                       xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"
-                      xmlns:mouse="clr-namespace:Dynamo.Wpf.UI;assembly=DynamoCoreWpf">
+                      xmlns:mouse="clr-namespace:Dynamo.Wpf.UI;assembly=DynamoCoreWpf"
+                      xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore">
 
     <ResourceDictionary.MergedDictionaries>
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
@@ -129,7 +130,13 @@
             <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
               Name="connector"
               Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" 
-              Style="{StaticResource SConnector}" Canvas.ZIndex="-1" 
+              Style="{StaticResource SConnector}" Canvas.ZIndex="-2" 
+                  Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
+            </Path>
+            <Path Stroke="Transparent"
+                  StrokeThickness="{Binding Source={x:Static configuration:Configurations.ConnectorHitAreaThickness}}"
+                  Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"
+                  Style="{StaticResource SConnector}" Canvas.ZIndex="-1"
                   Data="{Binding ComputedBezierPathGeometry, UpdateSourceTrigger=PropertyChanged}">
                 <i:Interaction.Behaviors>
                     <mouse:MouseBehaviour MouseX="{Binding PanelX, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" MouseY="{Binding PanelY, Mode=OneWayToSource,  UpdateSourceTrigger=PropertyChanged}" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Connectors.xaml
@@ -5,8 +5,7 @@
                       xmlns:i="clr-namespace:Dynamo.Microsoft.Xaml.Behaviors;assembly=Dynamo.Microsoft.Xaml.Behaviors"
                       xmlns:views="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
                       xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"
-                      xmlns:mouse="clr-namespace:Dynamo.Wpf.UI;assembly=DynamoCoreWpf"
-                      xmlns:configuration="clr-namespace:Dynamo.Configuration;assembly=DynamoCore">
+                      xmlns:mouse="clr-namespace:Dynamo.Wpf.UI;assembly=DynamoCoreWpf">
 
     <ResourceDictionary.MergedDictionaries>
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
@@ -127,7 +126,7 @@
             </Canvas>
 
             <!--Bezier Path-->
-            <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="{Binding Source={x:Static configuration:Configurations.ConnectorBaseThickness}}"
+            <Path Stroke="{DynamicResource BConnectorSelection}" StrokeThickness="3"
               Name="connector"
               Visibility="{Binding IsCollapsed, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" 
               Style="{StaticResource SConnector}" Canvas.ZIndex="-2" 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Threading;
-using Dynamo.Configuration;
 using Dynamo.Graph;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
@@ -1190,12 +1189,10 @@ namespace Dynamo.ViewModels
 
         private void UpdateDynamicStrokeThickness()
         {
-            DynamicStrokeThickness = Math.Max(
-                Configurations.ConnectorBaseThickness,
-                Configurations.ConnectorBaseThickness *
-                (1 / workspaceViewModel.Zoom) *
-                Configurations.ConnectorZoomScalingFactor
-            );
+            const double baseThickness = 3.0;
+            const double zoomScalingFactor = 2.0;
+
+            DynamicStrokeThickness = Math.Max(baseThickness, baseThickness * (1 / workspaceViewModel.Zoom) * zoomScalingFactor );
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Threading;
+using Dynamo.Configuration;
 using Dynamo.Graph;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
@@ -1189,10 +1190,12 @@ namespace Dynamo.ViewModels
 
         private void UpdateDynamicStrokeThickness()
         {
-            const double baseThickness = 3.0;
-            const double zoomScalingFactor = 2.0;
-
-            DynamicStrokeThickness = Math.Max(baseThickness, baseThickness * (1 / workspaceViewModel.Zoom) * zoomScalingFactor );
+            DynamicStrokeThickness = Math.Max(
+                Configurations.ConnectorBaseThickness,
+                Configurations.ConnectorBaseThickness *
+                (1 / workspaceViewModel.Zoom) *
+                Configurations.ConnectorZoomScalingFactor
+            );
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -49,15 +49,15 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// The offset for the anchor button, calculated as half the size.
         /// </summary>
-        public double AnchorOffset => AnchorSize / -2; //Log to public API
+        public double AnchorOffset => AnchorSize / -2;
         /// <summary>
         /// The vertical offset for the Watch and Pin buttons.
         /// </summary>
-        public double MarkerOffsetY => GetCachedScaledSize(-37); //Log to public API
+        public double MarkerOffsetY => GetCachedScaledSize(-37);
         /// <summary>
         /// The horizontal offset for the Pin button.
         /// </summary>
-        public double MarkerOffsetX => GetCachedScaledSize(-30); //Log to public API
+        public double MarkerOffsetX => GetCachedScaledSize(-30);
 
         /// <summary>
         /// Midpoint of the connector bezier curve.

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -41,15 +41,23 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// The size of the Watch and Pin icons (x &amp; y dimensions).
         /// </summary>
-        public double MarkerSize => GetCachedScaledSize(30);
+        public double MarkerSize { get; set; } = 30;
+        /// <summary>
+        /// The scaled size of the Watch and Pin icons (x &amp; y dimensions).
+        /// </summary>
+        public double ScaledMarkerSize => GetCachedScaledSize(MarkerSize);
         /// <summary>
         /// The size of the anchor button (x and y dimensions).
         /// </summary>
-        public double AnchorSize => GetCachedScaledSize(15);
+        public double AnchorSize { get; set; } = 15;
+        /// <summary>
+        /// The scaled size of the anchor button (x and y dimensions).
+        /// </summary>
+        public double ScaledAnchorSize => GetCachedScaledSize(AnchorSize);
         /// <summary>
         /// The offset for the anchor button, calculated as half the size.
         /// </summary>
-        public double AnchorOffset => AnchorSize / -2;
+        public double AnchorOffset => ScaledAnchorSize / -2;
         /// <summary>
         /// The vertical offset for the Watch and Pin buttons.
         /// </summary>

--- a/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/ConnectorAnchorViewModel.cs
@@ -18,6 +18,7 @@ namespace Dynamo.ViewModels
     public class ConnectorAnchorViewModel: ViewModelBase
     {
         #region Properties 
+        private WorkspaceViewModel WorkspaceViewModel { get; }
         private Point currentPosition;
         private bool isHalftone;
         private bool isTemporarilyVisible = false;
@@ -29,16 +30,34 @@ namespace Dynamo.ViewModels
         private bool pinIconPreviewOn = false;
         private string dataTooltipText;
 
+        private double? cachedZoom = null;
+        private Dictionary<double, double> cachedSizes = new Dictionary<double, double>();
+
         private ConnectorViewModel ViewModel { get; set; }
         private DynamoModel DynamoModel { get; set; }
         private DynamoViewModel DynamoViewModel { get; set; }
         private Dispatcher Dispatcher { get; set; }
 
         /// <summary>
-        /// The size of the Watch Icon (x &amp; y dimensions).
+        /// The size of the Watch and Pin icons (x &amp; y dimensions).
         /// </summary>
-        public double MarkerSize { get; set; } = 30;
-        public double AnchorSize { get; set; } = 15;
+        public double MarkerSize => GetCachedScaledSize(30);
+        /// <summary>
+        /// The size of the anchor button (x and y dimensions).
+        /// </summary>
+        public double AnchorSize => GetCachedScaledSize(15);
+        /// <summary>
+        /// The offset for the anchor button, calculated as half the size.
+        /// </summary>
+        public double AnchorOffset => AnchorSize / -2; //Log to public API
+        /// <summary>
+        /// The vertical offset for the Watch and Pin buttons.
+        /// </summary>
+        public double MarkerOffsetY => GetCachedScaledSize(-37); //Log to public API
+        /// <summary>
+        /// The horizontal offset for the Pin button.
+        /// </summary>
+        public double MarkerOffsetX => GetCachedScaledSize(-30); //Log to public API
 
         /// <summary>
         /// Midpoint of the connector bezier curve.
@@ -165,7 +184,7 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// This property acts as the main flag that signals whether or not watch icon/pin icon/tooltip
-        /// should be visibile/ hidden.
+        /// should be visible/ hidden.
         /// </summary>
         public bool CanDisplayIcons
         {
@@ -284,6 +303,7 @@ namespace Dynamo.ViewModels
             ViewModel = connectorViewModel;
             DynamoViewModel = dynamoViewModel;
             DynamoModel = DynamoViewModel.Model;
+            WorkspaceViewModel = dynamoViewModel.CurrentSpaceViewModel;
             DataToolTipText = tooltipText;
             InitCommands();
 
@@ -416,6 +436,49 @@ namespace Dynamo.ViewModels
         private int ConnectorSegmentIndex(Point midPoint, Point connectorLocation)
         {
             return midPoint.X > connectorLocation.X ? 0 : 1;
+        }
+
+        /// <summary>
+        /// Calculates a scaled size based on the zoom level, applying a non-linear decay.
+        /// Ensures the size decreases monotonically and approaches a minimum size as zoom decreases.
+        /// </summary>
+        private double CalculateScaledSize(double defaultSize)
+        {
+            // Proportion for the minimum size relative to defaultSize
+            const double resizingFactor = 0.5;
+            // Controls the rate of size decay for lower zoom levels
+            const double curveSteepness = 1.5;
+
+            double minSize = defaultSize * resizingFactor;
+
+            if (WorkspaceViewModel.Zoom >= 1)
+            {
+                return defaultSize;
+            }
+
+            // Apply non-linear decay formula
+            double zoomFactor = Math.Pow(WorkspaceViewModel.Zoom, curveSteepness);
+            return (minSize + (defaultSize - minSize) * zoomFactor) / WorkspaceViewModel.Zoom;
+        }
+
+        /// <summary>
+        /// Retrieves a scaled size from the cache or calculates it if the Zoom level has changed or the size is not cached.
+        /// </summary>
+        private double GetCachedScaledSize(double defaultSize)
+        {
+            if (cachedZoom != WorkspaceViewModel.Zoom)
+            {
+                cachedSizes.Clear();
+                cachedZoom = WorkspaceViewModel.Zoom;
+            }
+
+            if (!cachedSizes.TryGetValue(defaultSize, out var scaledSize))
+            {
+                scaledSize = CalculateScaledSize(defaultSize);
+                cachedSizes[defaultSize] = scaledSize;
+            }
+
+            return scaledSize;
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Controls.ConnectorAnchorView"
+<UserControl x:Class="Dynamo.Controls.ConnectorAnchorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -95,7 +95,7 @@
                 </Image>
             </StackPanel>
             <Button.RenderTransform>
-                <TranslateTransform X="-7.5" Y="-7.5" />
+                <TranslateTransform X="{Binding AnchorOffset}" Y="{Binding AnchorOffset}" />
             </Button.RenderTransform>
         </Button>
 
@@ -129,7 +129,7 @@
                 </Image>
             </StackPanel>
             <Button.RenderTransform>
-                <TranslateTransform X="0" Y="-37" />
+                <TranslateTransform X="0" Y="{Binding MarkerOffsetY}" />
             </Button.RenderTransform>
         </Button>
         <!--pin icon-->
@@ -162,7 +162,7 @@
                 </Image>
             </StackPanel>
             <Button.RenderTransform>
-                <TranslateTransform X="-30" Y="-37" />
+                <TranslateTransform X="{Binding MarkerOffsetX}" Y="{Binding MarkerOffsetY}" />
             </Button.RenderTransform>
         </Button>
     </Canvas>

--- a/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorAnchorView.xaml
@@ -64,8 +64,8 @@
                 x:Name="AnchorButton"
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
-                Height="{Binding AnchorSize}"
-                Width="{Binding AnchorSize}"
+                Height="{Binding ScaledAnchorSize}"
+                Width="{Binding ScaledAnchorSize}"
                 ToolTipService.ShowDuration="{x:Static Member=System:Int32.MaxValue}">
             <Button.ToolTip>
                 <ToolTip Style="{StaticResource ConnectorTooltip}"
@@ -104,8 +104,8 @@
                 Style="{StaticResource TransparentButtonWithTriggers}"
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
-                Height="{Binding MarkerSize}"
-                Width="{Binding MarkerSize}"
+                Height="{Binding ScaledMarkerSize}"
+                Width="{Binding ScaledMarkerSize}"
                 Command="{Binding PlaceWatchNodeCommand}"
                 MouseEnter="OnWatchIconHover"
                 MouseLeave="OnWatchIconUnhover">
@@ -137,8 +137,8 @@
                 Style="{StaticResource TransparentButtonWithTriggers}"
                 Canvas.Top="{Binding CurrentPosition.Y}"
                 Canvas.Left="{Binding CurrentPosition.X}"
-                Height="{Binding MarkerSize}"
-                Width="{Binding MarkerSize}"
+                Height="{Binding ScaledMarkerSize}"
+                Width="{Binding ScaledMarkerSize}"
                 Command="{Binding PinConnectorCommand}"
                 MouseEnter="OnPinIconHover"
                 MouseLeave="OnPinIconUnhover">


### PR DESCRIPTION
### Purpose

PR aims to address [DYN-7839](https://jira.autodesk.com/browse/DYN-7839).

This update enhances the snapping tolerance for connectors when interacting with the ConnectorAnchor.

A second, invisible connector has been introduced to handle MouseEnter and MouseLeave events. This invisible connector features a dynamic `StrokeThickness` that adjusts based on the current zoom level:

Zoom > 1: The `StrokeThickness` matches the visible connector's thickness (default: 3).
Zoom < 1: The `StrokeThickness` dynamically scales with the zoom factor, ensuring that the actual snapping area on the screen remains consistent regardless of the zoom level.
The `StrokeThickness` is doubled at smaller zoom factors to improve the responsiveness.

![DYN-7839-Fix](https://github.com/user-attachments/assets/fa542f91-4049-46cb-b074-f871234ff883)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Improved connector snapping at lower zoom levels for Pin and Watch buttons.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
