### PR TITLE
[DYN-7366] Fix CER crash on ConnectorViewModel

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1222,15 +1222,19 @@ namespace Dynamo.ViewModels
             {
                 NodeEnd.PropertyChanged -= nodeEndViewModel_PropertyChanged;
             }
-            ConnectorPinViewCollection.CollectionChanged -= HandleCollectionChanged;
+
+            if (ConnectorPinViewCollection != null)
+            {
+                ConnectorPinViewCollection.CollectionChanged -= HandleCollectionChanged;
+
+                foreach (var pin in ConnectorPinViewCollection.ToList())
+                {
+                    pin.RequestRedraw -= HandlerRedrawRequest;
+                    pin.RequestSelect -= HandleRequestSelected;
+                }
+            }
 
             workspaceViewModel.PropertyChanged -= WorkspaceViewModel_PropertyChanged;
-
-            foreach (var pin in ConnectorPinViewCollection.ToList())
-            {
-                pin.RequestRedraw -= HandlerRedrawRequest;
-                pin.RequestSelect -= HandleRequestSelected;
-            }
 
             this.PropertyChanged -= ConnectorViewModelPropertyChanged;
             DiscardAllConnectorPinModels();
@@ -1451,17 +1455,27 @@ namespace Dynamo.ViewModels
         /// </summary>
         public void Redraw()
         {
-            if (this.ConnectorModel?.End != null && ConnectorPinViewCollection?.Count > 0)
+            try
             {
-                RedrawBezierManyPoints();
-            }
-            else if (this.ConnectorModel?.End != null)
-            {
-                this.Redraw(this.ConnectorModel.End.Center);
-            }
+                if (this.ConnectorModel != null && ConnectorPinViewCollection != null)
+                {
+                    if (this.ConnectorModel?.End != null && ConnectorPinViewCollection?.Count > 0)
+                    {
+                        RedrawBezierManyPoints();
+                    }
+                    else if (this.ConnectorModel?.End != null)
+                    {
+                        this.Redraw(this.ConnectorModel.End.Center);
+                    }
+                }
 
-            this.SetCollapsedByNodeViewModel();
-            RaisePropertyChanged(nameof(ZIndex));
+                this.SetCollapsedByNodeViewModel();
+                RaisePropertyChanged(nameof(ZIndex));
+            }
+            catch (Exception ex)
+            {
+                workspaceViewModel.DynamoViewModel.Model.Logger.Log("Error when redrawing the connector: " + ex.StackTrace);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7366

After the fix on 3.3, we had couple of CER reports which are related to the connector redraw(). 

Added additional null check on ConnectorPinViewCollection as we are checking the count of that collection. Added a try catch around it as well.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[DYN-7366] Fix CER crash on ConnectorViewModel

### Reviewers
@saintentropy 

