### PR TITLE
[DYN-8026] Fix watch node which has corrupted size.

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -22,7 +22,7 @@ namespace Dynamo.Controls
         private readonly double widthPerCharacter = 7.5;
         private static readonly int defaultHeightSize = 200;
         private readonly int minWidthSize = 100;
-        private readonly int minHeightSize = 38;
+        private readonly int minHeightSize = 40;
         private readonly int minHeightForList = 83;
 
         public WatchTree(WatchViewModel vm)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -63,8 +63,8 @@ namespace CoreNodeModelsWpf.Nodes
 
             ResetWatch();
 
-            watchTree.Width = nodeModel.WatchWidth == 0 ? watchTree.Width : nodeModel.WatchWidth;
-            watchTree.Height = nodeModel.WatchHeight == 0 ? watchTree.Height : nodeModel.WatchHeight;
+            watchTree.Width = nodeModel.WatchWidth < watchTree.Width ? watchTree.Width : nodeModel.WatchWidth;
+            watchTree.Height = nodeModel.WatchHeight < watchTree.Height ? watchTree.Height : nodeModel.WatchHeight;
             
             //Store width and height info of the node in the dictionary.
             Watch.NodeSizes[watch.GUID] = new Tuple<double, double>(nodeModel.WatchWidth, nodeModel.WatchHeight);

--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -393,6 +393,19 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void WatchNodeWithBadSize()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\watch\WatchNodeBadSize.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+            ViewModel.HomeSpace.Run();
+
+            var watchNode = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace("355685ad-754c-400f-ac75-53a56c7d5423") as Watch;
+
+            Assert.AreEqual(100, watchNode.Width);
+            Assert.AreEqual(100, watchNode.Height);
+        }
+
+        [Test]  
         public void GetNodeLabelTree()
         {
             // Arrange

--- a/test/core/watch/WatchNodeBadSize.dyn
+++ b/test/core/watch/WatchNodeBadSize.dyn
@@ -1,0 +1,142 @@
+{
+  "Uuid": "2d99f611-7d17-4fbe-8e39-8fbd77cd1ecf",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "WatchNodeBadSize",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "WatchWidth": 50.0,
+      "WatchHeight": 38.0,
+      "Id": "355685ad754c400fac7553a56c7d5423",
+      "NodeType": "ExtensionNode",
+      "Inputs": [
+        {
+          "Id": "7feffa6f77e34900b45cb33858ad4e7a",
+          "Name": "",
+          "Description": "Node to show output from",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1d550c1aba7845b0be174dedaae60253",
+          "Name": "",
+          "Description": "Node output",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualizes a node's output"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "Id": "ca31ea53b3b94751b7a5254fb6cdb7b9",
+      "NodeType": "CodeBlockNode",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1adc5b91c52c4f87bbb113222f5c760b",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly",
+      "Code": "1..10;"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "1adc5b91c52c4f87bbb113222f5c760b",
+      "End": "7feffa6f77e34900b45cb33858ad4e7a",
+      "Id": "0f111a8fa2d84185aeeeee4ba37c718a",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "EnableLegacyPolyCurveBehavior": true,
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "3.5",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "3.4.1.7435",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "_Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Id": "355685ad754c400fac7553a56c7d5423",
+        "Name": "Watch",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 626.0,
+        "Y": 261.5
+      },
+      {
+        "Id": "ca31ea53b3b94751b7a5254fb6cdb7b9",
+        "Name": "Code Block",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "ShowGeometry": true,
+        "X": 268.0,
+        "Y": 267.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Task: https://jira.autodesk.com/browse/DYN-8026

Fixes the case where watch node has a wrong size serialized in the graph.

![watch node](https://github.com/user-attachments/assets/e75adbfa-10a4-4924-bb8a-081e1a9b74b7)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[DYN-8026] Fix watch node which has corrupted size.

### Reviewers
@QilongTang @mjkkirschner 

