### PR TITLE
Delay preview creation till it is actually needed.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -560,6 +560,14 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Ensures that a preview control is initialized only when it is
+        /// absolutely needed. It lives here so that it can be shared by
+        /// all node views for reduced overhead and better management.
+        /// </summary>
+        internal Wpf.Utilities.ActionDebouncer DelayNodePreviewControl
+            = new Wpf.Utilities.ActionDebouncer(null);
+
         #endregion
 
         public WorkspaceViewModel(WorkspaceModel model, DynamoViewModel dynamoViewModel)
@@ -721,6 +729,9 @@ namespace Dynamo.ViewModels
             InCanvasSearchViewModel?.Dispose();
             NodeAutoCompleteSearchViewModel.LuceneUtility?.DisposeAll();
             NodeAutoCompleteSearchViewModel?.Dispose();
+
+            DelayNodePreviewControl?.Dispose();
+            DelayNodePreviewControl = null;
         }
 
         internal void ZoomInInternal()

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -41,7 +41,6 @@ namespace Dynamo.Controls
         /// Old ZIndex of node. It's set, when mouse leaves node.
         /// </summary>
         private int oldZIndex;
-
         private bool nodeWasClicked;
 
         public NodeView TopControl
@@ -72,6 +71,14 @@ namespace Dynamo.Controls
             if (viewModel != null && viewModel.OnMouseLeave != null)
                 viewModel.OnMouseLeave();
         }
+
+        /// <summary>
+        /// This is a dispatcher timer that ensures a preview control is only initialized
+        /// when it is absolutely needed. It is static so that it can be shared for all
+        /// node views, instead of each having its own timer with additional overhead.
+        /// </summary>
+        private static DispatcherTimer delayPreviewControlTimer = null;
+        private static NodeView previewControlHost = null;
 
         internal PreviewControl PreviewControl
         {
@@ -130,6 +137,34 @@ namespace Dynamo.Controls
 
 
             Panel.SetZIndex(this, 1);
+        }
+
+        private static void DelayPreviewControlAction(object sender, EventArgs e)
+        {
+            delayPreviewControlTimer.Stop();
+            // potentially initialize the preview control only if the node is still in focus
+            if (previewControlHost?.IsMouseOver == true)
+            {
+                delayPreviewControlTimer.Dispatcher.BeginInvoke(previewControlHost.TryShowPreviewBubbles, DispatcherPriority.Loaded);
+            }
+
+            previewControlHost = null;
+        }
+
+        private void InitialTryShowPreviewBubble()
+        {
+            if (delayPreviewControlTimer == null) // prepare the shared timer
+            {
+                delayPreviewControlTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher);
+                delayPreviewControlTimer.Interval = TimeSpan.FromMilliseconds(300);
+                delayPreviewControlTimer.Tick += DelayPreviewControlAction;
+            }
+
+            // Always set old ZIndex to the last value, even if mouse is not over the node.
+            oldZIndex = NodeViewModel.StaticZIndex;
+
+            previewControlHost = this;
+            delayPreviewControlTimer.Start();
         }
 
         private void OnNodeViewUnloaded(object sender, RoutedEventArgs e)
@@ -226,10 +261,7 @@ namespace Dynamo.Controls
         {
             // If the mouse does not leave the node after the connector is added,
             // try to show the preview bubble without new mouse enter event. 
-            if (IsMouseOver)
-            {
-                Dispatcher.BeginInvoke(new Action(TryShowPreviewBubbles), DispatcherPriority.Loaded);
-            }
+            if (IsMouseOver) InitialTryShowPreviewBubble();
         }
 
         void NodeLogic_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -506,15 +538,12 @@ namespace Dynamo.Controls
             // if the node is located under "Hide preview bubbles" menu item and the item is clicked,
             // ViewModel.DynamoViewModel.ShowPreviewBubbles will be updated AFTER node mouse enter event occurs
             // so, wait while ShowPreviewBubbles binding updates value
