### PR TITLE
DYN-8045: Fix hanged node search when the user types faster than search

### DIFF
--- a/src/DynamoCore/Search/NodeSearchModel.cs
+++ b/src/DynamoCore/Search/NodeSearchModel.cs
@@ -233,8 +233,8 @@ namespace Dynamo.Search
 
         internal IEnumerable<NodeSearchElement> Search(string search, LuceneSearchUtility luceneSearchUtility)
         {
-            
-            if (luceneSearchUtility != null)
+            if (luceneSearchUtility == null) return null;
+            lock (luceneSearchUtility)
             {
                 //The DirectoryReader and IndexSearcher have to be assigned after commiting indexing changes and before executing the Searcher.Search() method, otherwise new indexed info won't be reflected
                 luceneSearchUtility.dirReader = luceneSearchUtility.writer != null ? luceneSearchUtility.writer.GetReader(applyAllDeletes: true) : DirectoryReader.Open(luceneSearchUtility.indexDir);
@@ -277,7 +277,6 @@ namespace Dynamo.Search
                 }
                 return candidates;
             }
-            return null;
         }
 
         internal NodeSearchElement FindModelForNodeNameAndCategory(string nodeName, string nodeCategory, string parameters)

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -204,7 +204,7 @@ namespace Dynamo.UI.Controls
                                 ExecuteSearchElement(searchElement);
                                 OnRequestShowInCanvasSearch(ShowHideFlags.Hide);
                             }
