### PR TITLE
Improved zoom and navigation performance for large graphs with many nodes

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -34,6 +34,27 @@ using Thickness = System.Windows.Thickness;
 
 namespace Dynamo.Controls
 {
+    public class BooleanStyleConverter : IValueConverter
+    {
+        public Style TrueStyle { get; set; }
+        public Style FalseStyle { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is bool v && v)
+            {
+                return TrueStyle;
+            }
+
+            return FalseStyle;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return false;
+        }
+    }
+
     public class ToolTipFirstLineOnly : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -7,7 +7,8 @@
                     xmlns:fa="clr-namespace:FontAwesome5;assembly=FontAwesome5.Net"
                     xmlns:nodes="clr-namespace:Dynamo.Nodes;assembly=DynamoCoreWpf"
                     xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-                    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf">
+                    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+                    xmlns:conv="clr-namespace:Dynamo.Controls;assembly=DynamoCoreWpf">
 
     <ResourceDictionary.MergedDictionaries>
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
@@ -867,9 +868,13 @@
     </Style>
 
     <!--  Zoom fade text  -->
-    <Style x:Key="SZoomFadeText" TargetType="{x:Type TextBlock}">
+    <Style
+        x:Key="SZoomFadeBase_Animation"
+        TargetType="{x:Type FrameworkElement}">
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
                 <DataTrigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>
@@ -892,36 +897,36 @@
         </Style.Triggers>
     </Style>
 
-    <!--  Zoom fade label  -->
-    <Style x:Key="SZoomFadeLabel" TargetType="{x:Type Label}">
+    <Style
+        x:Key="SZoomFadeBase_Basic"
+        TargetType="{x:Type FrameworkElement}">
+        <Setter
+            Property="Opacity"
+            Value="0" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
-                <DataTrigger.EnterActions>
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                             To="1.0"
-                                             Duration="0:0:0.2" />
-                        </Storyboard>
-                    </BeginStoryboard>
-                </DataTrigger.EnterActions>
-                <DataTrigger.ExitActions>
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                             To="0.0"
-                                             Duration="0:0:0.2" />
-                        </Storyboard>
-                    </BeginStoryboard>
-                </DataTrigger.ExitActions>
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
+                <Setter
+                    Property="Opacity"
+                    Value="1" />
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <conv:BooleanStyleConverter
+        x:Key="SZoomFadeControl"
+        TrueStyle="{StaticResource SZoomFadeBase_Basic}"
+        FalseStyle="{StaticResource SZoomFadeBase_Animation}" />
 
     <!--  Zoom fade preview  -->
-    <Style x:Key="SZoomFadePreview" TargetType="{x:Type Border}">
+    <Style
+        x:Key="SZoomFadePreview_Animation"
+        TargetType="{x:Type FrameworkElement}">
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
                 <DataTrigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>
@@ -944,10 +949,36 @@
         </Style.Triggers>
     </Style>
 
-    <!--  Zoom fade-in preview  -->
-    <Style x:Key="SZoomFadeInPreview" TargetType="{x:Type Border}">
+    <Style
+        x:Key="SZoomFadePreview_Basic"
+        TargetType="{x:Type FrameworkElement}">
+        <Setter
+            Property="Opacity"
+            Value="0.7" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
+                <Setter
+                    Property="Opacity"
+                    Value="0.4" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <conv:BooleanStyleConverter
+        x:Key="SZoomFadePreview"
+        TrueStyle="{StaticResource SZoomFadePreview_Basic}"
+        FalseStyle="{StaticResource SZoomFadePreview_Animation}" />
+
+    <!--  Zoom fade-in preview  -->
+    <Style
+        x:Key="SZoomFadeInPreview_Animation"
+        TargetType="{x:Type FrameworkElement}">
+        <Style.Triggers>
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
                 <DataTrigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>
@@ -970,10 +1001,36 @@
         </Style.Triggers>
     </Style>
 
