### PR TITLE
DYN-7898: dynamo losing focus fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -2378,6 +2378,8 @@ namespace Dynamo.Controls
 
             var cmd = Analytics.TrackCommandEvent("PackageManager");
             cmd.Dispose();
+
+            this.Activate();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Addressed `Dynamo loses focus when closing Package Manager window` by explicitly returning focus to Dynamo after the PM is closed. 

### Changes

![DynamoSandbox_J8Xh7Dld88](https://github.com/user-attachments/assets/50b66510-34aa-445f-b7aa-055b3b6b3568)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

- now activates explicitly to bring back focus to Dynamo after the PM is closed

### Reviewers

@QilongTang 
@avidit 

### FYIs

@reddyashish 
