### PR TITLE
DYN-6897 Dynamo Button Disabled Revit

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -41,6 +41,10 @@ namespace Dynamo.UI.Views
         // Used to ensure that OnClosing is called only once.
         private bool IsClosing = false;
 
+        internal enum CloseMode { ByStartingDynamo, ByCloseButton, ByOther };
+
+        internal CloseMode currentCloseMode = CloseMode.ByOther;
+
         // Timer used for Splash Screen loading
         internal Stopwatch loadingTimer;
 
@@ -162,6 +166,7 @@ namespace Dynamo.UI.Views
             RequestSignIn = SignIn;
             RequestSignOut = SignOut;
             this.enableSignInButton = enableSignInButton;
+            currentCloseMode = CloseMode.ByOther;
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -172,6 +177,11 @@ namespace Dynamo.UI.Views
             // webview2.Dispose => webview2.Visible.Set receives windows message => crash because object got disposed. 
             if (!IsClosing)
             {
+                //Means that the SplashScreen was closed by other way for example by using the Windows Task Bar
+                if(currentCloseMode == CloseMode.ByOther)
+                {
+                    CloseWasExplicit = true;
+                }
                 // First call to OnClosing
                 IsClosing = true;
             }
@@ -283,6 +293,7 @@ namespace Dynamo.UI.Views
             {
                 viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;
             }
+            currentCloseMode = CloseMode.ByStartingDynamo;
             Close();
             dynamoView?.Show();
             dynamoView?.Activate();
@@ -574,6 +585,8 @@ namespace Dynamo.UI.Views
         internal void CloseWindow(bool isCheckboxChecked = false)
         {
             CloseWasExplicit = true;
+            currentCloseMode = CloseMode.ByCloseButton;
+
             if (viewModel != null && isCheckboxChecked)
             {
                 viewModel.PreferenceSettings.EnableStaticSplashScreen = !isCheckboxChecked;


### PR DESCRIPTION
### Purpose

When opening Dynamo in Revit2025 and closing the SplashScreen using the Windows TaskBar the Dynamo button is disabled (there is no way to re-enable it) so you need to close Revit to be able to see the Dynamo button enabled again. So in this fix I'm handling the case of re-enable the Dynamo button in Revit when the SplashScreen is closed using the Windows TaskBar (CloseMode.ByOther).

**TODO** - **This is just covering the Scenario 2 described in the Jira task DYN-6897 for the Scenario 1 I'm still checking the problem** but in general until now I found that when closing the DynamoView (after was opened by pressing Start Dynamo in SplashScreen) we are generating the event WM_CLOSE (that's why the Dynamo button is re-enabled immediately) but when closing the SplashScreen using the close button or using the Windows Taskbar the WM_CLOSE event is not generated so the Dynamo button is not enabled immediately in Revit (just when the Revit workspace lose the Focus by clicking in a different part).

This was tested using Revit 2026 (Preview Release 20261111) using the DynamoRevit master branch and Dynamo RC3.4.0 branch.
In DynamoRevit I had to do a one line change for enabling the SplashScreen.
![image](https://github.com/user-attachments/assets/834f736d-6f5e-45b8-bfe6-d862d0b09bd7)

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing Scenario 2 when closing the SplashScreen using the Windows Taskbar and the Dynamo button in Revit is still disabled.

### Reviewers

@QilongTang 

### FYIs

