### PR TITLE
DYN-7945 pin home button Z-Index

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -807,6 +807,7 @@
                                                                     Width="42"
                                                                     Height="42"
                                                                     Margin="{Binding MinLeftMarginOffset, Converter={StaticResource LeftMarginConverter}}"
+                                                                    Panel.ZIndex="1"
                                                                     BorderThickness="0"
                                                                     Click="HomeButton_Click"
                                                                     Cursor="Hand">


### PR DESCRIPTION
### Purpose

A small follow up on https://github.com/DynamoDS/Dynamo/pull/15692. Now places the home button on top to retain responsiveness even if other  (invisible) elements move over during the resizing of the library panel . 

### UI Changes
![DynamoSandbox_qqBNmpTkjO](https://github.com/user-attachments/assets/41bf86f8-140d-4f38-be3b-5bd9c3b7290a)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now places the home button on top of the tab panel header to retain responsiveness when shrunk

### Reviewers

@achintyabhat 
@QilongTang 

### FYIs

@reddyashish 
