### PR TITLE
DYN-7946:PM - crash fix when removing custom nodes with identical names

### DIFF
--- a/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Dynamo;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.PackageManager;
@@ -75,6 +76,38 @@ namespace DynamoCoreWpfTests
             Assert.AreNotEqual(vm.UploadState, PackageUploadHandle.State.Uploaded);
             Console.WriteLine(vm.ErrorString);
 
+        }
+
+        [Test]
+        public void CanRemoveCustomNodesWithIdenticalNames()
+        {
+            var vm = new PublishPackageViewModel(this.ViewModel);
+
+            // Arrange
+            var customNode1 = new CustomNodeDefinition(Guid.NewGuid(), "Geometry.Curve", new List<NodeModel>());
+            var customNode2 = new CustomNodeDefinition(Guid.NewGuid(), "Building.Curve", new List<NodeModel>());
+            var customNode3 = new CustomNodeDefinition(Guid.NewGuid(), "Curve", new List<NodeModel>());
+
+            vm.CustomNodeDefinitions.Add(customNode1);
+            vm.CustomNodeDefinitions.Add(customNode2);
+            vm.CustomNodeDefinitions.Add(customNode3);
+
+            // Initial Assert
+            Assert.AreEqual(3, vm.CustomNodeDefinitions.Count);
+
+            var item1 = new PackageItemRootViewModel("Geometry.Curve.dyf", "C:\\test\\Geometry.Curve.dyf");
+            var item2 = new PackageItemRootViewModel("Building.Curve.dyf", "C:\\test\\Building.Curve.dyf");
+            var item3 = new PackageItemRootViewModel("Curve.dyf", "C:\\test\\Curve.dyf");
+
+            // Assert
+            vm.RemoveSingleItem(item1, DependencyType.CustomNodePreview);
+            Assert.AreEqual(2, vm.CustomNodeDefinitions.Count);
+
+            vm.RemoveSingleItem(item2, DependencyType.CustomNodePreview);
+            Assert.AreEqual(1, vm.CustomNodeDefinitions.Count);
+
+            vm.RemoveSingleItem(item3, DependencyType.CustomNodePreview);
+            Assert.AreEqual(0, vm.CustomNodeDefinitions.Count);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Fixes a crash where, while creating a new Package, attempting to remove `CustomNodeDefinitions` from the current loaded list of files would result in unhandled "Sequence contains no matching element" error. This is happening because of the way we handle custom nodes with duplicate naming, constructing the `Display Name` using the [namespace].[node name] combination. 

The PR addresses the underlying cause of the issue.

https://jira.autodesk.com/browse/DYN-7946

![image](https://github.com/user-attachments/assets/0c3cf43c-52fd-4195-a584-06be8bfda8ff)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- fixed a crash where removing custom nodes with identical names would cause a null "Sequence contains no matching element" due to how we handle duplicate node names

### Reviewers

@jnealb 
@QilongTang 

### FYIs


