### PR TITLE
DYN-8096 Fix crash as per CER report for exceptions while opening file dialog box

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1486,9 +1486,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void SetCollapsedByNodeViewModel()
         {
-            if (this.Nodevm.IsCollapsed && this.NodeEnd.IsCollapsed)
+            if (Nodevm?.IsCollapsed == true && NodeEnd?.IsCollapsed == true)
             {
-                this.IsCollapsed = true;
+                IsCollapsed = true;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1486,9 +1486,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void SetCollapsedByNodeViewModel()
         {
-            if (Nodevm?.IsCollapsed == true && NodeEnd?.IsCollapsed == true)
+            if (this.Nodevm.IsCollapsed && this.NodeEnd.IsCollapsed)
             {
-                IsCollapsed = true;
+                this.IsCollapsed = true;
             }
         }
 


### PR DESCRIPTION
### Purpose

The PR adds exception handling around Dynamo file dialog box, the exception may have occurred when the user tried to open the file from a zipped location in Windows. The fix will prevent crash for any exception that occurs while opening file dialog box.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Fix crash as per CER report for exceptions while opening file dialog box

### Reviewers

@DynamoDS/dynamo 
