### PR TITLE
[DYN-7841] Placement of wire for input ports in off when the group is collapsed

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -15,7 +15,7 @@
 
         <!--  Grid that contains the entire port  -->
         <Grid Name="MainGrid"
-              Height="35px"
+              Height="34px"
               Background="Transparent"
               IsHitTestVisible="True">
             <Grid.ColumnDefinitions>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/OutPorts.xaml
@@ -41,7 +41,7 @@
 
             <Grid.Style>
                 <Style>
-                    <Setter Property="Grid.Height" Value="35px" />
+                    <Setter Property="Grid.Height" Value="34px" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
                             <Setter Property="Grid.Height" Value="14px" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -483,7 +483,7 @@
             </DockPanel>
             <Grid.Style>
                 <Style>
-                    <Setter Property="Grid.Height" Value="35px" />
+                    <Setter Property="Grid.Height" Value="34px" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding Path=IsPortCondensed}" Value="True">
                             <Setter Property="Grid.Height" Value="14px" />

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -27,7 +27,7 @@ namespace Dynamo.ViewModels
         private IEnumerable<PortModel> originalOutPorts;
         private Dictionary<Guid, Geometry> GroupIdToCutGeometry = new Dictionary<Guid, Geometry>();
         // vertical offset accounts for the port margins
-        private const int verticalOffset = 20;
+        private const int verticalOffset = 17;
         private const int portVerticalMidPoint = 17;
         private ObservableCollection<Dynamo.Configuration.StyleItem> groupStyleList;
         private IEnumerable<Configuration.StyleItem> preferencesStyleItemsList;


### PR DESCRIPTION
### Purpose

PR aims to address [DYN-7841](https://jira.autodesk.com/browse/DYN-7841) which reported a misalignment between the centers of inports and the connector ends when a group is collapsed.

The issue was caused by a mismatch between `PortModel.Height` (34) and `Grid.Height` (35) in the related views. This inconsistency was resolved by setting both values to 34.

![DYN-7841](https://github.com/user-attachments/assets/8f62ad1a-70e4-44be-b07c-c3fe99ca7acb)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixed an issue where inports were misaligned with connector ends when a group was collapsed by standardizing port dimensions.

### Reviewers
@reddyashish 
@QilongTang 

### FYIs
@dnenov 