### PR TITLE
7946: DYN-7965 [Cherry-Pick]

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -357,6 +357,10 @@ Dynamo.Controls.LacingToVisibilityConverter
 Dynamo.Controls.LacingToVisibilityConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.LacingToVisibilityConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.LacingToVisibilityConverter.LacingToVisibilityConverter() -> void
+Dynamo.Controls.LeftMarginConverter
+Dynamo.Controls.LeftMarginConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
+Dynamo.Controls.LeftMarginConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
+Dynamo.Controls.LeftMarginConverter.LeftMarginConverter() -> void
 Dynamo.Controls.LeftThicknessConverter
 Dynamo.Controls.LeftThicknessConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.LeftThicknessConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
@@ -1999,6 +2003,8 @@ Dynamo.ViewModels.DynamoViewModel.LogText.get -> string
 Dynamo.ViewModels.DynamoViewModel.MainGuideManager.get -> Dynamo.Wpf.UI.GuidedTour.GuidesManager
 Dynamo.ViewModels.DynamoViewModel.MainGuideManager.set -> void
 Dynamo.ViewModels.DynamoViewModel.MakeNewHomeWorkspace(object parameter) -> void
+Dynamo.ViewModels.DynamoViewModel.MinLeftMarginOffset.get -> double
+Dynamo.ViewModels.DynamoViewModel.MinLeftMarginOffset.set -> void
 Dynamo.ViewModels.DynamoViewModel.Model.get -> Dynamo.Models.DynamoModel
 Dynamo.ViewModels.DynamoViewModel.MutateTestDelegateCommand.get -> Dynamo.UI.Commands.DelegateCommand
 Dynamo.ViewModels.DynamoViewModel.MutateTestDelegateCommand.set -> void

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -613,6 +613,24 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
+    /// A custom converter to 'pin' the location of the Home button in place when the slider goes under a certain value
+    /// Do not use for other purposes, and please, do not change
+    /// </summary>
+    public class LeftMarginConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            double offset = (double)value;
+            return new System.Windows.Thickness(offset * 1, 0, offset * -1, 0);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
     public class PathToFileNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -1,8 +1,7 @@
-<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
-    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf"
+                    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf">
 
     <ResourceDictionary.MergedDictionaries>
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
@@ -11,45 +10,38 @@
     <controls:ToolTipFirstLineOnly x:Key="ToolTipFirstLine" />
     <controls:ToolTipAllLinesButFirst x:Key="ToolTipFirstLineNot" />
     <controls:WorkspaceTypeConverter x:Key="WorkspaceTypeConverter" />
-    <controls:WorkspaceBackgroundColorConverter
-        x:Key="WorkspaceBackgroundColorConverter"
-        CustomBackgroundColor="{StaticResource WorkspaceBackgroundCustom}"
-        HomeBackgroundColor="{StaticResource WorkspaceBackgroundHome}" />
-    <controls:WorkspaceBackgroundBrushConverter
-        x:Key="WorkspaceBackgroundBrushConverter"
-        CustomBackgroundBrush="{StaticResource WorkspaceBackgroundCustomBrush}"
-        HomeBackgroundBrush="{StaticResource WorkspaceBackgroundHomeBrush}" />
+    <controls:WorkspaceBackgroundColorConverter x:Key="WorkspaceBackgroundColorConverter"
+                                                CustomBackgroundColor="{StaticResource WorkspaceBackgroundCustom}"
+                                                HomeBackgroundColor="{StaticResource WorkspaceBackgroundHome}" />
+    <controls:WorkspaceBackgroundBrushConverter x:Key="WorkspaceBackgroundBrushConverter"
+                                                CustomBackgroundBrush="{StaticResource WorkspaceBackgroundCustomBrush}"
+                                                HomeBackgroundBrush="{StaticResource WorkspaceBackgroundHomeBrush}" />
 
     <controls:MarginConverter x:Key="MarginConverter" />
 
-    <controls:BooleanToBrushConverter
-        x:Key="BooleanToBrushConverter"
-        FalseBrush="Black"
-        TrueBrush="#6AC0E7" />
+    <controls:BooleanToBrushConverter x:Key="BooleanToBrushConverter"
+                                      FalseBrush="Black"
+                                      TrueBrush="#6AC0E7" />
 