-                        });
+                        }, DispatcherPriority.Input);
                     });
                     break;
                 case Key.Up:

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -186,7 +186,7 @@ namespace Dynamo.UI.Controls
 
             switch (key)
             {
-                case Key.Escape:    
+                case Key.Escape:
                     OnRequestShowInCanvasSearch(ShowHideFlags.Hide);
                     break;
                 case Key.Enter:

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UILib>true</UILib>
   </PropertyGroup>
@@ -406,6 +406,7 @@
     </Compile>
     <Compile Include="UI\SharedResourceDictionary.cs" />
     <Compile Include="Utilities\PreferencesPanelUtilities.cs" />
+    <Compile Include="Utilities\SerialQueue.cs" />
     <Compile Include="Utilities\WebView2Utilities.cs" />
     <Compile Include="ViewModels\Core\AnnotationExtension.cs" />
     <Compile Include="ViewModels\Core\AnnotationViewModel.cs" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -331,6 +331,7 @@
     <Compile Include="Utilities\CrashReportTool.cs" />
     <Compile Include="Utilities\CrashUtilities.cs" />
     <Compile Include="Utilities\GroupStyleItemSelector.cs" />
+    <Compile Include="Utilities\JobDebouncer.cs" />
     <Compile Include="Utilities\LibraryDragAndDrop.cs" />
     <Compile Include="Utilities\MessageBoxUtilities.cs" />
     <Compile Include="Utilities\NodeContextMenuBuilder.cs" />

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -3672,19 +3672,10 @@ Dynamo.Wpf.Utilities.DynamoWebView2
 Dynamo.Wpf.Utilities.DynamoWebView2.DynamoWebView2() -> void
 Dynamo.Wpf.Utilities.GroupStyleItemSelector
 Dynamo.Wpf.Utilities.GroupStyleItemSelector.GroupStyleItemSelector() -> void
-Dynamo.Wpf.Utilities.JobDebouncer
-Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken
-Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.DebounceQueueToken() -> void
-Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.LastExecutionId -> long
-Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.SerialQueue -> Dynamo.Wpf.Utilities.SerialQueue
 Dynamo.Wpf.Utilities.LibraryDragAndDrop
 Dynamo.Wpf.Utilities.LibraryDragAndDrop.LibraryDragAndDrop() -> void
 Dynamo.Wpf.Utilities.MessageBoxService
 Dynamo.Wpf.Utilities.MessageBoxService.MessageBoxService() -> void
-Dynamo.Wpf.Utilities.SerialQueue
-Dynamo.Wpf.Utilities.SerialQueue.DispatchAsync(System.Action action) -> void
-Dynamo.Wpf.Utilities.SerialQueue.SerialQueue() -> void
-Dynamo.Wpf.Utilities.SerialQueue.UnhandledException -> System.Action<System.Action, System.Exception>
 Dynamo.Wpf.Utilities.WebView2Utilities
 Dynamo.Wpf.VariableInputNodeViewCustomization
 Dynamo.Wpf.VariableInputNodeViewCustomization.Dispose() -> void
@@ -5624,8 +5615,6 @@ static Dynamo.Wpf.UI.VisualConfigurations.ErrorTextFontWeight -> System.Windows.
 static Dynamo.Wpf.UI.VisualConfigurations.LibraryTooltipTextFontWeight -> System.Windows.FontWeight
 static Dynamo.Wpf.UI.VisualConfigurations.NodeTooltipTextFontWeight -> System.Windows.FontWeight
 static Dynamo.Wpf.Utilities.CompactBubbleHandler.Process(ProtoCore.Mirror.MirrorData value) -> Dynamo.ViewModels.CompactBubbleViewModel
-static Dynamo.Wpf.Utilities.JobDebouncer.EnqueueMandatoryJobAsync(System.Action job, Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken token) -> void
-static Dynamo.Wpf.Utilities.JobDebouncer.EnqueueOptionalJobAsync(System.Action job, Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken token) -> void
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Collections.Generic.IEnumerable<string> buttonNames, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -2867,6 +2867,7 @@ Dynamo.ViewModels.RequestBitmapSourceHandler
 Dynamo.ViewModels.RequestOpenDocumentationLinkHandler
 Dynamo.ViewModels.RequestPackagePublishDialogHandler
 Dynamo.ViewModels.SearchViewModel
+Dynamo.ViewModels.SearchViewModel.AfterLastPendingSearch(System.Action action) -> void
 Dynamo.ViewModels.SearchViewModel.BrowserRootCategories.get -> System.Collections.ObjectModel.ObservableCollection<Dynamo.Wpf.ViewModels.NodeCategoryViewModel>
 Dynamo.ViewModels.SearchViewModel.BrowserVisibility.get -> bool
 Dynamo.ViewModels.SearchViewModel.BrowserVisibility.set -> void
@@ -3674,11 +3675,16 @@ Dynamo.Wpf.Utilities.GroupStyleItemSelector.GroupStyleItemSelector() -> void
 Dynamo.Wpf.Utilities.JobDebouncer
 Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken
 Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.DebounceQueueToken() -> void
-Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.IsDirty -> bool
+Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.LastExecutionId -> long
+Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.SerialQueue -> Dynamo.Wpf.Utilities.SerialQueue
 Dynamo.Wpf.Utilities.LibraryDragAndDrop
 Dynamo.Wpf.Utilities.LibraryDragAndDrop.LibraryDragAndDrop() -> void
 Dynamo.Wpf.Utilities.MessageBoxService
 Dynamo.Wpf.Utilities.MessageBoxService.MessageBoxService() -> void
+Dynamo.Wpf.Utilities.SerialQueue
+Dynamo.Wpf.Utilities.SerialQueue.DispatchAsync(System.Action action) -> void
+Dynamo.Wpf.Utilities.SerialQueue.SerialQueue() -> void
+Dynamo.Wpf.Utilities.SerialQueue.UnhandledException -> System.Action<System.Action, System.Exception>
 Dynamo.Wpf.Utilities.WebView2Utilities
 Dynamo.Wpf.VariableInputNodeViewCustomization
 Dynamo.Wpf.VariableInputNodeViewCustomization.Dispose() -> void
@@ -4344,7 +4350,6 @@ readonly Dynamo.ViewModels.PortViewModel.node -> Dynamo.ViewModels.NodeViewModel
 readonly Dynamo.ViewModels.PortViewModel.port -> Dynamo.Graph.Nodes.PortModel
 readonly Dynamo.ViewModels.WorkspaceViewModel.Model -> Dynamo.Graph.Workspaces.WorkspaceModel
 readonly Dynamo.Wpf.Extensions.ViewLoadedParams.dynamoMenu -> System.Windows.Controls.Menu
-readonly Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.JobLock -> object
 readonly Dynamo.Wpf.ViewModels.Watch3D.DefaultWatch3DViewModel.dynamoModel -> Dynamo.Interfaces.IDynamoModel
 readonly Dynamo.Wpf.ViewModels.Watch3D.DefaultWatch3DViewModel.engineManager -> Dynamo.Models.IEngineControllerManager
 readonly Dynamo.Wpf.ViewModels.Watch3D.DefaultWatch3DViewModel.logger -> Dynamo.Logging.ILogger
@@ -5619,7 +5624,8 @@ static Dynamo.Wpf.UI.VisualConfigurations.ErrorTextFontWeight -> System.Windows.
 static Dynamo.Wpf.UI.VisualConfigurations.LibraryTooltipTextFontWeight -> System.Windows.FontWeight
 static Dynamo.Wpf.UI.VisualConfigurations.NodeTooltipTextFontWeight -> System.Windows.FontWeight
 static Dynamo.Wpf.Utilities.CompactBubbleHandler.Process(ProtoCore.Mirror.MirrorData value) -> Dynamo.ViewModels.CompactBubbleViewModel
-static Dynamo.Wpf.Utilities.JobDebouncer.EnqueueJobAsync(System.Action job, Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken token) -> System.Threading.Tasks.Task
+static Dynamo.Wpf.Utilities.JobDebouncer.EnqueueMandatoryJobAsync(System.Action job, Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken token) -> void
+static Dynamo.Wpf.Utilities.JobDebouncer.EnqueueOptionalJobAsync(System.Action job, Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken token) -> void
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Collections.Generic.IEnumerable<string> buttonNames, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -3671,6 +3671,10 @@ Dynamo.Wpf.Utilities.DynamoWebView2
 Dynamo.Wpf.Utilities.DynamoWebView2.DynamoWebView2() -> void
 Dynamo.Wpf.Utilities.GroupStyleItemSelector
 Dynamo.Wpf.Utilities.GroupStyleItemSelector.GroupStyleItemSelector() -> void
+Dynamo.Wpf.Utilities.JobDebouncer
+Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken
+Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.DebounceQueueToken() -> void
+Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.IsDirty -> bool
 Dynamo.Wpf.Utilities.LibraryDragAndDrop
 Dynamo.Wpf.Utilities.LibraryDragAndDrop.LibraryDragAndDrop() -> void
 Dynamo.Wpf.Utilities.MessageBoxService
@@ -4340,6 +4344,7 @@ readonly Dynamo.ViewModels.PortViewModel.node -> Dynamo.ViewModels.NodeViewModel
 readonly Dynamo.ViewModels.PortViewModel.port -> Dynamo.Graph.Nodes.PortModel
 readonly Dynamo.ViewModels.WorkspaceViewModel.Model -> Dynamo.Graph.Workspaces.WorkspaceModel
 readonly Dynamo.Wpf.Extensions.ViewLoadedParams.dynamoMenu -> System.Windows.Controls.Menu
+readonly Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken.JobLock -> object
 readonly Dynamo.Wpf.ViewModels.Watch3D.DefaultWatch3DViewModel.dynamoModel -> Dynamo.Interfaces.IDynamoModel
 readonly Dynamo.Wpf.ViewModels.Watch3D.DefaultWatch3DViewModel.engineManager -> Dynamo.Models.IEngineControllerManager
 readonly Dynamo.Wpf.ViewModels.Watch3D.DefaultWatch3DViewModel.logger -> Dynamo.Logging.ILogger
@@ -5614,6 +5619,7 @@ static Dynamo.Wpf.UI.VisualConfigurations.ErrorTextFontWeight -> System.Windows.
 static Dynamo.Wpf.UI.VisualConfigurations.LibraryTooltipTextFontWeight -> System.Windows.FontWeight
 static Dynamo.Wpf.UI.VisualConfigurations.NodeTooltipTextFontWeight -> System.Windows.FontWeight
 static Dynamo.Wpf.Utilities.CompactBubbleHandler.Process(ProtoCore.Mirror.MirrorData value) -> Dynamo.ViewModels.CompactBubbleViewModel
+static Dynamo.Wpf.Utilities.JobDebouncer.EnqueueJobAsync(System.Action job, Dynamo.Wpf.Utilities.JobDebouncer.DebounceQueueToken token) -> System.Threading.Tasks.Task
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, bool showRichTextBox, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Collections.Generic.IEnumerable<string> buttonNames, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult
 static Dynamo.Wpf.Utilities.MessageBoxService.Show(string msg, string title, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage img) -> System.Windows.MessageBoxResult

--- a/src/DynamoCoreWpf/Utilities/JobDebouncer.cs
+++ b/src/DynamoCoreWpf/Utilities/JobDebouncer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Dynamo.Wpf.Utilities
+{
+    public static class JobDebouncer
+    {
+        public class DebounceQueueToken
+        {
+            public bool IsDirty = false;
+            public readonly object JobLock = new();
+        };
+        /// <summary>
+        /// Action <paramref name="job"/> is guaranteed to run at most once for every call, and exactly once after the last call.
+        /// Execution is sequential, and jobs that share a <see cref="DebounceQueueToken"/> with a newer job will be ignored.
+        /// </summary>
+        /// <param name="job"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public static Task EnqueueJobAsync(Action job, DebounceQueueToken token)
+        {
+            token.IsDirty = true;
+            return Task.Run(() =>
+            {
+                lock (token.JobLock)
+                {
+                    while (token.IsDirty)
+                    {
+                        token.IsDirty = false;
+                        job();
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Utilities/SerialQueue.cs
+++ b/src/DynamoCoreWpf/Utilities/SerialQueue.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace Dynamo.Wpf.Utilities
 {
-    public class SerialQueue
+    internal class SerialQueue
     {
         class LinkedListNode(Action action)
         {

--- a/src/DynamoCoreWpf/Utilities/SerialQueue.cs
+++ b/src/DynamoCoreWpf/Utilities/SerialQueue.cs
@@ -1,0 +1,80 @@
+//https://github.com/gentlee/SerialQueue/blob/master/SerialQueue/SerialQueue.cs
+using System;
+using System.Threading;
+
+namespace Dynamo.Wpf.Utilities
+{
+    public class SerialQueue
+    {
+        class LinkedListNode(Action action)
+        {
+            public readonly Action Action = action;
+            public LinkedListNode Next;
+        }
+    
+        public event Action<Action, Exception> UnhandledException = delegate { };
+    
+        private LinkedListNode _queueFirst;
+        private LinkedListNode _queueLast;
+        private bool _isRunning = false;
+    
+        public void DispatchAsync(Action action)
+        {
+            var newNode = new LinkedListNode(action);
+    
+            lock (this)
+            {
+                if (_queueFirst == null)
+                {
+                    _queueFirst = newNode;
+                    _queueLast = newNode;
+    
+                    if (!_isRunning)
+                    {
+                        _isRunning = true;
+                        ThreadPool.QueueUserWorkItem(Run);
+                    }
+                }
+                else
+                {
+                    _queueLast!.Next = newNode;
+                    _queueLast = newNode;
+                }
+            }
+        }
+    
+        private void Run(object _)
+        {
+            while (true)
+            {
+                LinkedListNode firstNode;
+    
+                lock (this)
+                {
+                    if (_queueFirst == null)
+                    {
+                        _isRunning = false;
+                        return;
+                    }
+                    firstNode = _queueFirst;
+                    _queueFirst = null;
+                    _queueLast = null;
+                }
+    
+                while (firstNode != null)
+                {
+                    var action = firstNode.Action;
+                    firstNode = firstNode.Next;
+                    try
+                    {
+                        action();
+                    }
+                    catch (Exception error)
+                    {
+                        UnhandledException.Invoke(action, error);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -863,12 +863,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void SearchAndUpdateResults()
         {
-            //Unit tests don't have an Application.Current
-            (Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher).Invoke(() =>
-            {
-                searchResults.Clear();
-            });
-
             if (!String.IsNullOrEmpty(SearchText.Trim()))
             {
                 SearchAndUpdateResults(SearchText);
@@ -1178,7 +1172,12 @@ namespace Dynamo.ViewModels
         private static readonly JobDebouncer.DebounceQueueToken DebounceQueueToken = new();
         public void Search(object parameter)
         {
-            JobDebouncer.EnqueueJobAsync(SearchAndUpdateResults, DebounceQueueToken);
+            JobDebouncer.EnqueueOptionalJobAsync(SearchAndUpdateResults, DebounceQueueToken);
+        }
+
+        public void AfterLastPendingSearch(Action action)
+        {
+            JobDebouncer.EnqueueMandatoryJobAsync(action, DebounceQueueToken);
         }
 
         internal bool CanSearch(object parameter)

--- a/src/LibraryViewExtensionWebView2/Handlers/SearchResultDataProvider.cs
+++ b/src/LibraryViewExtensionWebView2/Handlers/SearchResultDataProvider.cs
@@ -47,7 +47,7 @@ namespace Dynamo.LibraryViewExtensionWebView2.Handlers
         public override Stream GetResource(string searchText, out string extension)
         {
             var text = Uri.UnescapeDataString(searchText);
-            var elements = model.Search(text, LuceneSearch.LuceneUtilityNodeSearch);
+            var elements = string.IsNullOrWhiteSpace(text) ? new List<NodeSearchElement>() : model.Search(text, LuceneSearch.LuceneUtilityNodeSearch);
             extension = "json";
             return GetNodeItemDataStream(elements, true);
         }

--- a/src/LibraryViewExtensionWebView2/LibraryViewController.cs
+++ b/src/LibraryViewExtensionWebView2/LibraryViewController.cs
@@ -461,9 +461,16 @@ namespace Dynamo.LibraryViewExtensionWebView2
 
             var synteticEventData = new Dictionary<string, string>
             {
-                [Enum.GetName(typeof(ModifiersJS), e.KeyboardDevice.Modifiers)] = "true",
                 ["key"] = e.Key.ToString()
             };
+
+            foreach(ModifiersJS modifier in Enum.GetValues(typeof(ModifiersJS)))
+            {
+                if (((int)e.KeyboardDevice.Modifiers & (int)modifier) != 0)
+                {
+                    synteticEventData[Enum.GetName(typeof(ModifiersJS), modifier)] = "true";
+                }
+            }
 
             _ = ExecuteScriptFunctionAsync(browser, "eventDispatcher", synteticEventData);
         }

--- a/src/LibraryViewExtensionWebView2/ScriptingObject.cs
+++ b/src/LibraryViewExtensionWebView2/ScriptingObject.cs
@@ -8,7 +8,6 @@ using System.Windows.Threading;
 using Dynamo.Wpf.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static Dynamo.Wpf.Utilities.JobDebouncer;
 
 namespace Dynamo.LibraryViewExtensionWebView2
 {

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -950,6 +950,32 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        [Category("UnitTests")]
+        public void InCanvasSearchTextChangeTriggersOneSearchCommand()
+        {
+            var currentWs = View.ChildOfType<WorkspaceView>();
+
+            // open context menu
+            RightClick(currentWs.zoomBorder);
+
+            // show in-canvas search
+            ViewModel.CurrentSpaceViewModel.ShowInCanvasSearchCommand.Execute(ShowHideFlags.Show);
+
+            var searchControl = currentWs.ChildrenOfType<Popup>().Select(x => (x as Popup)?.Child as InCanvasSearchControl).Where(c => c != null).FirstOrDefault();
+            Assert.IsNotNull(searchControl);
+
+            DispatcherUtil.DoEvents();
+
+            int count = 0;
+            (searchControl.DataContext as SearchViewModel).SearchCommand = new Dynamo.UI.Commands.DelegateCommand((object _) => { count++; });
+            searchControl.SearchTextBox.Text = "dsfdf";
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(currentWs.InCanvasSearchBar.IsOpen);
+            Assert.AreEqual(count, 1);
+        }
+
+        [Test]
         [TestCase(0)]
         [TestCase(50)]
         [TestCase(100)]

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -1008,7 +1008,7 @@ namespace DynamoCoreWpfTests
             }
             var tcs = new TaskCompletionSource();
             //we should only get the "Number Slider" node if we process up to the very last "r".
-            //otherwise ("Number Slide") we should get "Number". This wasn't added to the test because it would fragile to future Lucene weight updates.
+            //otherwise ("Number Slide") we should get "Number". This wasn't added to the test because it would be fragile to future Lucene weight updates.
             vm.AfterLastPendingSearch(() => {
                 tcs.SetResult();
             });

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -1000,19 +1000,19 @@ namespace DynamoCoreWpfTests
             for (var i = 1; i <= fullNodeName.Length; ++i)
             {
                 vm.SearchText = fullNodeName[..i];
-                vm.SearchCommand.Execute(null);
                 if (keyStrokeDelayMs > 0)
                 {
                     Thread.Sleep(keyStrokeDelayMs);
                 }
             }
-            var tcs = new TaskCompletionSource();
+            var mre = new ManualResetEvent(false);
             //we should only get the "Number Slider" node if we process up to the very last "r".
             //otherwise ("Number Slide") we should get "Number". This wasn't added to the test because it would be fragile to future Lucene weight updates.
             vm.AfterLastPendingSearch(() => {
-                tcs.SetResult();
+                mre.Set();
             });
-            await tcs.Task;
+            mre.WaitOne(1000);
+
             Assert.AreEqual(fullNodeName, vm.FilteredResults?.FirstOrDefault()?.Name);
         }
 

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -26,7 +26,6 @@ using Dynamo.UI.Controls;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Views;
-using Dynamo.Wpf.Utilities;
 using DynamoCoreWpfTests.Utility;
 using Moq;
 using Moq.Protected;


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

Currently the node search hangs when the user types faster than the time it takes Lucene to provide results because it is searching in the main UI thread. This PR provides a debouncing algorithm and performs searches sequentially outside of the main UI thread for a smoother search experience. [Currently there is no support for cancelling previous search tasks in lucenenet](https://github.com/apache/lucenenet/issues/922) so this is a fix around that limitation

Before fix:
![2024-12-19 00-33-21](https://github.com/user-attachments/assets/d47b7132-f37c-41f1-ad25-338e9b37b345)

After fix:
![2024-12-19 00-35-00](https://github.com/user-attachments/assets/a3e6db4e-abbc-4327-a505-34a6ecf1c2d9)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Prevent node search from hanging during fast typing.

### Reviewers

@RobertGlobant20 
@QilongTang
@sm6srw 

### FYIs

@avidit 
