### PR TITLE
DYN-7435 Corrupted Chars ON CHS OS

### DIFF
--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -99,8 +99,9 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="timeoutms">will return empty string if we don't finish reading all data in the timeout provided in milliseconds.</param>
         /// <param name="mockReadLine"> if this delegate is non null, it will be used instead of communicating with std out of the process. Used for testing only.</param>
+        ///  <param name="decodeData"> if this flag is true means that the process is returning base64 encoded data then we need to decode it</param>
         /// <returns></returns>
-        protected virtual string GetData(int timeoutms, Func<string> mockReadLine = null)
+        protected virtual string GetData(int timeoutms, Func<string> mockReadLine = null, bool decodeData = false)
         {
             var readStdOutTask = Task.Run(() =>
             {
@@ -144,10 +145,13 @@ namespace Dynamo.Utilities
                                 //if we have started recieving valid data, start recording
                                 if (!string.IsNullOrWhiteSpace(line) && start)
                                 {
-                                    //Encode the info to base64 and send it to the Md2Html tool
-                                    var base64EncodedBytes = Convert.FromBase64String(line);
-                                    var decodedData = Encoding.UTF8.GetString(base64EncodedBytes);
-                                    writer.WriteLine(decodedData);
+                                    if(decodeData == true)
+                                    {
+                                        //Encode the info to base64 and send it to the Md2Html tool
+                                        var base64EncodedBytes = Convert.FromBase64String(line);
+                                        line = Encoding.UTF8.GetString(base64EncodedBytes);
+                                    }                                 
+                                    writer.WriteLine(line);
                                 }
                             }
                         }

--- a/src/DynamoUtilities/CLIWrapper.cs
+++ b/src/DynamoUtilities/CLIWrapper.cs
@@ -144,7 +144,10 @@ namespace Dynamo.Utilities
                                 //if we have started recieving valid data, start recording
                                 if (!string.IsNullOrWhiteSpace(line) && start)
                                 {
-                                    writer.WriteLine(line);
+                                    //Encode the info to base64 and send it to the Md2Html tool
+                                    var base64EncodedBytes = Convert.FromBase64String(line);
+                                    var decodedData = Encoding.UTF8.GetString(base64EncodedBytes);
+                                    writer.WriteLine(decodedData);
                                 }
                             }
                         }

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using DynamoUtilities.Properties;
 using Newtonsoft.Json.Linq;
@@ -62,9 +63,13 @@ namespace Dynamo.Utilities
 
             try
             {
+                //Encode the info to base64 and send it to the Md2Html tool for Converting
+                var plainTextBytes = Encoding.UTF8.GetBytes(mdString);
+                var base64MDString = Convert.ToBase64String(plainTextBytes);
+
                 process.StandardInput.WriteLine(@"<<<<<Convert>>>>>");
                 process.StandardInput.WriteLine(mdPath);
-                process.StandardInput.WriteLine(mdString);
+                process.StandardInput.WriteLine(base64MDString);
                 process.StandardInput.WriteLine(@"<<<<<Eod>>>>>");
             }
             catch (Exception e) when (e is IOException || e is ObjectDisposedException)
@@ -90,8 +95,12 @@ namespace Dynamo.Utilities
 
             try
             {
+                //Encode the info to base64 and send it to the Md2Html tool for Sanitizing
+                var plainTextBytes = Encoding.UTF8.GetBytes(content);
+                var base64MDString = Convert.ToBase64String(plainTextBytes);
+
                 process.StandardInput.WriteLine(@"<<<<<Sanitize>>>>>");
-                process.StandardInput.WriteLine(content);
+                process.StandardInput.WriteLine(base64MDString);
                 process.StandardInput.WriteLine(@"<<<<<Eod>>>>>");
             }
             catch (Exception e) when (e is IOException || e is ObjectDisposedException)

--- a/src/DynamoUtilities/Md2Html.cs
+++ b/src/DynamoUtilities/Md2Html.cs
@@ -78,7 +78,7 @@ namespace Dynamo.Utilities
                 return GetCantCommunicateErrorMessage();
             }
 
