### PR TITLE
DYN-7268: Add IDSDK missing message when user tries to sign in from the splash screen

### DIFF
--- a/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
+++ b/src/DynamoCoreWpf/Views/SplashScreen/SplashScreen.xaml.cs
@@ -250,6 +250,7 @@ namespace Dynamo.UI.Views
         /// </summary>
         private bool SignIn()
         {
+            if (!viewModel.IsIDSDKInitialized(true, this)) return false;
             authManager.Login();
             bool ret = authManager.IsLoggedIn();
             Analytics.TrackEvent(Actions.SignIn, Categories.SplashScreenOperations, ret.ToString());


### PR DESCRIPTION
### Purpose

Add IDSDK missing message when user tries to sign in from the splash screen

@QilongTang tested with splash screen enabled, and we missed this case earlier, good catch!

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Add IDSDK missing message when user tries to sign in from the splash screen

### Reviewers

@DynamoDS/dynamo 

