### PR TITLE
flush dispatcher after node manipulation fixture

### DIFF
--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -90,10 +90,8 @@ namespace DynamoCoreWpfTests
 
             SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
 
-            if (!SkipDispatcherFlush)
-            {
-                Dispatcher.CurrentDispatcher.Hooks.OperationPosted += Hooks_OperationPosted;
-            }
+            Dispatcher.CurrentDispatcher.Hooks.OperationPosted += Hooks_OperationPosted;
+            
         }
 
         protected static void RaiseLoadedEvent(FrameworkElement element)
@@ -132,10 +130,10 @@ namespace DynamoCoreWpfTests
         [TearDown]
         public void Exit()
         {
+          
+            Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
             if (!SkipDispatcherFlush)
             {
-                Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
-
                 DispatcherUtil.DoEventsLoop(() => DispatcherOpsCounter == 0);
             }
 

--- a/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
+++ b/test/DynamoCoreWpfTests/ViewExtensions/NodeManipulatorExtensionTests.cs
@@ -2,6 +2,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Manipulation;
 using Dynamo.Models;
+using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -28,12 +29,18 @@ namespace DynamoCoreWpfTests.ViewExtensions
     public class NodeManipulatorExtensionTests : DynamoTestUIBase
     {
         [SetUp]
-        public virtual void Start()
+        public override void Start()
         {
             // Forcing the dispatcher to execute all of its tasks within these tests causes crashes in Helix.
             // For now just skip it.
             SkipDispatcherFlush = true;
             base.Start();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            DispatcherUtil.DoEventsLoop(() => DispatcherOpsCounter == 0);
         }
 
         protected override void GetLibrariesToPreload(List<string> libraries)


### PR DESCRIPTION
follow up to:
https://github.com/DynamoDS/Dynamo/pull/15768
that I want to test in isolation, this PR adds a one time tear down to the node manipulation test fixture that clears the dispatcher and somehow magically avoids the exception we were seeing from helix due to observable collection changes.