-    <controls:BooleanToBrushConverter
-        x:Key="PortConnectedBooleanToBrushConverter"
-        FalseBrush="White"
-        TrueBrush="Black" />
+    <controls:BooleanToBrushConverter x:Key="PortConnectedBooleanToBrushConverter"
+                                      FalseBrush="White"
+                                      TrueBrush="Black" />
 
-    <controls:BooleanToSelectionColorConverter
-        x:Key="BooleanToSelectionColorConverter"
-        False="#444"
-        True="#6AC0E7" />
+    <controls:BooleanToSelectionColorConverter x:Key="BooleanToSelectionColorConverter"
+                                               False="#444"
+                                               True="#6AC0E7" />
 
-    <controls:ConnectionStateToColorConverter
-        x:Key="ConnectionStateToColorConverter"
-        ExecutionPreview="#F2930C"
-        None="#444"
-        Selection="#6AC0E7"
-        Hover="#808080"/>
+    <controls:ConnectionStateToColorConverter x:Key="ConnectionStateToColorConverter"
+                                              ExecutionPreview="#F2930C"
+                                              Hover="#808080"
+                                              None="#444"
+                                              Selection="#6AC0E7" />
 
     <controls:ConnectionStateToBrushConverter x:Key="ConnectionStateToBrushConverter"
                                               ExecutionPreviewBrush="#F2930C"
-                                              SelectionBrush="#6AC0E7"
                                               HoverBrush="#808080"
-                                              NoneBrush="#444">
-    </controls:ConnectionStateToBrushConverter>
+                                              NoneBrush="#444"
+                                              SelectionBrush="#6AC0E7" />
 
     <controls:ConnectionStateToVisibilityCollapsedConverter x:Key="ConnectionStateToVisibilityCollapsedConverter" />
     <controls:AttachmentToPathConverter x:Key="AttachmentToPathConverter" />
@@ -86,15 +78,15 @@
     <controls:AutoLacingToVisibilityConverter x:Key="AutoLacingToVisibilityConverter" />
     <controls:LacingToAbbreviationConverter x:Key="LacingToAbbreviationConverter" />
     <controls:LacingToTooltipConverter x:Key="LacingToTooltipConverter" />
-    <controls:NodeWarningConverter x:Key="NodeWarningConverter"/>
+    <controls:NodeWarningConverter x:Key="NodeWarningConverter" />
     <controls:NodeOriginalNameToMarginConverter x:Key="NodeOriginalNameToMarginConverter" />
     <controls:BoolToFAIconNameConverter x:Key="BoolToFAIconNameConverter" />
     <controls:BoolToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <controls:BoolToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
     <controls:InverseBooleanToVisibilityCollapsedConverter x:Key="InverseBoolToVisibilityCollapsedConverter" />
     <controls:EmptyToVisibilityCollapsedConverter x:Key="EmptyToVisibilityCollapsedConverter" />
-    <controls:ZeroToVisibilityCollapsedConverter x:Key="ZeroToVisibilityCollapsedConverter" />    
-    <controls:EmptyToZeroLengthConverter x:Key="EmptyToZeroLengthConverter"/>
+    <controls:ZeroToVisibilityCollapsedConverter x:Key="ZeroToVisibilityCollapsedConverter" />
+    <controls:EmptyToZeroLengthConverter x:Key="EmptyToZeroLengthConverter" />
     <controls:NavigationToOpacityConverter x:Key="NavigationToOpacityConverter" />
     <controls:ViewButtonClipRectConverter x:Key="ViewButtonClipRectConverter" />
     <controls:ZoomToOpacityConverter x:Key="ZoomToOpacityConverter" />
@@ -131,14 +123,12 @@
     <controls:SearchHighlightMarginConverter x:Key="SearchHighlightMarginConverter" />
     <controls:ConfidenceScoreFormattingConverter x:Key="ConfidenceScoreFormattingConverter" />
     <controls:InOutParamTypeConverter x:Key="InOutParamTypeConverter" />