-            Dispatcher.BeginInvoke(new Action(TryShowPreviewBubbles), DispatcherPriority.Loaded);
+            InitialTryShowPreviewBubble();
         }
 
         private void TryShowPreviewBubbles()
         {
             nodeWasClicked = false;
-
-            // Always set old ZIndex to the last value, even if mouse is not over the node.
-            oldZIndex = NodeViewModel.StaticZIndex;
 
             // There is no need run further.
             if (IsPreviewDisabled()) return;
@@ -541,21 +570,29 @@ namespace Dynamo.Controls
             // Or preview is disabled for this node
             // Or preview shouldn't be shown for some nodes (e.g. number sliders, watch nodes etc.)
             // Or node is frozen.
+            // Or we are panning the view
             return !ViewModel.DynamoViewModel.ShowPreviewBubbles ||
                 ViewModel.WorkspaceViewModel.IsConnecting ||
                 ViewModel.WorkspaceViewModel.IsSelecting || !previewEnabled ||
-                !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen;
+                !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen ||
+                ViewModel.WorkspaceViewModel.IsPanning;
         }
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
             ViewModel.ZIndex = oldZIndex;
+            delayPreviewControlTimer.Stop();
 
-            //Watch nodes doesn't have Preview so we should avoid to use any method/property in PreviewControl class due that Preview is created automatically
+            // The preview hasn't been instantiated yet, we should stop here 
+            if (previewControl == null) return;
+
+            // Watch nodes doesn't have Preview so we should avoid to use any method/property in PreviewControl class due that Preview is created automatically
             if (ViewModel.NodeModel != null && ViewModel.NodeModel is CoreNodeModels.Watch) return;
 
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
-            if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen || IsMouseInsidePreview(e) ||
+            // check the field and not the property because that will trigger the instantiation
+            if (IsMouseOver || previewControl?.IsMouseOver == true ||
+                previewControl?.StaysOpen == true || IsMouseInsidePreview(e) ||
                 (Mouse.Captured is DragCanvas && IsMouseInsideNodeOrPreview(e.GetPosition(this)))) return;
 
             // If it's expanded, then first condense it.

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -72,13 +72,6 @@ namespace Dynamo.Controls
                 viewModel.OnMouseLeave();
         }
 
-        /// <summary>
-        /// This ensures that a preview control is initialized only when it is absolutely
-        /// needed. It is static so that it can be shared for all node views, instead of
-        /// each node having its own debouncer with additional overhead.
-        /// </summary>
-        private static ActionDebouncer delayPreviewControl = null;
-
         internal PreviewControl PreviewControl
         {
             get
@@ -150,21 +143,7 @@ namespace Dynamo.Controls
             // Always set old ZIndex to the last value, even if mouse is not over the node.
             oldZIndex = NodeViewModel.StaticZIndex;
 
-            if (delayPreviewControl == null)
-            {
-                delayPreviewControl = new ActionDebouncer(null);
-            }
-
-            delayPreviewControl.Debounce(300, DelayPreviewControlAction);
-        }
-
-        /// <summary>
-        /// Used to unload and dereference any stored node view preview data and events
-        /// </summary>
-        public static void ResetPreviewControlDelay()
-        {
-            delayPreviewControl?.Dispose();
-            delayPreviewControl = null;
+            viewModel.WorkspaceViewModel.DelayNodePreviewControl.Debounce(300, DelayPreviewControlAction);
         }
 
         private void OnNodeViewUnloaded(object sender, RoutedEventArgs e)
@@ -581,7 +560,7 @@ namespace Dynamo.Controls
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
             ViewModel.ZIndex = oldZIndex;
-            delayPreviewControl.Cancel();
+            viewModel.WorkspaceViewModel.DelayNodePreviewControl.Cancel();
 
             // The preview hasn't been instantiated yet, we should stop here 
             if (previewControl == null) return;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -167,6 +167,16 @@ namespace Dynamo.Controls
             delayPreviewControlTimer.Start();
         }
 
+        /// <summary>
+        /// Used to unload and dereference any stored node view preview data and events
+        /// </summary>
+        public static void ClearPreviewDelayTimer()
+        {
+            delayPreviewControlTimer.Tick -= DelayPreviewControlAction;
+            delayPreviewControlTimer = null;
+            previewControlHost = null;
+        }
+
         private void OnNodeViewUnloaded(object sender, RoutedEventArgs e)
         {
             ViewModel.NodeLogic.DispatchedToUI -= NodeLogic_DispatchedToUI;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -73,9 +73,9 @@ namespace Dynamo.Controls
         }
 
         /// <summary>
