### PR TITLE
DYN-7927 Prevent Crash from none styled Infobubble (#15707)

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
@@ -277,7 +277,8 @@ namespace Dynamo.Controls
                     SetStyle_ErrorCondensed();
                     break;
                 case InfoBubbleViewModel.Style.None:
-                    throw new ArgumentException("InfoWindow didn't have a style (456B24E0F400)");
+                    ViewModel.DynamoViewModel.Model.Logger.Log("InfoWindow didn't have a style (456B24E0F400)");
+                    break;
             }
         }
 


### PR DESCRIPTION
### Purpose

DYN-7927 Prevent Crash from none styled Infobubble (#15707)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Prevent Crash from none styled Infobubble created by switching between units on `Convert by Units` node

### Reviewers



### FYIs

@DynamoDS/dynamo 