### PR TITLE
DYN-8272 Update RestSharp to v112.0.0 (#15494)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -26,7 +26,7 @@ LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRe
 
 Third-Party Trademarks, Software Credits and Attributions
 
-Greg v.2.5.0.5076:
+Greg v.3.0.2.6284:
 (The MIT License)
 Copyright (c) 2013 Peter Boyer peter.boyer@autodesk.com Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -57,7 +57,7 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-RestSharp v.106.12.0.0:
+RestSharp v.112.0.0.0:
 http://www.apache.org/licenses/LICENSE-2.0
 Copyright © 2021 Alexe Zimarev
 

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -47,17 +47,19 @@ heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\li
 \snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af0\afs32 \ltrch\fcs0 \fs32\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \af0\afs26 
 \ltrch\fcs0 \fs26\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \ssemihidden \spriority9 Heading 2 Char;}{\*\cs17 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \fs24\cf20\kerning0\loch\f31502\hich\af31502\dbch\af31501 
 \sbasedon10 \slink3 \ssemihidden \spriority9 Heading 3 Char;}{\*\cs18 \additive \rtlch\fcs1 \ai\af0\afs24 \ltrch\fcs0 \i\fs24\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink4 \ssemihidden \spriority9 Heading 4 Char;}}
-{\*\rsidtbl \rsid7422124\rsid12128070\rsid16021563\rsid16677021}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Tiberiu Pinzariu}{\operator Aaron Tang}
-{\creatim\yr2024\mo3\dy18\hr10\min4}{\revtim\yr2025\mo2\dy7\hr15\min42}{\version4}{\edmins5}{\nofpages29}{\nofwords13384}{\nofchars76290}{\nofcharsws89496}{\vern109}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+{\*\rsidtbl \rsid5996112\rsid7422124\rsid12128070\rsid16021563\rsid16677021}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Tiberiu Pinzariu}
+{\operator Aaron Tang}{\creatim\yr2024\mo3\dy18\hr10\min4}{\revtim\yr2025\mo2\dy9\hr9\min53}{\version5}{\edmins5}{\nofpages29}{\nofwords13384}{\nofchars76290}{\nofcharsws89496}{\vern109}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/
+wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot12128070 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
 \pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
 \pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 @DYNAMO v.3.}{\rtlch\fcs1 
-\ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16021563 \hich\af4\dbch\af31505\loch\f4 3}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
-\hich\f4 .0 \'a9\loch\f4  2024 Autodesk, Inc.  All rights reserved.
+\ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16021563 \hich\af4\dbch\af31505\loch\f4 3}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 .}{\rtlch\fcs1 \ab\af4\afs22 
+\ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid5996112 \hich\af4\dbch\af31505\loch\f4 1}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4  \'a9
+\loch\f4  202}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid5996112 \hich\af4\dbch\af31505\loch\f4 5}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 
+\hich\af4\dbch\af31505\loch\f4  Autodesk, Inc.  All rights reserved.
 \par \hich\af4\dbch\af31505\loch\f4 Dynamo License
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 Those portions created by Ian are provided with the following copyright:
@@ -66,7 +68,8 @@ heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\li
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Those portions created by Autodesk employees are provided with the following copyright:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Copyright 2024 Autodesk, Inc.
+\par \hich\af4\dbch\af31505\loch\f4 Copyright 202}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid5996112 \hich\af4\dbch\af31505\loch\f4 5}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  Autodesk, Inc.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -79,9 +82,9 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 37003800300038006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036
 003100370039003400370035003200300031003200300035003100310025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068004d003400530045004300520058
-006c004900330059003300620068005700640030006e00370061005600460045005300380070005900660045003300740066006400690049006600620053007300640049006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e}
-}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+006c004900330059003300620068005700640030006e00370061005600460045005300380070005900660045003300740066006400690049006600620053007300640049006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e
+00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
 \hich\af4\dbch\af31505\loch\f4 ing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af40\afs20 \ltrch\fcs0 \b\f40\fs20\lang2057\langfe1033\langnp2057\insrsid16677021 
@@ -90,7 +93,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 s online and offline privacy practices, please see the }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bae00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f007400
-69006300650073002d00740072006100640065006d00610072006b0073002f0070007200690076006100630079002d00730074006100740065006d0065006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030002}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+69006300650073002d00740072006100640065006d00610072006b0073002f0070007200690076006100630079002d00730074006100740065006d0065006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Privacy Statement}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 .}{\rtlch\fcs1 \af40\afs16 \ltrch\fcs0 \f40\fs16\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par 
@@ -99,8 +102,8 @@ HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-stat
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
-740069006300650073002d00740072006100640065006d00610072006b0073002f0069006e00740065006c006c00650063007400750061006c002d00700072006f00700065007200740079002f00740072006100640065006d00610072006b0073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300e4}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Trademarks page}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+740069006300650073002d00740072006100640065006d00610072006b0073002f0069006e00740065006c006c00650063007400750061006c002d00700072006f00700065007200740079002f00740072006100640065006d00610072006b0073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300e400}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Trademarks page}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.  
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 All other brand names, product names or trademarks belong to their respective holders.
@@ -112,13 +115,13 @@ This Product or Service may incorporate or use background Autodesk online and de
 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd2000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f006100750074006f006400650073006b002d0063006c006f00750064002d0070006c006100740066006f0072006d002d0063006f006d0070006f006e0065006e00740073000000795881f43b1d7f48af2c825dc485276300000000a5ab00
-0300ff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 
+0300ff00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 
 \ltrch\fcs0 \f0\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af0\dbch\af31505\loch\f0  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 and }{\field{\*\fldinst 
 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"}{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd6000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f006100750074006f006400650073006b002d006400650073006b0074006f0070002d0070006c006100740066006f0072006d002d0063006f006d0070006f006e0065006e00740073000000795881f43b1d7f48af2c825dc4852763000000
-00a5ab00030072}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Desktop Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+00a5ab0003007200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Desktop Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 .
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sb168\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -127,7 +130,7 @@ LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRe
 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba8000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
-610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
@@ -141,33 +144,33 @@ LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRe
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2013 Peter Boyer }{\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af0\dbch\af31505\loch\f0 HYPERLINK "mailto:peter.boyer@autodesk.com" }{
 \rtlch\fcs1 \af0 \ltrch\fcs0 \f0\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b580000006d00610069006c0074006f003a00700065007400650072002e0062006f0079006500720040006100750074006f006400650073006b002e0063006f006d000000795881f43b1d7f48af2c825dc48527630000
-0000a5ab00035200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 peter.boyer@autodesk.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
- Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, 
-\hich\af4\dbch\af31505\loch\f4 merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+0000a5ab0003520033}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 peter.boyer@autodesk.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  Permission is hereby granted, free of charge, to any\hich\af4\dbch\af31505\loch\f4 
+ person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell c
+\hich\af4\dbch\af31505\loch\f4 opies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in al\hich\af4\dbch\af31505\loch\f4 l copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 TH\hich\af4\dbch\af31505\loch\f4 
+E SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE L
+\hich\af4\dbch\af31505\loch\f4 IABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft.CSharp v.4.0.0.0:
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
-\par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
+\par \hich\af4\dbch\af31505\loch\f4 Co\hich\af4\dbch\af31505\loch\f4 pyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do \hich\af4\dbch\af31505\loch\f4 so, subject to the following conditions:
+\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The above c\hich\af4\dbch\af31505\loch\f4 
+opyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TO\hich\af4\dbch\af31505\loch\f4 
-RT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTIO\hich\af4\dbch\af31505\loch\f4 
+N WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Newtonsoft.Json v.13.0.1:
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -180,9 +183,9 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 37003800300038006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036
 003100370039003400370035003200300034003100390032003000300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068007600520034006d005900670056
-0068004d005000700051006800340075004c0043004a00330050005900390059007700720038006d004d0030007600710058004600390038006100630038006d005000580041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030062}
-}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
+0068004d005000700051006800340075004c0043004a00330050005900390059007700720038006d004d0030007600710058004600390038006100630038006d005000580041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030062
+00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJamesNK%2FNewtonsoft.Json%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc
 \hich\af4\dbch\af31505\loch\f4 1d%7C0%7C0%7C637617947520429148%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=OuX0yvu%2F0kVS7X5KARjQ3p9Ycg8qvk67fFAaKNEWxbM%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
@@ -194,7 +197,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003200390031003400380025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00
 73006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a0058005600430049
 0036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004f0075005800300079007600750025003200460030006b00560053003700580035004b00410052006a0051003300700039005900630067003800710076006b003600370066004600410061004b004e0045005700
-780062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030074}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
+780062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003007400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007 James Newton-King
@@ -223,15 +226,15 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 37003800300038006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036
 003100370039003400370035003200300034003700380039003400370025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066006f0055006f0044005500500079
-00790038004f007200300072006b004e004a0074006c004c006a0049003900580066004a004f003700670065006d004f004c0046006e0075004b0049006b0066006c00480055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
-}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
+00790038004f007200300072006b004e004a0074006c004c006a0049003900580066004a004f003700670065006d004f004c0046006e0075004b0049006b0066006c00480055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000
+00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2021 Alexe Zimarev
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00031300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003130000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gover
 \hich\af4\dbch\af31505\loch\f4 ning permissions and limitations under the License.
@@ -256,12 +259,12 @@ y of this software and associated documentation files (the "Software"), to deal 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.nuget.org/packages/FontAwesome5/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1031\langfe1033\langnp1031\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f007700770077002e006e0075006700650074002e006f00720067002f007000610063006b0061006700650073002f0046006f006e00740041007700650073006f006d00
-650035002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.nuget.org/packages/FontAwesome5/}}}
+650035002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.nuget.org/packages/FontAwesome5/}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/MartinTopfstedt/FontAwesome5/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1031\langfe1033\langnp1031\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004d0061007200740069006e0054006f0070006600730074006500640074002f0046006f006e00740041007700
-650073006f006d00650035002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+650073006f006d00650035002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/MartinTopfstedt/FontAwesome5/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MIT License
@@ -271,8 +274,8 @@ y of this software and associated documentation files (the "Software"), to deal 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTR\hich\af4\dbch\af31505\loch\f4 
-ACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR I\hich\af4\dbch\af31505\loch\f4 
+N CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Cyotek.Drawing.BitmapFont v.2.0.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -286,7 +289,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 004300300025003700430036003300370036003100370039003400370035003200300031003600300033003400330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a004100
 77004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061
 003d006b00760064004f002500320046005000500067007a0033005000750041005300470036007a00760039003300440077004e004a003400670050006b004c00360054003600690073006c005700420077006f004900390058006b002500330044002600720065007300650072007600650064003d0030000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab000300c8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+3b1d7f48af2c825dc485276300000000a5ab000300c842}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont%2Fblob%2Fmaster%2FLICENSE.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5
@@ -299,7 +302,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300031003700300032003900370025003700430055006e006b006e006f0077006e00
 2500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061
 005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0057006a00450066002500320046007900450031006b006f006b006c0062006f0076007800660046007a00480072005300630063006b0049004c004f0069004100
-4f0051006c0047006b00680050004c0061005a002500320046004c0038002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+4f0051006c0047006b00680050004c0061005a002500320046004c0038002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2012-2021 Cyotek Ltd.
@@ -330,7 +333,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d00440041006900
 4c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0064006600570071
 0062006c00420038005600640044004c003600330041007900610077004e0066006700720046004700320054004400300038005000430072006800650071007300750025003200420037004b003000550073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485
-276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+276300000000a5ab0003003000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit%2Fblob%2Fdevelop%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2d
@@ -343,7 +346,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e006f0077006e0025003700430054005700460070006200
 47005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056
 004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d007100550050006c0070003600450058004100780048004f006b0039006500410043005900370044006f0070006100630055006c00560043006e003300350035004b004c0065006e0055007a006e005600
-250032004600740030002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300a8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+250032004600740030002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300a800}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2019 Helix Toolkit contributors
@@ -377,8 +380,8 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003800380038003900350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a00
 6f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031
 003000300030002600730064006100740061003d0056004f005900680062003200490041005a004700470030006a0078002500320046007700510078004a00320051003900480058004e0032007400360058004b00560056005000360041006900420045006400440025003200460033004500250033004400260072006500
-7300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/sharpdx/SharpDX/blob/master/LICENSE}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+7300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/sharpdx/SharpDX/blob/master/LICENSE}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
@@ -396,11 +399,11 @@ WARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 ICSharpCode.AvalonEdit v.6.3.0.90:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.avalonedit.net/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f007700770077002e006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300af}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f007700770077002e006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300af00}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.avalonedit.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://licenses.nuget.org/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b56000000680074007400700073003a002f002f006c006900630065006e007300650073002e006e0075006700650074002e006f00720067002f004d00490054000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000300a8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+a5ab000300a810}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MIT License
@@ -429,7 +432,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 00300025003700430036003300370036003100370039003400370035003200300034003300390031003100300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a0041007700
 4d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d
 00750077006d00740054006c006200420055006a00710025003200420031007a0025003200460076004a007300620039006a0053004a003700690036004d003800680049004d006c006c00310071006e007a006e00420030006d00440077002500330044002600720065007300650072007600650064003d00300000007958
-81f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.google.com/fonts/specimen/Open+Sans}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+81f43b1d7f48af2c825dc485276300000000a5ab00030000a4}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.google.com/fonts/specimen/Open+Sans}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0.html&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C63761794752
@@ -442,14 +445,14 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 00430036003300370036003100370039003400370035003200300034003400390030003600360025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d0044004100
 69004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d007500340053
 00300037005600440046003200300025003200420068004b0073007700570075005000780066004e00780064004d007600450056003600750036006b005500780056005800690064003500370054004d006b0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+c485276300000000a5ab0003004400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  [yyyy] Steve Matteson
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf22\insrsid16677021 \hich\af0\dbch\af31505\loch\f0  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
 \hich\af4\dbch\af31505\loch\f4 ing permissions and limitations under the License.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf22\insrsid16677021 
@@ -511,7 +514,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Firon
 3700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003300300030003200360025003700430055006e006b006e006f
 0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b00
 3100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0069006d00520043005200350077006e007a004f00520069004f00250032004200480063006f00410073003400710059002500320046005500730067
-003200460033002500320042007600700051007300710075004700340070004c005000620063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+003200460033002500320042007600700051007300710075004700340070004c005000620063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopensource.org%2Flicenses%2Fapache2.0.php&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C63761794752033
@@ -524,14 +527,14 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopen
 00370036003100370039003400370035003200300033003300390035003500310025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c004300
 4a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d00470071007a004e00330079
 0077006b006500670048006e0038005800770078006d006b006a0065003500480075004a004e004f0037006900650063007700420047005a00550033004c004f006f004e004900750073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab
-00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2018 Iron Python Community
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004a00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gover
 \hich\af4\dbch\af31505\loch\f4 ning permissions and limitations under the License.
@@ -539,16 +542,15 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopen
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python.Runtime.NETStandard v.3.7.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2006-2021 the contributors of the Python.NET project
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to t\hich\af4\dbch\af31505\loch\f4 he following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and as\hich\af4\dbch\af31505\loch\f4 
+sociated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to 
+\hich\af4\dbch\af31505\loch\f4 whom the Software is furnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE 
-\hich\af4\dbch\af31505\loch\f4 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, \hich\af4\dbch\af31505\loch\f4 
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY\hich\af4\dbch\af31505\loch\f4 
+ OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+\hich\af4\dbch\af31505\loch\f4 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python.Included v.3.7.3.4
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 PSF LICENSE AGREEMENT FOR PYTHON 3.10.4
@@ -591,7 +593,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003500390034003600350025003700
 430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a00420054
 0069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d003700410074005700450048006800480033006800320045003000650044006c0076007900680071004d0030004f007900