-        /// This is a dispatcher timer that ensures a preview control is only initialized
-        /// when it is absolutely needed. It is static so that it can be shared for all
-        /// node views, instead of each having its own timer with additional overhead.
+        /// This ensures that a preview control is initialized only when it is absolutely
+        /// needed. It is static so that it can be shared for all node views, instead of
+        /// each node having its own debouncer with additional overhead.
         /// </summary>
         private static ActionDebouncer delayPreviewControl = null;
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -149,6 +149,8 @@ namespace Dynamo.Views
             ViewModel.Model.CurrentOffsetChanged -= vm_CurrentOffsetChanged;
             DynamoSelection.Instance.Selection.CollectionChanged -= OnSelectionCollectionChanged;
             infiniteGridView.DetachFromZoomBorder(zoomBorder);
+
+            NodeView.ClearPreviewDelayTimer();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -149,8 +149,6 @@ namespace Dynamo.Views
             ViewModel.Model.CurrentOffsetChanged -= vm_CurrentOffsetChanged;
             DynamoSelection.Instance.Selection.CollectionChanged -= OnSelectionCollectionChanged;
             infiniteGridView.DetachFromZoomBorder(zoomBorder);
-
-            NodeView.ResetPreviewControlDelay();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -810,6 +810,11 @@ namespace Dynamo.Views
                 GeoScalingPopup.IsOpen = false;
             
             if(PortContextMenu.IsOpen) DestroyPortContextMenu();
+
+            if (!ViewModel.IsPanning && e.MiddleButton == MouseButtonState.Pressed)
+            {
+                ViewModel.RequestTogglePanMode();
+            }
         }
 
         /// <summary>
@@ -845,6 +850,11 @@ namespace Dynamo.Views
                 // open if workspace is right-clicked itself 
                 // (not node, note, not buttons from viewControlPanel such as zoom, pan and so on)
                 ContextMenuPopup.IsOpen = true;
+            }
+
+            if (ViewModel.IsPanning && e.MiddleButton == MouseButtonState.Released)
+            {
+                ViewModel.RequestTogglePanMode();
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -150,7 +150,7 @@ namespace Dynamo.Views
             DynamoSelection.Instance.Selection.CollectionChanged -= OnSelectionCollectionChanged;
             infiniteGridView.DetachFromZoomBorder(zoomBorder);
 
-            NodeView.ClearPreviewDelayTimer();
+            NodeView.ResetPreviewControlDelay();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Node preview bubbles, while incredibly useful, eat up a lot of resources the first time they are instantiated. Currently, when a graph loads the previews are not initialized (great!), but as soon as the mouse passes over the node, even for a fraction of a second, you have to pay the loading cost (not great :( ). Let's say you're just trying to pan a large graph from one side to the other. You're just trying to navigate, to a different spot in the graph and for some reason there are constant spikes of lag.

This PR tries to resolve the problem in two ways - first, we make sure that just passing over a node with the mouse does not immediately instantiate the preview. Instead we start a short timer and initialize the preview only if the mouse focus stays until it fires. Secondly, we make sure the state machine is updated correctly when you pan the graph with middle mouse button (which is by far the most common navigation method; I don't have the numbers but I'm sure a lot more people use the MMB instead of the pan switch in the top right corner) and disable all popups during panning. 

---

### Metrics
When trying to quickly navigate the MaRS graph (~700 nodes) from start to finish, preview instantiation can easily take up over 10% of the CPU time:

![devenv_I1Z5UIpETR](https://github.com/user-attachments/assets/58db1d8b-b78b-4ea2-b141-d8cdc1938c04)

![devenv_QcuBAklpOQ](https://github.com/user-attachments/assets/873456b9-eb70-4767-b3bc-c498a6540c50)

We can completely negate that with the proposed updates (I did get an extra ping in the second run because I was a bit slower and hovered over a node for too long):

![devenv_00No0TNpYT](https://github.com/user-attachments/assets/97900f9b-716a-44de-a01e-c12adebb64b9)
![devenv_Q70oSgelGK](https://github.com/user-attachments/assets/a0f3e81a-40dd-4e26-885b-40f59b424122)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers
@pinzart90 , @mjkkirschner 

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
