### PR TITLE
DYN-7531 Catch WebView2 initialization exception

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1430,25 +1430,25 @@ namespace Dynamo.Controls
                 try
                 {
                     homePage = new UI.Views.HomePage();
+                    homePage.DataContext = startPage;
+
+                    var visibilityBinding = new System.Windows.Data.Binding
+                    {
+                        RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor, typeof(DynamoView), 1),
+                        Path = new PropertyPath("DataContext.ShowStartPage"),
+                        Mode = BindingMode.OneWay,
+                        Converter = new BooleanToVisibilityConverter(),
+                        UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+                    };
+
+                    BindingOperations.SetBinding(homePage, UIElement.VisibilityProperty, visibilityBinding);
+
+                    this.newHomePageContainer.Children.Add(homePage);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Log(ex.Message);
                 }
-                homePage.DataContext = startPage;
-
-                var visibilityBinding = new System.Windows.Data.Binding
-                {
-                    RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor, typeof(DynamoView), 1),
-                    Path = new PropertyPath("DataContext.ShowStartPage"),
-                    Mode = BindingMode.OneWay,
-                    Converter = new BooleanToVisibilityConverter(),
-                    UpdateSourceTrigger = UpdateSourceTrigger.Explicit
-                };
-
-                BindingOperations.SetBinding(homePage, UIElement.VisibilityProperty, visibilityBinding);
-
-                this.newHomePageContainer.Children.Add(homePage);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1427,7 +1427,14 @@ namespace Dynamo.Controls
         {
             if (homePage == null && (startPage != null))
             {
-                homePage = new UI.Views.HomePage();
+                try
+                {
+                    homePage = new UI.Views.HomePage();
+                }
+                catch(Exception ex)
+                {
+                    Log(ex.Message);
+                }
                 homePage.DataContext = startPage;
 
                 var visibilityBinding = new System.Windows.Data.Binding


### PR DESCRIPTION
### Purpose

Per CER report https://cer.autodesk.com/search/v2/buckets/52352002, add some code to prevent WebView2 initialization (Dynamo Home) crashing Dynamo.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add some code to prevent WebView2 initialization (Dynamo Home) crashing Dynamo

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