-    <!--  Zoom fade-in preview  -->
-    <Style x:Key="SZoomFadeOutPreview" TargetType="{x:Type Border}">
+    <Style
+        x:Key="SZoomFadeInPreview_Basic"
+        TargetType="{x:Type FrameworkElement}">
+        <Setter
+            Property="Opacity"
+            Value="0.5" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
+                <Setter
+                    Property="Opacity"
+                    Value="0.0" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <conv:BooleanStyleConverter
+        x:Key="SZoomFadeInPreview"
+        TrueStyle="{StaticResource SZoomFadeInPreview_Basic}"
+        FalseStyle="{StaticResource SZoomFadeInPreview_Animation}" />
+
+    <!--  Zoom fade-out preview  -->
+    <Style
+        x:Key="SZoomFadeOutPreview_Animation"
+        TargetType="{x:Type FrameworkElement}">
+        <Style.Triggers>
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
                 <DataTrigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>
@@ -996,36 +1053,36 @@
         </Style.Triggers>
     </Style>
 
-    <!--  Zoom fade-out framework element  -->
-    <Style x:Key="SZoomFadeOutFrameworkElement" TargetType="{x:Type FrameworkElement}">
+    <Style
+        x:Key="SZoomFadeOutPreview_Basic"
+        TargetType="{x:Type FrameworkElement}">
+        <Setter
+            Property="Opacity"
+            Value="0.0" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
-                <DataTrigger.EnterActions>
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                             To="1.0"
-                                             Duration="0:0:0.2" />
-                        </Storyboard>
-                    </BeginStoryboard>
-                </DataTrigger.EnterActions>
-                <DataTrigger.ExitActions>
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                             To="0.0"
-                                             Duration="0:0:0.2" />
-                        </Storyboard>
-                    </BeginStoryboard>
-                </DataTrigger.ExitActions>
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
+                <Setter
+                    Property="Opacity"
+                    Value="0.5" />
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <conv:BooleanStyleConverter
+        x:Key="SZoomFadeOutPreview"
+        TrueStyle="{StaticResource SZoomFadeOutPreview_Basic}"
+        FalseStyle="{StaticResource SZoomFadeOutPreview_Animation}" />
 
     <!--  Zoom fade-in framework element  -->
-    <Style x:Key="SZoomFadeInFrameworkElement" TargetType="{x:Type FrameworkElement}">
+    <Style
+        x:Key="SZoomFadeInControl_Animation"
+        TargetType="{x:Type FrameworkElement}">
         <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}" Value="true">
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
                 <DataTrigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>
@@ -1047,6 +1104,28 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <Style
+        x:Key="SZoomFadeInControl_Basic"
+        TargetType="{x:Type FrameworkElement}">
+        <Setter
+            Property="Opacity"
+            Value="1" />
+        <Style.Triggers>
+            <DataTrigger
+                Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                Value="true">
+                <Setter
+                    Property="Opacity"
+                    Value="0.0" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <conv:BooleanStyleConverter
+        x:Key="SZoomFadeInControl"
+        TrueStyle="{StaticResource SZoomFadeInControl_Basic}"
+        FalseStyle="{StaticResource SZoomFadeInControl_Animation}" />
 
     <Style x:Key="TextButtonStyle" TargetType="Button">
         <Setter Property="HorizontalAlignment" Value="Right" />
@@ -1800,7 +1879,7 @@
                                        FontSize="{TemplateBinding FontSize}"
                                        FontWeight="Bold"
                                        Foreground="{TemplateBinding Foreground}"
-                                       Style="{StaticResource SZoomFadeText}"
+                                       Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}"
                                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}" />
                         </Border>
                     </Grid>
@@ -1845,7 +1924,7 @@
                                        FontSize="28px"
                                        FontWeight="Bold"
                                        Foreground="#999999"
-                                       Style="{StaticResource SZoomFadeText}"
+                                       Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}"
                                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}" />
                         </Border>
                     </Grid>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -11,7 +11,8 @@
                     xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
                     xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
                     xmlns:viewModels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
-                    xmlns:views="clr-namespace:Dynamo.UI.Views;assembly=DynamoCoreWpf">
+                    xmlns:views="clr-namespace:Dynamo.UI.Views;assembly=DynamoCoreWpf"
+                    xmlns:controlsWpf="clr-namespace:Dynamo.Views;assembly=DynamoCoreWpf">
 
     <!-- Templates
 