-    <controls:NodeTypeToColorConverter
-        x:Key="NodeTypeToColorConverter"
-        FalseBrush="#777777"
-        TrueBrush="#cccccc" />
-    <controls:BooleanToBrushConverter
-        x:Key="DescriptionToColorConverter"
-        FalseBrush="#666666"
-        TrueBrush="#cccccc" />
+    <controls:NodeTypeToColorConverter x:Key="NodeTypeToColorConverter"
+                                       FalseBrush="#777777"
+                                       TrueBrush="#cccccc" />
+    <controls:BooleanToBrushConverter x:Key="DescriptionToColorConverter"
+                                      FalseBrush="#666666"
+                                      TrueBrush="#cccccc" />
     <controls:GroupFontSizeToEditorEnabledConverter x:Key="GroupFontSizeToEditorEnabledConverter" />
     <controls:ElementTypeToShortConverter x:Key="ElementTypeToShortConverter" />
     <controls:GroupTitleVisibilityConverter x:Key="GroupTitleVisibilityConverter" />
@@ -157,30 +147,24 @@
     <controls:ClassViewMarginConverter x:Key="ClassViewMarginConverter" />
     <controls:ElementGroupToColorConverter x:Key="ElementGroupToColorConverter" />
     <controls:RgbaStringToBrushConverter x:Key="RgbaStringToBrushConverter" />
-    <controls:BooleanToBrushConverter
-        x:Key="FilterIsSelertedCategoryToBrushConverter"
-        FalseBrush="{StaticResource FilterCategoryIsNotSelectedColor}"
-        TrueBrush="{StaticResource CommonSidebarTextColor}" />
-    <controls:BooleanToBrushConverter
-        x:Key="FilterIconForegroundConverter"
-        FalseBrush="{StaticResource LibraryItemHostBackground}"
-        TrueBrush="{StaticResource FilterIconColor}" />
-    <controls:BooleanToBrushConverter
-        x:Key="FilterIsSelertedCategoryForegroundConverter"
-        FalseBrush="{StaticResource NodeCategoryForeground}"
-        TrueBrush="{StaticResource NodeNameForeground}" />
-    <controls:BooleanToBrushConverter
-        x:Key="CompactLayoutForegroundConverter"
-        FalseBrush="{StaticResource NodeNameForeground}"
-        TrueBrush="{StaticResource UnSelectedLayoutForeground}" />
-    <controls:BooleanToBrushConverter
-        x:Key="DetailedLayoutForegroundConverter"
-        FalseBrush="{StaticResource UnSelectedLayoutForeground}"
-        TrueBrush="{StaticResource NodeNameForeground}" />
-    <controls:BooleanToBrushConverter
-        x:Key="PinIconForegroundConverter"
-        FalseBrush="{StaticResource UnpinnedIconForegroundColor}"
-        TrueBrush="{StaticResource PinnedIconForegroundColor}" />
+    <controls:BooleanToBrushConverter x:Key="FilterIsSelertedCategoryToBrushConverter"
+                                      FalseBrush="{StaticResource FilterCategoryIsNotSelectedColor}"
+                                      TrueBrush="{StaticResource CommonSidebarTextColor}" />
+    <controls:BooleanToBrushConverter x:Key="FilterIconForegroundConverter"
+                                      FalseBrush="{StaticResource LibraryItemHostBackground}"
+                                      TrueBrush="{StaticResource FilterIconColor}" />
+    <controls:BooleanToBrushConverter x:Key="FilterIsSelertedCategoryForegroundConverter"
+                                      FalseBrush="{StaticResource NodeCategoryForeground}"
+                                      TrueBrush="{StaticResource NodeNameForeground}" />
+    <controls:BooleanToBrushConverter x:Key="CompactLayoutForegroundConverter"
+                                      FalseBrush="{StaticResource NodeNameForeground}"
+                                      TrueBrush="{StaticResource UnSelectedLayoutForeground}" />
+    <controls:BooleanToBrushConverter x:Key="DetailedLayoutForegroundConverter"
+                                      FalseBrush="{StaticResource UnSelectedLayoutForeground}"
+                                      TrueBrush="{StaticResource NodeNameForeground}" />
+    <controls:BooleanToBrushConverter x:Key="PinIconForegroundConverter"
+                                      FalseBrush="{StaticResource UnpinnedIconForegroundColor}"
+                                      TrueBrush="{StaticResource PinnedIconForegroundColor}" />
     <controls:NestedGroupsLabelConverter x:Key="NestedGroupsLabelConverter" />
     <controls:CollectionHasMoreThanNItemsToBoolConverter x:Key="CollectionHasMoreThanNItemsToBoolConverter" />
     <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
@@ -188,4 +172,5 @@
     <controls:TextForegroundSaturationColorConverter x:Key="TextForegroundSaturationColorConverter" />
     <controls:PortTypeToStringConverter x:Key="PortTypeToStringConverter" />
     <controls:BooleanNegationConverter x:Key="BooleanNegationConverter" />
