### PR TITLE
Add dispatcher ops count logs after evert test

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -170,7 +170,7 @@ namespace DynamoCoreWpfTests
             }
 
             TestUtilities.WebView2Tag = string.Empty;
-            System.Console.WriteLine($"PID {Process.GetCurrentProcess().Id} Finished test: {TestContext.CurrentContext.Test.Name}");
+            System.Console.WriteLine($"PID {Process.GetCurrentProcess().Id} Finished test: {TestContext.CurrentContext.Test.Name} with DispatcherOpsCounter = {DispatcherOpsCounter}");
         }
 
         protected virtual void GetLibrariesToPreload(List<string> libraries)


### PR DESCRIPTION

### Purpose

Add dispatcher ops count logs after evert test
Hopefully it will tell us if the dispatcher is getting overrun with events

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
