### PR TITLE
Update ActionDebouncer.cs to support tests with no Sync context

### DIFF
--- a/src/DynamoCoreWpf/Utilities/ActionDebouncer.cs
+++ b/src/DynamoCoreWpf/Utilities/ActionDebouncer.cs
@@ -2,7 +2,6 @@ using Dynamo.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Threading;
 
 namespace Dynamo.Wpf.Utilities
 {
@@ -46,8 +45,10 @@ namespace Dynamo.Wpf.Utilities
                 taskScheduler = TaskScheduler.FromCurrentSynchronizationContext();
             }
             else
-            {// This might happen when running tests in non UI threads.
-                if (Dispatcher.CurrentDispatcher != null)
+            {
+                // This might happen when running tests in non UI threads.
+                // But if we are in a UI thread, then log this as a potential error.
+                if (System.Windows.Application.Current?.Dispatcher?.Thread == Thread.CurrentThread)
                 {// UI thread.
                     logger?.LogError("The UI thread does not seem to have a SyncronizationContext.");
                 }

--- a/src/DynamoCoreWpf/Utilities/ActionDebouncer.cs
+++ b/src/DynamoCoreWpf/Utilities/ActionDebouncer.cs
@@ -26,7 +26,7 @@ namespace Dynamo.Wpf.Utilities
 
         /// <summary>
         /// Delays the "action" for a "timeout" number of milliseconds
-        /// The input Action will run on same syncronization context as the Debounce method call.
+        /// The input Action will run on same syncronization context as the Debounce method call (or the thread pool if a sync context does not exist, ex. in non UI tests).
         /// </summary>
         /// <param name="timeout">Number of milliseconds to wait</param>
         /// <param name="action">The action to execute after the timeout runs out.</param>
@@ -35,6 +35,11 @@ namespace Dynamo.Wpf.Utilities
         {
             Cancel();
             cts = new CancellationTokenSource();
+
+            // The TaskScheduler.FromCurrentSynchronizationContext() exists only if there is a valid SyncronizationContex.
+            // Calling this method from a non UI thread could have a null SyncronizationContex.Current,
+            // so in that case we use the default TaskScheduler which uses the thread pool.
+            var taskScheduler = SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
 
             Task.Delay(timeout, cts.Token).ContinueWith((t) =>
             {
@@ -50,7 +55,7 @@ namespace Dynamo.Wpf.Utilities
                     logger?.Log("Failed to run debounce action with the following error:");
                     logger?.Log(ex.ToString());
                 }
-            }, TaskScheduler.FromCurrentSynchronizationContext());
+            }, taskScheduler);
         }
 
         public void Dispose()

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -71,11 +71,11 @@ namespace DynamoCoreWpfTests
 
         internal void BeforeCleanupDiagnostics()
         {
+            Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
             if (!SkipDispatcherFlush)
             {
                 DispatcherUtil.DoEventsLoop(() => DispatcherOpsCounter == 0);
             }
-            Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
         }
 
         internal void AfterCleanupDiagnostics()

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -59,7 +59,7 @@ namespace DynamoCoreWpfTests
             Console.WriteLine("}");
         }
 
-        internal void SetupStartupDiagnostics()
+        internal void StartupDiagnostics()
         {
             System.Console.WriteLine($"PID {Process.GetCurrentProcess().Id} Start test: {TestContext.CurrentContext.Test.Name}");
             TestUtilities.WebView2Tag = TestContext.CurrentContext.Test.Name;
@@ -69,16 +69,16 @@ namespace DynamoCoreWpfTests
             Dispatcher.CurrentDispatcher.Hooks.OperationPosted += Hooks_OperationPosted;
         }
 
-        internal void SetupBeforeCleanupDiagnostics()
+        internal void BeforeCleanupDiagnostics()
         {
-            Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
             if (!SkipDispatcherFlush)
             {
                 DispatcherUtil.DoEventsLoop(() => DispatcherOpsCounter == 0);
             }
+            Dispatcher.CurrentDispatcher.Hooks.OperationPosted -= Hooks_OperationPosted;
         }
 
-        internal void SetupAfterCleanupDiagnostics()
+        internal void AfterCleanupDiagnostics()
         {
             TestUtilities.WebView2Tag = string.Empty;
             using (var currentProc = Process.GetCurrentProcess())
@@ -93,10 +93,10 @@ namespace DynamoCoreWpfTests
             }
         }
 
-        internal void SetupCleanupDiagnostics()
+        internal void CleanupDiagnostics()
         {
-            SetupBeforeCleanupDiagnostics();
-            SetupAfterCleanupDiagnostics();
+            BeforeCleanupDiagnostics();
+            AfterCleanupDiagnostics();
         }
     }
 
@@ -132,7 +132,7 @@ namespace DynamoCoreWpfTests
         [SetUp]
         public virtual void Start()
         {
-            testDiagnostics.SetupStartupDiagnostics();
+            testDiagnostics.StartupDiagnostics();
             var assemblyPath = Assembly.GetExecutingAssembly().Location;
             preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
             preloader.Preload();
@@ -229,7 +229,7 @@ namespace DynamoCoreWpfTests
             {
                 Console.WriteLine(ex.StackTrace);
             }
-            testDiagnostics.SetupAfterCleanupDiagnostics();
+            testDiagnostics.AfterCleanupDiagnostics();
         }
 
         protected virtual void GetLibrariesToPreload(List<string> libraries)

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -54,7 +54,7 @@ namespace DynamoCoreWpfTests
 
         public override void Setup()
         {
-            testDiagnostics.SetupStartupDiagnostics();
+            testDiagnostics.StartupDiagnostics();
 
             base.Setup();
             // Fixed seed randomizer for predictability.
@@ -63,10 +63,10 @@ namespace DynamoCoreWpfTests
 
         public override void Cleanup()
         {
-            testDiagnostics.SetupBeforeCleanupDiagnostics();
+            testDiagnostics.BeforeCleanupDiagnostics();
             commandCallback = null;
             base.Cleanup();
-            testDiagnostics.SetupAfterCleanupDiagnostics();
+            testDiagnostics.AfterCleanupDiagnostics();
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Xml;
 using System.Threading;
 using CoreNodeModels.Input;
@@ -24,10 +23,6 @@ using NUnit.Framework;
 using ProtoCore;
 using PythonNodeModels;
 using SystemTestServices;
-using System.Windows.Threading;
-using DynamoCoreWpfTests.Utility;
-using System.Diagnostics;
-using System.Threading.Tasks;
 
 namespace DynamoCoreWpfTests
 {


### PR DESCRIPTION
We have a lot of tests that do not setup any SyncronizationContext but still test WPF controls.
This does not work when calling FromCurrentSynchronizationContext (throws exception)

Ex
https://master-5.jenkins.autodesk.com/job/Dynamo/job/DynamoSelfServe/job/pullRequestValidation/17145/testReport/junit/DynamoCoreWpfTests/ConverterTests/SearchHighlightMarginConverterTest/

### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