+    <controls:LeftMarginConverter x:Key="LeftMarginConverter" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -366,6 +366,23 @@ namespace Dynamo.ViewModels
             }
         }
 
+        private double minLeftMarignOffset;
+        /// <summary>
+        /// The 
+        /// </summary>
+        public double MinLeftMarginOffset
+        {
+            get => minLeftMarignOffset;
+            set
+            {
+                if(minLeftMarignOffset != value)
+                {
+                    minLeftMarignOffset = value;
+                    RaisePropertyChanged(nameof(MinLeftMarginOffset));
+                }
+            }
+        }
+
         /// <summary>
         /// Indicates if preview bubbles should be displayed on nodes.
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -807,6 +807,7 @@
                                                                     Width="42"
                                                                     Height="42"
                                                                     Margin="{Binding MinLeftMarginOffset, Converter={StaticResource LeftMarginConverter}}"
+                                                                    Panel.ZIndex="1"
                                                                     BorderThickness="0"
                                                                     Click="HomeButton_Click"
                                                                     Cursor="Hand">

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -806,6 +806,7 @@
                                                             <Button Name="HomeButton"
                                                                     Width="42"
                                                                     Height="42"
+                                                                    Margin="{Binding MinLeftMarginOffset, Converter={StaticResource LeftMarginConverter}}"
                                                                     BorderThickness="0"
                                                                     Click="HomeButton_Click"
                                                                     Cursor="Hand">

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -269,6 +269,7 @@ namespace Dynamo.Controls
             }
 
             DefaultMinWidth = MinWidth;
+            PinHomeButton();
         }
         private void OnRequestCloseHomeWorkSpace()
         {
@@ -2918,17 +2919,18 @@ namespace Dynamo.Controls
             UpdateLibraryCollapseIcon();
         }
 
+        // The Workspace TabItems must appear to the right of icon buttons (New File, Open, Save, Undo, Redo)
+        // but never overlap them. 230 is the minimum offset required to achieve this. 
+        // If the library panel is stretched greater than 230, they must align with its width instead.
+        private const int FirstTabItemMinimumLeftMarginOffset = 230;
+        private const int LibraryScrollBarWidth = 15;
+
         /// <summary>
         /// Updates the workspace TabItems to have the correct margins in response to events
         /// such as the library being stretched or a Custom Node workspace being created.
         /// </summary>
         private void UpdateWorkspaceTabSizes()
         {
-            // The Workspace TabItems must appear to the right of icon buttons (New File, Open, Save, Undo, Redo)
-            // but never overlap them. 230 is the minimum offset required to achieve this. 
-            // If the library panel is stretched greater than 230, they must align with its width instead.
-            const int FirstTabItemMinimumLeftMarginOffset = 230;
-            const int LibraryScrollBarWidth = 15;
             
             // We measure the full library width at runtime.
             int fullLibraryWidth = dynamoViewModel.LibraryWidth + LibraryScrollBarWidth;
@@ -2953,6 +2955,8 @@ namespace Dynamo.Controls
             {
                 tabItem.Margin = new System.Windows.Thickness(-leftMargin, 0, leftMargin, 0);
             }
+
+            PinHomeButton();
         }
 
         private void DynamoView_OnDrop(object sender, DragEventArgs e)
@@ -3076,6 +3080,26 @@ namespace Dynamo.Controls
         {
             if (this.dynamoViewModel.ShowStartPage)
                 this.dynamoViewModel.ShowStartPage = false;
+        }
+
+        private void PinHomeButton()
+        {
+            const int minimumLeftMarginOffset = FirstTabItemMinimumLeftMarginOffset - LibraryScrollBarWidth;
+
+            var parentGrid = (Grid)verticalSplitter.Parent;
+            var columnWidth = parentGrid.ColumnDefinitions[0].ActualWidth == 0
+                ? dynamoViewModel.LibraryWidth + LibraryScrollBarWidth
+                : parentGrid.ColumnDefinitions[0].ActualWidth;
+
+            // Constrain the position of the HomeButton.
+            if (columnWidth < minimumLeftMarginOffset)
+            {
+                this.dynamoViewModel.MinLeftMarginOffset = minimumLeftMarginOffset - columnWidth;
+            }
+            else
+            {
+                this.dynamoViewModel.MinLeftMarginOffset = 0;
+            }
         }
 
         public void Dispose()

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -377,8 +377,11 @@ namespace Dynamo.PackageManager
         /// </summary>
         internal static bool IsVersionCompatible(Greg.Responses.Compatibility compatibility, Version version)
         {
+            // Start by trimming away the Revision value 
+            version = VersionUtilities.NormalizeVersion(version);
+
             // Check if the version is explicitly listed
-            bool isListedInVersions = compatibility.versions?.Contains(version.ToString()) ?? false;
+            bool isListedInVersions = NormalizeAndContain(compatibility.versions, version);
 
             // Parse min and max values, if provided, and check for valid range
             bool isWithinMinMax = false;
@@ -419,6 +422,33 @@ namespace Dynamo.PackageManager
             }
 
             return isListedInVersions || isWithinMinMax;