@@ -125,7 +126,7 @@
                                FontWeight="Medium"
                                Foreground="{StaticResource PrimaryCharcoal200Brush}"
                                IsHitTestVisible="False"
-                               Style="{StaticResource SZoomFadeLabel}" />
+                            Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controlsWpf:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}" />
                         <Grid.Style>
                             <Style TargetType="Grid">
                                 <Setter Property="Height" Value="{Binding Path=Height}" />
@@ -326,7 +327,7 @@
                            Foreground="Transparent"
                            IsHitTestVisible="False"
                            Opacity="0.4"
-                           Style="{StaticResource SZoomFadeText}"
+                           Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controlsWpf:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}"
                            Text="{Binding Path=PortName}" />
                 <dynui:UseLevelSpinner x:Name="useLevelControl"
                                        Width="50"

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -480,6 +480,10 @@ namespace Dynamo.ViewModels
         }
 
         [JsonIgnore]
+        public bool StopAnimations { get => stopAnimations; set { stopAnimations = value; RaisePropertyChanged(nameof(StopAnimations)); } }
+        private bool stopAnimations = false;
+
+        [JsonIgnore]
         public bool CanZoomIn
         {
             get { return CanZoom(Configurations.ZoomIncrement); }
@@ -886,6 +890,8 @@ namespace Dynamo.ViewModels
             nodeViewModel.NodeLogic.Modified -= OnNodeModified;
         }
 
+        private const int MaxNodesBeforeAnimationStops = 150;
+
         void Model_NodeRemoved(NodeModel node)
         {
             NodeViewModel nodeViewModel;
@@ -901,6 +907,8 @@ namespace Dynamo.ViewModels
             nodeViewModel.Dispose();
 
             PostNodeChangeActions();
+
+            StopAnimations = Nodes.Count > MaxNodesBeforeAnimationStops;
         }
 
         void Model_NodeAdded(NodeModel node)
@@ -916,6 +924,8 @@ namespace Dynamo.ViewModels
                 Errors.Add(nodeViewModel.ErrorBubble);
 
             PostNodeChangeActions();
+
+            StopAnimations = Nodes.Count > MaxNodesBeforeAnimationStops;
         }
 
         void PostNodeChangeActions()

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -8,6 +8,7 @@
              xmlns:dp="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              xmlns:controls="clr-namespace:Dynamo.Views"
              xmlns:fa="clr-namespace:FontAwesome5;assembly=FontAwesome5.Net" xmlns:dp1="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
+             xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
              Name="topControl"
              Width="Auto"
              Height="Auto"
@@ -18,6 +19,14 @@
              MouseRightButtonDown="DisplayNodeContextMenu"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
              PreviewMouseMove="OnNodeViewMouseMove">
+
+    <UserControl.Resources>
+        <BitmapImage
+            po:Freeze="true"
+            RenderOptions.BitmapScalingMode="LowQuality"
+            x:Key="defaultIcon"
+            UriSource="/DynamoCoreWpf;component/UI/Images/default-node-icon.png" />
+    </UserControl.Resources>
 
     <Grid Name="grid"
           HorizontalAlignment="Left"
@@ -315,28 +324,16 @@
                    Panel.ZIndex="3"
                    FlowDirection="LeftToRight">
             <!--  The Icon for this Node  -->
-            <Rectangle Name="nodeIcon"
-                     Width="34"
-                     Height="34">
-                <Rectangle.Style>
-                    <Style TargetType="Rectangle">
-                        <Setter Property="Fill">
-                            <Setter.Value>
-                                <ImageBrush ImageSource="{Binding ImageSource}" Stretch="UniformToFill" />
-                            </Setter.Value>
-                        </Setter>
-                        <Style.Triggers>
-                            <!--  If no icon can be found, use default icon  -->
-                            <DataTrigger Binding="{Binding ImageSource, UpdateSourceTrigger=PropertyChanged}" Value="{x:Null}">
-                                <Setter Property="Fill">
-                                    <Setter.Value>
-                                        <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/default-node-icon.png" Stretch="UniformToFill" />
-                                    </Setter.Value>
-                                </Setter>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Rectangle.Style>
+            <Rectangle
+                Name="nodeIcon"
+                Width="34"
+                Height="34">
+                <Rectangle.Fill>
+                    <ImageBrush
+                        RenderOptions.BitmapScalingMode="LowQuality"
+                        ImageSource="{Binding ImageSource, FallbackValue={StaticResource defaultIcon}, TargetNullValue={StaticResource defaultIcon}}"
+                        Stretch="UniformToFill" />
+                </Rectangle.Fill>
             </Rectangle>
 
             <TextBlock Name="NameBlock"
