### PR TITLE
DYN-8268: fix noNetworkMode for PM client

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -57,8 +57,6 @@ namespace Dynamo.PackageManager
             this.uploadBuilder = builder;
             this.client = client;
             this.packageMaintainers = new Dictionary<string, bool>();
-
-            this.LoadCompatibilityMap();  // Load the compatibility map
         }
 
         internal bool Upvote(string packageId)
@@ -370,7 +368,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Method to load the map once, making it accessible to all elements
         /// </summary>
-        private void LoadCompatibilityMap()
+        internal void LoadCompatibilityMap()
         {
             if (compatibilityMap == null)  // Load only if not already loaded
             {

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -161,8 +161,16 @@ namespace Dynamo.PackageManager
                 new GregClient(startupParams.AuthProvider, url),
                 uploadBuilder, packageUploadDirectory);
 
-            LoadPackages(startupParams.Preferences, startupParams.PathManager);
             noNetworkMode = startupParams.NoNetworkMode;
+
+            //we don't ask dpm for the compatibility map in offline mode.
+            if (!noNetworkMode)
+            {
+                // Load the compatibility map
+                PackageManagerClient.LoadCompatibilityMap();
+            }
+
+            LoadPackages(startupParams.Preferences, startupParams.PathManager);
         }
 
         /// <summary>


### PR DESCRIPTION
Stop calling pm KnownHosts while under NoNetworkMode

### Purpose

https://jira.autodesk.com/browse/DYN-8268


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