-520045004a00750067004e0044007300590061006900340053003500650067007700580063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+520045004a00750067004e0044007300590061006900340053003500650067007700580063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/IPython/extensions/autoreload.py}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -605,8 +607,8 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003500390034003600350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a00
 6f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031
 003000300030002600730064006100740061003d00500069006c006b003000710053006a0059007100700062003400670077007300680039004300460061004700340032006d006b00350077006e006700420058004f00530079006b006700690042006a003100450051002500330044002600720065007300650072007600
-650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/LICENSE}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/LICENSE}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD 3-Clause License
 \par \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2008-Present, IPython Development Team
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2001-2007, Fernando Perez <fernando.perez@colorado.edu>
@@ -638,7 +640,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003200390031003400380025003700430055006e006b006e006f0077
 006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100
 680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004200550066004e006b002500320046006c0077002500320042006300490066003600390077003200250032004600550066003000520071002500320046
-00690044006400780074006c006d00340055004f0072006b006c005700750031006a00420063006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300bd}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00690044006400780074006c006d00340055004f0072006b006c005700750031006a00420063006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300bd00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2002-2013 Charlie Poole\line \hich\f4 Copyright \'a9\loch\f4  2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov
 \line \hich\f4 Copyright \'a9\loch\f4  2000-2002 Philip A. Craig
@@ -659,21 +661,21 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 This license is based on\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "http://www.opensource.org/licenses/zlib-license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f007a006c00690062002d006c00
-6900630065006e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 the open source zlib/libpng license}}}
+6900630065006e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 the open source zlib/libpng license}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://opensource.org/licenses/zlib-license.html }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f007a006c00690062002d006c00690063006500
-6e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/zlib-license.html}}}
+6e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000080}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/zlib-license.html}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 ). The idea was to keep the license as simple as possible to encourage use of NUnit in free and commercial applications and libraries, but to keep the source code together and to give credit to the NUnit contributors for their efforts. While this license 
 \hich\af4\dbch\af31505\loch\f4 allows shipping NUnit in source and binary form, if shipping a NUnit variant is the sole purpose of your product, please\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c0000006d00610069006c0074006f003a00630070006f006f006c006500400070006f006f006c00650063006f006e00730075006c00740069006e0067002e0063006f006d000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003c037}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 let us know}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
-\hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\cf21\insrsid12128070 {\*\datafield 
+276300000000a5ab0003c03700}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 let us know}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c0000006d00610069006c0074006f003a00630070006f006f006c006500400070006f006f006c00650063006f006e00730075006c00740069006e0067002e0063006f006d000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003c074}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 cpoole@pooleconsulting.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+276300000000a5ab0003c07400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 cpoole@pooleconsulting.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  ).
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang3082\langfe1033\kerning1\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Moq v.4.18.4:
@@ -688,7 +690,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003000390032003500330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d00
 4300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030
 002600730064006100740061003d00480025003200460077004e006700790025003200460070004d00590049006700640025003200460046006c00500031004900550031006400620076005400550043006100750069007a0049004a004b0043004100550036004900530051005a0049002500330044002600720065007300
-650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/moq/moq4/blob/master/License.txt/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD 3-Clause License
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors. All rights reserved.
@@ -696,17 +698,17 @@ https://github.com/moq/moq4/blob/master/License.txt/}}}\sectd \ltrsect\linex0\se
 \par \hich\af4\dbch\af31505\loch\f4 Redistribution and use in source and binary forms, with or without
 \par \hich\af4\dbch\af31505\loch\f4 modification, are permitted provided that the following conditions are met:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+\par \hich\af4\dbch\af31505\loch\f4 *\hich\af4\dbch\af31505\loch\f4  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 \par \hich\af4\dbch\af31505\loch\f4 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-\par \hich\af4\dbch\af31505\loch\f4 * Neither the names of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written \hich\af4\dbch\af31505\loch\f4 permission.
+\par \hich\af4\dbch\af31505\loch\f4 * Neither the names of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written p\hich\af4\dbch\af31505\loch\f4 ermission.
 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SH
 \hich\af4\dbch\af31505\loch\f4 
-ALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+ALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR B
 \hich\af4\dbch\af31505\loch\f4 
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+USINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang3082\langfe1033\kerning1\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Libiconv v.1.14.0.1:
@@ -720,8 +722,8 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 30003800640039003400360032003500310066006600360025003700430036003700620066006600370039006500370066003900310034003400330033006100380065003500630039003200350032006400320064006400630031006400250037004300300025003700430030002500370043003600330037003600310037
 0039003400370035003200300033003600390034003200300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a00
 6f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066007900760051003800610078006400300037
-003200370041005200630073006300720032003300320069007100650057003100730047004b00360046005400710025003200460050003700730031005a0074004300360073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
-}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+003200370041005200630073006300720032003300320069007100650057003100730047004b00360046005400710025003200460050003700730031005a0074004300360073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000
+3a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a
@@ -734,7 +736,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003600390034003200300025003700430055006e006b006e00
 6f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b
 003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e005a005400390074004e0079005a006200790050007700310057004f004c007a00250032004200450036005300680077007800510044005700
-480042004a00390075004c0053007900480068004b0050004800570048006b002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+480042004a00390075004c0053007900480068004b0050004800570048006b002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000039}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  1998, 2013 Free Software Foundation, Inc.  
@@ -742,12 +744,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 \par \hich\af4\dbch\af31505\loch\f4 This Autodesk software contains libiconv v. 1.14.0.1.  libiconv is licensed under the GNU Lesser General Public License v.2.1, which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e0067006e0075002e006f00720067002f006c006900630065006e007300650073002f006f006c0064006c006900630065006e007300650073002f006c00
-670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ff31}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 . A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libiconv from }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030f002e}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
@@ -764,11 +766,11 @@ Contain a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a
 \par \hich\af4\dbch\af31505\loch\f4 This Aut\hich\af4\dbch\af31505\loch\f4 odesk software name and release number; That you are requesting  the source code for libiconvv .1.14.0.1; and The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030f0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 ) so that Autodesk may properly respond to your request.  The offer to receive this libiconv source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030fff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030fff5a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.  You may modify, debug and relink libiconv to this Autodesk software as provided under the terms of the GNU L
 \hich\af4\dbch\af31505\loch\f4 esser General Public License v.2.1.
@@ -784,7 +786,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 38006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039
 003400370035003200300032003000300031003600340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f00
 6900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e00660032003100580070004b0069004c00300077
-006b00250032004600760035006f00390035006e0036004e004800550039007900420054007300560057006d004b004c0066007100310041004a0047005100310062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c}}
+006b00250032004600760035006f00390035006e0036004e004800550039007900420054007300560057006d004b004c0066007100310041004a0047005100310062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c13}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -798,7 +800,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e00
 6f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b
 003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066006d003400630072006400340050002500320042007900360053004c00250032004600300067006c004c004b00770078004300770056003900
-4e006a004c005a0073003700660032004c0041006f004e004800660069003200510045002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+4e006a004c005a0073003700660032004c0041006f004e004800660069003200510045002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000066}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4 \hich\f4  Copyright \'a9\loch\f4  1991, 1999 Free Software Foundation, Inc.
@@ -806,12 +808,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 \par \hich\af4\dbch\af31505\loch\f4 This Autodesk software contains libintl v.0.19.8.3.  libintl is licensed under the GNU Lesser General Public License v.2.1 , which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e0067006e0075002e006f00720067002f006c006900630065006e007300650073002f006f006c0064006c006900630065006e007300650073002f006c00
-670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030062}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 . }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
-A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libintl v.0.19.8.3  from }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
+670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006231}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 . }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libintl v.0.19.8.3  from }{\field{\*\fldinst {
+\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab0003000022}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
@@ -829,13 +831,13 @@ c485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs
 \par \hich\af4\dbch\af31505\loch\f4 b. That you are requesting  the source code for libintl v.0.19.8.3; and
 \par \hich\af4\dbch\af31505\loch\f4 c. The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK www.autodesk.com/lgplsource }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
-}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000
+00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 )
 \par \hich\af4\dbch\af31505\loch\f4 so that Autodesk may properly respond to your request.  The offer to receive this libintl source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK www.autodesk.com/lgplsource }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
-}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000
+00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.
 \par \hich\af4\dbch\af31505\loch\f4 You may modify, debug and relink libintl to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.2.1.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
@@ -852,7 +854,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fncal
 37006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003000390032003500330025003700430055
 006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a00420054006900
 4900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004d0058004a004e00610052003600390045004300670050004a0044004a005900500053006e0079004c00710047007800390041
-004700530077007a0025003200460051005a0052003500350046006e00440050007600350055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+004700530077007a0025003200460051005a0052003500350046006e00440050007600350055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  2011 Sebastien Ros
@@ -880,7 +882,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdes
 003300370036003100370039003400370035003200300033003800390033003200350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c00
 43004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e0059003100700047
 007000340052007500730031004900680058006f004c004500410067006500510067006300460033006700730051004b00350068006800700064004200590031004b00470078007400530059002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000300d0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+a5ab000300d000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fmiconvexhull.codeplex.com%2Flicense&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520389325%7
@@ -892,7 +894,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fmico
 64003900340036003200350031006600660036002500370043003600370062006600660037003900650037006600390031003400340033003300610038006500350063003900320035003200640032006400640063003100640025003700430030002500370043003000250037004300360033003700360031003700390034
 00370035003200300033003800390033003200350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900
 560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068004e0053006f005a0037005100580070006400440034
-00460068006600300044006c00610049007a006d0032007800460039005800470073006b007300430059004e006c0057006e0070005800510025003200420069004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031303}}
+00460068006600300044006c00610049007a006d0032007800460039005800470073006b007300430059004e006c0057006e0070005800510025003200420069004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003130300}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010 David Sehnal, Matthew Campbell
@@ -910,9 +912,9 @@ WARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 StarMath v.2.0.17:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
-HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FDesignEngrLab%2FStarMath%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7
-\hich\af4\dbch\af31505\loch\f4 C0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=QlLJQ5zjjCkV03%2BrjgrcdUTiz9O6pTyzKdtSv5xpHsg%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
+HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FDesignEngrLab%2FStarMath%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%\hich\af4\dbch\af31505\loch\f4 
+7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=QlLJQ5zjjCkV03%2BrjgrcdUTiz9O6pTyzKdtSv5xpHsg%3D&res
+\hich\af4\dbch\af31505\loch\f4 erved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b80030000680074007400700073003a002f002f006e0061006d00310031002e0073006100660065006c0069006e006b0073002e00700072006f00740065006300740069006f006e002e006f00750074006c006f006f00
 6b002e0063006f006d002f003f00750072006c003d00680074007400700073002500330041002500320046002500320046006700690074006800750062002e0063006f006d00250032004600440065007300690067006e0045006e00670072004c006100620025003200460053007400610072004d00610074006800250032
 00460062006c006f0062002500320046006d00610073007400650072002500320046004c004900430045004e0053004500260064006100740061003d0030003400250037004300300031002500370043004a0061006d00650073002e0043006f006e006e00650072002500340030006100750074006f006400650073006b00
@@ -920,7 +922,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003800380038003900350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a007300620033006400
 3800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e0030
 0025003300440025003700430031003000300030002600730064006100740061003d0051006c004c004a00510035007a006a006a0043006b0056003000330025003200420072006a0067007200630064005500540069007a0039004f0036007000540079007a004b0064007400530076003500780070004800730067002500
-330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2015 DesignEngrLab
@@ -942,7 +944,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
 \hich\af4\dbch\af31505\loch\f4 ing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
@@ -952,17 +954,17 @@ Unless required by applicable law or agreed to in writing, software distributed 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt 
 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0046006f007200740041007700650073006f006d0065002f0046006f006e0074002d0041007700650073006f00
-6d0065002f0062006c006f0062002f0035002e0078002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6d0065002f0062006c006f0062002f0035002e0078002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 CC BY 4.0 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  (}
 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://creativecommons.org/licenses/by/4.0/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f006300720065006100740069007600650063006f006d006d006f006e0073002e006f00720067002f006c006900630065006e007300650073002f00620079002f003400
-2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
+2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2022 Fonticons, Inc.}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://fontawesome.com }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt 
-{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}
+}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 \par 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 In the Font Awesome Free download, the CC BY 4.0 license applies to all icons packaged as SVG and JS file types.
@@ -970,7 +972,7 @@ https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt}}}\sectd \ltrse
 \par \hich\af4\dbch\af31505\loch\f4 Icons: CC BY 4.0 License (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://creativecommons.org/licenses/by/4.0/ }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f006300720065006100740069007600650063006f006d006d006f006e0073002e006f00720067002f006c006900630065006e007300650073002f00620079002f003400
-2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
+2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 ):  The Font Awesome Free download is licensed under a Creative Commons Attribution 4.0 International License and applies to all icons packaged as SVG and JS file types.
 \par 
@@ -978,20 +980,20 @@ https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt}}}\sectd \ltrse
 \par \hich\af4\dbch\af31505\loch\f4 In the Font Awesome Free download, the SIL OFL license applies to all icons packaged as web and desktop font files.
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2023 Fonticons, Inc. (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://fontawesome.com }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt 
-{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
-
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004400}}
+}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+\hich\af4\dbch\af31505\loch\f4 )
 \par \hich\af4\dbch\af31505\loch\f4 with Reserved Font Name: "Font Awesome".
 \par \hich\af4\dbch\af31505\loch\f4 This Font Software is licensed under the SIL Open Font License, Version 1.1. 
 \par \hich\af4\dbch\af31505\loch\f4 This license can be found at: }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://scripts.sil.org/OFL }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f0073006300720069007000740073002e00730069006c002e006f00720067002f004f0046004c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300cc}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f0073006300720069007000740073002e00730069006c002e006f00720067002f004f0046004c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300cc00}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://scripts.sil.org/OFL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Code: MIT License (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://opensource.org/licenses/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b60000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f004d00490054000000795881f43b1d7f48af2c
-825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 \par \hich\af4\dbch\af31505\loch\f4 In the Font Awesome Free download, the MIT license applies to all non-font and
 \par \hich\af4\dbch\af31505\loch\f4 non-icon files.
@@ -1006,8 +1008,8 @@ HYPERLINK https://opensource.org/licenses/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fc
 \par \hich\af4\dbch\af31505\loch\f4 copies or substantial portions of the Software.
 \par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 \par \hich\af4\dbch\af31505\loch\f4 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-\par \hich\af4\dbch\af31505\loch\f4 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-\par \hich\af4\dbch\af31505\loch\f4 HOLDERS BE LIABLE FOR ANY CLAIM, DAMA\hich\af4\dbch\af31505\loch\f4 GES OR OTHER LIABILITY, WHETHER IN AN ACTION
