### PR TITLE
DYN-7601: resizable string nodes

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -13,7 +13,6 @@ using Dynamo.Migration;
 using Dynamo.Utilities;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
-using ProtoCore.DSASM;
 
 namespace CoreNodeModels.Input
 {
@@ -36,6 +35,16 @@ namespace CoreNodeModels.Input
                 return "StringInputNode";
             }
         }
+
+        /// <summary>
+        /// The serialized Width property of the text input; Width is taken and JsonIgnore applied to
+        /// </summary>
+        public double SerializedWidth { get; set; }
+
+        /// <summary>
+        /// The serialized Height property of the text input; Height is taken and JsonIgnore applied to
+        /// </summary>
+        public double SerializedHeight { get; set; }
 
         [JsonConstructor]
         private StringInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -36,15 +36,40 @@ namespace CoreNodeModels.Input
             }
         }
 
+
+        private double _serializedWidth;
         /// <summary>
         /// The serialized Width property of the text input; Width is taken and JsonIgnore applied to
         /// </summary>
-        public double SerializedWidth { get; set; }
+        public double SerializedWidth
+        {
+            get => _serializedWidth;
+            set
+            {
+                if (_serializedWidth != value)
+                {
+                    _serializedWidth = value;
+                    RaisePropertyChanged(nameof(SerializedWidth)); // Notify change
+                }
+            }
+        }
 
+        private double _serializedHeight;
         /// <summary>
         /// The serialized Height property of the text input; Height is taken and JsonIgnore applied to
         /// </summary>
-        public double SerializedHeight { get; set; }
+        public double SerializedHeight
+        {
+            get => _serializedHeight;
+            set
+            {
+                if (_serializedHeight != value)
+                {
+                    _serializedHeight = value;
+                    RaisePropertyChanged(nameof(SerializedHeight)); // Notify change
+                }
+            }
+        }
 
         [JsonConstructor]
         private StringInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
@@ -70,6 +95,16 @@ namespace CoreNodeModels.Input
                 Value = value; 
                 return true; // UpdateValueCore handled.
             }
+            if (name == "SerializedWidth" && double.TryParse(value, out double width))
+            {
+                SerializedWidth = width;
+                return true; // UpdateValueCore handled
+            }
+            if (name == "SerializedHeight" && double.TryParse(value, out double height))
+            {
+                SerializedHeight = height;
+                return true; // UpdateValueCore handled
+            }
 
             // There's another 'UpdateValueCore' method in 'String' base class,
             // since they are both bound to the same property, 'StringInput' 
@@ -85,6 +120,8 @@ namespace CoreNodeModels.Input
 
             var helper = new XmlElementHelper(outEl);
             helper.SetAttribute("value", SerializeValue());
+            helper.SetAttribute("serializedWidth", SerializedWidth.ToString(CultureInfo.InvariantCulture));
+            helper.SetAttribute("serializedHeight", SerializedHeight.ToString(CultureInfo.InvariantCulture));
             nodeElement.AppendChild(outEl);
         }
 
@@ -100,6 +137,14 @@ namespace CoreNodeModels.Input
                         if (attr.Name.Equals("value"))
                         {
                             Value = DeserializeValue(attr.Value);
+                        }
+                        if (attr.Name.Equals("serializedWidth") && double.TryParse(attr.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out double width))
+                        {
+                            SerializedWidth = width;
+                        }
+                        if (attr.Name.Equals("serializedHeight") && double.TryParse(attr.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out double height))
+                        {
+                            SerializedHeight = height;
                         }
                     }
                 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/StringInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/StringInput.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using CoreNodeModels.Input;
 using Dynamo.Controls;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Nodes;
 using Dynamo.UI.Prompts;
 using Dynamo.ViewModels;
@@ -19,6 +20,7 @@ namespace CoreNodeModelsWpf.Nodes
     public class StringInputNodeViewCustomization : INodeViewCustomization<StringInput>
     {
         private DynamoViewModel dynamoViewModel;
+        private WorkspaceModel workspace;
         private StringInput nodeModel;
         private MenuItem editWindowItem;
         private readonly int minWidthSize = 100;
@@ -29,6 +31,7 @@ namespace CoreNodeModelsWpf.Nodes
         {
             this.nodeModel = stringInput;
             this.dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
+            this.workspace = this.dynamoViewModel.CurrentSpace;
 
             this.editWindowItem = new MenuItem
             {
@@ -108,6 +111,10 @@ namespace CoreNodeModelsWpf.Nodes
 
                 stringInput.SerializedWidth = tb.ActualWidth;
                 stringInput.SerializedHeight = tb.ActualHeight;
+
+                // Mark the node as modified
+                if(!this.workspace.HasUnsavedChanges)
+                    this.workspace.HasUnsavedChanges = true;
             };
         }
 

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/StringInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/StringInput.cs
@@ -39,16 +39,31 @@ namespace CoreNodeModelsWpf.Nodes
 
             editWindowItem.Click += editWindowItem_Click;
 
-            //add a text box to the input grid of the control
+            // Add a text box to the input grid of the control
             var tb = new StringTextBox
             {
                 AcceptsReturn = true,
                 AcceptsTab = true,
                 TextWrapping = TextWrapping.Wrap,
                 MinHeight = minHeightSize,
-                MaxWidth = defMaxWidthSize,
-                VerticalAlignment = VerticalAlignment.Top
+                VerticalAlignment = VerticalAlignment.Top,
             };
+
+            // Set the recorded Width, if any
+            if (stringInput.SerializedWidth != 0)
+            {
+                tb.Width = stringInput.SerializedWidth;
+            }
+            else
+            {
+                tb.MaxWidth = defMaxWidthSize;
+            }
+
+            // Set the recorded Height, if any
+            if (stringInput.SerializedHeight != 0)
+            {
+                tb.Height = stringInput.SerializedHeight;
+            }
 
             nodeView.inputGrid.Children.Add(tb);
             Grid.SetColumn(tb, 0);
@@ -90,6 +105,9 @@ namespace CoreNodeModelsWpf.Nodes
 
                 stringInput.Width = tb.ActualWidth;
                 stringInput.Height = tb.ActualHeight;
+
+                stringInput.SerializedWidth = tb.ActualWidth;
+                stringInput.SerializedHeight = tb.ActualHeight;
             };
         }
 


### PR DESCRIPTION
### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference to the tracking task that it is part or all of the solution for.

![DynamoSandbox_A7Q1Y3GGFp](https://github.com/user-attachments/assets/42630512-5397-442c-965a-46242a5d1e82)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- resizing via thumb
- removes maxwidth if resizing is done and forfeits auto-expand/shrink capabilities
- now serialized width and height
- different than the Width and Height parameters of the base class 
- add resizing to the undo/redo stack

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
