### PR TITLE
[DYN-4361] Revert changed to WatchTree

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -352,23 +352,19 @@
                             </TextBlock.Style>
                         </TextBlock>
 
-                        <TextBox Width="Auto"
-                                 Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
-                                 VerticalAlignment="Center"
-                                 FontFamily="{StaticResource SourceCodePro}"
-                                 Text="{Binding Path=NodeLabel}"
-                                 Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}"
-                                 IsReadOnly="True"
-                                 Background="Transparent"
-                                 BorderThickness="0"
-                                 TextWrapping="Wrap">
+                        <TextBlock Width="Auto"
+                                   Margin="{Binding Path=IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}"
+                                   VerticalAlignment="Center"                                                                      
+                                   FontFamily="{StaticResource SourceCodePro}"
+                                   Text="{Binding Path=NodeLabel}"
+                                   Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}" >
                             <TextBlock.Foreground>
                                 <MultiBinding Converter="{StaticResource ObjectTypeConverter}">
                                     <Binding Path="ValueType" />
                                     <Binding Path="NodeLabel" />
                                 </MultiBinding>
                             </TextBlock.Foreground>
-                        </TextBox>
+                        </TextBlock>
 
                         <Button Margin="10,2,2,2"
                                 Padding="4,0,4,0"

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -292,12 +292,8 @@ namespace DynamoCoreWpfTests
             var tree = nodeView.ChildrenOfType<WatchTree>();
             Assert.AreEqual(1, tree.Count());
 
-            // text block for list indexes
-            var textBlocks = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(4, textBlocks.Count());
-            // text boxes for list items
-            var textBoxes = tree.First().treeView1.ChildrenOfType<TextBox>();
-            Assert.AreEqual(4, textBoxes.Count());
+            var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
+            Assert.AreEqual(8, items.Count());
         }
 
         [Test, Category("DisplayHardwareDependent")]
@@ -441,12 +437,7 @@ namespace DynamoCoreWpfTests
 
             var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
             // watch is computed with cbn and has its value
-            // text block for list indexes
-            var textBlocks = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(4, textBlocks.Count());
-            // text boxes for list items
-            var textBoxes = tree.First().treeView1.ChildrenOfType<TextBox>();
-            Assert.AreEqual(4, textBoxes.Count());
+            Assert.AreEqual(8, items.Count());
 
             // disconnect watch
             Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
@@ -473,10 +464,8 @@ namespace DynamoCoreWpfTests
             Run();
             DispatcherUtil.DoEvents();
             tree = nodeView.ChildrenOfType<WatchTree>();
-            textBlocks = tree.First().treeView1.ChildrenOfType<TextBlock>();
-            Assert.AreEqual(4, textBlocks.Count());
-            textBoxes = tree.First().treeView1.ChildrenOfType<TextBox>();
-            Assert.AreEqual(4, textBoxes.Count());
+            items = tree.First().treeView1.ChildrenOfType<TextBlock>();
+            Assert.AreEqual(8, items.Count());
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Reverts the changes made to `WatchTree`. Text from `TreeViewItems` can not longer be copied, but the up/down navigation functionality is back.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Reverts the changes made to `WatchTree`. Text from `TreeViewItems` can not longer be copied, but the up/down navigation functionality is back.

### Reviewers
@QilongTang 
@reddyashish 
### FYIs
@dnenov 