+\par \hich\af4\dbch\af31505\loch\f4 PARTICULAR PURPOSE AND NONINFRINGEME\hich\af4\dbch\af31505\loch\f4 NT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+\par \hich\af4\dbch\af31505\loch\f4 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 \par \hich\af4\dbch\af31505\loch\f4 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 \par \hich\af4\dbch\af31505\loch\f4 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.}{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 \line \line }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 AngleSharp v.0.14.0: Copyright (c) 2013 - 2019 AngleSharp
@@ -1015,14 +1017,15 @@ HYPERLINK https://opensource.org/licenses/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fc
 \par \hich\af4\dbch\af31505\loch\f4 \hich\f4 AngleSharp.CSS v.0.14.2: Copyright \'a9\loch\f4  2013-2020 AngleSharp
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, \hich\af4\dbch\af31505\loch\f4 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated\hich\af4\dbch\af31505\loch\f4 
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+\hich\af4\dbch\af31505\loch\f4  Software is furnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABI\hich\af4\dbch\af31505\loch\f4 
-LITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
-\hich\af4\dbch\af31505\loch\f4 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY \hich\af4\dbch\af31505\loch\f4 
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+\hich\af4\dbch\af31505\loch\f4  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HTMLSanitizer v.5.0.372:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -1036,7 +1039,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 003400370035003200300032003200300031003400390025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f00
 6900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d00740037005700440030006d006b006f002500320042
 002500320046004600250032004600640070004b004b004c00480079004d003900330055004300580072005800250032004200580077006f0033007900550059005600470050005a0051006300470073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab00038bf0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00000000a5ab00038bf000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%
@@ -1049,7 +1052,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003200300031003400390025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300
 64003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e
 00300025003300440025003700430031003000300030002600730064006100740061003d00700068004c0047006e006c006f005400250032004600430067006c00610062006500620068002500320046007300550053006300360069006900440079007400360044003300760053004d00500050004b004100250032004600
-67004f004a0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+67004f004a0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003130000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2013-2016 Michael Ganss and HtmlSanitizer contributors
@@ -1076,7 +1079,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 36003200350031006600660036002500370043003600370062006600660037003900650037006600390031003400340033003300610038006500350063003900320035003200640032006400640063003100640025003700430030002500370043003000250037004300360033003700360031003700390034003700350032
 00300033003700390033003700350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c00
 75004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0049006b00610057006a0071006a00360055007700490071006f00550042
-003800450051004f0065005a004b0059004d007a003400710062005700670038006b0062006200430063005a00300051006100250032004600680067002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {
+003800450051004f0065005a004b0059004d007a003400710062005700670038006b0062006200430063005a00300051006100250032004600680067002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -1090,7 +1093,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003700390033003700350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300640038006500
 79004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e003000250033
 00440025003700430031003000300030002600730064006100740061003d00650049004c0033003700630039004700250032004200310031007500710031006800740058003800410052006800530043007600650066007000510049004f004d0058006a005600410071004d00680031006100630065005500250033004400
-2600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/lunet-io/markdig/blob/master/license.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2018-2019, Alexandre Mutel
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
@@ -1230,7 +1233,7 @@ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILI
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030001}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000100}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gover
 \hich\af4\dbch\af31505\loch\f4 ning permissions and limitations under the License.
@@ -1271,7 +1274,7 @@ The Artifakt font software is Autodesk proprietary and confidential, and may be 
 \hich\af4\dbch\af31505\loch\f4 operty rights as well as a breach of your agreement with Autodesk. Go to }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://brand.autodesk.com/brand-system/typography }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7e000000680074007400700073003a002f002f006200720061006e0064002e006100750074006f006400650073006b002e0063006f006d002f006200720061006e0064002d00730079007300740065006d002f007400
-790070006f006700720061007000680079000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://brand.autodesk.com/brand-system/typography}}}
+790070006f006700720061007000680079000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004400}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://brand.autodesk.com/brand-system/typography}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  for detailed usage guidelines on when and how to use the Artifakt designer collection.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 DirectX
@@ -1279,21 +1282,21 @@ HYPERLINK https://brand.autodesk.com/brand-system/typography }{\rtlch\fcs1 \af4\
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfe000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f0044006900720065006300740058002000530044004b
-002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/directx%20redist.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfa000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f00640069007200650063007400780020007200650064
-006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e60000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 ImageMagick
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://imagemagick.org/script/license.php }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f0069006d006100670065006d0061006700690063006b002e006f00720067002f007300630072006900700074002f006c006900630065006e00730065002e0070006800
-70000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+70000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 LiveChartsCore v.2.0.0-}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
@@ -1327,7 +1330,7 @@ https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/Licen
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright [2013] [dlemstra]
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/dlemstra/Magick.NET/blob/main/License.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b92000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006c0065006d0073007400720061002f004d0061006700690063006b002e004e00450054002f0062006c00
-6f0062002f006d00610069006e002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6f0062002f006d00610069006e002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License");
@@ -1337,7 +1340,7 @@ https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\l
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 Unless required by applicable law or agreed to in writing, software
@@ -1349,7 +1352,7 @@ https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\l
 \par \hich\af4\dbch\af31505\loch\f4 Magick.NET-Q8-AnyCPU v7.24.1:
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://imagemagick.org/script/license.php }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f0069006d006100670065006d0061006700690063006b002e006f00720067002f007300630072006900700074002f006c006900630065006e00730065002e0070006800
-70000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+70000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004402}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Copyright 1999-2021 ImageMagick Studio LLC, a non-profit organization dedicated to making software imaging solutions freely available.
@@ -1357,66 +1360,66 @@ Copyright 1999-2021 ImageMagick Studio LLC, a non-profit organization dedicated 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Open XML SDK
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/OfficeDev/Open-XML-SDK }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004f00660066006900630065004400650076002f004f00700065006e002d0058004d004c002d00530044004b00
-0000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/OfficeDev/Open-XML-SDK}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+0000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/OfficeDev/Open-XML-SDK}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004f00660066006900630065004400650076002f004f00700065006e002d0058004d004c002d00530044004b00
-2f0062006c006f0062002f006d00610069006e002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2f0062006c006f0062002f006d00610069006e002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python Standard Library
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/library/" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b62000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900620072006100720079002f000000795881f43b1d7f48
-af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
+af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/license.html" }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900630065006e00730065002e00680074006d006c000000
-795881f43b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html
+795881f43b1d7f48af2c825dc485276300000000a5ab0003e60000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python Modules}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\highlight8\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://numpy.org/ }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f006e0075006d00700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://numpy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License: Distributed under a liberal}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf24\highlight8\insrsid16677021 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f006e0075006d00700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://numpy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License: Distributed under a liberal}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf24\highlight8\insrsid16677021 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006d00700079002f006e0075006d00700079002f0062006c006f0062002f006d00610069006e002f00
-4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
+4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pandas.pydata.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e000000680074007400700073003a002f002f00700061006e006400610073002e007000790064006100740061002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e000000680074007400700073003a002f002f00700061006e006400610073002e007000790064006100740061002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000048}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pandas.pydata.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 :}{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  BSD 3-Clause "New" or "Revised" License}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://scipy.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f00730063006900700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://scipy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f00730063006900700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000a4}}}{\fldrslt {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://scipy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 Distributed under a liberal}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006d00700079002f006e0075006d00700079002f0062006c006f0062002f006d00610069006e002f00
-4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000316f8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
+4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000316f848}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pypi.org/project/openpyxl/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e000000680074007400700073003a002f002f0070007900700069002e006f00720067002f00700072006f006a006500630074002f006f00700065006e007000790078006c002f000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030055}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/openpyxl/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab0003005500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/openpyxl/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:\~MIT License (MIT)}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\highlight8\insrsid16677021 
 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://matplotlib.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b48000000680074007400700073003a002f002f006d006100740070006c006f0074006c00690062002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00039000}}}{\fldrslt {
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b48000000680074007400700073003a002f002f006d006100740070006c006f0074006c00690062002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003900000}}}{\fldrslt {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://matplotlib.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 : }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Matplotlib only uses BSD compatible code, and its license is based on the\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://docs.python.org/3/license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b66000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0033002f006c006900630065006e00730065002e00680074006d006c000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 PSF}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+3b1d7f48af2c825dc485276300000000a5ab0003e60000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 PSF}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 license}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf24\highlight8\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pypi.org/project/Pillow/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5a000000680074007400700073003a002f002f0070007900700069002e006f00720067002f00700072006f006a006500630074002f00500069006c006c006f0077002f000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/Pillow/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/Pillow/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf24\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~
 \hich\af4\dbch\af31505\loch\f4 Historical Permission Notice}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  and Disclaimer (HPND) }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf23\highlight8\insrsid16677021 
@@ -1427,13 +1430,13 @@ HYPERLINK "https://docs.python.org/3/license.html" }{\rtlch\fcs1 \af4\afs22 \ltr
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://opensource.org/licenses/ms-pl.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006d0073002d0070006c002e00680074006d00
-6c000000795881f43b1d7f48af2c825dc485276300000000a5ab00032065}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License
+6c000000795881f43b1d7f48af2c825dc485276300000000a5ab0003206500}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be2000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007800630065006500640073006f006600740077006100720065002f0077007000660074006f006f006c006b00
 690074002f0062006c006f0062002f0030006500640034006500640038003400310035003200640036006100330065003200610036003200370066003200650066003000350066003800320036003200370066006400610066003300660063002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f
-48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af40\afs20 \ltrch\fcs0 \b\f40\fs20\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft.Web.WebView2 v.1.0.2045.28
@@ -1458,7 +1461,7 @@ https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f826
 \par \hich\af4\dbch\af31505\loch\f4 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 \par \hich\af4\dbch\af31505\loch\f4 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT\hich\af4\dbch\af31505\loch\f4  SHALL THE COPYRIGHT
 \par \hich\af4\dbch\af31505\loch\f4 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-\par \hich\af4\dbch\af31505\loch\f4 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+\par \hich\af4\dbch\af31505\loch\f4 SPECIAL, EX\hich\af4\dbch\af31505\loch\f4 EMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 \par \hich\af4\dbch\af31505\loch\f4 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 \par \hich\af4\dbch\af31505\loch\f4 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 \par \hich\af4\dbch\af31505\loch\f4 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
@@ -1467,26 +1470,26 @@ https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f826
 \par 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Lucene.Net v.4.8.0-beta00016
 \par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.Analysis.Common v.4.8.0-beta00016
-\par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.Queries v.4.8.\hich\af4\dbch\af31505\loch\f4 0-beta00016
+\par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.Queries v.4.8.0-beta00016
 \par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.QueryParser v.4.8.0-beta00016
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Lucene.Net.Sandbox v.4.8.0-beta00016
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://lucenenet.apache.org/"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54000000680074007400700073003a002f002f006c007500630065006e0065006e00650074002e006100700061006300680065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://lucenenet.apache.org/
+0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://lucenenet.apache.org/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/apache/lucenenet/blob/master/LICENSE.txt }{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006100700061006300680065002f006c007500630065006e0065006e00650074002f0062006c006f0062002f00
-6d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 
+6d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/apache/lucenenet/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright 2022 Apache Lucene.NET
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \ab\af4\afs22 
 \ltrch\fcs0 \b\fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\kerning1\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e6ff}}}{\fldrslt {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e6ff00}}}{\fldrslt {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language gove
 \hich\af4\dbch\af31505\loch\f4 rning permissions and limitations under the License.
@@ -1496,7 +1499,7 @@ Lucene.Net.Sandbox v.4.8.0-beta00016
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/dotnet/runtime/blob/main/LICENSE.TXT }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b88000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f00720075006e00740069006d0065002f0062006c006f0062002f006d006100
-69006e002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00037cff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+69006e002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00037cff00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/dotnet/runtime/blob/main/LICENSE.TXT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf22\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf22\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
@@ -1506,7 +1509,7 @@ https://github.com/dotnet/runtime/blob/main/LICENSE.TXT}}}\sectd \ltrsect\linex0
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
 \hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above\hich\af4\dbch\af31505\loch\f4  copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The abo\hich\af4\dbch\af31505\loch\f4 ve copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
@@ -1518,13 +1521,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\kerning1\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a006f007300680043006c006f00730065002f00430073007600480065006c007000650072002f0062006c00
-6f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030eff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030eff44}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf22\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000033}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language gove
 \hich\af4\dbch\af31505\loch\f4 rning permissions and limitations under the License.
@@ -1533,7 +1536,7 @@ https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt}}}\sectd \ltrsect
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt }{\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b94000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0050007200690073006d004c006900620072006100720079002f0050007200690073006d002f0062006c006f00
-62002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+62002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000037}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) Prism Library
@@ -1551,14 +1554,14 @@ TWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://lucenenet.apache.org/"}{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54000000680074007400700073003a002f002f006c007500630065006e0065006e00650074002e006100700061006300680065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MimeMapping v2.0.0
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MIT License
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://licenses.nuget.org/MIT }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\kerning1\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b56000000680074007400700073003a002f002f006c006900630065006e007300650073002e006e0075006700650074002e006f00720067002f004d00490054000000795881f43b1d7f48af2c825dc485276300000000
-a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf22\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) <year> <copyright holders>
 \par 
@@ -1569,17 +1572,18 @@ this software and associated documentation files}{\rtlch\fcs1 \af4\afs22 \ltrch\
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this \hich\af4\dbch\af31505\loch\f4 permission notice\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 (including the next paragraph)}{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\~}{
-\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 THE AUTHORS OR COPYRIGHT HOLDERS}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS P\hich\af4\dbch\af31505\loch\f4 
+ROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 
+\i\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 THE AUTHORS OR COPYRIGHT HOLDERS}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 
 BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf25\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 DotNetProjects.Extended.Wpf.Toolkit v5.0.103
-\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Micro\hich\af4\dbch\af31505\loch\f4 soft Public License
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft Public Licen\hich\af4\dbch\af31505\loch\f4 se
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb4000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e0065007400700072006f006a0065006300740073002f005700700066004500780074006500
-6e0064006500640054006f006f006c006b00690074002f0062006c006f0062002f0045007800740065006e006400650064002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+6e0064006500640054006f006f006c006b00690074002f0062006c006f0062002f0045007800740065006e006400650064002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -1588,43 +1592,43 @@ This license governs use of the accompanying software. If you use the software, 
 \par \hich\af4\dbch\af31505\loch\f4 1. Definitions
 \par \hich\af4\dbch\af31505\loch\f4 
 The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law. A "contribution" is the original software, or any additions or changes to the software. A "contributor" is any person tha
