### PR TITLE
DYN-9999 : fix string type regex

### DIFF
--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -382,10 +382,10 @@ namespace Dynamo.PythonServices
         internal static readonly Regex MATCH_VARIABLE_ASSIGNMENTS = new Regex(@"^[ \t]*?(\w+(\s*?,\s*?\w+)*)\s*?=\s*(.+)", RegexOptions.Compiled | RegexOptions.Multiline);
 
         internal static readonly Regex STRING_VARIABLE = new Regex("^[\"']([^\"']*)[\"']$", RegexOptions.Compiled);
-        internal static readonly Regex DOUBLE_VARIABLE = new Regex("^-?\\d+\\.\\d+", RegexOptions.Compiled);
-        internal static readonly Regex INT_VARIABLE = new Regex("^-?\\d+", RegexOptions.Compiled);
-        internal static readonly Regex LIST_VARIABLE = new Regex("\\[.*\\]", RegexOptions.Compiled);
-        internal static readonly Regex DICT_VARIABLE = new Regex("{.*}", RegexOptions.Compiled);
+        internal static readonly Regex DOUBLE_VARIABLE = new Regex("^-?\\d+\\.\\d+$", RegexOptions.Compiled);
+        internal static readonly Regex INT_VARIABLE = new Regex("^-?\\d+$", RegexOptions.Compiled);
+        internal static readonly Regex LIST_VARIABLE = new Regex("^\\[.*\\]$", RegexOptions.Compiled);
+        internal static readonly Regex DICT_VARIABLE = new Regex("^{.*}$", RegexOptions.Compiled);
 
         internal static readonly string BAD_ASSIGNEMNT_ENDS = ",([{";
 

--- a/src/NodeServices/PythonServices.cs
+++ b/src/NodeServices/PythonServices.cs
@@ -381,7 +381,7 @@ namespace Dynamo.PythonServices
         internal static readonly Regex MATCH_FROM_IMPORT_STATEMENTS = new Regex(@"from\s+?([\w.]+)\s+?import\s+?([\w, *]+)", RegexOptions.Compiled | RegexOptions.Multiline);
         internal static readonly Regex MATCH_VARIABLE_ASSIGNMENTS = new Regex(@"^[ \t]*?(\w+(\s*?,\s*?\w+)*)\s*?=\s*(.+)", RegexOptions.Compiled | RegexOptions.Multiline);
 
-        internal static readonly Regex STRING_VARIABLE = new Regex("[\"']([^\"']*)[\"']", RegexOptions.Compiled);
+        internal static readonly Regex STRING_VARIABLE = new Regex("^[\"']([^\"']*)[\"']$", RegexOptions.Compiled);
         internal static readonly Regex DOUBLE_VARIABLE = new Regex("^-?\\d+\\.\\d+", RegexOptions.Compiled);
         internal static readonly Regex INT_VARIABLE = new Regex("^-?\\d+", RegexOptions.Compiled);
         internal static readonly Regex LIST_VARIABLE = new Regex("\\[.*\\]", RegexOptions.Compiled);


### PR DESCRIPTION
### Purpose
Improve the autocomplete in the python editor.
We prepare autocomplete based on the variable type and  sometimes we do not assign the correct type and the autocomplete is erroneous. 
For example aa = HellowWorld("aaa") will be processed as aa being of type string and the autocomplete will be related to string type.


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Reviewers

### FYIs

