### PR TITLE
DYN-7268 Improve UX when IDSDK is not installed on system running Dynamo

### DIFF
--- a/src/DynamoCore/Core/IDSDKManager.cs
+++ b/src/DynamoCore/Core/IDSDKManager.cs
@@ -240,8 +240,6 @@ namespace Dynamo.Core
 
         private bool Initialize()
         {
-            OnErrorInitializingIDSDK();
-            return false;
             try
             {
                 if (Client.IsInitialized())

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3732,6 +3732,25 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to It seems like Autodesk Identity Manager is not set up on your system. To ensure full access to all features, please sign in to your Autodesk account using Autodesk Identity Manager.
+        ///#Download and install=https://manage.autodesk.com/products/updates it here or through Autodesk Access, then sign in..
+        /// </summary>
+        public static string IDSDKErrorMessage {
+            get {
+                return ResourceManager.GetString("IDSDKErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Download Autodesk Identity Manager.
+        /// </summary>
+        public static string IDSDKErrorMessageTitle {
+            get {
+                return ResourceManager.GetString("IDSDKErrorMessageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import Library.
         /// </summary>
         public static string ImportLibraryDialogTitle {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4105,4 +4105,11 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PackageUnknownCompatibilityVersionDownloadMsg" xml:space="preserve">
     <value>The compatibility of this version with your setup has not been verified. It may or may not work as expected.</value>
   </data>
+  <data name="IDSDKErrorMessage" xml:space="preserve">
+    <value>It seems like Autodesk Identity Manager is not set up on your system. To ensure full access to all features, please sign in to your Autodesk account using Autodesk Identity Manager.
+#Download and install=https://manage.autodesk.com/products/updates it here or through Autodesk Access, then sign in.</value>
+  </data>
+  <data name="IDSDKErrorMessageTitle" xml:space="preserve">
+    <value>Download Autodesk Identity Manager</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4092,4 +4092,11 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PackageUnknownCompatibilityVersionDownloadMsg" xml:space="preserve">
     <value>The compatibility of this version with your setup has not been verified. It may or may not work as expected. </value>
   </data>
+  <data name="IDSDKErrorMessage" xml:space="preserve">
+    <value>It seems like Autodesk Identity Manager is not set up on your system. To ensure full access to all features, please sign in to your Autodesk account using Autodesk Identity Manager.
+#Download and install=https://manage.autodesk.com/products/updates it here or through Autodesk Access, then sign in.</value>
+  </data>
+  <data name="IDSDKErrorMessageTitle" xml:space="preserve">
+    <value>Download Autodesk Identity Manager</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -4815,6 +4815,8 @@ static Dynamo.Wpf.Properties.Resources.GroupStylesCancelButtonText.get -> string
 static Dynamo.Wpf.Properties.Resources.GroupStylesSaveButtonText.get -> string
 static Dynamo.Wpf.Properties.Resources.HideClassicNodeLibrary.get -> string
 static Dynamo.Wpf.Properties.Resources.HideWiresPopupMenuItem.get -> string
+static Dynamo.Wpf.Properties.Resources.IDSDKErrorMessage.get -> string
+static Dynamo.Wpf.Properties.Resources.IDSDKErrorMessageTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.ImportLibraryDialogTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.ImportPreferencesInfo.get -> string
 static Dynamo.Wpf.Properties.Resources.ImportPreferencesText.get -> string

--- a/src/DynamoCoreWpf/UI/GuidedTour/CustomRichTextBox.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/CustomRichTextBox.cs
@@ -130,7 +130,10 @@ namespace Dynamo.Wpf.UI.GuidedTour
                         }
                         //The hyperlink name is the next word followed by the # char (empty spaces are allowed) and the URL value is the one followed after the = char
                         else
+                        {
                             hyperlinkName += word.Replace("#", "") + " ";
+                            continue;
+                        }   
                     }
                     else if (bBoldActive)
                     {


### PR DESCRIPTION
### Purpose

The PR adds an event in auth provider (IDSDKManager) that gets triggered when IDSDK initialization fails, this happens due to missing Adsk Identity Manager on the host machine. In this case we are displaying a dialog box with appropriate message and a download link to get the required software. A flag is used to restrict the warning from being displayed multiple times as IDSDK initialization is done at various places.

![Screenshot 2025-01-28 at 7 06 12 PM](https://github.com/user-attachments/assets/a2dedea5-e5ef-4217-ac58-520076a94abc)

![Lzi9Lfu0h8](https://github.com/user-attachments/assets/e75f30e5-1b80-42c7-b666-252e5a7d7ba1)



### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Improve UX when IDSDK is not installed on system running Dynamo

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
