### PR TITLE
don't execute the setup method for NodeManipulatorExtensionTests tests twice

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -90,10 +90,8 @@ namespace DynamoCoreWpfTests
 
             SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
 
-            if (!SkipDispatcherFlush)
-            {
-                Dispatcher.CurrentDispatcher.Hooks.OperationPosted += Hooks_OperationPosted;
-            }
+            Dispatcher.CurrentDispatcher.Hooks.OperationPosted += Hooks_OperationPosted;
+            
         }
 
         protected static void RaiseLoadedEvent(FrameworkElement element)
@@ -132,10 +130,10 @@ namespace DynamoCoreWpfTests
         [TearDown]
         public void Exit()
         {
+          
+            Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
             if (!SkipDispatcherFlush)
             {
-                Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
-
                 DispatcherUtil.DoEventsLoop(() => DispatcherOpsCounter == 0);
             }
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
@@ -28,7 +28,7 @@ namespace DynamoCoreWpfTests.ViewExtensions
     public class NodeManipulatorExtensionTests : DynamoTestUIBase
     {
         [SetUp]
-        public virtual void Start()
+        public override void Start()
         {
             // Forcing the dispatcher to execute all of its tasks within these tests causes crashes in Helix.
             // For now just skip it.


### PR DESCRIPTION
### Purpose

I noticed that because we were not overriding the start method and instead hiding it that nunit was calling both methods that were marked with `[setup]` so we were basically starting dynamo twice. I have no idea if this will stabilize the intermittent failures we have been seeing but it can't hurt!

locally, this change lowers the number of operations in the dispatcher queue from 131 to 28 when it moves on to the next test fixture.