-            return GetData(processCommunicationTimeoutms);
+            return GetData(processCommunicationTimeoutms,null,true);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Dynamo.Utilities
                 return GetCantCommunicateErrorMessage();
             }
 
-            return GetData(processCommunicationTimeoutms);
+            return GetData(processCommunicationTimeoutms, null, true);
         }
 
         /// <summary>

--- a/src/Tools/Md2Html/Program.cs
+++ b/src/Tools/Md2Html/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using CommandLine;
 using CommandLine.Text;
 
@@ -27,12 +28,12 @@ namespace Md2Html
                 while (true)
                 {
                     var line = Console.ReadLine();
-                    if (line.Contains(@"<<<<<Sanitize>>>>>"))
+                    if (line.Contains(@"<<Sanitize>>"))
                     {
                         Console.WriteLine(@"<<<<<Sod>>>>>");
                         Sanitize();
                     }
-                    else if (line.Contains(@"<<<<<Convert>>>>>"))
+                    else if (line.Contains(@"<<Convert>>"))
                     {
                         Console.WriteLine(@"<<<<<Sod>>>>>");
                         Convert();
@@ -50,9 +51,17 @@ namespace Md2Html
         {
             var data = GetData();
 
-            var output = Md2Html.Sanitize(data);
+            //Decode the base64 data sent by the client
+            var base64EncodedBytes = System.Convert.FromBase64String(data);
+            var decodedData = Encoding.UTF8.GetString(base64EncodedBytes);
 
-            Console.WriteLine(output);
+            var output = Md2Html.Sanitize(decodedData);
+
+            //Encode to base64 and send it back to the client 
+            var plainTextBytes = Encoding.UTF8.GetBytes(output);
+            var base64MDString = System.Convert.ToBase64String(plainTextBytes);
+
+            Console.WriteLine(base64MDString);
         }
 
         static void Convert()
@@ -62,9 +71,18 @@ namespace Md2Html
             var data = GetData();
 
             var instance = Md2Html.Instance;
-            var output = instance.ParseToHtml(data, mdPath);
 
-            Console.WriteLine(output);
+            //Decode the base64 data sent by the client
+            var base64EncodedBytes = System.Convert.FromBase64String(data);
+            var decodedData = Encoding.UTF8.GetString(base64EncodedBytes);
+
+            var output = instance.ParseToHtml(decodedData, mdPath);
+
+            //Encode to base64 and send it back to the client 
+            var plainTextBytes = Encoding.UTF8.GetBytes(output);
+            var base64MDString = System.Convert.ToBase64String(plainTextBytes);
+
+            Console.WriteLine(base64MDString);
         }
 
         static string GetData()
@@ -74,7 +92,7 @@ namespace Md2Html
                 while (true)
                 {
                     var line = Console.ReadLine();
-                    if (line == @"<<<<<Eod>>>>>")
+                    if (line == @"<<Eod>>")
                     {
                         break;
                     }

--- a/src/Tools/Md2Html/Program.cs
+++ b/src/Tools/Md2Html/Program.cs
@@ -92,7 +92,7 @@ namespace Md2Html
                 while (true)
                 {
                     var line = Console.ReadLine();
-                    if (line == @"<<Eod>>")
+                    if (line.Contains(@"<<Eod>>"))
                     {
                         break;
                     }


### PR DESCRIPTION
### Purpose

Fix for not showing weird characters in DocumentationBrowser in a CHS OS
When using a Windows 10 OS installed in Chinese Traditional if you open DocumentationBrowser several times for each node in the workspace, the DocumentationBrowser starts to show weird characters and the html layout seems different, this was happening due that the Md2Html.Convert and Md2Html.Sanitize methods were not executed, after my fix now they were executed but was still showing weird characters (due that Md2Html encoding was in Chinese Traditional). Then for fixing this problem I had to encode the info using base64 and decoded when is needed.
There was a freeze reported in the Jira task but I was not able to reproduce it after my fix.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix for not showing weird characters in DocumentationBrowser in a CHS OS

### Reviewers

@QilongTang 

### FYIs

