### PR TITLE
NodeView Icon xaml simplification

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -8,6 +8,7 @@
              xmlns:dp="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              xmlns:controls="clr-namespace:Dynamo.Views"
              xmlns:fa="clr-namespace:FontAwesome5;assembly=FontAwesome5.Net" xmlns:dp1="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
+             xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
              Name="topControl"
              Width="Auto"
              Height="Auto"
@@ -18,6 +19,14 @@
              MouseRightButtonDown="DisplayNodeContextMenu"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
              PreviewMouseMove="OnNodeViewMouseMove">
+
+    <UserControl.Resources>
+        <BitmapImage
+            po:Freeze="true"
+            RenderOptions.BitmapScalingMode="LowQuality"
+            x:Key="defaultIcon"
+            UriSource="/DynamoCoreWpf;component/UI/Images/default-node-icon.png" />
+    </UserControl.Resources>
 
     <Grid Name="grid"
           HorizontalAlignment="Left"
@@ -315,28 +324,16 @@
                    Panel.ZIndex="3"
                    FlowDirection="LeftToRight">
             <!--  The Icon for this Node  -->
-            <Rectangle Name="nodeIcon"
-                     Width="34"
-                     Height="34">
-                <Rectangle.Style>
-                    <Style TargetType="Rectangle">
-                        <Setter Property="Fill">
-                            <Setter.Value>
-                                <ImageBrush ImageSource="{Binding ImageSource}" Stretch="UniformToFill" />
-                            </Setter.Value>
-                        </Setter>
-                        <Style.Triggers>
-                            <!--  If no icon can be found, use default icon  -->
-                            <DataTrigger Binding="{Binding ImageSource, UpdateSourceTrigger=PropertyChanged}" Value="{x:Null}">
-                                <Setter Property="Fill">
-                                    <Setter.Value>
-                                        <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/default-node-icon.png" Stretch="UniformToFill" />
-                                    </Setter.Value>
-                                </Setter>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Rectangle.Style>
+            <Rectangle
+                Name="nodeIcon"
+                Width="34"
+                Height="34">
+                <Rectangle.Fill>
+                    <ImageBrush
+                        RenderOptions.BitmapScalingMode="LowQuality"
+                        ImageSource="{Binding ImageSource, FallbackValue={StaticResource defaultIcon}, TargetNullValue={StaticResource defaultIcon}}"
+                        Stretch="UniformToFill" />
+                </Rectangle.Fill>
             </Rectangle>
 
             <TextBlock Name="NameBlock"
@@ -459,7 +456,7 @@
                  Foreground="{StaticResource Blue400Brush}"
                  VerticalAlignment="Center"
                  HorizontalAlignment="Center">
-                      <fa:ImageAwesome.ToolTip>
+                    <fa:ImageAwesome.ToolTip>
                         <ToolTip Content="{x:Static dp:Resources.DocsExperimentalPrefixMessage}" Style="{StaticResource GenericToolTipLight}"/>
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
@@ -467,6 +464,8 @@
             <Grid x:Name="FrozenGlyph" 
                   Visibility="{Binding Path=IsFrozen, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, Mode=OneWay}">
                 <Image x:Name="FrozenImage"
+                       po:Freeze="true"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        Width="16px"
                        Height="16px"
                        HorizontalAlignment="Center"
@@ -477,6 +476,8 @@
             <Grid x:Name="HiddenEyeGlyph" 
                   Visibility="{Binding Path=IsVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}, Mode=OneWay}">
                 <Image x:Name="HiddenEyeImage"
+                       po:Freeze="true"
+                       RenderOptions.BitmapScalingMode="LowQuality"
                        Width="16px"
                        Height="16px"
                        HorizontalAlignment="Center"
@@ -512,7 +513,7 @@
                            FontFamily="{StaticResource ArtifaktElementRegular}"
                            FontSize="10px"
                            Foreground="Black"
-                           Style="{StaticResource SZoomFadeLabel}" />
+                           Style="{StaticResource SZoomFadeLabel}"/>
                 </Border>
                 <Grid.Style>
                     <Style TargetType="Grid">
@@ -546,6 +547,7 @@
                                                 Background="Transparent"
                                                 CornerRadius="2" />
                                         <Image x:Name="DotsImage"
+                                               RenderOptions.BitmapScalingMode="LowQuality"
                                                Width="16px"
                                                Height="16px"
                                                Margin="1.5,0,0,0"
@@ -630,63 +632,69 @@
                                      Converter={StaticResource ZoomToVisibilityCollapsedConverter}}" />
 
         <!-- Grid containing the State overlay Glyphs in Zoomed Out state -->