-\hich\af4\dbch\af31505\loch\f4 t distributes its contribution under this license. "Licensed patents" are a c\hich\af4\dbch\af31505\loch\f4 ontributor's patent claims that read directly on its contribution.
+\hich\af4\dbch\af31505\loch\f4 t distributes its contribution under this license. "Licensed patents" are a\hich\af4\dbch\af31505\loch\f4  contributor's patent claims that read directly on its contribution.
 \par \hich\af4\dbch\af31505\loch\f4 2. Grant of Rights
 \par \hich\af4\dbch\af31505\loch\f4 
 (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivat
 \hich\af4\dbch\af31505\loch\f4 ive works of its contribution, and distribute its contribution or any derivative works that you create.
-\par \hich\af4\dbch\af31505\loch\f4 (B) Patent Grant- Subject to the terms of this license, including t\hich\af4\dbch\af31505\loch\f4 
-he license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution
-\hich\af4\dbch\af31505\loch\f4  in the software or derivative works of the contribution in the software.
+\par \hich\af4\dbch\af31505\loch\f4 (B) Patent Grant- Subject to the terms of this license, including\hich\af4\dbch\af31505\loch\f4 
+ the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contributi
+\hich\af4\dbch\af31505\loch\f4 on in the software or derivative works of the contribution in the software.
 \par \hich\af4\dbch\af31505\loch\f4 3. Conditions and Limitations
 \par \hich\af4\dbch\af31505\loch\f4 (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-\par \hich\af4\dbch\af31505\loch\f4 (B) If you bring a patent claim agai\hich\af4\dbch\af31505\loch\f4 nst any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+\par \hich\af4\dbch\af31505\loch\f4 (B) If you bring a patent claim ag\hich\af4\dbch\af31505\loch\f4 ainst any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
 
 \par \hich\af4\dbch\af31505\loch\f4 (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-\par \hich\af4\dbch\af31505\loch\f4 (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute 
-\hich\af4\dbch\af31505\loch\f4 any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+\par \hich\af4\dbch\af31505\loch\f4 (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribut
+\hich\af4\dbch\af31505\loch\f4 e any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
 \par \hich\af4\dbch\af31505\loch\f4 
 (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees, or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent perm
-\hich\af4\dbch\af31505\loch\f4 itted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpos\hich\af4\dbch\af31505\loch\f4 e and non-infringement.
+\hich\af4\dbch\af31505\loch\f4 itted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purp\hich\af4\dbch\af31505\loch\f4 ose and non-infringement.
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 CastleCore v.5.1.1
 \par \hich\af4\dbch\af31505\loch\f4 APACHE 2.0
 \par \hich\af4\dbch\af31505\loch\f4 Copyright 2004-2021 Castle Project - }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.castleproject.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5400000068007400740070003a002f002f007700770077002e0063006100730074006c006500700072006f006a006500630074002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.castleproject.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.castleproject.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 
 \par 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/castleproject/Core/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0063006100730074006c006500700072006f006a006500630074002f0043006f00720065002f0062006c006f00
-62002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00032c00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+62002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00032c0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/castleproject/Core/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 DynamicLanguageRuntime v.1.2.2
 \par \hich\af4\dbch\af31505\loch\f4 APACHE 2.0
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/IronLanguages/dlr/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00490072006f006e004c0061006e006700750061006700650073002f0064006c0072002f0062006c006f006200
-2f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/IronLanguages/dlr/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
@@ -1633,7 +1637,7 @@ https://github.com/IronLanguages/dlr/blob/master/LICENSE}}}\sectd \ltrsect\linex
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e60000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an ""AS IS"" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gov
 \hich\af4\dbch\af31505\loch\f4 erning permissions and limitations under the License.
@@ -1679,8 +1683,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0063006f007600650072006c00650074002d0063006f007600650072006100670065002f0063006f0076006500
-72006c00650074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
-https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+72006c00650074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004421}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
+\hich\af4\dbch\af31505\loch\f4 https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2018 Toni Solarin-Sodara
 \par 
@@ -1706,7 +1710,7 @@ https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE}}}\sectd \ltrs
 \par \hich\af4\dbch\af31505\loch\f4 APACHE 2.0
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004e0069006700680074004f0077006c003800380038002f004a0032004e002f0062006c006f0062002f006d00
-610069006e002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+610069006e002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000078}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 JUnitTestLogger v.1.1.0
@@ -1714,7 +1718,7 @@ https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00730079006e00630072006f006d00610074006900630073002f004a0055006e00690074005400650073007400
-4c006f0067006700650072002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030e02}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+4c006f0067006700650072002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030e0200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang1053\langfe1033\langnp1053\insrsid16677021 
 \par 
@@ -1743,7 +1747,7 @@ https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007300700065006b0074002f006a0075006e00690074002e0074006500730074006c006f006700670065007200
-2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00032709}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003270900}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2017-2018
@@ -1770,7 +1774,7 @@ https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md}}}\sectd \ltrse
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/nunit/nunit.analyzers/blob/master/license.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006e00690074002f006e0075006e00690074002e0061006e0061006c0079007a006500720073002f00
-62006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003137c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+62006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003137c00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/nunit/nunit.analyzers/blob/master/license.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1936,8 +1940,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000040a6
-1cd3a079db01feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000010eb
+8b69027bdb01feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -3,14 +3,14 @@
 {\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f84\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}{\f85\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}
-{\f87\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f88\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f89\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}{\f90\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}
-{\f91\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f92\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
-{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
-{\f444\fbidi \fswiss\fcharset238\fprq2 Verdana CE;}{\f445\fbidi \fswiss\fcharset204\fprq2 Verdana Cyr;}{\f447\fbidi \fswiss\fcharset161\fprq2 Verdana Greek;}{\f448\fbidi \fswiss\fcharset162\fprq2 Verdana Tur;}
-{\f451\fbidi \fswiss\fcharset186\fprq2 Verdana Baltic;}{\f452\fbidi \fswiss\fcharset163\fprq2 Verdana (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f46\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f47\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f49\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f50\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f51\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f52\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f53\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f54\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f86\fbidi \fswiss\fcharset238\fprq2 Helvetica CE;}{\f87\fbidi \fswiss\fcharset204\fprq2 Helvetica Cyr;}
+{\f89\fbidi \fswiss\fcharset161\fprq2 Helvetica Greek;}{\f90\fbidi \fswiss\fcharset162\fprq2 Helvetica Tur;}{\f91\fbidi \fswiss\fcharset177\fprq2 Helvetica (Hebrew);}{\f92\fbidi \fswiss\fcharset178\fprq2 Helvetica (Arabic);}
+{\f93\fbidi \fswiss\fcharset186\fprq2 Helvetica Baltic;}{\f94\fbidi \fswiss\fcharset163\fprq2 Helvetica (Vietnamese);}{\f386\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f387\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
+{\f389\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f390\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f393\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f394\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
+{\f446\fbidi \fswiss\fcharset238\fprq2 Verdana CE;}{\f447\fbidi \fswiss\fcharset204\fprq2 Verdana Cyr;}{\f449\fbidi \fswiss\fcharset161\fprq2 Verdana Greek;}{\f450\fbidi \fswiss\fcharset162\fprq2 Verdana Tur;}
+{\f453\fbidi \fswiss\fcharset186\fprq2 Verdana Baltic;}{\f454\fbidi \fswiss\fcharset163\fprq2 Verdana (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -47,11 +47,11 @@ heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\li
 \snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af0\afs32 \ltrch\fcs0 \fs32\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \af0\afs26 
 \ltrch\fcs0 \fs26\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \ssemihidden \spriority9 Heading 2 Char;}{\*\cs17 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \fs24\cf20\kerning0\loch\f31502\hich\af31502\dbch\af31501 
 \sbasedon10 \slink3 \ssemihidden \spriority9 Heading 3 Char;}{\*\cs18 \additive \rtlch\fcs1 \ai\af0\afs24 \ltrch\fcs0 \i\fs24\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink4 \ssemihidden \spriority9 Heading 4 Char;}}
-{\*\rsidtbl \rsid12128070\rsid16021563\rsid16677021}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Tiberiu Pinzariu}{\operator Aaron Tang}
-{\creatim\yr2024\mo3\dy18\hr10\min4}{\revtim\yr2024\mo4\dy12\hr10\min38}{\version3}{\edmins4}{\nofpages29}{\nofwords13384}{\nofchars76291}{\nofcharsws89497}{\vern89}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+{\*\rsidtbl \rsid7422124\rsid12128070\rsid16021563\rsid16677021}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Tiberiu Pinzariu}{\operator Aaron Tang}
+{\creatim\yr2024\mo3\dy18\hr10\min4}{\revtim\yr2025\mo2\dy7\hr15\min42}{\version4}{\edmins5}{\nofpages29}{\nofwords13384}{\nofchars76290}{\nofcharsws89496}{\vern109}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale150\rsidroot12128070 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot12128070 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
 \pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
 \pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 
@@ -79,8 +79,8 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 37003800300038006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036
 003100370039003400370035003200300031003200300035003100310025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068004d003400530045004300520058
-006c004900330059003300620068005700640030006e00370061005600460045005300380070005900660045003300740066006400690049006600620053007300640049006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+006c004900330059003300620068005700640030006e00370061005600460045005300380070005900660045003300740066006400690049006600620053007300640049006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
 \hich\af4\dbch\af31505\loch\f4 ing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
@@ -90,7 +90,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 s online and offline privacy practices, please see the }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bae00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f007400
-69006300650073002d00740072006100640065006d00610072006b0073002f0070007200690076006100630079002d00730074006100740065006d0065006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+69006300650073002d00740072006100640065006d00610072006b0073002f0070007200690076006100630079002d00730074006100740065006d0065006e0074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030002}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Privacy Statement}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 .}{\rtlch\fcs1 \af40\afs16 \ltrch\fcs0 \f40\fs16\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par 
@@ -99,7 +99,7 @@ HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-stat
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
-740069006300650073002d00740072006100640065006d00610072006b0073002f0069006e00740065006c006c00650063007400750061006c002d00700072006f00700065007200740079002f00740072006100640065006d00610072006b0073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+740069006300650073002d00740072006100640065006d00610072006b0073002f0069006e00740065006c006c00650063007400750061006c002d00700072006f00700065007200740079002f00740072006100640065006d00610072006b0073000000795881f43b1d7f48af2c825dc485276300000000a5ab000300e4}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Trademarks page}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.  
 \par 
@@ -112,13 +112,13 @@ This Product or Service may incorporate or use background Autodesk online and de
 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd2000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f006100750074006f006400650073006b002d0063006c006f00750064002d0070006c006100740066006f0072006d002d0063006f006d0070006f006e0065006e00740073000000795881f43b1d7f48af2c825dc485276300000000a5ab00
-0300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 
+0300ff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Cloud Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 
 \ltrch\fcs0 \f0\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af0\dbch\af31505\loch\f0  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 and }{\field{\*\fldinst 
 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"}{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd6000000680074007400700073003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f0063006f006d00700061006e0079002f006c006500670061006c002d006e006f00
 740069006300650073002d00740072006100640065006d00610072006b0073002f006100750074006f006400650073006b002d006400650073006b0074006f0070002d0070006c006100740066006f0072006d002d0063006f006d0070006f006e0065006e00740073000000795881f43b1d7f48af2c825dc4852763000000
-00a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Desktop Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+00a5ab00030072}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Desktop Platform Components}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 .
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sb168\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -127,7 +127,7 @@ LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRe
 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba8000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
-610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+610073007400650072002f0064006f0063002f0064006900730074007200690062002f004100750074006f006400650073006b002e007200740066000000795881f43b1d7f48af2c825dc485276300000000a5ab0003002f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
@@ -135,12 +135,13 @@ LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRe
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Third-Party Trademarks, Software Credits and Attributions
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Greg v.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af0\dbch\af31505\loch\f0  }{
-\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 v.2.5.0.5076:
+\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 v.2.5.0.}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid7422124 
+\hich\af4\dbch\af31505\loch\f4 6246}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 :
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 (The MIT License)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2013 Peter Boyer }{\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af0\dbch\af31505\loch\f0 HYPERLINK "mailto:peter.boyer@autodesk.com" }{
 \rtlch\fcs1 \af0 \ltrch\fcs0 \f0\ul\cf22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b580000006d00610069006c0074006f003a00700065007400650072002e0062006f0079006500720040006100750074006f006400650073006b002e0063006f006d000000795881f43b1d7f48af2c825dc48527630000
-0000a5ab000352}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 peter.boyer@autodesk.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+0000a5ab00035200}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 peter.boyer@autodesk.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, 
 \hich\af4\dbch\af31505\loch\f4 merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -179,8 +180,8 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 37003800300038006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036
 003100370039003400370035003200300034003100390032003000300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068007600520034006d005900670056
-0068004d005000700051006800340075004c0043004a00330050005900390059007700720038006d004d0030007600710058004600390038006100630038006d005000580041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+0068004d005000700051006800340075004c0043004a00330050005900390059007700720038006d004d0030007600710058004600390038006100630038006d005000580041002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030062}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJamesNK%2FNewtonsoft.Json%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc
@@ -193,7 +194,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003200390031003400380025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00
 73006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a0058005600430049
 0036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004f0075005800300079007600750025003200460030006b00560053003700580035004b00410052006a0051003300700039005900630067003800710076006b003600370066004600410061004b004e0045005700
-780062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
+780062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030074}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007 James Newton-King
@@ -202,13 +203,16 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
 \hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyrig\hich\af4\dbch\af31505\loch\f4 ht notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH\hich\af4\dbch\af31505\loch\f4 
+ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par 
-\par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 RestSharp v.106.12.0.0:
+\par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 RestSharp v.1}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid7422124 
+\hich\af4\dbch\af31505\loch\f4 12}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 .}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid7422124 0}{\rtlch\fcs1 
+\ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 .0.0:
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C6376179475204789
 \hich\af4\dbch\af31505\loch\f4 47%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=foUoDUPyy8Or0rkNJtlLjI9XfJO7gemOLFnuKIkflHU%3D&reserved=0" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
@@ -219,15 +223,15 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 37003800300038006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036
 003100370039003400370035003200300034003700380039003400370025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a005100
 49006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066006f0055006f0044005500500079
-00790038004f007200300072006b004e004a0074006c004c006a0049003900580066004a004f003700670065006d004f004c0046006e0075004b0049006b0066006c00480055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+00790038004f007200300072006b004e004a0074006c004c006a0049003900580066004a004f003700670065006d004f004c0046006e0075004b0049006b0066006c00480055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2021 Alexe Zimarev
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000313}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00031300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gover
 \hich\af4\dbch\af31505\loch\f4 ning permissions and limitations under the License.
@@ -238,27 +242,26 @@ System.Collections.Immutable v.8.0.0:
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang2057\langfe1033\langnp2057\insrsid16677021 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a cop\hich\af4\dbch\af31505\loch\f4 
+y of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, 
+\hich\af4\dbch\af31505\loch\f4 and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above\hich\af4\dbch\af31505\loch\f4  copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECT\hich\af4\dbch\af31505\loch\f4 
-ION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED \hich\af4\dbch\af31505\loch\f4 
+"AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DA
+\hich\af4\dbch\af31505\loch\f4 MAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\lang2057\langfe1033\langnp2057\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 FontAwesome5 v.2.1.11:
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://www.nuget.org/packages/FontAwesome5/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1031\langfe1033\langnp1031\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f007700770077002e006e0075006700650074002e006f00720067002f007000610063006b0061006700650073002f0046006f006e00740041007700650073006f006d00
-650035002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.nuget.org/packages/FontAwesome5/}}}
+650035002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.nuget.org/packages/FontAwesome5/}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/MartinTopfstedt/FontAwesome5/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1031\langfe1033\langnp1031\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004d0061007200740069006e0054006f0070006600730074006500640074002f0046006f006e00740041007700
-650073006f006d00650035002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+650073006f006d00650035002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/MartinTopfstedt/FontAwesome5/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MIT License
@@ -283,7 +286,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 004300300025003700430036003300370036003100370039003400370035003200300031003600300033003400330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a004100
 77004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061
 003d006b00760064004f002500320046005000500067007a0033005000750041005300470036007a00760039003300440077004e004a003400670050006b004c00360054003600690073006c005700420077006f004900390058006b002500330044002600720065007300650072007600650064003d0030000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+3b1d7f48af2c825dc485276300000000a5ab000300c8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont%2Fblob%2Fmaster%2FLICENSE.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5
