### PR TITLE
Use Bitmap cache for smoother panning

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -482,8 +482,8 @@ namespace Dynamo.ViewModels
        /// <summary>
        /// When enabled, some child wpf framework elements will not animate opacity changes.
        /// Useful for improving performance during zoom.
-       /// TODO DYN-8193 a future optimiztion if found to be neccesary is to modify the styles this flag controls
-       /// to set visibility instead of opacity, this will likely lead to many fewers elements in the visual tree to
+       /// TODO DYN-8193 a future optimization if found to be necessary is to modify the styles this flag controls
+       /// to set visibility instead of opacity, this will likely lead to many fewer elements in the visual tree to
        /// layout and render.
        /// </summary>
         [JsonIgnore]

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -679,7 +679,7 @@ namespace Dynamo.Views
                 return;
             }
 
-            var newRenderScale = newZoomScale < .2 ? .2 : newZoomScale < .5 ? .5 : 1;
+            var newRenderScale = newZoomScale <= .2 ? .2 : newZoomScale <= .5 ? .5 : 1;
 
             if (Math.Abs(newRenderScale - currentRenderScale) <= 0.01)
             {

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -135,7 +135,7 @@ namespace Dynamo.Views
             ViewModel.RequestPortContextMenu -= ShowHidePortContextMenu;
             ViewModel.DynamoViewModel.PropertyChanged -= ViewModel_PropertyChanged;
 
-            ViewModel.ZoomChanged -= Vm_ZoomChanged;
+            ViewModel.ZoomChanged -= vm_ZoomChanged;
             ViewModel.RequestZoomToViewportCenter -= vm_ZoomAtViewportCenter;
             ViewModel.RequestZoomToViewportPoint -= vm_ZoomAtViewportPoint;
             ViewModel.RequestZoomToFitView -= vm_ZoomToFitView;
@@ -166,7 +166,7 @@ namespace Dynamo.Views
             ViewModel.RequestPortContextMenu += ShowHidePortContextMenu;
             ViewModel.DynamoViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
-            ViewModel.ZoomChanged += Vm_ZoomChanged;
+            ViewModel.ZoomChanged += vm_ZoomChanged;
             ViewModel.RequestZoomToViewportCenter += vm_ZoomAtViewportCenter;
             ViewModel.RequestZoomToViewportPoint += vm_ZoomAtViewportPoint;
             ViewModel.RequestZoomToFitView += vm_ZoomToFitView;
@@ -641,7 +641,7 @@ namespace Dynamo.Views
             zoomBorder.SetTranslateTransformOrigin((e as PointEventArgs).Point);
         }
 
-        void Vm_ZoomChanged(object sender, EventArgs e)
+        void vm_ZoomChanged(object sender, EventArgs e)
         {
             var newZoomScale = (e as ZoomEventArgs).Zoom;
             zoomBorder.SetZoom(newZoomScale);
@@ -787,7 +787,7 @@ namespace Dynamo.Views
             ViewModel.Model.Y = resultOffset.Y;
 
             vm_CurrentOffsetChanged(this, new PointEventArgs(resultOffset));
-            Vm_ZoomChanged(this, new ZoomEventArgs(resultZoom));
+            vm_ZoomChanged(this, new ZoomEventArgs(resultZoom));
         }
 
         void vm_ZoomToFitView(object sender, EventArgs e)
@@ -829,7 +829,7 @@ namespace Dynamo.Views
             ViewModel.Model.Y = resultOffset.Y;
 
             vm_CurrentOffsetChanged(this, new PointEventArgs(resultOffset));
-            Vm_ZoomChanged(this, new ZoomEventArgs(scaleRequired));
+            vm_ZoomChanged(this, new ZoomEventArgs(scaleRequired));
         }
 
         private void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
### Purpose

Building on the logic in https://github.com/DynamoDS/Dynamo/pull/15764, I propose we use the same mechanism that triggers when the number of nodes on canvas is higher than a certain threshold and replace the all node views with rendered bitmaps. Luckily WPF already has an existing mechanism that we can use called `BitmapCache`. Based on the current zoom, we can vary the resolution of the images and create a pseudo LOD system that switches between a low, medium, high and native scale. I spent a lot of time trying out different scaling options and different ways to trigger the cache and I think that the selected settings strike a good balance between UX and performance.

Here's a preview of the changes below. On the left is the proposed behavior and on the right, the current:
![DynamoSandbox_rjHFbME1GB](https://github.com/user-attachments/assets/6b33a75f-f807-47a6-b5a8-9ee7acc981ba)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
