### PR TITLE
add memory logging during ui tests

### DIFF
--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -118,20 +118,21 @@ namespace Dynamo.Wpf.Extensions
 
             if (added)
             {
-                dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.ExtensionAdded);
+                dynamoViewModel.Model.Logger.Log($"{viewExtension.Name} : {Wpf.Properties.Resources.ExtensionAdded}");
             }
             else
             {
-                dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.ExtensionAlreadyPresent);
+                dynamoViewModel.Model.Logger.Log($"{viewExtension.Name} : {Wpf.Properties.Resources.ExtensionAlreadyPresent}");
+
             }
         }
 
-        /// <summary>
-        /// Close the tab for extension UI control element in the extensions side bar.
-        /// </summary>
-        /// <param name="viewExtension">Instance of the view extension object that is being added to the extensions side bar.</param>
-        /// <returns></returns>
-        public void CloseExtensioninInSideBar(IViewExtension viewExtension)
+            /// <summary>
+            /// Close the tab for extension UI control element in the extensions side bar.
+            /// </summary>
+            /// <param name="viewExtension">Instance of the view extension object that is being added to the extensions side bar.</param>
+            /// <returns></returns>
+            public void CloseExtensioninInSideBar(IViewExtension viewExtension)
         {
             dynamoView.CloseExtensionControl(viewExtension);
         }

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -170,7 +170,36 @@ namespace DynamoCoreWpfTests
             }
 
             TestUtilities.WebView2Tag = string.Empty;
-            System.Console.WriteLine($"PID {Process.GetCurrentProcess().Id} Finished test: {TestContext.CurrentContext.Test.Name} with DispatcherOpsCounter = {DispatcherOpsCounter}");
+            using (var currentProc = Process.GetCurrentProcess())
+            {
+                int id = currentProc.Id;
+                var name = TestContext.CurrentContext.Test.Name;
+                System.Console.WriteLine($"PID {id} Finished test: {name} with DispatcherOpsCounter = {DispatcherOpsCounter}");
+                System.Console.WriteLine($"PID {id} Finished test: {name} with WorkingSet = {currentProc.WorkingSet64}");
+                System.Console.WriteLine($"PID {id} Finished test: {name} with PrivateBytes = {currentProc.PrivateMemorySize64}");
+                System.Console.Write($"PID {id} Finished test: {name} with GC Memory Info: ");
+                PrettyPrint(GC.GetGCMemoryInfo());
+            }
+        }
+
+        private static void PrettyPrint(object obj)
+        {
+            Type type = obj.GetType();
+            PropertyInfo[] properties = type.GetProperties();
+
+            Console.WriteLine("{");
+            foreach (var property in properties)
+            {
+                try
+                {
+                    Console.WriteLine($"  {property.Name}: {property.GetValue(obj)}");
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"  {property.Name}: {e.Message}");
+                }
+            }
+            Console.WriteLine("}");
         }
 
         protected virtual void GetLibrariesToPreload(List<string> libraries)


### PR DESCRIPTION
### Purpose

add more logging to ui test base class - trying to determine why some tests are flaky - hypothesis is memory leak leading to poor performance.
