### PR TITLE
8150: DYN-8176: Fixes from PythonNet3

### DIFF
--- a/src/Libraries/DSCPython/CPythonEvaluator.cs
+++ b/src/Libraries/DSCPython/CPythonEvaluator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Autodesk.DesignScript.Runtime;
@@ -145,6 +146,8 @@ namespace DSCPython
 
         private static PyScope globalScope;
         private static DynamoLogger dynamoLogger;
+        private static string path;
+
         internal static DynamoLogger DynamoLogger {
             get
             { // Session is null when running unit tests.
@@ -261,60 +264,65 @@ for modname,mod in sys.modules.copy().items():
             {
                 PythonEngine.Initialize();
                 PythonEngine.BeginAllowThreads();
-                
-            }
+
                 using (Py.GIL())
+                using (PyScope scope = Py.CreateScope())
                 {
-                    if (globalScope == null)
+                    scope.Exec("import sys" + Environment.NewLine + "path = str(sys.path)");
+                    path = scope.Get<string>("path");
+                }
+            }
+
+            using (Py.GIL())
+            {
+                globalScope ??= CreateGlobalScope();
+                using PyScope scope = Py.CreateScope();
+
+                if (path is not null)
+                {
+                    // Reset the 'sys.path' value to the default python paths on node evaluation. See https://github.com/DynamoDS/Dynamo/pull/10977. 
+                    var pythonNodeSetupCode = "import sys" + Environment.NewLine + $"sys.path = {path}";
+                    scope.Exec(pythonNodeSetupCode);
+                }
+
+                ProcessAdditionalBindings(scope, bindingNames, bindingValues);
+
+                int amt = Math.Min(bindingNames.Count, bindingValues.Count);
+
+                for (int i = 0; i < amt; i++)
+                {
+                    scope.Set((string)bindingNames[i], InputMarshaler.Marshal(bindingValues[i]).ToPython());
+                }
+
+                try
+                {
+                    OnEvaluationBegin(scope, code, bindingValues);
+                    scope.Exec(code);
+                    var result = scope.Contains("OUT") ? scope.Get("OUT") : null;
+
+                    return OutputMarshaler.Marshal(result);
+                }
+                catch (Exception e)
+                {
+                    evaluationSuccess = false;
+                    var traceBack = GetTraceBack(e);
+                    if (!string.IsNullOrEmpty(traceBack))
                     {
-                        globalScope = CreateGlobalScope();
+                        // Throw a new error including trace back info added to the message
+                        throw new InvalidOperationException($"{e.Message} {traceBack}", e);
                     }
-
-                    using (PyScope scope = Py.CreateScope())
+                    else
                     {
-                        // Reset the 'sys.path' value to the default python paths on node evaluation. 
-                        var pythonNodeSetupCode = "import sys" + Environment.NewLine + "sys.path = sys.path[0:3]";
-                        scope.Exec(pythonNodeSetupCode);
-
-                        ProcessAdditionalBindings(scope, bindingNames, bindingValues);
-
-                        int amt = Math.Min(bindingNames.Count, bindingValues.Count);
-
-                        for (int i = 0; i < amt; i++)
-                        {
-                            scope.Set((string)bindingNames[i], InputMarshaler.Marshal(bindingValues[i]).ToPython());
-                        }
-
-                        try
-                        {
-                            OnEvaluationBegin(scope, code, bindingValues);
-                            scope.Exec(code);
-                            var result = scope.Contains("OUT") ? scope.Get("OUT") : null;
-
-                            return OutputMarshaler.Marshal(result);
-                        }
-                        catch (Exception e)
-                        {
-                            evaluationSuccess = false;
-                            var traceBack = GetTraceBack(e);
-                            if (!string.IsNullOrEmpty(traceBack))
-                            {
-                                // Throw a new error including trace back info added to the message
-                                throw new InvalidOperationException($"{e.Message} {traceBack}", e);
-                            }
-                            else
-                            {
 #pragma warning disable CA2200 // Rethrow to preserve stack details
-                                throw e;
+                        throw e;
 #pragma warning restore CA2200 // Rethrow to preserve stack details
-                            }
-                        }
-                        finally
-                        {
-                            OnEvaluationEnd(evaluationSuccess, scope, code, bindingValues);
-                        }
                     }
                 }
+                finally
+                {
+                    OnEvaluationEnd(evaluationSuccess, scope, code, bindingValues);
+                }
+            }
         }
 
         public static object EvaluatePythonScript(
@@ -462,20 +470,25 @@ sys.stdout = DynamoStdOut({0})
                     {
                         if (PyDict.IsDictType(pyObj))
                         {
-                            using (var pyDict = new PyDict(pyObj))
+                            using var pyDict = new PyDict(pyObj);
+                            var dict = new PyDict();
+                            foreach (PyObject item in pyDict.Items())
                             {
-                                var dict = new PyDict();
-                                foreach (PyObject item in pyDict.Items())
-                                {
-                                    dict.SetItem(
-                                        ConverterExtension.ToPython(dataMarshalerToUse.Marshal(item.GetItem(0))),
-                                        ConverterExtension.ToPython(dataMarshalerToUse.Marshal(item.GetItem(1)))
-                                    );
-                                }
-                                return dict;
+                                dict.SetItem(
+                                    ConverterExtension.ToPython(dataMarshalerToUse.Marshal(item.GetItem(0))),
+                                    ConverterExtension.ToPython(dataMarshalerToUse.Marshal(item.GetItem(1)))
+                                );
                             }
+                            return dict;
                         }
                         var unmarshalled = pyObj.AsManagedObject(typeof(object));
+
+                        // Avoid calling this marshaler infinitely.
+                        if (unmarshalled is PyObject)
+                        {
+                            return unmarshalled;
+                        }
+
                         return dataMarshalerToUse.Marshal(unmarshalled);
                     }
                 }

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -633,7 +633,6 @@ namespace Dynamo.Tests
             var sysPathList = GetFlattenedPreviewValues(firstPythonNodeGUID);
 
             // Verify that the custom path is added to the 'sys.path'.
-            Assert.AreEqual(sysPathList.Count(), 4);
             Assert.AreEqual(sysPathList.Last(), "C:\\Program Files\\dotnet");
 
             // Change the python engine for the 2nd node and verify that the custom path is not reflected in the 2nd node. 
@@ -642,7 +641,6 @@ namespace Dynamo.Tests
             var pynode = nodeModel as PythonNode;
             UpdatePythonEngineAndRun(pynode, PythonEngineManager.CPython3EngineName);
             sysPathList = GetFlattenedPreviewValues(secondPythonNodeGUID);
-            Assert.AreEqual(sysPathList.Count(), 3);
             Assert.AreNotEqual(sysPathList.Last(), "C:\\Program Files\\dotnet");
         }
 


### PR DESCRIPTION
### Purpose

Apply a few fixes from PythonNet3 work to CPython3:

- Improve `path` handling. Currently we just chop off all but the first three path entries. This PR caches the path before all Python nodes run and uses the cached path for each run. This will fix, for example, the issue where `site-packages` isn't on the path (If site-packages folder is present the default Python path has 4 items).
- Prevent unwrap marshaler from looping infinitely (no known cases of this with CPython3, but seems like a good safety)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Preserve full original Python path on each Python node run.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