+        }
+
+        // Aligns Dynamo's fully-defined version with Compatibility Matrix partial version strings
+        internal static bool NormalizeAndContain(IEnumerable<string> versionStrings, Version version)
+        {
+            if (versionStrings == null) return false;
+
+            // Normalize the input version to a 3-part format (Major.Minor.Build)
+            var normalizedVersion = VersionUtilities.NormalizeVersion(version);
+
+            foreach (var v in versionStrings)
+            {
+                // Parse and normalize each version string
+                var parsedVersion = VersionUtilities.Parse(v);
+                if (parsedVersion != null)
+                {
+                    var normalizedParsedVersion = VersionUtilities.NormalizeVersion(parsedVersion);
+
+                    // Compare the normalized versions
+                    if (normalizedVersion.Equals(normalizedParsedVersion))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         // Method to find Dynamo compatibility based on other hosts in the compatibilityMatrix

--- a/src/DynamoUtilities/VersionUtilities.cs
+++ b/src/DynamoUtilities/VersionUtilities.cs
@@ -49,7 +49,7 @@ namespace Dynamo.Utilities
             // Try parsing directly; if successful, return the parsed version
             if (Version.TryParse(version, out Version parsedVersion))
             {
-                return parsedVersion;
+                return NormalizeVersion(parsedVersion);
             }
 
             // If parsing failed, pad the version string
@@ -127,6 +127,20 @@ namespace Dynamo.Utilities
         private static string AppendWildcardVersion(string major, string minor = WILDCARD_MAX_VERSION, string patch = "0")
         {
             return $"{major}.{minor}.{patch}";
+        }
+
+        /// <summary>
+        /// Helper method to normalize versions to a 3-part format
+        /// </summary>
+        /// <param name="version">A potentially partial version</param>
+        /// <returns></returns>
+        internal static Version NormalizeVersion(Version version)
+        {
+            return new Version(
+                version.Major,
+                version.Minor == -1 ? 0 : version.Minor,
+                version.Build == -1 ? 0 : version.Build
+            );
         }
     }
 }

--- a/test/DynamoCoreTests/VersionUtilitiesTests.cs
+++ b/test/DynamoCoreTests/VersionUtilitiesTests.cs
@@ -113,7 +113,7 @@ namespace Dynamo.Tests
             Version result = VersionUtilities.Parse(version);
 
             // Assert
-            Assert.AreEqual(new Version(2019, 1, 2, 0), result, "Expected version '2019.1.2.0' when input is '2019.1.2.0'.");
+            Assert.AreEqual(new Version(2019, 1, 2), result, "Expected version '2019.1.2' when input is '2019.1.2.0'.");
         }
 
         [Test]
@@ -256,6 +256,28 @@ namespace Dynamo.Tests
 
             // Assert
             Assert.IsNull(result, "Expected null when input has too many components '1.2.3.4.*'.");
