### PR TITLE
DYN-7919: Fix stray helpdoc filenames in infobubbles, remove dangling reference to inexistent helpdocs.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1039,7 +1039,7 @@ namespace Dynamo.ViewModels
     public struct InfoBubbleDataPacket : IEquatable<InfoBubbleDataPacket>
     {
         private const string externalLinkIdentifier = "href=";
-        private static readonly Regex externalLinkMatcher = new($@"({Regex.Escape(externalLinkIdentifier)}[^ \n]*?)([ \n]|$)", RegexOptions.Compiled);
+        private static readonly Regex externalLinkMatcher = new($@"({Regex.Escape(externalLinkIdentifier)}[^ \r\n]*?)([ \r\n]|$)", RegexOptions.Compiled);
         public InfoBubbleViewModel.Style Style;
         public Point TopLeft;
         public Point BotRight;

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1039,8 +1039,7 @@ namespace Dynamo.ViewModels
     public struct InfoBubbleDataPacket : IEquatable<InfoBubbleDataPacket>
     {
         private const string externalLinkIdentifier = "href=";
-        private const string externalLinkSuffix = ".html";
-        private static readonly Regex externalLinkMatcher = new(Regex.Escape(externalLinkIdentifier) + ".*?" + Regex.Escape(externalLinkSuffix), RegexOptions.Compiled);
+        private static readonly Regex externalLinkMatcher = new($@"({Regex.Escape(externalLinkIdentifier)}[^ \n]*?)([ \n]|$)", RegexOptions.Compiled);
         public InfoBubbleViewModel.Style Style;
         public Point TopLeft;
         public Point BotRight;

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -1089,7 +1089,7 @@ namespace Dynamo.ViewModels
             if (!text.Contains(externalLinkIdentifier)) return text;
 
             // remove all links from the text (marked as starting with externalLinkIdentifier)
-            return externalLinkMatcher.Replace(text, string.Empty);
+            return externalLinkMatcher.Replace(text, "$2").Trim();
         }
 
         private static Uri ParseLinkFromText(string text)

--- a/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/InfoBubbleViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using Dynamo.Logging;
 using Dynamo.Wpf.ViewModels.Core;
@@ -1038,6 +1039,8 @@ namespace Dynamo.ViewModels
     public struct InfoBubbleDataPacket : IEquatable<InfoBubbleDataPacket>
     {
         private const string externalLinkIdentifier = "href=";
+        private const string externalLinkSuffix = ".html";
+        private static readonly Regex externalLinkMatcher = new(Regex.Escape(externalLinkIdentifier) + ".*?" + Regex.Escape(externalLinkSuffix), RegexOptions.Compiled);
         public InfoBubbleViewModel.Style Style;
         public Point TopLeft;
         public Point BotRight;
@@ -1086,9 +1089,8 @@ namespace Dynamo.ViewModels
             // if there is no link, we do nothing
             if (!text.Contains(externalLinkIdentifier)) return text;
 
-            // return the text without the link or identifier
-            string[] split = text.Split(new string[] { externalLinkIdentifier }, StringSplitOptions.None);
-            return String.Concat(split);
+            // remove all links from the text (marked as starting with externalLinkIdentifier)
+            return externalLinkMatcher.Replace(text, string.Empty);
         }
 
         private static Uri ParseLinkFromText(string text)

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -1133,7 +1133,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Converting a double to an int may lose information. href=testing.html.
+        ///   Looks up a localized string similar to Converting a double to an int may lose information..
         /// </summary>
         public static string kConvertDoubleToInt {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -229,7 +229,7 @@
     <value>Converting an array to {0} would cause array rank reduction and is not permitted href=kConvertArrayToNonArray.html</value>
   </data>
   <data name="kConvertDoubleToInt" xml:space="preserve">
-    <value>Converting a double to an int may lose information. href=testing.html</value>
+    <value>Converting a double to an int may lose information.</value>
   </data>
   <data name="kConvertNonConvertibleTypes" xml:space="preserve">
     <value>Asked to convert non-convertible types</value>
@@ -921,7 +921,7 @@ Parameter name: {0}. href=ArgumentNullException.html</value>
     <value>Invalid list@level syntax, consider using @L1 for level 1.</value>
   </data>
   <data name="VariableRedifinitionError" xml:space="preserve">
-    <value>Variable {0} has been defined in this code block node. You cannot define a variable more than once. href=testing.html</value>
+    <value>Variable {0} has been defined in this code block node. You cannot define a variable more than once.</value>
   </data>
   <data name="VariableRecursiveReference" xml:space="preserve">
     <value>Variable {0} is used in the same statement that you defined it. Recursive dependency is not allowed.</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -232,7 +232,7 @@
     <value>Converting an array to {0} would cause array rank reduction and is not permitted href=kConvertArrayToNonArray.html</value>
   </data>
   <data name="kConvertDoubleToInt" xml:space="preserve">
-    <value>Converting a double to an int may lose information. href=testing.html</value>
+    <value>Converting a double to an int may lose information.</value>
   </data>
   <data name="kConvertNonConvertibleTypes" xml:space="preserve">
     <value>Asked to convert non-convertible types</value>

--- a/test/DynamoCoreWpfTests/InfoBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/InfoBubbleTests.cs
@@ -364,6 +364,11 @@ namespace DynamoCoreWpfTests
                 InfoBubbleViewModel.Direction.Top);
 
             Assert.AreEqual(expectedLink, packet.Link?.ToString());
+            if (expectedLink != null)
+            {
+                Assert.IsTrue(!packet.Text?.Contains("href="));
+                Assert.IsTrue(!packet.Text?.Contains(expectedLink));
+            }
         }
 
         private string NullIfSystemUriCannotParseValue(string link)

--- a/test/DynamoCoreWpfTests/InfoBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/InfoBubbleTests.cs
@@ -57,7 +57,7 @@ namespace DynamoCoreWpfTests
             const string i = "href=";
             var goodLink = "ExcelNotInstalled.html";
             var badWhitespaceLink = " ";
-            var partialDotLink = " . ";
+            var partialDotLink = ". ";
             var goodRemoteLink = "https://dictionary.dynamobim.org/#/";
             var partialRemoteLink = ".com";
             var badIdentifierIncomplete = "href";


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

https://github.com/DynamoDS/Dynamo/pull/14514 Introduced a bug in which the linked helpdoc file appears concatenated at the end of the message info bubbles (See DereferencingNonPointer.html in the PR screenshots). This PR fixes that issue by properly sanitizing the message content and it also removes dangling references to a testing.html helpdoc that never existed.

Message with bug:
![image](https://github.com/user-attachments/assets/9d015753-1f5c-40b0-809f-c3384d9691e7)

Message without bug in case of several warnings:
![image](https://github.com/user-attachments/assets/1ee242c0-80b0-449b-8022-4506844a2578)


Message without bug in case of a single warning:

![image](https://github.com/user-attachments/assets/01185454-122e-4c09-bc43-56cd07c8899b)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Fix stray helpdoc filename at the end of infobubble messages, remove dangling reference to inexistent helpdocs.

### Reviewers

@QilongTang 
@RobertGlobant20 

### FYIs

@avidit 
