### PR TITLE
8268: [DYN-8278] Cherry-pick and version bump for 3.4.2: Fix noNetworkMode for PM client

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-@DYNAMO v.3.4.1 © 2024 Autodesk, Inc.  All rights reserved.
+@DYNAMO v.3.4.2 © 2025 Autodesk, Inc.  All rights reserved.
 Dynamo License
 
 Those portions created by Ian are provided with the following copyright:
@@ -7,7 +7,7 @@ Copyright 2017 Ian Keough
 
 Those portions created by Autodesk employees are provided with the following copyright:
 
-Copyright 2022 Autodesk, Inc.
+Copyright 2025 Autodesk, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 

--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -1,8 +1,8 @@
 {\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033\deflangfe2052{\fonttbl{\f0\fswiss\fprq2\fcharset0 Helvetica;}{\f1\fswiss\fprq2\fcharset0 Verdana;}{\f2\froman\fprq2\fcharset0 Times New Roman;}}
 {\colortbl ;\red165\green165\blue165;\red109\green210\blue255;\red0\green0\blue255;\red70\green70\blue70;\red255\green255\blue255;\red74\green74\blue74;\red5\green99\blue193;\red36\green41\blue47;}
 {\stylesheet{ Normal;}{\s1 heading 1;}{\s2 heading 2;}{\s3 heading 3;}{\s4 heading 4;}}
-{\*\generator Riched20 10.0.22621}{\*\mmathPr\mnaryLim0\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
-\pard\nowidctlpar\sb240\sl276\slmult1\cf1\b\f0\fs22\lang2057 @DYNAMO v.3.4.1 \'a9 2024 Autodesk, Inc.  All rights reserved.\par
+{\*\generator Riched20 10.0.22000}{\*\mmathPr\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
+\pard\nowidctlpar\sb240\sl276\slmult1\cf1\b\f0\fs22\lang2057 @DYNAMO v.3.4.2 \'a9 2025 Autodesk, Inc.  All rights reserved.\par
 Dynamo License\par
 
 \pard\widctlpar\b0\par
@@ -12,7 +12,7 @@ Copyright 2017 Ian Keough\par
 \par
 Those portions created by Autodesk employees are provided with the following copyright:\par
 \par
-Copyright 2024 Autodesk, Inc.\par
+Copyright 2025 Autodesk, Inc.\par
 \par
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf2\ul{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520120511%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=hM4SECRXlI3Y3bhWd0n7aVFES8pYfE3tfdiIfbSsdIo%3D&reserved=0" }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0}}}}\cf2\ul\f0\fs22  \cf1\ulnone Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\cf2\ul\par
 \cf0\ulnone\b\f1\fs20\par

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
 [assembly: AssemblyProduct("Dynamo")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2024")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2025")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set
@@ -69,7 +69,7 @@ using System.Runtime.InteropServices;
 <#+
 int MajorVersion = 3;
 int MinorVersion = 4;
-int BuildNumber = 1;
+int BuildNumber = 2;
 // The datetime baseline we choose using this algorithm will affect build number and all nuget packages uploaded
 // Please only change when major or minor version got incremented
 int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2023,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;

--- a/src/Config/upiconfig.xml
+++ b/src/Config/upiconfig.xml
@@ -14,7 +14,7 @@
             <upi_attribute name='id' value='Win64'/>
             <upi_element name='level'>
               <upi_attribute name='name' value='build'/>
-              <upi_attribute name='id' value='3.4.1' />
+              <upi_attribute name='id' value='3.4.2' />
             </upi_element>
           </upi_element>
         </upi_element>

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -57,8 +57,6 @@ namespace Dynamo.PackageManager
             this.uploadBuilder = builder;
             this.client = client;
             this.packageMaintainers = new Dictionary<string, bool>();
-
-            this.LoadCompatibilityMap();  // Load the compatibility map
         }
 
         internal bool Upvote(string packageId)
@@ -370,7 +368,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Method to load the map once, making it accessible to all elements
         /// </summary>
-        private void LoadCompatibilityMap()
+        internal void LoadCompatibilityMap()
         {
             if (compatibilityMap == null)  // Load only if not already loaded
             {

--- a/src/DynamoPackages/PackageManagerExtension.cs
+++ b/src/DynamoPackages/PackageManagerExtension.cs
@@ -161,8 +161,16 @@ namespace Dynamo.PackageManager
                 new GregClient(startupParams.AuthProvider, url),
                 uploadBuilder, packageUploadDirectory);
 
-            LoadPackages(startupParams.Preferences, startupParams.PathManager);
             noNetworkMode = startupParams.NoNetworkMode;
+
+            //we don't ask dpm for the compatibility map in offline mode.
+            if (!noNetworkMode)
+            {
+                // Load the compatibility map
+                PackageManagerClient.LoadCompatibilityMap();
+            }
+
+            LoadPackages(startupParams.Preferences, startupParams.PathManager);
         }
 
         /// <summary>

--- a/tools/autobuild/build.json
+++ b/tools/autobuild/build.json
@@ -2,8 +2,8 @@
   "product_id": "DYN",
   "release_id": "3.4.0",
   "master_id": "Win64",
-  "build_id": "3.4.1",
-  "name": "3.4.1",
-  "build_milestone": "Update 1",
+  "build_id": "3.4.2",
+  "name": "3.4.2",
+  "build_milestone": "Update 2",
   "description":"Build"
 }


### PR DESCRIPTION
### Purpose

Cherrypick for #15809 
DYN-8268 to fix noNetworkMode for PM client
Version bumped to 3.4.2 for hotfix.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

[Cherry-pick] DYN-8268 and version bump for 3.4.2: Fix noNetworkMode for PM client

### Reviewers

@DynamoDS/dynamo 