@@ -296,7 +299,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300031003700300032003900370025003700430055006e006b006e006f0077006e00
 2500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061
 005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0057006a00450066002500320046007900450031006b006f006b006c0062006f0076007800660046007a00480072005300630063006b0049004c004f0069004100
-4f0051006c0047006b00680050004c0061005a002500320046004c0038002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+4f0051006c0047006b00680050004c0061005a002500320046004c0038002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2012-2021 Cyotek Ltd.
@@ -327,7 +330,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d00440041006900
 4c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0064006600570071
 0062006c00420038005600640044004c003600330041007900610077004e0066006700720046004700320054004400300038005000430072006800650071007300750025003200420037004b003000550073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485
-276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+276300000000a5ab00030030}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/helix-toolkit/helix-toolkit}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit%2Fblob%2Fdevelop%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2d
@@ -340,7 +343,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e006f0077006e0025003700430054005700460070006200
 47005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056
 004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d007100550050006c0070003600450058004100780048004f006b0039006500410043005900370044006f0070006100630055006c00560043006e003300350035004b004c0065006e0055007a006e005600
-250032004600740030002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+250032004600740030002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300a8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2019 Helix Toolkit contributors
@@ -374,7 +377,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003800380038003900350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a00
 6f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031
 003000300030002600730064006100740061003d0056004f005900680062003200490041005a004700470030006a0078002500320046007700510078004a00320051003900480058004e0032007400360058004b00560056005000360041006900420045006400440025003200460033004500250033004400260072006500
-7300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/sharpdx/SharpDX/blob/master/LICENSE}}}
+7300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/sharpdx/SharpDX/blob/master/LICENSE}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
 \par 
@@ -393,12 +396,12 @@ WARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 ICSharpCode.AvalonEdit v.6.3.0.90:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.avalonedit.net/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f007700770077002e006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f007700770077002e006100760061006c006f006e0065006400690074002e006e00650074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300af}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.avalonedit.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://licenses.nuget.org/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b56000000680074007400700073003a002f002f006c006900630065006e007300650073002e006e0075006700650074002e006f00720067002f004d00490054000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
-
+a5ab000300a8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MIT License
 \par 
@@ -426,7 +429,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 00300025003700430036003300370036003100370039003400370035003200300034003300390031003100300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a0041007700
 4d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d
 00750077006d00740054006c006200420055006a00710025003200420031007a0025003200460076004a007300620039006a0053004a003700690036004d003800680049004d006c006c00310071006e007a006e00420030006d00440077002500330044002600720065007300650072007600650064003d00300000007958
-81f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.google.com/fonts/specimen/Open+Sans}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+81f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.google.com/fonts/specimen/Open+Sans}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0.html&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C63761794752
@@ -439,14 +442,14 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 00430036003300370036003100370039003400370035003200300034003400390030003600360025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d0044004100
 69004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d007500340053
 00300037005600440046003200300025003200420068004b0073007700570075005000780066004e00780064004d007600450056003600750036006b005500780056005800690064003500370054004d006b0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825d
-c485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
-\ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+c485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  [yyyy] Steve Matteson
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf22\insrsid16677021 \hich\af0\dbch\af31505\loch\f0  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
 \hich\af4\dbch\af31505\loch\f4 ing permissions and limitations under the License.}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f0\fs22\ul\cf22\insrsid16677021 
@@ -455,43 +458,43 @@ Unless required by applicable law or agreed to in writing, software distributed 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) Microsoft Corporation
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated docu\hich\af4\dbch\af31505\loch\f4 
-mentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Soft
-\hich\af4\dbch\af31505\loch\f4 ware is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated doc\hich\af4\dbch\af31505\loch\f4 
+umentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Sof
+\hich\af4\dbch\af31505\loch\f4 tware is furnished to do so, subject to the following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,\hich\af4\dbch\af31505\loch\f4 
- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN A
-\hich\af4\dbch\af31505\loch\f4 N ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND\hich\af4\dbch\af31505\loch\f4 
+, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN 
+\hich\af4\dbch\af31505\loch\f4 AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 IronPython.StdLib v.2.7.9:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2018 Slide & Slozier
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 1. This LICENSE AGREEMENT is between the Python Soft\hich\af4\dbch\af31505\loch\f4 
-ware Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using Python 2.7.18 software in source or binary form and its associated documentation.
+\par \hich\af4\dbch\af31505\loch\f4 1. This LICENSE AGREEMENT is between the Python Sof\hich\af4\dbch\af31505\loch\f4 
+tware Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using Python 2.7.18 software in source or binary form and its associated documentation.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise
-\hich\af4\dbch\af31505\loch\f4  use Python 2.7.18 alone or in any derivative version, provided, howeve\hich\af4\dbch\af31505\loch\f4 \hich\f4 r, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright \'a9\loch\f4 
+\hich\af4\dbch\af31505\loch\f4  use Python 2.7.18 alone or in any derivative version, provided, howev\hich\af4\dbch\af31505\loch\f4 \hich\f4 er, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright \'a9\loch\f4 
  2001-2020 Python Software Foundation; All Rights Reserved" are retained in Python 2.7.18 alone or in any derivative version prepared by Licensee.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 3. In the event Licensee prepares a derivative work that is based on or incorporates Python 2.7.18 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a
-\hich\af4\dbch\af31505\loch\f4  brief summary of the change\hich\af4\dbch\af31505\loch\f4 s made to Python 2.7.18.
+\hich\af4\dbch\af31505\loch\f4  brief summary of the chang\hich\af4\dbch\af31505\loch\f4 es made to Python 2.7.18.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 4. PSF is making Python 2.7.18 available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY 
 \hich\af4\dbch\af31505\loch\f4 OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 2.7.18 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 2.7.18 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 2.7.18, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED O
-\hich\af4\dbch\af31505\loch\f4 F THE POSSIBILITY THEREOF.
+\par \hich\af4\dbch\af31505\loch\f4 5. PSF\hich\af4\dbch\af31505\loch\f4 
+ SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 2.7.18 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 2.7.18, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE 
+\hich\af4\dbch\af31505\loch\f4 POSSIBILITY THEREOF.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture \hich\af4\dbch\af31505\loch\f4 
-between PSF and Licensee.  This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
+\par \hich\af4\dbch\af31505\loch\f4 7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture betwee\hich\af4\dbch\af31505\loch\f4 
+n PSF and Licensee.  This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 8. By copying, installing or otherwise using Python 2.7.18, Licensee agrees to be bound by the terms and conditions of this License Agreement.
 \par 
@@ -508,7 +511,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Firon
 3700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003300300030003200360025003700430055006e006b006e006f
 0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b00
 3100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0069006d00520043005200350077006e007a004f00520069004f00250032004200480063006f00410073003400710059002500320046005500730067
-003200460033002500320042007600700051007300710075004700340070004c005000620063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+003200460033002500320042007600700051007300710075004700340070004c005000620063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://ironpython.net/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopensource.org%2Flicenses%2Fapache2.0.php&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C63761794752033
@@ -521,14 +524,14 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopen
 00370036003100370039003400370035003200300033003300390035003500310025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c004300
 4a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d00470071007a004e00330079
 0077006b006500670048006e0038005800770078006d006b006a0065003500480075004a004e004f0037006900650063007700420047005a00550033004c004f006f004e004900750073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab
-000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://opensource.org/licenses/apache2.0.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2018 Iron Python Community
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004a}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gover
 \hich\af4\dbch\af31505\loch\f4 ning permissions and limitations under the License.
@@ -536,15 +539,16 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopen
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python.Runtime.NETStandard v.3.7.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2006-2021 the contributors of the Python.NET project
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and as\hich\af4\dbch\af31505\loch\f4 
-sociated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to 
-\hich\af4\dbch\af31505\loch\f4 whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
+\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to t\hich\af4\dbch\af31505\loch\f4 he following conditions:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY\hich\af4\dbch\af31505\loch\f4 
- OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-\hich\af4\dbch\af31505\loch\f4 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE 
+\hich\af4\dbch\af31505\loch\f4 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, \hich\af4\dbch\af31505\loch\f4 
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python.Included v.3.7.3.4
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 PSF LICENSE AGREEMENT FOR PYTHON 3.10.4
@@ -553,25 +557,25 @@ sociated documentation files (the "Software"), to deal in the Software without r
 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using Python 3.7.3.4 software in source or binary form and its associated documentation.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
-2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, di
-\hich\af4\dbch\af31505\loch\f4 \hich\f4 stribute, and otherwise use Python 3.7.3.4 alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright \'a9\loch\f4 
- 2001-2022 Python Software Foundation; All Rights Reserved" are retained in Pyt\hich\af4\dbch\af31505\loch\f4 hon 3.7.3.4 alone or in any derivative version prepared by Licensee.
+2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise
+\hich\af4\dbch\af31505\loch\f4  use Python 3.7.3.\hich\af4\dbch\af31505\loch\f4 \hich\f4 4 alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright \'a9\loch\f4 
+ 2001-2022 Python Software Foundation; All Rights Reserved" are retained in Python 3.7.3.4 alone or in any derivative ve\hich\af4\dbch\af31505\loch\f4 rsion prepared by Licensee.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 3. In the event Licensee prepares a derivative work that is based on or incorporates Python 3.7.3.4 or any part thereof, and wants to make the derivative work available to others as provi\hich\af4\dbch\af31505\loch\f4 
-ded herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python 3.7.3.4.
+\par \hich\af4\dbch\af31505\loch\f4 
+3. In the event Licensee prepares a derivative work that is based on or incorporates Python 3.7.3.4 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees t
+\hich\af4\dbch\af31505\loch\f4 o include in any such work a brief summary of the changes made to Python 3.7.3.4.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 4. PSF is making Python 3.7.3.4 available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY
 \hich\af4\dbch\af31505\loch\f4  OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 3.7.3.4 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 5. PSF SHALL NOT \hich\af4\dbch\af31505\loch\f4 
-BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.7.3.4 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.3.4, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILI
-\hich\af4\dbch\af31505\loch\f4 TY THEREOF.
+\par \hich\af4\dbch\af31505\loch\f4 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS \hich\af4\dbch\af31505\loch\f4 
+OF PYTHON 3.7.3.4 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.3.4, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and\hich\af4\dbch\af31505\loch\f4 
- Licensee. This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
+\par \hich\af4\dbch\af31505\loch\f4 7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee. This License Agreement does no\hich\af4\dbch\af31505\loch\f4 
+t grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 8. By copying, installing or otherwise using Python 3.7.3.4, Licensee agrees to be bound by the terms and conditions of this License Agreement.
 \par 
@@ -587,7 +591,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003500390034003600350025003700
 430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a00420054
 0069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d003700410074005700450048006800480033006800320045003000650044006c0076007900680071004d0030004f007900
-520045004a00750067004e0044007300590061006900340053003500650067007700580063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+520045004a00750067004e0044007300590061006900340053003500650067007700580063002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/IPython/extensions/autoreload.py}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -601,7 +605,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003500390034003600350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a00
 6f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031
 003000300030002600730064006100740061003d00500069006c006b003000710053006a0059007100700062003400670077007300680039004300460061004700340032006d006b00350077006e006700420058004f00530079006b006700690042006a003100450051002500330044002600720065007300650072007600
-650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/LICENSE}}}\sectd \ltrsect
+650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/ipython/ipython/blob/master/LICENSE}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD 3-Clause License
 \par \hich\af4\dbch\af31505\loch\f4 - Copyright (c) 2008-Present, IPython Development Team
@@ -634,7 +638,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003200390031003400380025003700430055006e006b006e006f0077
 006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100
 680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004200550066004e006b002500320046006c0077002500320042006300490066003600390077003200250032004600550066003000520071002500320046
-00690044006400780074006c006d00340055004f0072006b006c005700750031006a00420063006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00690044006400780074006c006d00340055004f0072006b006c005700750031006a00420063006f002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300bd}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.nunit.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2002-2013 Charlie Poole\line \hich\f4 Copyright \'a9\loch\f4  2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov
 \line \hich\f4 Copyright \'a9\loch\f4  2000-2002 Philip A. Craig
@@ -655,21 +659,21 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 This license is based on\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "http://www.opensource.org/licenses/zlib-license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f007a006c00690062002d006c00
-6900630065006e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 the open source zlib/libpng license}}}
+6900630065006e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 the open source zlib/libpng license}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://opensource.org/licenses/zlib-license.html }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f007a006c00690062002d006c00690063006500
-6e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/zlib-license.html}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6e00730065002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/zlib-license.html}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 ). The idea was to keep the license as simple as possible to encourage use of NUnit in free and commercial applications and libraries, but to keep the source code together and to give credit to the NUnit contributors for their efforts. While this license 
 \hich\af4\dbch\af31505\loch\f4 allows shipping NUnit in source and binary form, if shipping a NUnit variant is the sole purpose of your product, please\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c0000006d00610069006c0074006f003a00630070006f006f006c006500400070006f006f006c00650063006f006e00730075006c00740069006e0067002e0063006f006d000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003c0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 let us know}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+276300000000a5ab0003c037}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 let us know}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "mailto:cpoole@pooleconsulting.com" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5c0000006d00610069006c0074006f003a00630070006f006f006c006500400070006f006f006c00650063006f006e00730075006c00740069006e0067002e0063006f006d000000795881f43b1d7f48af2c825dc485
-276300000000a5ab0003c0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 cpoole@pooleconsulting.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+276300000000a5ab0003c074}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 cpoole@pooleconsulting.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  ).
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang3082\langfe1033\kerning1\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Moq v.4.18.4:
@@ -684,7 +688,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003000390032003500330025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d00
 4300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030
 002600730064006100740061003d00480025003200460077004e006700790025003200460070004d00590049006700640025003200460046006c00500031004900550031006400620076005400550043006100750069007a0049004a004b0043004100550036004900530051005a0049002500330044002600720065007300
-650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/moq/moq4/blob/master/License.txt/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD 3-Clause License
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors. All rights reserved.
@@ -694,14 +698,16 @@ https://github.com/moq/moq4/blob/master/License.txt/}}}\sectd \ltrsect\linex0\se
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 \par \hich\af4\dbch\af31505\loch\f4 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-\par \hich\af4\dbch\af31505\loch\f4 * Neither the names of the copyright holders nor the names of its contributors may be used to endorse o\hich\af4\dbch\af31505\loch\f4 r promote products derived from this software without specific prior written permission.
+\par \hich\af4\dbch\af31505\loch\f4 * Neither the names of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written \hich\af4\dbch\af31505\loch\f4 permission.
 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SH
-\hich\af4\dbch\af31505\loch\f4 ALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PR\hich\af4\dbch\af31505\loch\f4 
-OCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-\hich\af4\dbch\af31505\loch\f4  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+\hich\af4\dbch\af31505\loch\f4 
+ALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+\hich\af4\dbch\af31505\loch\f4 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang3082\langfe1033\kerning1\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Libiconv v.1.14.0.1:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -714,8 +720,8 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 30003800640039003400360032003500310066006600360025003700430036003700620066006600370039006500370066003900310034003400330033006100380065003500630039003200350032006400320064006400630031006400250037004300300025003700430030002500370043003600330037003600310037
 0039003400370035003200300033003600390034003200300025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a00
 6f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066007900760051003800610078006400300037