-        <Grid Name="zoomGlyphsGrid"
-                    Grid.Row="0"
-                    Grid.RowSpan="4"
-                    Grid.Column="0"
-                    Grid.ColumnSpan="3"
-                    Canvas.ZIndex="7" 
-                    IsHitTestVisible="False"
-                    Margin="0 5 0 0"
-                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch" 
-                    Style="{StaticResource SZoomFadeInFrameworkElement}"                    
-                    Visibility="{Binding Path=DataContext.Zoom, 
-                                         RelativeSource={RelativeSource FindAncestor, 
-                                         AncestorType={x:Type controls:WorkspaceView}}, 
-                                         Converter={StaticResource ZoomToVisibilityCollapsedConverter}}" 
-                    MinWidth="48">
+        <Grid
+            Name="zoomGlyphsGrid"
+            Grid.Row="0"
+            Grid.RowSpan="4"
+            Grid.Column="0"
+            Grid.ColumnSpan="3"
+            Canvas.ZIndex="7"
+            IsHitTestVisible="False"
+            Margin="0 5 0 0"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Style="{StaticResource SZoomFadeInFrameworkElement}"       
+            Visibility="{Binding Path=DataContext.Zoom, 
+                                 RelativeSource={RelativeSource FindAncestor, 
+                                 AncestorType={x:Type controls:WorkspaceView}}, 
+                                 Converter={StaticResource ZoomToVisibilityCollapsedConverter}}"
+            MinWidth="48">
             <Grid.RowDefinitions>
-                <RowDefinition Height="{Binding ImgGlyphThreeSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                <RowDefinition
+                    Height="{Binding ImgGlyphThreeSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
                 <RowDefinition></RowDefinition>
             </Grid.RowDefinitions>
-            <UniformGrid  Grid.Row="0"
-                          Margin="0 10 0 -10"
-                          Columns="1" Rows="1" Name="ZoomGlyphRowZero" 
-                          HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                          Visibility="{Binding ImgGlyphThreeSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}">
-                <Image Stretch="Uniform"  HorizontalAlignment="Center" VerticalAlignment="Bottom" 
-                       x:Name="ZoomStateImgOne"
-                       Width="64"
-                       Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                       Visibility="{Binding ImgGlyphThreeSource,Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
-            </UniformGrid>
-            <Grid Grid.Row="1" 
-                  Margin="0 0 0 0"
-                  Name="ZoomGlyphRowOne" 
-                  HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="{Binding ImgGlyphOneSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                    <ColumnDefinition Width="{Binding ImgGlyphTwoSource, Mode=OneWay, Converter={StaticResource EmptyToZeroLengthConverter}, UpdateSourceTrigger=PropertyChanged}" />
-                </Grid.ColumnDefinitions>
-                <Image Grid.Column="0"
-                       x:Name="ZoomStateImgTwo"
-                       Stretch="Uniform" 
-                       HorizontalAlignment="Left" VerticalAlignment="Center"
-                       Margin="5 0 "
-                       Width="64"
-                       Source="{Binding ImgGlyphOneSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                       Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
-                <Image Grid.Column="1"
-                       x:Name="ZoomStateImgThree"
-                       Stretch="Uniform"  
-                       HorizontalAlignment="Right" VerticalAlignment="Center" 
-                       Margin="5 0"
-                       Width="64"
-                       Source="{Binding ImgGlyphTwoSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
-                       Visibility="{Binding ImgGlyphTwoSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}"/>
-            </Grid>
-        </Grid>
 
+            <Image
+                Stretch="Uniform"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
+                Grid.Row="0"
+                Grid.ColumnSpan="2"
+                Margin="0 10 0 -10"
+                RenderOptions.BitmapScalingMode="LowQuality"
+                x:Name="ZoomStateImgOne"
+                Width="64"
+                Source="{Binding ImgGlyphThreeSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                Visibility="{Binding ImgGlyphThreeSource,Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+
+            <WrapPanel
+                Grid.Row="1"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <Image
+                    x:Name="ZoomStateImgTwo"
+                    Stretch="Uniform"
+                    RenderOptions.BitmapScalingMode="LowQuality"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Margin="5 0 "
+                    Width="64"
+                    Source="{Binding ImgGlyphOneSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                    Visibility="{Binding ImgGlyphOneSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+
+                <Image
+                    x:Name="ZoomStateImgThree"
+                    Stretch="Uniform"
+                    RenderOptions.BitmapScalingMode="LowQuality"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Margin="5 0"
+                    Width="64"
+                    Source="{Binding ImgGlyphTwoSource, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Null}}"
+                    Visibility="{Binding ImgGlyphTwoSource, Converter={StaticResource EmptyToVisibilityCollapsedConverter}, UpdateSourceTrigger=PropertyChanged}" />
+            </WrapPanel>
+        </Grid>
 
         <!--  Displays when the node is selected  -->
         <Border Name="selectionBorder"


### PR DESCRIPTION
### Purpose

extracts some changes from:
https://github.com/DynamoDS/Dynamo/pull/15749 by @dimven 

does the following:
* uses freeze and lower image rendering quality for icons on the node view
* removes style trigger for dealing with null icon - provides null fallback
* replaces zoom grid with images / wrap panel


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB


