### PR TITLE
[DYN-7942] Catch exception during undo operation.

### DIFF
--- a/src/DynamoCore/Core/UndoRedoRecorder.cs
+++ b/src/DynamoCore/Core/UndoRedoRecorder.cs
@@ -251,7 +251,6 @@ namespace Dynamo.Core
                 Log(ex);
                 return null;
             }
-
         }
         #endregion
 
@@ -320,7 +319,7 @@ namespace Dynamo.Core
             childNode.Attributes.Append(actionAttribute);
         }
 
-        private XmlElement PopActionGroupFromUndoStack()
+        internal XmlElement PopActionGroupFromUndoStack()
         {
             if (CanUndo == false)
             {

--- a/src/DynamoCore/Core/UndoRedoRecorder.cs
+++ b/src/DynamoCore/Core/UndoRedoRecorder.cs
@@ -6,6 +6,7 @@ using Dynamo.Graph;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Logging;
 
 namespace Dynamo.Core
 {
@@ -56,7 +57,7 @@ namespace Dynamo.Core
         ModelBase GetModelForElement(XmlElement modelData);
     }
 
-    internal class UndoRedoRecorder
+    internal class UndoRedoRecorder : LogSourceBase
     {
         #region Private Class Data Members
 
@@ -241,7 +242,16 @@ namespace Dynamo.Core
                     "UndoStack cannot be popped with non-empty RedoStack");
             }
 
-            return PopActionGroupFromUndoStack();
+            try
+            {
+                return PopActionGroupFromUndoStack();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Log(ex);
+                return null;
+            }
+
         }
         #endregion
 

--- a/test/DynamoCoreTests/UndoRedoRecorderTests.cs
+++ b/test/DynamoCoreTests/UndoRedoRecorderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -565,7 +565,7 @@ namespace Dynamo.Tests
         public void TestPopFromUndoGroup()
         {
             //Assert that it cannot pop from an empty undostack
-            Assert.Throws<InvalidOperationException>(() => { recorder.PopFromUndoGroup(); });
+            Assert.Throws<InvalidOperationException>(() => { recorder.PopActionGroupFromUndoStack(); });
 
             //Add models
             workspace.AddModel(new DummyModel(1, 10));


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7942

The PopActionGroupFromUndoStack() throws an invalid operation exception when the undo stack is empty. We are not catching it and returning the value directly in PopFromUndoGroup(). So added the try catch for that.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[DYN-7942] Catch exception during undo operation.

### Reviewers
@zeusongit @QilongTang 