-003200370041005200630073006300720032003300320069007100650057003100730047004b00360046005400710025003200460050003700730031005a0074004300360073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
+003200370041005200630073006300720032003300320069007100650057003100730047004b00360046005400710025003200460050003700730031005a0074004300360073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/libiconv/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a
@@ -728,7 +734,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003600390034003200300025003700430055006e006b006e00
 6f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b
 003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e005a005400390074004e0079005a006200790050007700310057004f004c007a00250032004200450036005300680077007800510044005700
-480042004a00390075004c0053007900480068004b0050004800570048006b002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+480042004a00390075004c0053007900480068004b0050004800570048006b002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  1998, 2013 Free Software Foundation, Inc.  
@@ -736,12 +742,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 \par \hich\af4\dbch\af31505\loch\f4 This Autodesk software contains libiconv v. 1.14.0.1.  libiconv is licensed under the GNU Lesser General Public License v.2.1, which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e0067006e0075002e006f00720067002f006c006900630065006e007300650073002f006f006c0064006c006900630065006e007300650073002f006c00
-670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300ff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 . A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libiconv from }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
@@ -755,14 +761,14 @@ c485276300000000a5ab00030f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22
 Contain a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or the envelope you have chosen) weighing  5 oun
 \hich\af4\dbch\af31505\loch\f4 ces from San Rafael,    California USA to your indicated address; and Identify:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 This Autodesk software name and release number; That you are requesting  the source code for libiconvv .1.14.0.1; and The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
-\hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
+\par \hich\af4\dbch\af31505\loch\f4 This Aut\hich\af4\dbch\af31505\loch\f4 odesk software name and release number; That you are requesting  the source code for libiconvv .1.14.0.1; and The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030f00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 ) so that Autodesk may properly respond to your request.  The offer to receive this libiconv source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab00030f}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030fff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.  You may modify, debug and relink libiconv to this Autodesk software as provided under the terms of the GNU L
 \hich\af4\dbch\af31505\loch\f4 esser General Public License v.2.1.
@@ -778,7 +784,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 38006400390034003600320035003100660066003600250037004300360037006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039
 003400370035003200300032003000300031003600340025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f00
 6900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e00660032003100580070004b0069004c00300077
-006b00250032004600760035006f00390035006e0036004e004800550039007900420054007300560057006d004b004c0066007100310041004a0047005100310062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+006b00250032004600760035006f00390035006e0036004e004800550039007900420054007300560057006d004b004c0066007100310041004a0047005100310062004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003005c}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -792,7 +798,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003100300031003100330025003700430055006e006b006e00
 6f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b
 003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0066006d003400630072006400340050002500320042007900360053004c00250032004600300067006c004c004b00770078004300770056003900
-4e006a004c005a0073003700660032004c0041006f004e004800660069003200510045002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+4e006a004c005a0073003700660032004c0041006f004e004800660069003200510045002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4 \hich\f4  Copyright \'a9\loch\f4  1991, 1999 Free Software Foundation, Inc.
@@ -800,12 +806,12 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww
 \par \hich\af4\dbch\af31505\loch\f4 This Autodesk software contains libintl v.0.19.8.3.  libintl is licensed under the GNU Lesser General Public License v.2.1 , which can be found at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8200000068007400740070003a002f002f007700770077002e0067006e0075002e006f00720067002f006c006900630065006e007300650073002f006f006c0064006c006900630065006e007300650073002f006c00
-670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 . }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+670070006c002d0032002e0031002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030062}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 . }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libintl v.0.19.8.3  from }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "http://www.autodesk.com/lgplsource" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e00000068007400740070003a002f002f007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825d
-c485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  or by sending a written request  to:
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Autodesk, Inc.
@@ -823,13 +829,13 @@ c485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22
 \par \hich\af4\dbch\af31505\loch\f4 b. That you are requesting  the source code for libintl v.0.19.8.3; and
 \par \hich\af4\dbch\af31505\loch\f4 c. The above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK www.autodesk.com/lgplsource }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 )
 \par \hich\af4\dbch\af31505\loch\f4 so that Autodesk may properly respond to your request.  The offer to receive this libintl source code via the above URL (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 HYPERLINK www.autodesk.com/lgplsource }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
-}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+00d0c9ea79f9bace118c8200aa004ba90b0200000001000000e0c9ea79f9bace118c8200aa004ba90b500000007700770077002e006100750074006f006400650073006b002e0063006f006d002f006c00670070006c0073006f0075007200630065000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}
+}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 www.autodesk.com/lgplsource}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.
 \par \hich\af4\dbch\af31505\loch\f4 You may modify, debug and relink libintl to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.2.1.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
@@ -846,7 +852,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fncal
 37006200660066003700390065003700660039003100340034003300330061003800650035006300390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003000390032003500330025003700430055
 006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a00420054006900
 4900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004d0058004a004e00610052003600390045004300670050004a0044004a005900500053006e0079004c00710047007800390041
-004700530077007a0025003200460051005a0052003500350046006e00440050007600350055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+004700530077007a0025003200460051005a0052003500350046006e00440050007600350055002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://ncalc.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang3082\langfe1033\langnp3082\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \loch\af4\dbch\af31505\hich\f4 \'a9\loch\f4  2011 Sebastien Ros
@@ -874,7 +880,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdes
 003300370036003100370039003400370035003200300033003800390033003200350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c00
 43004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d004e0059003100700047
 007000340052007500730031004900680058006f004c004500410067006500510067006300460033006700730051004b00350068006800700064004200590031004b00470078007400530059002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+a5ab000300d0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fmiconvexhull.codeplex.com%2Flicense&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520389325%7
@@ -886,7 +892,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fmico
 64003900340036003200350031006600660036002500370043003600370062006600660037003900650037006600390031003400340033003300610038006500350063003900320035003200640032006400640063003100640025003700430030002500370043003000250037004300360033003700360031003700390034
 00370035003200300033003800390033003200350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900
 560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0068004e0053006f005a0037005100580070006400440034
-00460068006600300044006c00610049007a006d0032007800460039005800470073006b007300430059004e006c0057006e0070005800510025003200420069004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000313}}
+00460068006600300044006c00610049007a006d0032007800460039005800470073006b007300430059004e006c0057006e0070005800510025003200420069004d002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031303}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://miconvexhull.codeplex.com/license}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2010 David Sehnal, Matthew Campbell
@@ -914,7 +920,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 0032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300034003800380038003900350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a007300620033006400
 3800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e0030
 0025003300440025003700430031003000300030002600730064006100740061003d0051006c004c004a00510035007a006a006a0043006b0056003000330025003200420072006a0067007200630064005500540069007a0039004f0036007000540079007a004b0064007400530076003500780070004800730067002500
-330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2015 DesignEngrLab
@@ -936,7 +942,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language govern
 \hich\af4\dbch\af31505\loch\f4 ing permissions and limitations under the License.}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
@@ -946,17 +952,17 @@ Unless required by applicable law or agreed to in writing, software distributed 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt 
 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0046006f007200740041007700650073006f006d0065002f0046006f006e0074002d0041007700650073006f00
-6d0065002f0062006c006f0062002f0035002e0078002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6d0065002f0062006c006f0062002f0035002e0078002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 CC BY 4.0 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  (}
 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://creativecommons.org/licenses/by/4.0/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f006300720065006100740069007600650063006f006d006d006f006e0073002e006f00720067002f006c006900630065006e007300650073002f00620079002f003400
-2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
+2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2022 Fonticons, Inc.}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4  (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://fontawesome.com }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt 
+{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
 \b\fs22\cf21\lang1031\langfe1033\kerning2\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 \par 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 In the Font Awesome Free download, the CC BY 4.0 license applies to all icons packaged as SVG and JS file types.
@@ -964,7 +970,7 @@ https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt}}}\sectd \ltrse
 \par \hich\af4\dbch\af31505\loch\f4 Icons: CC BY 4.0 License (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://creativecommons.org/licenses/by/4.0/ }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f006300720065006100740069007600650063006f006d006d006f006e0073002e006f00720067002f006c006900630065006e007300650073002f00620079002f003400
-2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
+2e0030002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://creativecommons.org/licenses/by/4.0/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 ):  The Font Awesome Free download is licensed under a Creative Commons Attribution 4.0 International License and applies to all icons packaged as SVG and JS file types.
 \par 
@@ -972,20 +978,20 @@ https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt}}}\sectd \ltrse
 \par \hich\af4\dbch\af31505\loch\f4 In the Font Awesome Free download, the SIL OFL license applies to all icons packaged as web and desktop font files.
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2023 Fonticons, Inc. (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://fontawesome.com }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {
-\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4a000000680074007400700073003a002f002f0066006f006e00740061007700650073006f006d0065002e0063006f006d002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt 
+{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://fontawesome.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 
 \par \hich\af4\dbch\af31505\loch\f4 with Reserved Font Name: "Font Awesome".
 \par \hich\af4\dbch\af31505\loch\f4 This Font Software is licensed under the SIL Open Font License, Version 1.1. 
 \par \hich\af4\dbch\af31505\loch\f4 This license can be found at: }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://scripts.sil.org/OFL }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f0073006300720069007000740073002e00730069006c002e006f00720067002f004f0046004c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e00000068007400740070003a002f002f0073006300720069007000740073002e00730069006c002e006f00720067002f004f0046004c000000795881f43b1d7f48af2c825dc485276300000000a5ab000300cc}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://scripts.sil.org/OFL}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Code: MIT License (}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://opensource.org/licenses/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b60000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f004d00490054000000795881f43b1d7f48af2c
-825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://opensource.org/licenses/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 )
 \par \hich\af4\dbch\af31505\loch\f4 In the Font Awesome Free download, the MIT license applies to all non-font and
 \par \hich\af4\dbch\af31505\loch\f4 non-icon files.
@@ -1000,8 +1006,8 @@ HYPERLINK https://opensource.org/licenses/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fc
 \par \hich\af4\dbch\af31505\loch\f4 copies or substantial portions of the Software.
 \par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 \par \hich\af4\dbch\af31505\loch\f4 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-\par \hich\af4\dbch\af31505\loch\f4 PARTICULAR PURPOSE AND NONINFRINGEME\hich\af4\dbch\af31505\loch\f4 NT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-\par \hich\af4\dbch\af31505\loch\f4 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+\par \hich\af4\dbch\af31505\loch\f4 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+\par \hich\af4\dbch\af31505\loch\f4 HOLDERS BE LIABLE FOR ANY CLAIM, DAMA\hich\af4\dbch\af31505\loch\f4 GES OR OTHER LIABILITY, WHETHER IN AN ACTION
 \par \hich\af4\dbch\af31505\loch\f4 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 \par \hich\af4\dbch\af31505\loch\f4 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.}{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 \line \line }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 AngleSharp v.0.14.0: Copyright (c) 2013 - 2019 AngleSharp
@@ -1009,15 +1015,14 @@ HYPERLINK https://opensource.org/licenses/MIT }{\rtlch\fcs1 \af4\afs22 \ltrch\fc
 \par \hich\af4\dbch\af31505\loch\f4 \hich\f4 AngleSharp.CSS v.0.14.2: Copyright \'a9\loch\f4  2013-2020 AngleSharp
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, \hich\af4\dbch\af31505\loch\f4 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABI\hich\af4\dbch\af31505\loch\f4 
+LITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+\hich\af4\dbch\af31505\loch\f4 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HTMLSanitizer v.5.0.372:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -1031,7 +1036,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 003400370035003200300032003200300031003400390025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f00
 6900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d00740037005700440030006d006b006f002500320042
 002500320046004600250032004600640070004b004b004c00480079004d003900330055004300580072005800250032004200580077006f0033007900550059005600470050005a0051006300470073002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab00038b}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00000000a5ab00038bf0}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/mganss/HtmlSanitizer}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%
@@ -1044,7 +1049,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00390032003500320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300032003200300031003400390025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300
 64003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e
 00300025003300440025003700430031003000300030002600730064006100740061003d00700068004c0047006e006c006f005400250032004600430067006c00610062006500620068002500320046007300550053006300360069006900440079007400360044003300760053004d00500050004b004100250032004600
-67004f004a0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000313}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+67004f004a0051002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00031300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2013-2016 Michael Ganss and HtmlSanitizer contributors
@@ -1071,7 +1076,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 36003200350031006600660036002500370043003600370062006600660037003900650037006600390031003400340033003300610038006500350063003900320035003200640032006400640063003100640025003700430030002500370043003000250037004300360033003700360031003700390034003700350032
 00300033003700390033003700350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a0073006200330064003800650079004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c00
 75004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e00300025003300440025003700430031003000300030002600730064006100740061003d0049006b00610057006a0071006a00360055007700490071006f00550042
-003800450051004f0065005a004b0059004d007a003400710062005700670038006b0062006200430063005a00300051006100250032004600680067002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {
+003800450051004f0065005a004b0059004d007a003400710062005700670038006b0062006200430063005a00300051006100250032004600680067002500330044002600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/lunet-io/markdig}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -1085,7 +1090,7 @@ HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit
 00320064003200640064006300310064002500370043003000250037004300300025003700430036003300370036003100370039003400370035003200300033003700390033003700350025003700430055006e006b006e006f0077006e002500370043005400570046007000620047005a00730062003300640038006500
 79004a00570049006a006f0069004d004300340077004c006a00410077004d004400410069004c0043004a00510049006a006f006900560032006c0075004d007a00490069004c0043004a004200540069004900360049006b003100680061005700770069004c0043004a00580056004300490036004d006e003000250033
 00440025003700430031003000300030002600730064006100740061003d00650049004c0033003700630039004700250032004200310031007500710031006800740058003800410052006800530043007600650066007000510049004f004d0058006a005600410071004d00680031006100630065005500250033004400
-2600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2600720065007300650072007600650064003d0030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/lunet-io/markdig/blob/master/license.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1031\langfe1033\langnp1031\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2018-2019, Alexandre Mutel
 \par \hich\af4\dbch\af31505\loch\f4 All rights reserved.
@@ -1178,27 +1183,27 @@ ION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
-\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copie\hich\af4\dbch\af31505\loch\f4 s of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all\hich\af4\dbch\af31505\loch\f4  copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABL\hich\af4\dbch\af31505\loch\f4 
-E FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs18 \ltrch\fcs0 \f40\fs18\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Rapidjson v.1.1.0:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4 
  2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including 
-\hich\af4\dbch\af31505\loch\f4 
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright noti
-\hich\af4\dbch\af31505\loch\f4 ce and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
+\hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject\hich\af4\dbch\af31505\loch\f4 
+ to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNE\hich\af4\dbch\af31505\loch\f4 
-SS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SO
-\hich\af4\dbch\af31505\loch\f4 FTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+\par \hich\af4\dbch\af31505\loch\f4 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERW\hich\af4\dbch\af31505\loch\f4 
+ISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Mono.Cecil v.0.11.4:
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2008 - 2015 Jb Evain
@@ -1225,7 +1230,7 @@ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILI
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030001}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gover
 \hich\af4\dbch\af31505\loch\f4 ning permissions and limitations under the License.
