### PR TITLE
[DYN-7838] Color range Node: Show Input ports with default value

### DIFF
--- a/src/Libraries/CoreNodeModels/ColorRange.cs
+++ b/src/Libraries/CoreNodeModels/ColorRange.cs
@@ -32,6 +32,15 @@ namespace CoreNodeModels
     [AlsoKnownAs("DSCoreNodesUI.ColorRange")]
     public class ColorRange : NodeModel
     {
+        private List<Color> _defaultColors;
+        private List<Color> DefaultColors => _defaultColors ??= DefaultColorRanges.Analysis.ToList();
+
+        private AssociativeNode _defaultColorsNode;
+        private AssociativeNode DefaultColorsNode => _defaultColorsNode ??= CreateDefaultColorsNode(DefaultColors);
+
+        private AssociativeNode _defaultIndicesNode;
+        private AssociativeNode DefaultIndicesNode => _defaultIndicesNode ??= CreateDefaultIndicesNode(DefaultColors);
+
         public event Action RequestChangeColorRange;
         protected virtual void OnRequestChangeColorRange()
         {
@@ -42,6 +51,18 @@ namespace CoreNodeModels
         [JsonConstructor]
         private ColorRange(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
+            if (inPorts.Count() == 3 && outPorts.Count() == 1)
+            {
+                inPorts.ElementAt(0).DefaultValue = DefaultColorsNode;
+                inPorts.ElementAt(1).DefaultValue = DefaultIndicesNode;
+            }
+            else
+            {
+                // If information from json does not look correct, clear the default ports and add ones with default value
+                InPorts.Clear();
+                InitializePorts();
+            }
+
             this.PropertyChanged += ColorRange_PropertyChanged;
             foreach (var port in InPorts)
             {
@@ -51,6 +72,8 @@ namespace CoreNodeModels
 
         public ColorRange()
         {
+            // Initialize default values of the ports
+            InitializePorts();
             RegisterAllPorts();
 
             this.PropertyChanged += ColorRange_PropertyChanged;
@@ -58,6 +81,14 @@ namespace CoreNodeModels
             {
                 port.Connectors.CollectionChanged += Connectors_CollectionChanged;
             }
+        }
+
+        private void InitializePorts()
+        {
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("colors", Resources.ColorRangePortDataColorsToolTip, DefaultColorsNode)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("indices", Resources.ColorRangePortDataIndicesToolTip, DefaultIndicesNode)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("value", Resources.ColorRangePortDataValueToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("color", Resources.ColorRangePortDataResultToolTip)));            
         }
 
         void Connectors_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -119,7 +150,7 @@ namespace CoreNodeModels
             List<double> parameters;
 
             // If there are colors supplied
-            if (InPorts[0].IsConnected)
+            if (InPorts[0].Connectors.Any())
             {
                 var colorsNode = InPorts[0].Connectors[0].Start.Owner;
                 var colorsIndex = InPorts[0].Connectors[0].Start.Index;
@@ -131,10 +162,14 @@ namespace CoreNodeModels
             {
                 colors = new List<Color>();
                 colors.AddRange(DefaultColorRanges.Analysis);
+
+                // Create an AssociativeNode for the default colors
+                InPorts[0].DefaultValue = DefaultColorsNode;
+                InPorts[0].UsingDefaultValue = true;
             }
 
             // If there are indices supplied
-            if (InPorts[1].IsConnected)
+            if (InPorts[1].Connectors.Any())
             {
                 var valuesNode = InPorts[1].Connectors[0].Start.Owner;
                 var valuesIndex = InPorts[1].Connectors[0].Start.Index;
@@ -145,9 +180,41 @@ namespace CoreNodeModels
             else
             {
                 parameters = CreateParametersForColors(colors);
+
+                // Create an AssociativeNode for the default indices
+                InPorts[1].DefaultValue = DefaultIndicesNode;
+                InPorts[1].UsingDefaultValue = true;
             }
 
             return ColorRange1D.ByColorsAndParameters(colors, parameters);
+        }
+
+        private AssociativeNode CreateDefaultColorsNode(List<Color> defaultColors)
+        {
+            return AstFactory.BuildExprList(
+                    defaultColors.Select(color =>
+                        AstFactory.BuildFunctionCall(
+                            new Func<int, int, int, int, Color>(DSCore.Color.ByARGB),
+                            new List<AssociativeNode>
+                            {
+                                AstFactory.BuildIntNode(color.Red),
+                                AstFactory.BuildIntNode(color.Green),
+                                AstFactory.BuildIntNode(color.Blue)
+                            }
+                        )
+                    ).ToList()
+                );
+        }
+
+        private AssociativeNode CreateDefaultIndicesNode(List<Color> defaultColors)
+        {
+            var parameters = CreateParametersForColors(defaultColors);
+
+            return AstFactory.BuildExprList(
+                parameters.Select(AstFactory.BuildDoubleNode)
+                .Cast<AssociativeNode>()
+                .ToList()
+            );
         }
 
         private static List<double> CreateParametersForColors(List<Color> colors)


### PR DESCRIPTION
### Purpose

This PR aims to address [DYN-7838](https://jira.autodesk.com/browse/DYN-7838) where two input ports (colors and indices) were not showing as blue to indicate they have default values. Default values are now assigned during initialization, and the ports can toggle between using default values and user-supplied inputs.

I've added initialization for default values `DefaultColorsNode` and `DefaultIndicesNode`.
Updated the initialization logic for input ports to correctly display their default state.
Users can still override default values when needed.

![DYN-7838-ColorRangeInPortsFix](https://github.com/user-attachments/assets/b41f9f59-a174-4400-8cc9-6cc3e7551b3f)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

This PR aims to address [DYN-7838](https://jira.autodesk.com/browse/DYN-7838) where two input ports (colors and indices) were not showing as blue to indicate they have default values. Default values are now assigned during initialization, and the ports can toggle between using default values and user-supplied inputs.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