+        }
+
+        [Test]
+        public void NormalizeVersion_ShouldReturnCorrectlyNormalizedVersion()
+        {
+            // Test case 1: Partial version with only Major
+            Version.TryParse("3.0", out Version input1);
+            var expected1 = new Version(3, 0, 0);
+            var result1 = VersionUtilities.NormalizeVersion(input1);
+            Assert.AreEqual(expected1, result1, $"Expected {expected1} but got {result1}");
+
+            // Test case 2: Partial version with Major and Minor
+            Version.TryParse("3.1", out Version input2);
+            var expected2 = new Version(3, 1, 0);
+            var result2 = VersionUtilities.NormalizeVersion(input2);
+            Assert.AreEqual(expected2, result2, $"Expected {expected2} but got {result2}");
+
+            // Test case 3: Full version that doesn't need normalization
+            var input3 = new Version(3, 1, 2);
+            var expected3 = new Version(3, 1, 2);
+            var result3 = VersionUtilities.NormalizeVersion(input3);
+            Assert.AreEqual(expected3, result3, $"Expected {expected3} but got {result3}");
         }
 
     }

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -1146,12 +1146,12 @@ namespace Dynamo.PackageManager.Wpf.Tests
 
 
         [Test]
-        [TestCase("2.9.9", false)] // Incompatible Dynamo version
-        [TestCase("3.0.0", true)]  // Compatible Dynamo version
-        [TestCase("3.1.0", true)]  // Compatible Dynamo version
-        [TestCase("3.2.2", true)]  // Compatible Dynamo version
-        [TestCase("3.3.0", false)] // Incompatible Dynamo version
-        [TestCase("3.4.0", false)] // Incompatible Dynamo version
+        [TestCase("2.9.9.2114", false)] // Incompatible Dynamo version
+        [TestCase("3.0.0.2114", true)]  // Compatible Dynamo version
+        [TestCase("3.1.0.2114", true)]  // Compatible Dynamo version
+        [TestCase("3.2.2.2114", true)]  // Compatible Dynamo version
+        [TestCase("3.3.0.2114", false)] // Incompatible Dynamo version
+        [TestCase("3.4.0.2114", false)] // Incompatible Dynamo version
         public void TestComputeMultipleSingleCompatibility(string dynamoVersion, bool expectedCompatibility)
         {
             // Arrange
@@ -1171,21 +1171,21 @@ namespace Dynamo.PackageManager.Wpf.Tests
         }
 
         [Test]
-        [TestCase("2.19", true)] // Compatible Dynamo version
-        [TestCase("2.19.1", false)] // Incompatible Dynamo version
-        [TestCase("2.19.5", true)] // Compatible Dynamo version
-        [TestCase("2.19.6", true)] // Compatible Dynamo version
-        [TestCase("3.0.0", true)]  // Compatible Dynamo version
-        [TestCase("3.1.0", true)]  // Compatible Dynamo version
-        [TestCase("3.2.2", true)]  // Compatible Dynamo version
-        [TestCase("3.3.0", false)] // Incompatible Dynamo version
+        [TestCase("2.19.0.2114", true)] // Compatible Dynamo version
+        [TestCase("2.19.1.2114", false)] // Incompatible Dynamo version
+        [TestCase("2.19.5.2114", true)] // Compatible Dynamo version
+        [TestCase("2.19.6.2114", true)] // Compatible Dynamo version
+        [TestCase("3.0.0.2114", true)]  // Compatible Dynamo version
+        [TestCase("3.1.0.2114", true)]  // Compatible Dynamo version
+        [TestCase("3.2.2.2114", true)]  // Compatible Dynamo version
+        [TestCase("3.3.0.1232", false)] // Incompatible Dynamo version
         [TestCase("3.4.0.6825", true)] // Compatible Dynamo version
         public void TestComputeMinMaxMultipleSingleCompatibility(string dynamoVersion, bool expectedCompatibility)
         {
             // Arrange
             var hostOnlyCompatibilityMatrix = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "dynamo", min = "2.19.5", max = "3.2.2", versions = new List<string> { "2.19", "3.4.0.6825" } }
+                new Greg.Responses.Compatibility { name = "dynamo", min = "2.19.5", max = "3.2.2", versions = new List<string> { "2.19", "3.4.0" } }
             };
 
             var versionToTest = new Version(dynamoVersion);
@@ -1198,16 +1198,16 @@ namespace Dynamo.PackageManager.Wpf.Tests
             Assert.AreEqual(expectedCompatibility, result, $"Expected compatibility to be {expectedCompatibility} for version {dynamoVersion}.");
         }
 
-        [TestCase("3.1", true)]  // Compatible Dynamo version
-        [TestCase("3.1.0", false)]  // Incompatible Dynamo version
-        [TestCase("3.4.0", false)] // Incompatible Dynamo version
+        [TestCase("3.1.0.2123", true)]  // Compatible Dynamo version
         [TestCase("3.4.0.6825", true)] // Compatible Dynamo version