@@ -348,7 +345,7 @@
                        FontWeight="Medium"
                        Foreground="{StaticResource PrimaryCharcoal200Brush}"
                        IsHitTestVisible="False"
-                       Style="{StaticResource SZoomFadeText}"
+                       Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}"
                        Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
                        Visibility="Visible"
                        TextAlignment="Center" />
@@ -448,7 +445,7 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
                     Canvas.ZIndex="4"
-                    Style="{StaticResource SZoomFadeOutFrameworkElement}"
+                    Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}"
                     FlowDirection="LeftToRight"
                     Orientation="Horizontal">
             <Grid x:Name="ExperimentalGlyph" 
@@ -467,6 +464,8 @@
             <Grid x:Name="FrozenGlyph" 
                   Visibility="{Binding Path=IsFrozen, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, Mode=OneWay}">
                 <Image x:Name="FrozenImage"
+                       po:Freeze="true"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        Width="16px"
                        Height="16px"
                        HorizontalAlignment="Center"
@@ -477,6 +476,8 @@
             <Grid x:Name="HiddenEyeGlyph" 
                   Visibility="{Binding Path=IsVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, Mode=OneWay}">
                 <Image x:Name="HiddenEyeImage"
+                       po:Freeze="true"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        Width="16px"
                        Height="16px"
                        HorizontalAlignment="Center"
@@ -492,7 +493,7 @@
                    FontFamily="{StaticResource ArtifaktElementRegular}"
                    FontSize="10px"
                    Foreground="{StaticResource NodeLacingGlyphBackground}"
-                   Style="{StaticResource SZoomFadeLabel}"
+                   Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}"
                    ToolTipService.ShowDuration="30000"
                    Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter}}">
                 <Label.ToolTip>
@@ -512,7 +513,7 @@
                            FontFamily="{StaticResource ArtifaktElementRegular}"
                            FontSize="10px"
                            Foreground="Black"
-                           Style="{StaticResource SZoomFadeLabel}" />
+                           Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeControl}}" />
                 </Border>
                 <Grid.Style>
                     <Style TargetType="Grid">
@@ -546,6 +547,7 @@
                                                 Background="Transparent"
                                                 CornerRadius="2" />
                                         <Image x:Name="DotsImage"
+                                               RenderOptions.BitmapScalingMode="LowQuality"
                                                Width="16px"
                                                Height="16px"
                                                Margin="1.5,0,0,0"
@@ -609,7 +611,7 @@
                                   RelativeSource={RelativeSource FindAncestor, 
                                   AncestorType={x:Type controls:WorkspaceView}}, 
                                   Converter={StaticResource ZoomToOpacityConverter}}"
-                Style="{StaticResource SZoomFadeOutPreview}"
+                Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeOutPreview}}"
                 Visibility="{Binding Path=IsFrozen, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <!--  Displays when the node is Frozen/Warning/Error state and Zoom is below 0.4 -->
@@ -623,7 +625,7 @@
                 CornerRadius="8,8,0,0"
                 IsHitTestVisible="False"
                 Opacity="0.5"
-                Style="{StaticResource SZoomFadeInPreview}"
+                Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeInPreview}}"
                 Visibility="{Binding Path=DataContext.Zoom, 
                                      RelativeSource={RelativeSource FindAncestor, 
                                      AncestorType={x:Type controls:WorkspaceView}}, 
@@ -638,8 +640,8 @@
                     Canvas.ZIndex="7" 
                     IsHitTestVisible="False"
                     Margin="0 5 0 0"
-                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch" 
-                    Style="{StaticResource SZoomFadeInFrameworkElement}"                    
+                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                    Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeInControl}}"
                     Visibility="{Binding Path=DataContext.Zoom, 
                                          RelativeSource={RelativeSource FindAncestor, 
                                          AncestorType={x:Type controls:WorkspaceView}}, 