@@ -1247,19 +1252,18 @@ G BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Nlohmann.json v.3.7.3
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Copyright \'a9\loch\f4  2013-2022 Niels Lohmann
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 Permission is hereb\hich\af4\dbch\af31505\loch\f4 
-y granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, dist
-\hich\af4\dbch\af31505\loch\f4 ribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+\par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy of thi\hich\af4\dbch\af31505\loch\f4 
+s software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to p
+\hich\af4\dbch\af31505\loch\f4 ermit persons to whom the Software is
 \par \hich\af4\dbch\af31505\loch\f4 furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substant\hich\af4\dbch\af31505\loch\f4 ial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-\hich\af4\dbch\af31505\loch\f4  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+\par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS",\hich\af4\dbch\af31505\loch\f4 
+ WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+\hich\af4\dbch\af31505\loch\f4  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid16677021 
-\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Artifakt F\hich\af4\dbch\af31505\loch\f4 onts
-
+\par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Autodesk Artifakt Fonts
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 \hich\f4 Licensing information: \'a9\loch\f4  Autodesk, Inc. All Rights Reserved.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
@@ -1267,7 +1271,7 @@ The Artifakt font software is Autodesk proprietary and confidential, and may be 
 \hich\af4\dbch\af31505\loch\f4 operty rights as well as a breach of your agreement with Autodesk. Go to }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://brand.autodesk.com/brand-system/typography }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7e000000680074007400700073003a002f002f006200720061006e0064002e006100750074006f006400650073006b002e0063006f006d002f006200720061006e0064002d00730079007300740065006d002f007400
-790070006f006700720061007000680079000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://brand.autodesk.com/brand-system/typography}}}
+790070006f006700720061007000680079000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://brand.autodesk.com/brand-system/typography}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  for detailed usage guidelines on when and how to use the Artifakt designer collection.
 \par }{\rtlch\fcs1 \af40\afs20 \ltrch\fcs0 \f40\fs20\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 DirectX
@@ -1275,21 +1279,21 @@ HYPERLINK https://brand.autodesk.com/brand-system/typography }{\rtlch\fcs1 \af4\
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfe000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f0044006900720065006300740058002000530044004b
-002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+002000450055004c0041002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/directx%20redist.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bfa000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0074007200650065002f006d00
 610073007400650072002f0074006f006f006c0073002f0069006e007300740061006c006c002f00450078007400720061002f0044006900720065006300740058002f004c006900630065006e00730065002000410067007200650065006d0065006e00740073002f00640069007200650063007400780020007200650064
-006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e6}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+006900730074002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 ImageMagick
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://imagemagick.org/script/license.php }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f0069006d006100670065006d0061006700690063006b002e006f00720067002f007300630072006900700074002f006c006900630065006e00730065002e0070006800
-70000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+70000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 LiveChartsCore v.2.0.0-}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 
@@ -1323,7 +1327,7 @@ https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/Licen
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright [2013] [dlemstra]
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/dlemstra/Magick.NET/blob/main/License.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b92000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006c0065006d0073007400720061002f004d0061006700690063006b002e004e00450054002f0062006c00
-6f0062002f006d00610069006e002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6f0062002f006d00610069006e002f004c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License");
@@ -1333,7 +1337,7 @@ https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\l
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 Unless required by applicable law or agreed to in writing, software
@@ -1345,7 +1349,7 @@ https://github.com/dlemstra/Magick.NET/blob/main/License.txt}}}\sectd \ltrsect\l
 \par \hich\af4\dbch\af31505\loch\f4 Magick.NET-Q8-AnyCPU v7.24.1:
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://imagemagick.org/script/license.php }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f0069006d006100670065006d0061006700690063006b002e006f00720067002f007300630072006900700074002f006c006900630065006e00730065002e0070006800
-70000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+70000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://imagemagick.org/script/license.php}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Copyright 1999-2021 ImageMagick Studio LLC, a non-profit organization dedicated to making software imaging solutions freely available.
@@ -1353,66 +1357,66 @@ Copyright 1999-2021 ImageMagick Studio LLC, a non-profit organization dedicated 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Open XML SDK
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/OfficeDev/Open-XML-SDK }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004f00660066006900630065004400650076002f004f00700065006e002d0058004d004c002d00530044004b00
-0000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/OfficeDev/Open-XML-SDK}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+0000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/OfficeDev/Open-XML-SDK}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004f00660066006900630065004400650076002f004f00700065006e002d0058004d004c002d00530044004b00
-2f0062006c006f0062002f006d00610069006e002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2f0062006c006f0062002f006d00610069006e002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4 \ltrch\fcs0 \b\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python Standard Library
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/library/" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b62000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900620072006100720079002f000000795881f43b1d7f48
-af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
+af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/library/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://docs.python.org/2.7/license.html" }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6a000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0032002e0037002f006c006900630065006e00730065002e00680074006d006c000000
-795881f43b1d7f48af2c825dc485276300000000a5ab0003e6}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html
+795881f43b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://docs.python.org/2.7/license.html
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Python Modules}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\highlight8\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://numpy.org/ }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f006e0075006d00700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f006e0075006d00700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://numpy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License: Distributed under a liberal}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf24\highlight8\insrsid16677021 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006d00700079002f006e0075006d00700079002f0062006c006f0062002f006d00610069006e002f00
-4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
+4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pandas.pydata.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e000000680074007400700073003a002f002f00700061006e006400610073002e007000790064006100740061002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4e000000680074007400700073003a002f002f00700061006e006400610073002e007000790064006100740061002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}
 }{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pandas.pydata.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 :}{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  BSD 3-Clause "New" or "Revised" License}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf26\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://scipy.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f00730063006900700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b3e000000680074007400700073003a002f002f00730063006900700079002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://scipy.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 Distributed under a liberal}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b82000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006d00700079002f006e0075006d00700079002f0062006c006f0062002f006d00610069006e002f00
-4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000316}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
+4c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000316f8}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf25\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 BSD license}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pypi.org/project/openpyxl/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5e000000680074007400700073003a002f002f0070007900700069002e006f00720067002f00700072006f006a006500630074002f006f00700065006e007000790078006c002f000000795881f43b1d7f48af2c825d
-c485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/openpyxl/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+c485276300000000a5ab00030055}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/openpyxl/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:\~MIT License (MIT)}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\highlight8\insrsid16677021 
 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://matplotlib.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b48000000680074007400700073003a002f002f006d006100740070006c006f0074006c00690062002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000390}}}{\fldrslt {
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b48000000680074007400700073003a002f002f006d006100740070006c006f0074006c00690062002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00039000}}}{\fldrslt {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://matplotlib.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 : }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Matplotlib only uses BSD compatible code, and its license is based on the\~}{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK "https://docs.python.org/3/license.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b66000000680074007400700073003a002f002f0064006f00630073002e0070007900740068006f006e002e006f00720067002f0033002f006c006900630065006e00730065002e00680074006d006c000000795881f4
-3b1d7f48af2c825dc485276300000000a5ab0003e6}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 PSF}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+3b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf2\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 PSF}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 license}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf24\highlight8\insrsid16677021 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://pypi.org/project/Pillow/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5a000000680074007400700073003a002f002f0070007900700069002e006f00720067002f00700072006f006a006500630074002f00500069006c006c006f0077002f000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/Pillow/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+00000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://pypi.org/project/Pillow/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf24\highlight8\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 License:}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~
 \hich\af4\dbch\af31505\loch\f4 Historical Permission Notice}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4  and Disclaimer (HPND) }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf23\highlight8\insrsid16677021 
@@ -1423,13 +1427,13 @@ HYPERLINK "https://docs.python.org/3/license.html" }{\rtlch\fcs1 \af4\afs22 \ltr
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://opensource.org/licenses/ms-pl.html" }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e000000680074007400700073003a002f002f006f00700065006e0073006f0075007200630065002e006f00720067002f006c006900630065006e007300650073002f006d0073002d0070006c002e00680074006d00
-6c000000795881f43b1d7f48af2c825dc485276300000000a5ab000320}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License
+6c000000795881f43b1d7f48af2c825dc485276300000000a5ab00032065}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft Public License
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be2000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007800630065006500640073006f006600740077006100720065002f0077007000660074006f006f006c006b00
 690074002f0062006c006f0062002f0030006500640034006500640038003400310035003200640036006100330065003200610036003200370066003200650066003000350066003800320036003200370066006400610066003300660063002f006c006900630065006e00730065002e006d0064000000795881f43b1d7f
-48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1036\langfe1033\langnp1036\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af40\afs20 \ltrch\fcs0 \b\f40\fs20\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Microsoft.Web.WebView2 v.1.0.2045.28
@@ -1443,7 +1447,7 @@ https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f826
 \par \hich\af4\dbch\af31505\loch\f4 notice, this list of conditions and the following disclaimer.
 \par \hich\af4\dbch\af31505\loch\f4    * Redistributions in binary form must reproduce the above
 \par \hich\af4\dbch\af31505\loch\f4 copyright notice, this list of conditions and the following disclaimer
-\par \hich\af4\dbch\af31505\loch\f4 in the documentation and/or other materials pro\hich\af4\dbch\af31505\loch\f4 vided with the
+\par \hich\af4\dbch\af31505\loch\f4 in the d\hich\af4\dbch\af31505\loch\f4 ocumentation and/or other materials provided with the
 \par \hich\af4\dbch\af31505\loch\f4 distribution.
 \par \hich\af4\dbch\af31505\loch\f4    * The name of Microsoft Corporation, or the names of its contributors 
 \par \hich\af4\dbch\af31505\loch\f4 may not be used to endorse or promote products derived from this
@@ -1452,8 +1456,8 @@ https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f826
 \par \hich\af4\dbch\af31505\loch\f4 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 \par \hich\af4\dbch\af31505\loch\f4 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 \par \hich\af4\dbch\af31505\loch\f4 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-\par \hich\af4\dbch\af31505\loch\f4 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-\par \hich\af4\dbch\af31505\loch\f4 OWNER OR CONTRIBUT\hich\af4\dbch\af31505\loch\f4 ORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+\par \hich\af4\dbch\af31505\loch\f4 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT\hich\af4\dbch\af31505\loch\f4  SHALL THE COPYRIGHT
+\par \hich\af4\dbch\af31505\loch\f4 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 \par \hich\af4\dbch\af31505\loch\f4 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 \par \hich\af4\dbch\af31505\loch\f4 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 \par \hich\af4\dbch\af31505\loch\f4 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
@@ -1463,26 +1467,26 @@ https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f826
 \par 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Lucene.Net v.4.8.0-beta00016
 \par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.Analysis.Common v.4.8.0-beta00016
-\par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.Queries v.4.8.0-beta00016
+\par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.Queries v.4.8.\hich\af4\dbch\af31505\loch\f4 0-beta00016
 \par \hich\af4\dbch\af31505\loch\f4 Lucene.Net.QueryParser v.4.8.0-beta00016
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 Lucene.Net.Sandbox v.4.8.0-beta00016
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://lucenenet.apache.org/"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54000000680074007400700073003a002f002f006c007500630065006e0065006e00650074002e006100700061006300680065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://lucenenet.apache.org/
+00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://lucenenet.apache.org/
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/apache/lucenenet/blob/master/LICENSE.txt }{\rtlch\fcs1 
 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b90000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006100700061006300680065002f006c007500630065006e0065006e00650074002f0062006c006f0062002f00
-6d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 
+6d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 
 \hich\af4\dbch\af31505\loch\f4 https://github.com/apache/lucenenet/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\lang1053\langfe1033\kerning1\langnp1053\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright 2022 Apache Lucene.NET
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \ab\af4\afs22 
 \ltrch\fcs0 \b\fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\kerning1\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e6}}}{\fldrslt {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e6ff}}}{\fldrslt {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language gove
 \hich\af4\dbch\af31505\loch\f4 rning permissions and limitations under the License.
@@ -1492,7 +1496,7 @@ Lucene.Net.Sandbox v.4.8.0-beta00016
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/dotnet/runtime/blob/main/LICENSE.TXT }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b88000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e00650074002f00720075006e00740069006d0065002f0062006c006f0062002f006d006100
-69006e002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00037c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+69006e002f004c004900430045004e00530045002e005400580054000000795881f43b1d7f48af2c825dc485276300000000a5ab00037cff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/dotnet/runtime/blob/main/LICENSE.TXT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf22\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf22\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
@@ -1502,7 +1506,7 @@ https://github.com/dotnet/runtime/blob/main/LICENSE.TXT}}}\sectd \ltrsect\linex0
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, m
 \hich\af4\dbch\af31505\loch\f4 erge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The abo\hich\af4\dbch\af31505\loch\f4 ve copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+\par \hich\af4\dbch\af31505\loch\f4 The above\hich\af4\dbch\af31505\loch\f4  copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
@@ -1514,13 +1518,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\kerning1\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004a006f007300680043006c006f00730065002f00430073007600480065006c007000650072002f0062006c00
-6f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030e}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+6f0062002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030eff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf22\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language gove
 \hich\af4\dbch\af31505\loch\f4 rning permissions and limitations under the License.
@@ -1529,7 +1533,7 @@ https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt}}}\sectd \ltrsect
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 The MIT License (MIT)
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt }{\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b94000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0050007200690073006d004c006900620072006100720079002f0050007200690073006d002f0062006c006f00
-62002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+62002f006d00610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4 \ltrch\fcs0 \insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4 \ltrch\fcs0 \ul\cf22\insrsid16677021 
 \par }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) Prism Library
@@ -1547,14 +1551,14 @@ TWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://lucenenet.apache.org/"}{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b54000000680074007400700073003a002f002f006c007500630065006e0065006e00650074002e006100700061006300680065002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
+00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par }}}\pard\plain \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af4\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MimeMapping v2.0.0
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 MIT License
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://licenses.nuget.org/MIT }{\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\kerning1\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b56000000680074007400700073003a002f002f006c006900630065006e007300650073002e006e0075006700650074002e006f00720067002f004d00490054000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://licenses.nuget.org/MIT}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf22\kerning1\insrsid16677021 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 Copyright (c) <year> <copyright holders>
 \par 
