### PR TITLE
[DYN-7840] Placement of UI pop up for input nodes in collapsed group mode is not accurate

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -22,6 +22,7 @@ namespace Dynamo.ViewModels
         private DelegateCommand keepListStructureCommand;
         private bool showUseLevelMenu;
         private const double autocompletePopupSpacing = 2.5;
+        private const double proxyPortContextMenuOffset = 20;
         internal bool inputPortDisconnectedByConnectCommand = false;
         protected static readonly SolidColorBrush PortBackgroundColorPreviewOff = new SolidColorBrush(Color.FromRgb(102, 102, 102));
         protected static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
@@ -238,6 +239,33 @@ namespace Dynamo.ViewModels
             return new PortViewModel(node, portModel);
         }
 
+        private UIElement FindProxyPortUIElement(PortViewModel proxyPortViewModel)
+        {
+            var mainWindow = Application.Current.MainWindow;
+
+            return FindChild<UIElement>(mainWindow, e =>
+                e is FrameworkElement fe && fe.DataContext == proxyPortViewModel);
+        }
+
+        private T FindChild<T>(DependencyObject parent, Func<T, bool> predicate) where T : DependencyObject
+        {
+            if (parent == null) return null;
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t && predicate(t))
+                {
+                    return t;
+                }
+
+                var foundChild = FindChild(child, predicate);
+                if (foundChild != null)
+                    return foundChild;
+            }
+            return null;
+        }
+
         /// <summary>
         /// Sets up the node autocomplete window to be placed relative to the node.
         /// </summary>
@@ -254,8 +282,45 @@ namespace Dynamo.ViewModels
         /// <param name="popup">Node context menu popup.</param>
         internal void SetupPortContextMenuPlacement(Popup popup)
         {
+            var zoom = node.WorkspaceViewModel.Zoom;
+
+            if (PortModel.IsProxyPort)
+            {
+                // Find the UI element associated with the proxy port
+                var proxyPortElement = FindProxyPortUIElement(this);
+                if (proxyPortElement != null)
+                {
+                    popup.PlacementTarget = proxyPortElement;
+                    ConfigurePopupPlacement(popup, zoom);
+                    return;
+                }
+            }
+
             node.OnRequestPortContextMenuPlacementTarget(popup);
             popup.CustomPopupPlacementCallback = PlacePortContextMenu;
+        }
+
+        /// <summary>
+        /// Configures the custom placement of the proxyport context menu popup.
+        /// </summary>
+        private void ConfigurePopupPlacement(Popup popup, double zoom)
+        {
+            popup.CustomPopupPlacementCallback = (popupSize, targetSize, offset) =>
+            {
+                double x;
+                double y = (targetSize.Height - popupSize.Height) / 2;
+
+                if (this is InPortViewModel)
+                {
+                    x = -popupSize.Width + proxyPortContextMenuOffset * zoom;                    
+                }
+                else
+                {
+                    x = targetSize.Width - proxyPortContextMenuOffset * zoom;
+                }
+
+                return new[] { new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.None) };
+            };
         }
 
         private CustomPopupPlacement[] PlaceAutocompletePopup(Size popupSize, Size targetSize, Point offset)
@@ -305,7 +370,7 @@ namespace Dynamo.ViewModels
                 x = scaledWidth + targetSize.Width;
             }
             // Important - while zooming in and out, Node elements are scaled, while popup is not
-            // Calculate absolute popup halfheight to deduct from the overal y pos
+            // Calculate absolute popup halfheight to deduct from the overall y pos
             // Then add the header, port height and port index position
             var popupHeightOffset = - popupSize.Height * 0.5;
             var headerHeightOffset = 2 * NodeModel.HeaderHeight * zoom;


### PR DESCRIPTION
### Purpose

PR aims to address [DYN-7840](https://jira.autodesk.com/browse/DYN-7840) where the placement of the UI pop for input ports are off when the group is collapsed.

The code now uses the proxyPorts as `PlacementTarget` and uses different placement method for them.

![DYN-7840-Fix](https://github.com/user-attachments/assets/281ff23a-0a45-45a8-9979-76b5510a7421)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixed placement of Context menu popup for nodes in collapsed groups.

### Reviewers
@reddyashish 
@QilongTang 

### FYIs
@dnenov 