+        [TestCase("2.19.0.6825", false)] // Incompatible Dynamo version
+        [TestCase("2.0.0.6825", true)] // Compatible Dynamo version
         public void TestPreciseSingleCompatibility(string dynamoVersion, bool expectedCompatibility)
         {
             // Arrange
             var hostOnlyCompatibilityMatrix = new List<Greg.Responses.Compatibility>
             {
-                new Greg.Responses.Compatibility { name = "dynamo", versions = new List<string> { "3.1", "3.4.0.6825" } }
+                new Greg.Responses.Compatibility { name = "dynamo", versions = new List<string> { "3.1", "3.4.0", "2" } }
             };
 
             var versionToTest = new Version(dynamoVersion);
@@ -1591,6 +1591,28 @@ namespace Dynamo.PackageManager.Wpf.Tests
 
             Assert.IsTrue(PackageManagerSearchElement.IsVersionCompatible(compatibility, version),
                           "Expected compatibility to be true when major version is greater than Max major version and there is an invalid max range.");
+        }
+
+        [Test]
+        public void NormalizeAndCompareVersionStringList_ShouldSucceed()
+        {
+
+            var versions = new List<string> { "2.1.0", "2.3.0", "2", "2.4.*", "afs" };
+            var version = new Version(2,1,0,1252);
+
+            var isListedInVersions = PackageManagerSearchElement.NormalizeAndContain(versions, version);
+            Assert.IsTrue(isListedInVersions);
+        }
+
+        [Test]
+        public void NormalizeAndCompareVersionStringList_ShouldFail()
+        {
+
+            var versions = new List<string> { "2.19" };
+            var version = new Version(2, 19, 1, 1252);
+
+            var isListedInVersions = PackageManagerSearchElement.NormalizeAndContain(versions, version);
+            Assert.IsFalse(isListedInVersions);
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Dynamo;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.PackageManager;
@@ -75,6 +76,38 @@ namespace DynamoCoreWpfTests
             Assert.AreNotEqual(vm.UploadState, PackageUploadHandle.State.Uploaded);
             Console.WriteLine(vm.ErrorString);
 
+        }
+
+        [Test]
+        public void CanRemoveCustomNodesWithIdenticalNames()
+        {
+            var vm = new PublishPackageViewModel(this.ViewModel);
+
+            // Arrange
+            var customNode1 = new CustomNodeDefinition(Guid.NewGuid(), "Geometry.Curve", new List<NodeModel>());
+            var customNode2 = new CustomNodeDefinition(Guid.NewGuid(), "Building.Curve", new List<NodeModel>());
+            var customNode3 = new CustomNodeDefinition(Guid.NewGuid(), "Curve", new List<NodeModel>());
+
+            vm.CustomNodeDefinitions.Add(customNode1);
+            vm.CustomNodeDefinitions.Add(customNode2);
+            vm.CustomNodeDefinitions.Add(customNode3);
+
+            // Initial Assert
+            Assert.AreEqual(3, vm.CustomNodeDefinitions.Count);
+
+            var item1 = new PackageItemRootViewModel("Geometry.Curve.dyf", "C:\\test\\Geometry.Curve.dyf");
+            var item2 = new PackageItemRootViewModel("Building.Curve.dyf", "C:\\test\\Building.Curve.dyf");
+            var item3 = new PackageItemRootViewModel("Curve.dyf", "C:\\test\\Curve.dyf");
+
+            // Assert
+            vm.RemoveSingleItem(item1, DependencyType.CustomNodePreview);
+            Assert.AreEqual(2, vm.CustomNodeDefinitions.Count);
+
+            vm.RemoveSingleItem(item2, DependencyType.CustomNodePreview);
+            Assert.AreEqual(1, vm.CustomNodeDefinitions.Count);
+
+            vm.RemoveSingleItem(item3, DependencyType.CustomNodePreview);
+            Assert.AreEqual(0, vm.CustomNodeDefinitions.Count);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Follow up of https://github.com/DynamoDS/Dynamo/pull/15704, Cherry-picking 

DYN-7946
- https://github.com/DynamoDS/Dynamo/pull/15694

DYN-7945
- https://github.com/DynamoDS/Dynamo/pull/15692
- https://github.com/DynamoDS/Dynamo/pull/15702

DYN-7889
- https://github.com/DynamoDS/Dynamo/pull/15682

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