@@ -1562,7 +1566,7 @@ a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\kerning1\insrsi
 this software and associated documentation files}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 
 (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnish
 \hich\af4\dbch\af31505\loch\f4 ed to do so, subject to the following conditions:
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 (including the next parag\hich\af4\dbch\af31505\loch\f4 raph)}{
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this \hich\af4\dbch\af31505\loch\f4 permission notice\~}{\rtlch\fcs1 \ai\af4\afs22 \ltrch\fcs0 \i\fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 (including the next paragraph)}{
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \~\hich\af4\dbch\af31505\loch\f4 shall be included in all copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\~}{
@@ -1575,7 +1579,7 @@ BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CON
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 HYPERLINK https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb4000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0064006f0074006e0065007400700072006f006a0065006300740073002f005700700066004500780074006500
-6e0064006500640054006f006f006c006b00690074002f0062006c006f0062002f0045007800740065006e006400650064002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+6e0064006500640054006f006f006c006b00690074002f0062006c006f0062002f0045007800740065006e006400650064002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\ul\cf22\insrsid16677021 
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\sl288\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\kerning1\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
@@ -1584,43 +1588,43 @@ This license governs use of the accompanying software. If you use the software, 
 \par \hich\af4\dbch\af31505\loch\f4 1. Definitions
 \par \hich\af4\dbch\af31505\loch\f4 
 The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law. A "contribution" is the original software, or any additions or changes to the software. A "contributor" is any person tha
-\hich\af4\dbch\af31505\loch\f4 t distributes its contribution under this license. "Licensed patents" are a\hich\af4\dbch\af31505\loch\f4  contributor's patent claims that read directly on its contribution.
+\hich\af4\dbch\af31505\loch\f4 t distributes its contribution under this license. "Licensed patents" are a c\hich\af4\dbch\af31505\loch\f4 ontributor's patent claims that read directly on its contribution.
 \par \hich\af4\dbch\af31505\loch\f4 2. Grant of Rights
 \par \hich\af4\dbch\af31505\loch\f4 
 (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivat
 \hich\af4\dbch\af31505\loch\f4 ive works of its contribution, and distribute its contribution or any derivative works that you create.
-\par \hich\af4\dbch\af31505\loch\f4 (B) Patent Grant- Subject to the terms of this license, including\hich\af4\dbch\af31505\loch\f4 
- the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contributi
-\hich\af4\dbch\af31505\loch\f4 on in the software or derivative works of the contribution in the software.
+\par \hich\af4\dbch\af31505\loch\f4 (B) Patent Grant- Subject to the terms of this license, including t\hich\af4\dbch\af31505\loch\f4 
+he license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution
+\hich\af4\dbch\af31505\loch\f4  in the software or derivative works of the contribution in the software.
 \par \hich\af4\dbch\af31505\loch\f4 3. Conditions and Limitations
 \par \hich\af4\dbch\af31505\loch\f4 (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-\par \hich\af4\dbch\af31505\loch\f4 (B) If you bring a patent claim ag\hich\af4\dbch\af31505\loch\f4 ainst any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+\par \hich\af4\dbch\af31505\loch\f4 (B) If you bring a patent claim agai\hich\af4\dbch\af31505\loch\f4 nst any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
 
 \par \hich\af4\dbch\af31505\loch\f4 (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-\par \hich\af4\dbch\af31505\loch\f4 (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribut
-\hich\af4\dbch\af31505\loch\f4 e any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+\par \hich\af4\dbch\af31505\loch\f4 (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute 
+\hich\af4\dbch\af31505\loch\f4 any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
 \par \hich\af4\dbch\af31505\loch\f4 
 (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees, or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent perm
-\hich\af4\dbch\af31505\loch\f4 itted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purp\hich\af4\dbch\af31505\loch\f4 ose and non-infringement.
+\hich\af4\dbch\af31505\loch\f4 itted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpos\hich\af4\dbch\af31505\loch\f4 e and non-infringement.
 \par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par \hich\af4\dbch\af31505\loch\f4 CastleCore v.5.1.1
 \par \hich\af4\dbch\af31505\loch\f4 APACHE 2.0
 \par \hich\af4\dbch\af31505\loch\f4 Copyright 2004-2021 Castle Project - }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.castleproject.org/ }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5400000068007400740070003a002f002f007700770077002e0063006100730074006c006500700072006f006a006500630074002e006f00720067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab
-000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.castleproject.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.castleproject.org/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
+
 \par 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/castleproject/Core/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0063006100730074006c006500700072006f006a006500630074002f0043006f00720065002f0062006c006f00
-62002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00032c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+62002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00032c00}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/castleproject/Core/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 DynamicLanguageRuntime v.1.2.2
 \par \hich\af4\dbch\af31505\loch\f4 APACHE 2.0
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPER\hich\af4\dbch\af31505\loch\f4 LINK https://github.com/IronLanguages/dlr/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
-\fs22\insrsid12128070 {\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/IronLanguages/dlr/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00490072006f006e004c0061006e006700750061006700650073002f0064006c0072002f0062006c006f006200
-2f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/IronLanguages/dlr/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) .NET Foundation and Contributors
@@ -1629,7 +1633,7 @@ https://github.com/IronLanguages/dlr/blob/master/LICENSE}}}\sectd \ltrsect\linex
 \par \hich\af4\dbch\af31505\loch\f4 Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 
 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b6e00000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
-30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e6}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+30000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e600}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 http://www.apache.org/licenses/LICENSE-2.0}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an ""AS IS"" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language gov
 \hich\af4\dbch\af31505\loch\f4 erning permissions and limitations under the License.
@@ -1675,7 +1679,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9c000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f0063006f007600650072006c00650074002d0063006f007600650072006100670065002f0063006f0076006500
-72006c00650074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+72006c00650074002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030044}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2018 Toni Solarin-Sodara
@@ -1702,7 +1706,7 @@ https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE}}}\sectd \ltrs
 \par \hich\af4\dbch\af31505\loch\f4 APACHE 2.0
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f004e0069006700680074004f0077006c003800380038002f004a0032004e002f0062006c006f0062002f006d00
-610069006e002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+610069006e002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 JUnitTestLogger v.1.1.0
@@ -1710,7 +1714,7 @@ https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1053\langfe1033\langnp1053\insrsid12128070 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba0000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00730079006e00630072006f006d00610074006900630073002f004a0055006e00690074005400650073007400
-4c006f0067006700650072002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030e}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+4c006f0067006700650072002f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045000000795881f43b1d7f48af2c825dc485276300000000a5ab00030e02}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\lang1053\langfe1033\langnp1053\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
 \fs22\cf21\lang1053\langfe1033\langnp1053\insrsid16677021 
 \par 
@@ -1723,7 +1727,7 @@ https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex
 \par \hich\af4\dbch\af31505\loch\f4 copies of the Software, and to permit persons to whom the Software is
 \par \hich\af4\dbch\af31505\loch\f4 furnished to do so, subject to the following conditions:
 \par 
-\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice and this permission notice shall be included in all
+\par \hich\af4\dbch\af31505\loch\f4 The above copyright notice \hich\af4\dbch\af31505\loch\f4 and this permission notice shall be included in all
 \par \hich\af4\dbch\af31505\loch\f4 copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -1731,7 +1735,7 @@ https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex
 \par \hich\af4\dbch\af31505\loch\f4 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 \par \hich\af4\dbch\af31505\loch\f4 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 \par \hich\af4\dbch\af31505\loch\f4 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-\par \hich\af4\dbch\af31505\loch\f4 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+\par \hich\af4\dbch\af31505\loch\f4 OUT OF OR IN CONNECTION WITH THE SOFTW\hich\af4\dbch\af31505\loch\f4 ARE OR THE USE OR OTHER DEALINGS IN THE
 \par \hich\af4\dbch\af31505\loch\f4 SOFTWARE.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 JunitXml.TestLogger v.3.0.124
@@ -1739,7 +1743,7 @@ https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt}}}\sectd \ltrsect\linex
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f007300700065006b0074002f006a0075006e00690074002e0074006500730074006c006f006700670065007200
-2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000327}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+2f0062006c006f0062002f006d00610073007400650072002f004c004900430045004e00530045002e006d0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00032709}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Copyright (c) 2017-2018
@@ -1766,7 +1770,7 @@ https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md}}}\sectd \ltrse
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 HYPERLINK https://github.com/nunit/nunit.analyzers/blob/master/license.txt }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid12128070 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9a000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f006e0075006e00690074002f006e0075006e00690074002e0061006e0061006c0079007a006500720073002f00
-62006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab000313}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
+62006c006f0062002f006d00610073007400650072002f006c006900630065006e00730065002e007400780074000000795881f43b1d7f48af2c825dc485276300000000a5ab0003137c}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\insrsid16677021 \hich\af4\dbch\af31505\loch\f4 
 https://github.com/nunit/nunit.analyzers/blob/master/license.txt}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf21\insrsid16677021 
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1780,8 +1784,8 @@ https://github.com/nunit/nunit.analyzers/blob/master/license.txt}}}\sectd \ltrse
 \par \hich\af4\dbch\af31505\loch\f4 all copies or substantial portions of the Software.
 \par 
 \par \hich\af4\dbch\af31505\loch\f4 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-\par \hich\af4\dbch\af31505\loch\f4 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-\par \hich\af4\dbch\af31505\loch\f4 FITNESS FOR A PARTICULAR PURPOSE A\hich\af4\dbch\af31505\loch\f4 ND NONINFRINGEMENT. IN NO EVENT SHALL THE
+\par \hich\af4\dbch\af31505\loch\f4 IMPLIED, INCLUDING BUT NOT LIM\hich\af4\dbch\af31505\loch\f4 ITED TO THE WARRANTIES OF MERCHANTABILITY,
+\par \hich\af4\dbch\af31505\loch\f4 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 \par \hich\af4\dbch\af31505\loch\f4 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 \par \hich\af4\dbch\af31505\loch\f4 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 \par \hich\af4\dbch\af31505\loch\f4 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -1932,8 +1936,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000009048
-9311e78cda01feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000040a6
+1cd3a079db01feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -31,10 +31,8 @@
   </ItemGroup>
   <ItemGroup Label="Common dependencies">
     <PackageReference Include="Autodesk.IDSDK" Version="1.1.8" />
-    <PackageReference Include="Greg" Version="3.0.2.5756" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" GeneratePathProperty="true" />
     <PackageReference Include="Greg" Version="3.0.2.6284" />
-    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.6246" GeneratePathProperty="true" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" CopyXML="true" />
     <PackageReference Include="RestSharp" Version="112.0.0" CopyXML="true" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -33,8 +33,10 @@
     <PackageReference Include="Autodesk.IDSDK" Version="1.1.8" />
     <PackageReference Include="Greg" Version="3.0.2.5756" />
     <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" GeneratePathProperty="true" />
+    <PackageReference Include="Greg" Version="3.0.2.6284" />
+    <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.6246" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" CopyXML="true" />
-    <PackageReference Include="RestSharp" Version="108.0.1" CopyXML="true" />
+    <PackageReference Include="RestSharp" Version="112.0.0" CopyXML="true" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -189,10 +189,8 @@
       <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" />
     <PackageReference Include="FontAwesome5" Version="2.1.11" />
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
-    <PackageReference Include="Greg" Version="3.0.2.5756" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
     <PackageReference Include="Greg" Version="3.0.2.6284" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -191,8 +191,10 @@
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" CopyXML="true" />
     <PackageReference Include="Greg" Version="3.0.2.5756" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2045.28" />
+    <PackageReference Include="Greg" Version="3.0.2.6284" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="108.0.1" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0">

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -741,7 +741,7 @@ namespace Dynamo.PackageManager
             var hostFilter = new List<FilterEntry>();
             try
             {
-                foreach (var host in PackageManagerClientViewModel.Model.GetKnownHosts())
+                foreach (var host in PackageManagerClientViewModel.Model?.GetKnownHosts())
                 {
                     hostFilter.Add(new FilterEntry(host, Resources.PackageFilterByHost, Resources.PackageHostDependencyFilterContextItem, this));
                 }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1229,9 +1229,16 @@ namespace Dynamo.PackageManager
         private List<HostComboboxEntry> initializeHostSelections()
         {
             var hostSelections = new List<HostComboboxEntry>();
-            foreach (var host in dynamoViewModel.PackageManagerClientViewModel.Model.GetKnownHosts())
+            try
             {
-                hostSelections.Add(new HostComboboxEntry(host));
+                foreach (var host in dynamoViewModel.PackageManagerClientViewModel.Model?.GetKnownHosts())
+                {
+                    hostSelections.Add(new HostComboboxEntry(host));
+                }
+            }
+            catch (Exception ex)
+            {
+                dynamoViewModel.Model.Logger.Log("Could not fetch hosts: " + ex.Message);
             }
             return hostSelections;
         }

--- a/src/DynamoMLDataPipeline/DynamoMLDataPipeline.csproj
+++ b/src/DynamoMLDataPipeline/DynamoMLDataPipeline.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="RestSharp" Version="108.0.1" />
-        <PackageReference Include="Greg" Version="3.0.2.5756" />
+        <PackageReference Include="RestSharp" Version="112.0.0" />
+        <PackageReference Include="Greg" Version="3.0.2.6284" />
   </ItemGroup>
   <ItemGroup>
 	<ProjectReference Include="..\DynamoCore\DynamoCore.csproj">

--- a/src/DynamoPackages/DynamoPackages.csproj
+++ b/src/DynamoPackages/DynamoPackages.csproj
@@ -30,9 +30,9 @@
     <Content Include="PackageManagerExtension_ExtensionDefinition.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Greg" Version="3.0.2.5756" />
+    <PackageReference Include="Greg" Version="3.0.2.6284" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="108.0.1" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
+++ b/src/PackageDetailsViewExtension/PackageDetailsViewExtension.csproj
@@ -14,9 +14,9 @@
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Greg" Version="3.0.2.5756" />
+	<PackageReference Include="Greg" Version="3.0.2.6284" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-	<PackageReference Include="RestSharp" Version="108.0.1" />
+	<PackageReference Include="RestSharp" Version="112.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DynamoCoreWpf\DynamoCoreWpf.csproj">

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -12,10 +12,8 @@
   </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
-        <PackageReference Include="Greg" Version="3.0.2.5756" />
-        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" />
         <PackageReference Include="Greg" Version="3.0.2.6284" />
-        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.6246" />
+        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" />
         <PackageReference Include="Magick.NET.Core" Version="7.0.1" />
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/NodeDocumentationMarkdownGenerator.csproj
@@ -14,10 +14,12 @@
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
         <PackageReference Include="Greg" Version="3.0.2.5756" />
         <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.5365" />
+        <PackageReference Include="Greg" Version="3.0.2.6284" />
+        <PackageReference Include="DynamoVisualProgramming.LibG_230_0_0" Version="3.0.0.6246" />
         <PackageReference Include="Magick.NET.Core" Version="7.0.1" />
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="RestSharp" Version="108.0.1" />
+        <PackageReference Include="RestSharp" Version="112.0.0" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     </ItemGroup>
   <ItemGroup>

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -34,7 +34,7 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Greg" Version="3.0.2.5756">
+        <PackageReference Include="Greg" Version="3.0.2.6284">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -45,7 +45,7 @@
 
         <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="RestSharp" Version="108.0.1">
+        <PackageReference Include="RestSharp" Version="112.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -37,13 +37,13 @@
       
     <PackageReference Include="Moq" Version="4.18.4" />
 	  <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
-	  <PackageReference Include="Greg" Version="3.0.2.5756">
+	  <PackageReference Include="Greg" Version="3.0.2.6284">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	  <PackageReference Include="NUnit" Version="3.13.3" />
-	  <PackageReference Include="RestSharp" Version="108.0.1">
+	  <PackageReference Include="RestSharp" Version="112.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
+++ b/test/Libraries/PackageManagerTests/PackageManagerTests.csproj
@@ -14,13 +14,13 @@
   </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="RestSharp" Version="108.0.1">
+        <PackageReference Include="RestSharp" Version="112.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="Greg" Version="3.0.2.5756">
+        <PackageReference Include="Greg" Version="3.0.2.6284">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
### Purpose

CherryPick https://github.com/DynamoDS/Dynamo/pull/15494 to RC3.3.1 to update RestSharp from v108 to v112.

Tested locally that the package manager still works:
![image](https://github.com/user-attachments/assets/0ddb4c5f-6aba-4dce-bdb6-9fe51c9587fa)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

update RestSharp from v108 to v112 to address security vulnerability

### Reviewers

@DynamoDS/dynamo 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