@@ -654,7 +656,8 @@
                           Columns="1" Rows="1" Name="ZoomGlyphRowZero" 
                           HorizontalAlignment="Center" VerticalAlignment="Bottom"
                           Visibility="{Binding ImgGlyphThreeSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
-                <Image Stretch="Uniform"  HorizontalAlignment="Center" VerticalAlignment="Bottom" 
+                <Image Stretch="Uniform"  HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        x:Name="ZoomStateImgOne"
                        Width="64"
                        Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
@@ -670,7 +673,8 @@
                 </Grid.ColumnDefinitions>
                 <Image Grid.Column="0"
                        x:Name="ZoomStateImgTwo"
-                       Stretch="Uniform" 
+                       Stretch="Uniform"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        HorizontalAlignment="Left" VerticalAlignment="Center"
                        Margin="5 0 "
                        Width="64"
@@ -678,7 +682,8 @@
                        Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
                 <Image Grid.Column="1"
                        x:Name="ZoomStateImgThree"
-                       Stretch="Uniform"  
+                       Stretch="Uniform"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        HorizontalAlignment="Right" VerticalAlignment="Center" 
                        Margin="5 0"
                        Width="64"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -632,66 +632,69 @@
                                      Converter={StaticResource ZoomToVisibilityCollapsedConverter}}" />
 
         <!-- Grid containing the State overlay Glyphs in Zoomed Out state -->
-        <Grid Name="zoomGlyphsGrid"
-                    Grid.Row="0"
-                    Grid.RowSpan="4"
-                    Grid.Column="0"
-                    Grid.ColumnSpan="3"
-                    Canvas.ZIndex="7" 
-                    IsHitTestVisible="False"
-                    Margin="0 5 0 0"
-                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                    Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeInControl}}"
-                    Visibility="{Binding Path=DataContext.Zoom, 
-                                         RelativeSource={RelativeSource FindAncestor, 
-                                         AncestorType={x:Type controls:WorkspaceView}}, 
-                                         Converter={StaticResource ZoomToVisibilityCollapsedConverter}}" 
-                    MinWidth="48">
+        <Grid
+            Name="zoomGlyphsGrid"
+            Grid.Row="0"
+            Grid.RowSpan="4"
+            Grid.Column="0"
+            Grid.ColumnSpan="3"
+            Canvas.ZIndex="7"
+            IsHitTestVisible="False"
+            Margin="0 5 0 0"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Style="{Binding Path=DataContext.StopAnimations, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource SZoomFadeInControl}}"
+            Visibility="{Binding Path=DataContext.Zoom, 
+                                 RelativeSource={RelativeSource FindAncestor, 
+                                 AncestorType={x:Type controls:WorkspaceView}}, 
+                                 Converter={StaticResource ZoomToVisibilityCollapsedConverter}}"
+            MinWidth="48">
             <Grid.RowDefinitions>
-                <RowDefinition Height="{Binding ImgGlyphThreeSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                <RowDefinition
+                    Height="{Binding ImgGlyphThreeSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
                 <RowDefinition></RowDefinition>
             </Grid.RowDefinitions>
