### PR TITLE
DYN-7927 Prevent Crash from none styled Infobubble

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
@@ -16,6 +16,7 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.UI;
 using Dynamo.Wpf.Utilities;
+using Microsoft.VisualBasic.Logging;
 using InfoBubbleViewModel = Dynamo.ViewModels.InfoBubbleViewModel;
 
 namespace Dynamo.Controls
@@ -277,7 +278,8 @@ namespace Dynamo.Controls
                     SetStyle_ErrorCondensed();
                     break;
                 case InfoBubbleViewModel.Style.None:
-                    throw new ArgumentException("InfoWindow didn't have a style (456B24E0F400)");
+                    ViewModel.DynamoViewModel.Model.Logger.Log("InfoWindow didn't have a style (456B24E0F400)");
+                    break;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -16,7 +16,6 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.UI;
 using Dynamo.Wpf.Utilities;
-using Microsoft.VisualBasic.Logging;
 using InfoBubbleViewModel = Dynamo.ViewModels.InfoBubbleViewModel;
 
 namespace Dynamo.Controls


### PR DESCRIPTION
### Purpose

Some convert exception would cause `Convert By Units` to throw an exception and with no InfoBubble style, Dynamo got a crash from some code 13 years ago. Never happened in my experiences, so I am going to log it instead of throwing. 

There was no comment about what the value `456B24E0F400` means so if anyone has idea, please let me know.
![image](https://github.com/user-attachments/assets/4f15d9cc-f0b6-476a-8780-3a46de936ce8)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