-            <UniformGrid  Grid.Row="0"
-                          Margin="0 10 0 -10"
-                          Columns="1" Rows="1" Name="ZoomGlyphRowZero" 
-                          HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                          Visibility="{Binding ImgGlyphThreeSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
-                <Image Stretch="Uniform"  HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                       RenderOptions.BitmapScalingMode="LowQuality"
-                       x:Name="ZoomStateImgOne"
-                       Width="64"
-                       Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                       Visibility="{Binding ImgGlyphThreeSource,Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
-            </UniformGrid>
-            <Grid Grid.Row="1" 
-                  Margin="0 0 0 0"
-                  Name="ZoomGlyphRowOne" 
-                  HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="{Binding ImgGlyphOneSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                    <ColumnDefinition Width="{Binding ImgGlyphTwoSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                </Grid.ColumnDefinitions>
-                <Image Grid.Column="0"
-                       x:Name="ZoomStateImgTwo"
-                       Stretch="Uniform"
-                       RenderOptions.BitmapScalingMode="LowQuality"
-                       HorizontalAlignment="Left" VerticalAlignment="Center"
-                       Margin="5 0 "
-                       Width="64"
-                       Source="{Binding ImgGlyphOneSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                       Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
-                <Image Grid.Column="1"
-                       x:Name="ZoomStateImgThree"
-                       Stretch="Uniform"
-                       RenderOptions.BitmapScalingMode="LowQuality"
-                       HorizontalAlignment="Right" VerticalAlignment="Center" 
-                       Margin="5 0"
-                       Width="64"
-                       Source="{Binding ImgGlyphTwoSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                       Visibility="{Binding ImgGlyphTwoSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
-            </Grid>
-        </Grid>
 
+            <Image
+                Stretch="Uniform"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
+                Grid.Row="0"
+                Grid.ColumnSpan="2"
+                Margin="0 10 0 -10"
+                RenderOptions.BitmapScalingMode="LowQuality"
+                x:Name="ZoomStateImgOne"
+                Width="64"
+                Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                Visibility="{Binding ImgGlyphThreeSource,Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+
+            <WrapPanel
+                Grid.Row="1"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <Image
+                    x:Name="ZoomStateImgTwo"
+                    Stretch="Uniform"
+                    RenderOptions.BitmapScalingMode="LowQuality"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Margin="5 0 "
+                    Width="64"
+                    Source="{Binding ImgGlyphOneSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                    Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+
+                <Image
+                    x:Name="ZoomStateImgThree"
+                    Stretch="Uniform"
+                    RenderOptions.BitmapScalingMode="LowQuality"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Margin="5 0"
+                    Width="64"
+                    Source="{Binding ImgGlyphTwoSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                    Visibility="{Binding ImgGlyphTwoSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+            </WrapPanel>
+        </Grid>
 
         <!--  Displays when the node is selected  -->
         <Border Name="selectionBorder"


### PR DESCRIPTION
_this is a cleaned up version of the [original PR](https://github.com/DynamoDS/Dynamo/pull/15730)_

### Purpose
Currently large graphs perform very poorly. It can take up to multiple seconds to zoom in and out, particularly when moving past the 0.4 zoom stage, where the node and port names disappear and the effect borders appear. Panning the view can also be slow.

There are multiple reasons for this slowdown but the biggest contributor by far are the many fade in/out animations that happen at that particular transition. This was particularly difficult to trace, because the slowdown does not happen in the C# managed code. Instead, it actually comes from the multiple animation bindings to the "Zoom" property of the `WorkspaceViewModel` in every single node. This is why the hotpath stops at raising the property changed event and can not be expanded further:

![image](https://github.com/user-attachments/assets/b79e878b-5c40-4dc2-89c4-7c9c02c1bd24)

From what I've gathered, WPF animations get pre-compiled to native platform code and that is why we can't get further details in both VS and dotTrace.

This is further exasperated by the fact that the animations target the contols' opacity property. Apparently when you modify an element’s opacity property, it can cause WPF to create temporary surfaces which results in an even bigger performance hit. 

With this PR, I propose we have a cut-off point after a certain number of nodes are placed, where the animations are turned off (for example after placing 150 nodes on the canvas).

Another reason highlighted in the above image, is that every single placed node and group throws a binding failure, which slows down graph loading/rendering times. In the PR I propose that we simplify the XAML visual tree, which also avoids the binding failures and is beneficial to the overall performance. Plus, since the node icons are already so tiny, we can further improve the performance of large graphs by using speedier image rendering options.

---
# User Experience
Currently with a graph of around 350 nodes, each zoom in/out action can take multiple seconds, which totally breaks the flow:
![Revit_vWmYYm5rIl](https://github.com/user-attachments/assets/3ab9b178-beeb-4e9b-b762-58497ad087d1)

With the proposed changes, animations still work for small graphs but for large graphs they are replaced with data trigger setters that replicate the end state:
![Revit_b0h26xWkH3](https://github.com/user-attachments/assets/eb5b8184-ba56-4249-9c97-37d990c98624)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

@mjkkirschner


(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of