### PR TITLE
DYN-6634 Update About Box content to move the license information to an online file

### DIFF
--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -1,941 +1,214 @@
-{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033\deflangfe2052{\fonttbl{\f0\fswiss\fprq2\fcharset0 Helvetica;}{\f1\fswiss\fprq2\fcharset0 Verdana;}{\f2\froman\fprq2\fcharset0 Times New Roman;}}
-{\colortbl ;\red165\green165\blue165;\red109\green210\blue255;\red0\green0\blue255;\red70\green70\blue70;\red255\green255\blue255;\red74\green74\blue74;\red5\green99\blue193;\red36\green41\blue47;}
-{\stylesheet{ Normal;}{\s1 heading 1;}{\s2 heading 2;}{\s3 heading 3;}{\s4 heading 4;}}
-{\*\generator Riched20 10.0.22621}{\*\mmathPr\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
-\pard\nowidctlpar\sb240\sl276\slmult1\cf1\b\f0\fs22\lang2057 @DYNAMO v.3.5.0 \'a9 2024 Autodesk, Inc.  All rights reserved.\par
-Dynamo License\par
-
-\pard\widctlpar\b0\par
-Those portions created by Ian are provided with the following copyright:\par
-\par
-Copyright 2017 Ian Keough\par
-\par
-Those portions created by Autodesk employees are provided with the following copyright:\par
-\par
-Copyright 2024 Autodesk, Inc.\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf2\ul{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520120511%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=hM4SECRXlI3Y3bhWd0n7aVFES8pYfE3tfdiIfbSsdIo%3D&reserved=0" }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0}}}}\cf2\ul\f0\fs22  \cf1\ulnone Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\cf2\ul\par
-\cf0\ulnone\b\f1\fs20\par
-
-\pard\nowidctlpar\sb240\sl276\slmult1\cf1\f0\fs22 Privacy\par
-
-\pard\widctlpar\b0 To learn more about Autodesk\rquote s online and offline privacy practices, please see the {\cf2\ul{\field{\*\fldinst{HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"}}{\fldrslt{Autodesk Privacy Statement}}}}\cf2\ul\f0\fs22 .\cf0\ulnone\f1\fs16\par
-\par
-
-\pard\nowidctlpar\sb240\sl276\slmult1\cf1\b\f0\fs22 Autodesk Trademarks\par
-
-\pard\widctlpar\b0 The trademarks on the {\cf2\ul{\field{\*\fldinst{HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"}}{\fldrslt{Autodesk Trademarks page}}}}\f0\fs22  are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.  \par
-\par
-All other brand names, product names or trademarks belong to their respective holders.\par
-
-\pard\nowidctlpar\sb240\sl276\slmult1\b Autodesk Cloud and Desktop Components\cf0\f1\par
-
-\pard\widctlpar\cf1\b0\f0 This Product or Service may incorporate or use background Autodesk online and desktop technology components.\~ For information about these components, see\cf0\f1  {\cf2\ul\f0{\field{\*\fldinst{HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"}}{\fldrslt{Autodesk Cloud Platform Components}}}}\cf1\f2\fs22  \f0 and {\cf2\ul{\field{\*\fldinst{HYPERLINK "https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"}}{\fldrslt{Autodesk Desktop Platform Components}}}}\cf2\ul\f0\fs22 .\par
-\cf0\ulnone\f1\fs18\par
-
-\pard\widctlpar\sb168\cf1\b\f0\fs22 LIBG, ProtoGeometry v.2.7.0, DynamoVisualProgramming.Analytics, CER, ADP, GRegRevitAuth, AGET, IDSDK, IDSDK Wrapper, ForgeUnits.NET, ForgeUnits.Schemas,, and Autodesk.GeometryPrimitives.Dynamo\b0  are closed source files licensed by Autodesk under the license that can be found here {\cf0{\field{\*\fldinst{HYPERLINK https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf }}{\fldrslt{https://github.com/DynamoDS/Dynamo/tree/master/doc/distrib/Autodesk.rtf\ul0\cf0}}}}\f0\fs22\par
-
-\pard\widctlpar\cf0\f1\fs18\par
-\fs20\par
-\cf1\b\f0\fs22 Third-Party Trademarks, Software Credits and Attributions\par
-\cf0\b0\f1\fs18\par
-\cf1\b\f0\fs22 Greg v.\cf0\b0\f2\fs24  \cf1\b\f0\fs22 v.3.0.2.6284:\par
-\b0 (The MIT License)\par
-Copyright (c) 2013 Peter Boyer {\cf2\ul\f2\fs24{\field{\*\fldinst{HYPERLINK "mailto:peter.boyer@autodesk.com" }}{\fldrslt{\f0\fs22 peter.boyer@autodesk.com}}}}\f0\fs22  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-\cf1\b\f0\fs22 Microsoft.CSharp v.4.0.0.0:\par
-\b0 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\ul\par
-\ulnone The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-\cf1\b\f0\fs22 Newtonsoft.Json v.13.0.1:\par
-{\cf2\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJamesNK%2FNewtonsoft.Json&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520419200%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=hvR4mYgVhMPpQh4uLCJ3PY9Ywr8mM0vqXF98ac8mPXA%3D&reserved=0" }}{\fldrslt{https://github.com/JamesNK/Newtonsoft.Json}}}}\cf2\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FJamesNK%2FNewtonsoft.Json%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520429148%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=OuX0yvu%2F0kVS7X5KARjQ3p9Ycg8qvk67fFAaKNEWxbM%3D&reserved=0" }}{\fldrslt{https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md}}}}\f0\fs22\par
-\cf1\ulnone The MIT License (MIT)\par
-Copyright (c) 2007 James Newton-King\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-\b RestSharp v.112.0.0.0:\par
-{\cf2\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520478947%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=foUoDUPyy8Or0rkNJtlLjI9XfJO7gemOLFnuKIkflHU%3D&reserved=0" }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0}}}}\cf2\ul\b0\f0\fs22\par
-\cf1\ulnone Copyright \'a9 2021 Alexe Zimarev\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs22  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 System.Collections.Immutable v.8.0.0:\par
-
-\pard\widctlpar\kerning0\b0\lang1033 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\lang2057\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-\cf1\kerning2\b\f0\fs22\lang1031 FontAwesome5 v.2.1.11:\par
-{\cf0\kerning0\b0{\field{\*\fldinst{HYPERLINK https://www.nuget.org/packages/FontAwesome5/ }}{\fldrslt{https://www.nuget.org/packages/FontAwesome5/\ul0\cf0}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{\cf0\ulnone{\field{\*\fldinst{HYPERLINK https://github.com/MartinTopfstedt/FontAwesome5/blob/master/LICENSE }}{\fldrslt{https://github.com/MartinTopfstedt/FontAwesome5/blob/master/LICENSE\ul0\cf0}}}}\f0\fs22\par
-\cf1\ulnone\lang1033 MIT License\par
-Copyright (c) 2018 MartinTopfstedt\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Cyotek.Drawing.BitmapFont v.2.0.0:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520160343%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=kvdO%2FPPgz3PuASG6zv93DwNJ4gPkL6T6islWBwoI9Xk%3D&reserved=0" }}{\fldrslt{https://github.com/cyotek/Cyotek.Drawing.BitmapFont}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fcyotek%2FCyotek.Drawing.BitmapFont%2Fblob%2Fmaster%2FLICENSE.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520170297%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=WjEf%2FyE1koklbovxfFzHrScckILOiAOQlGkhPLaZ%2FL8%3D&reserved=0" }}{\fldrslt{https://github.com/cyotek/Cyotek.Drawing.BitmapFont/blob/master/LICENSE.txt}}}}\f0\fs22\par
-\cf1\ulnone The MIT License (MIT)\par
-Copyright \'a9 2012-2021 Cyotek Ltd.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-\cf1\kerning1\b\f0\fs22 Helix Toolkit v.2.24.0:\par
-HelixToolkit.Core.Wpf v.2.24.0:\par
-HelixToolkit.SharpDX.Core v.2.24.0:\par
-HelixToolkit.SharpDX.Core.Wpf v.2.24.0:\par
-{\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=dfWqblB8VdDL63AyawNfgrFG2TD08PCrheqsu%2B7K0Us%3D&reserved=0" }}{\fldrslt{https://github.com/helix-toolkit/helix-toolkit}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fhelix-toolkit%2Fhelix-toolkit%2Fblob%2Fdevelop%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=qUPlp6EXAxHOk9eACY7DopacUlVCn355KLenUznV%2Ft0%3D&reserved=0" }}{\fldrslt{https://github.com/helix-toolkit/helix-toolkit/blob/develop/LICENSE}}}}\f0\fs22\par
-\cf1\ulnone The MIT License (MIT)\par
-Copyright (c) 2019 Helix Toolkit contributors\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 SharpDX v.4.2.0:\par
-SharpDX.D3DCompiler v.4.2.0:\par
-SharpDX.Direct2D1 v.4.2.0:\par
-SharpDX.Direct3D11 v.4.2.0:\par
-SharpDX.Direct3D9 v.4.2.0:\par
-SharpDX.DXGI v.4.2.0:\par
-SharpDX.Mathematics v.4.2.0:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsharpdx%2FSharpDX%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=VOYhb2IAZGG0jx%2FwQxJ2Q9HXN2t6XKVVP6AiBEdD%2F3E%3D&reserved=0" }}{\fldrslt{https://github.com/sharpdx/SharpDX/blob/master/LICENSE}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-\cf1\ulnone Copyright (c) 2010-2014 SharpDX - Alexandre Mutel\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-\cf1\f0\fs22\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b ICSharpCode.AvalonEdit v.6.3.0.90:\par
-
-\pard\widctlpar {\cf0\kerning0\b0{\field{\*\fldinst{HYPERLINK http://www.avalonedit.net/ }}{\fldrslt{http://www.avalonedit.net/\ul0\cf0}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{\cf0\ulnone{\field{\*\fldinst{HYPERLINK https://licenses.nuget.org/MIT }}{\fldrslt{https://licenses.nuget.org/MIT\ul0\cf0}}}}\f0\fs22\par
-\cf0\ulnone\f1\fs18\par
-\cf1\f0\fs22 MIT License\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Google OpenSans:\par
-
-\pard\widctlpar\kerning0\b0 OpenSans font from Google\par
-{\cf2\ul{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.google.com%2Ffonts%2Fspecimen%2FOpen%2BSans&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520439110%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=uwmtTlbBUjq%2B1z%2FvJsb9jSJ7i6M8hIMll1qnznB0mDw%3D&reserved=0" }}{\fldrslt{http://www.google.com/fonts/specimen/Open+Sans}}}}\cf2\ul\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0.html&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520449066%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=u4S07VDF20%2BhKswWuPxfNxdMvEV6u6kUxVXid57TMkQ%3D&reserved=0" }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0.html}}}}\f0\fs22\par
-\cf1\ulnone Copyright \'a9 [yyyy] Steve Matteson\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\cf2\ul\f2\fs22  \cf1\ulnone\f0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\cf2\ul\f2\par
-\cf0\ulnone\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 DocumentFormat.OpenXml v.2.12.3:\par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) Microsoft Corporation\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 IronPython.StdLib v.2.7.9:\par
-
-\pard\widctlpar\kerning0\b0 Copyright \'a9 2018 Slide & Slozier\par
-\par
-1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using Python 2.7.18 software in source or binary form and its associated documentation.\par
-\par
-2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python 2.7.18 alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright \'a9 2001-2020 Python Software Foundation; All Rights Reserved" are retained in Python 2.7.18 alone or in any derivative version prepared by Licensee.\par
-\par
-3. In the event Licensee prepares a derivative work that is based on or incorporates Python 2.7.18 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python 2.7.18.\par
-\par
-4. PSF is making Python 2.7.18 available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 2.7.18 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.\par
-\par
-5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 2.7.18 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 2.7.18, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.\par
-\par
-6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.\par
-\par
-7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee.  This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.\par
-\par
-8. By copying, installing or otherwise using Python 2.7.18, Licensee agrees to be bound by the terms and conditions of this License Agreement.\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b IronPython v.2.7.9\par
-DynamicLanguageRuntime v.1.2.2\par
-
-\pard\widctlpar\kerning0\b0 Iron Python, Dynamic Language Runtime\par
-{\cf2\ul{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fironpython.net%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520230026%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=imRCR5wnzORiO%2BHcoAs4qY%2FUsg2F3%2BvpQsquG4pLPbc%3D&reserved=0" }}{\fldrslt{http://ironpython.net/}}}}\cf2\ul\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fopensource.org%2Flicenses%2Fapache2.0.php&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520339551%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=GqzN3ywkegHn8Xwxmkje5HuJNO7iecwBGZU3LOoNIus%3D&reserved=0" }}{\fldrslt{http://opensource.org/licenses/apache2.0.php}}}}\f0\fs22\par
-\cf1\ulnone Copyright \'a9 2018 Iron Python Community\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs22  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Python.Runtime.NETStandard v.3.7.0:\par
-
-\pard\widctlpar\kerning0\b0 Copyright (c) 2006-2021 the contributors of the Python.NET project\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Python.Included v.3.7.3.4\par
-
-\pard\widctlpar\kerning0\b0 PSF LICENSE AGREEMENT FOR PYTHON 3.10.4\par
-\par
-1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using Python 3.7.3.4 software in source or binary form and its associated documentation.\par
-\par
-2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python 3.7.3.4 alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright \'a9 2001-2022 Python Software Foundation; All Rights Reserved" are retained in Python 3.7.3.4 alone or in any derivative version prepared by Licensee.\par
-\par
-3. In the event Licensee prepares a derivative work that is based on or incorporates Python 3.7.3.4 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python 3.7.3.4.\par
-\par
-4. PSF is making Python 3.7.3.4 available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 3.7.3.4 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.\par
-\par
-5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.7.3.4 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.7.3.4, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.\par
-\par
-6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.\par
-\par
-7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee. This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.\par
-\par
-8. By copying, installing or otherwise using Python 3.7.3.4, Licensee agrees to be bound by the terms and conditions of this License Agreement.\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b IPython (autoreload.py) v.7.24.1:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fipython%2Fipython%2Fblob%2Fmaster%2FIPython%2Fextensions%2Fautoreload.py&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520359465%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=7AtWEHhH3h2E0eDlvyhqM0OyREJugNDsYai4S5egwXc%3D&reserved=0" }}{\fldrslt{https://github.com/ipython/ipython/blob/master/IPython/extensions/autoreload.py}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fipython%2Fipython%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520359465%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=Pilk0qSjYqpb4gwsh9CFaG42mk5wngBXOSykgiBj1EQ%3D&reserved=0" }}{\fldrslt{https://github.com/ipython/ipython/blob/master/LICENSE}}}}\f0\fs22\par
-\cf1\ulnone BSD 3-Clause License\par
-- Copyright (c) 2008-Present, IPython Development Team\par
-\lang3082 - Copyright (c) 2001-2007, Fernando Perez <fernando.perez@colorado.edu>\par
-\lang1033 - Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>\par
-- Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>\par
-All rights reserved.\par
-\par
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\par
-\par
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\par
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\par
-* Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\par
-\par
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Nunit v.3.13.3\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.nunit.org%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520429148%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=BUfNk%2Flw%2BcIf69w2%2FUf0Rq%2FiDdxtlm4UOrklWu1jBco%3D&reserved=0" }}{\fldrslt{http://www.nunit.org/}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-\cf1\ulnone Copyright \'a9 2002-2013 Charlie Poole\line Copyright \'a9 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov\line Copyright \'a9 2000-2002 Philip A. Craig\par
-\par
-This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.\par
-Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:\par
-\par
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment (see the following) in the product documentation is required. Portions Copyright \'a9 2002-2009 Charlie Poole or Copyright\~\'a9 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov or Copyright\~\'a9 2000-2002 Philip A. Craig\~\par
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.\~\par
-3. This notice may not be removed or altered from any source distribution.\par
-
-\pard\widctlpar\li720\par
-
-\pard\widctlpar\s4 License Note\par
-
-\pard\widctlpar This license is based on\~{{\field{\*\fldinst{HYPERLINK "http://www.opensource.org/licenses/zlib-license.html" }}{\fldrslt{\ul\cf3\cf3\ul the open source zlib/libpng license}}}}\f0\fs22  ({\cf0{\field{\*\fldinst{HYPERLINK https://opensource.org/licenses/zlib-license.html }}{\fldrslt{https://opensource.org/licenses/zlib-license.html\ul0\cf0}}}}\f0\fs22 ). The idea was to keep the license as simple as possible to encourage use of NUnit in free and commercial applications and libraries, but to keep the source code together and to give credit to the NUnit contributors for their efforts. While this license allows shipping NUnit in source and binary form, if shipping a NUnit variant is the sole purpose of your product, please\~{{\field{\*\fldinst{HYPERLINK "mailto:cpoole@pooleconsulting.com" }}{\fldrslt{\ul\cf3\cf3\ul let us know}}}}\f0\fs22  ({{\field{\*\fldinst{HYPERLINK "mailto:cpoole@pooleconsulting.com" }}{\fldrslt{\ul\cf3\cf3\ul cpoole@pooleconsulting.com}}}}\f0\fs22  ).\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b\lang3082 Moq v.4.18.4:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmoq%2Fmoq4%2Fblob%2Fmaster%2FLicense.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520409253%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=H%2FwNgy%2FpMYIgd%2FFlP1IU1dbvTUCauizIJKCAU6ISQZI%3D&reserved=0" }}{\fldrslt{https://github.com/moq/moq4/blob/master/License.txt/}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-\cf1\ulnone\lang1033 BSD 3-Clause License\par
-Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors. All rights reserved.\par
-\par
-Redistribution and use in source and binary forms, with or without\par
-modification, are permitted provided that the following conditions are met:\par
-\par
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\par
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\par
-* Neither the names of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\par
-\par
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22\lang3082 Libiconv v.1.14.0.1:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Flibiconv%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520369420%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=fyvQ8axd0727ARcscr232iqeW1sGK6FTq%2FP7s1ZtC6s%3D&reserved=0" }}{\fldrslt{https://www.gnu.org/software/libiconv/}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520369420%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=NZT9tNyZbyPw1WOLz%2BE6ShwxQDWHBJ9uLSyHhKPHWHk%3D&reserved=0" }}{\fldrslt{https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}}\f0\fs22\par
-\cf1\ulnone\lang1033\'a9 1998, 2013 Free Software Foundation, Inc.  \par
-\par
-This Autodesk software contains libiconv v. 1.14.0.1.  libiconv is licensed under the GNU Lesser General Public License v.2.1, which can be found at {\cf0{\field{\*\fldinst{HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }}{\fldrslt{http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt\ul0\cf0}}}}\f0\fs22 . A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libiconv from {\cf2\ul{\field{\*\fldinst{HYPERLINK "http://www.autodesk.com/lgplsource" }}{\fldrslt{www.autodesk.com/lgplsource}}}}\f0\fs22  or by sending a written request  to:\par
-\par
-Autodesk, Inc.\par
-Attention:  General Counsel\par
-Legal Department\par
-111 McInnis Parkway\par
-San Rafael, CA 94903\par
-Your written request must:\par
-\par
-Contain a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or the envelope you have chosen) weighing  5 ounces from San Rafael,    California USA to your indicated address; and Identify:\par
-\par
-This Autodesk software name and release number; That you are requesting  the source code for libiconvv .1.14.0.1; and The above URL ({\cf2\ul{\field{\*\fldinst{HYPERLINK "http://www.autodesk.com/lgplsource" }}{\fldrslt{www.autodesk.com/lgplsource}}}}\f0\fs22 ) so that Autodesk may properly respond to your request.  The offer to receive this libiconv source code via the above URL ({\cf2\ul{\field{\*\fldinst{HYPERLINK "http://www.autodesk.com/lgplsource" }}{\fldrslt{www.autodesk.com/lgplsource}}}}\f0\fs22 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.  You may modify, debug and relink libiconv to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.2.1.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 GNU gettext (libintl) v.0.19.8.3:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520200164%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=Nf21XpKiL0wk%2Fv5o95n6NHU9yBTsVWmKLfq1AJGQ1bM%3D&reserved=0" }}{\fldrslt{https://www.gnu.org/software/gettext/}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gnu.org%2Fsoftware%2Fgettext%2Fmanual%2Fhtml_node%2FGNU-LGPL.html%23GNU-LGPL&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520210113%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=fm4crd4P%2By6SL%2F0glLKwxCwV9NjLZs7f2LAoNHfi2QE%3D&reserved=0" }}{\fldrslt{https://www.gnu.org/software/gettext/manual/html_node/GNU-LGPL.html#GNU-LGPL}}}}\f0\fs22\par
-\cf1\ulnone\'a9 Copyright \'a9 1991, 1999 Free Software Foundation, Inc.\par
-\par
-This Autodesk software contains libintl v.0.19.8.3.  libintl is licensed under the GNU Lesser General Public License v.2.1 , which can be found at {\cf0{\field{\*\fldinst{HYPERLINK http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt }}{\fldrslt{http://www.gnu.org/licenses/oldlicenses/lgpl-2.1.txt\ul0\cf0}}}}\cf2\ul\f0\fs22 . \cf1\ulnone A text copy of this license is included on the media or with the download of this Autodesk software.  You may obtain a copy of the source code for libintl v.0.19.8.3  from {\cf2\ul{\field{\*\fldinst{HYPERLINK "http://www.autodesk.com/lgplsource" }}{\fldrslt{www.autodesk.com/lgplsource}}}}\f0\fs22  or by sending a written request  to:\par
-\par
-Autodesk, Inc.\par
-Attention:  General Counsel\par
-Legal Department\par
-111 McInnis Parkway\par
-San Rafael, CA 94903\par
-\par
-Your written request must:\par
-1. Contain a self-addressed CD/DVD mailer (or envelope sufficiently large to hold a DVD) with postage sufficient to cover the amount of the current U.S. Post Office First Class postage rate for CD/DVD mailers (or the envelope you have chosen) weighing  5 ounces from San Rafael, California USA to your indicated address; and\par
-2. Identify:\par
-a. This Autodesk software name and release number;\par
-b. That you are requesting  the source code for libintl v.0.19.8.3; and\par
-c. The above URL ({\cf0{\field{\*\fldinst{HYPERLINK www.autodesk.com/lgplsource }}{\fldrslt{www.autodesk.com/lgplsource\ul0\cf0}}}}\f0\fs22 )\par
-so that Autodesk may properly respond to your request.  The offer to receive this libintl source code via the above URL ({\cf0{\field{\*\fldinst{HYPERLINK www.autodesk.com/lgplsource }}{\fldrslt{www.autodesk.com/lgplsource\ul0\cf0}}}}\f0\fs22 ) or by written request to Autodesk is valid for a period of three (3) years  from the date you purchased your license to this Autodesk software.\par
-You may modify, debug and relink libintl to this Autodesk software as provided under the terms of the GNU Lesser General Public License v.2.1.\par
-\cf0\f1\fs18\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22\lang3082 Ncalc v.1.3.8.0:\cf2\kerning0\ul\b0\par
-
-\pard\widctlpar {{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fncalc.codeplex.com%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520409253%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=MXJNaR69ECgPJDJYPSnyLqGx9AGSwz%2FQZR55FnDPv5U%3D&reserved=0" }}{\fldrslt{http://ncalc.codeplex.com/}}}}\f0\fs22\par
-\cf1\ulnone\lang1033\'a9 2011 Sebastien Ros\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 MIConvexHull.NET v.1.0.17.411\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdesignengrlab.github.io%2FMIConvexHull%2F&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520389325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=NY1pGp4Rus1IhXoLEAgeQgcF3gsQK5hhpdBY1KGxtSY%3D&reserved=0" }}{\fldrslt{http://miconvexhull.codeplex.com/}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fmiconvexhull.codeplex.com%2Flicense&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520389325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=hNSoZ7QXpdD4Fhf0DlaIzm2xF9XGsksCYNlWnpXQ%2BiM%3D&reserved=0" }}{\fldrslt{http://miconvexhull.codeplex.com/license}}}}\f0\fs22\par
-\cf1\ulnone Copyright (c) 2010 David Sehnal, Matthew Campbell\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. \par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22\lang1053 StarMath v.2.0.17:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FDesignEngrLab%2FStarMath%2Fblob%2Fmaster%2FLICENSE&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520488895%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=QlLJQ5zjjCkV03%2BrjgrcdUTiz9O6pTyzKdtSv5xpHsg%3D&reserved=0" }}{\fldrslt{https://github.com/DesignEngrLab/StarMath/blob/master/LICENSE}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-\cf1\ulnone\lang1033 The MIT License (MIT)\par
-Copyright (c) 2015 DesignEngrLab\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b DiffPlex v.1.6.3:\par
-
-\pard\widctlpar\kerning0\b0\'a9 2020 mmanela\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at\par
-{\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\cf2\ul\f0\fs22  \cf1\ulnone Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\cf2\ul\par
-\cf0\ulnone\f1\fs18\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning2\b\f0\fs22 FontAwesome v.5.15.4:\par
-
-\pard\widctlpar {\cf0\kerning0\b0{\field{\*\fldinst{HYPERLINK https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt }}{\fldrslt{https://github.com/FortAwesome/Font-Awesome/blob/5.x/LICENSE.txt\ul0\cf0}}}}\f0\fs22\lang1031\par
-\kerning0\b0\lang1033 CC BY 4.0 License\kerning2\b\lang1031  ({\cf0\kerning0\b0\lang1033{\field{\*\fldinst{HYPERLINK https://creativecommons.org/licenses/by/4.0/ }}{\fldrslt{https://creativecommons.org/licenses/by/4.0/\ul0\cf0}}}}\f0\fs22 )\par
-\kerning0\b0\lang1033 Copyright (c) 2022 Fonticons, Inc.\kerning2\b\lang1031  ({\cf0\kerning0\b0\lang1033{\field{\*\fldinst{HYPERLINK https://fontawesome.com }}{\fldrslt{https://fontawesome.com\ul0\cf0}}}}\f0\fs22 )\par
-\par
-\kerning0\b0\lang1033 In the Font Awesome Free download, the CC BY 4.0 license applies to all icons packaged as SVG and JS file types.\par
-\par
-Icons: CC BY 4.0 License ({\cf0{\field{\*\fldinst{HYPERLINK https://creativecommons.org/licenses/by/4.0/ }}{\fldrslt{https://creativecommons.org/licenses/by/4.0/\ul0\cf0}}}}\f0\fs22 ):  The Font Awesome Free download is licensed under a Creative Commons Attribution 4.0 International License and applies to all icons packaged as SVG and JS file types.\par
-\par
-Fonts: SIL OFL 1.1 License\par
-In the Font Awesome Free download, the SIL OFL license applies to all icons packaged as web and desktop font files.\par
-Copyright (c) 2023 Fonticons, Inc. ({\cf0{\field{\*\fldinst{HYPERLINK https://fontawesome.com }}{\fldrslt{https://fontawesome.com\ul0\cf0}}}}\f0\fs22 )\par
-with Reserved Font Name: "Font Awesome".\par
-This Font Software is licensed under the SIL Open Font License, Version 1.1. \par
-This license can be found at: {\cf0{\field{\*\fldinst{HYPERLINK http://scripts.sil.org/OFL }}{\fldrslt{http://scripts.sil.org/OFL\ul0\cf0}}}}\f0\fs22\par
-\cf0\f1\fs18\par
-\cf1\f0\fs22 Code: MIT License ({\cf0{\field{\*\fldinst{HYPERLINK https://opensource.org/licenses/MIT }}{\fldrslt{https://opensource.org/licenses/MIT\ul0\cf0}}}}\f0\fs22 )\par
-In the Font Awesome Free download, the MIT license applies to all non-font and\par
-non-icon files.\par
-Copyright 2023 Fonticons, Inc.\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of\par
-this software and associated documentation files (the "Software"), to deal in the\par
-Software without restriction, including without limitation the rights to use, copy,\par
-modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,\par
-and to permit persons to whom the Software is furnished to do so, subject to the\par
-following conditions:\par
-The above copyright notice and this permission notice shall be included in all\par
-copies or substantial portions of the Software.\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,\par
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\par
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT\par
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\par
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\par
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\cf0\f1\fs18\line\line\cf1\f0\fs22\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b AngleSharp v.0.14.0: Copyright (c) 2013 - 2019 AngleSharp\par
-AngleSharp.CSS v.0.14.2: Copyright \'a9 2013-2020 AngleSharp\par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 HTMLSanitizer v.5.0.372:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520220149%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=t7WD0mko%2B%2FF%2FdpKKLHyM93UCXrX%2BXwo3yUYVGPZQcGs%3D&reserved=0" }}{\fldrslt{https://github.com/mganss/HtmlSanitizer}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmganss%2FHtmlSanitizer%2Fblob%2Fmaster%2FLICENSE.md&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520220149%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=phLGnloT%2FCglabebh%2FsUSc6iiDyt6D3vSMPPKA%2FgOJQ%3D&reserved=0" }}{\fldrslt{https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md}}}}\f0\fs22\par
-\cf1\ulnone The MIT License (MIT)\par
-Copyright (c) 2013-2016 Michael Ganss and HtmlSanitizer contributors\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b\lang1031 Markdig v.0.22.0:\par
-
-\pard\widctlpar {\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Flunet-io%2Fmarkdig&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520379375%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=IkaWjqj6UwIqoUB8EQOeZKYMz4qbWg8kbbCcZ0Qa%2Fhg%3D&reserved=0" }}{\fldrslt{https://github.com/lunet-io/markdig}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK "https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Flunet-io%2Fmarkdig%2Fblob%2Fmaster%2Flicense.txt&data=04%7C01%7CJames.Conner%40autodesk.com%7Cdaecd65781944b855e7808d946251ff6%7C67bff79e7f914433a8e5c9252d2ddc1d%7C0%7C0%7C637617947520379375%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=eIL37c9G%2B11uq1htX8ARhSCvefpQIOMXjVAqMh1aceU%3D&reserved=0" }}{\fldrslt{https://github.com/lunet-io/markdig/blob/master/license.txt}}}}\f0\fs22\par
-\cf1\ulnone\lang1033 Copyright (c) 2018-2019, Alexandre Mutel\par
-All rights reserved.\par
-\par
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\par
-\par
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\par
-\par
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\par
-\par
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\par
-\cf0\f1\fs18\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 System.Buffers v.4.5.1\par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 System.Memory v.4.5.4\par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-\kerning1\b System.Reflection.MetadataLoadContext v.8.0.0\par
-\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 System.Numerics.Vectors v.4.5.0\par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 System.Text.Encoding.CodePages v.4.5.0 \par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs18\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Rapidjson v.1.1.0:\par
-
-\pard\widctlpar\kerning0\b0 Copyright \'a9 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. \par
-\cf0\f1\fs20\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Mono.Cecil v.0.11.4:\par
-
-\pard\widctlpar\kerning0\b0 Copyright (c) 2008 - 2015 Jb Evain\par
-Copyright (c) 2008 - 2011 Novell, Inc.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,\par
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs20\par
-\cf1\kerning1\b\f0\fs22 LaunchDarkly.Clientsdk v.5.1.0\par
-LaunchDarkly.CommonSdk v.5.5.0\par
-LaunchDarkly.EventSource v.4.1.3\par
-LaunchDarkly.InternalSdk v.2.3.2\par
-LaunchDarkly.JsonStream v.1.0.3\par
-LaunchDarkly.Logging v.1.0.1\line Copyright 2018 Catamorphic, Co.\par
-\kerning0\b0\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs22  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\par
-\cf0\f1\fs20\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 CommandLineParser v.2.8.0:\par
-
-\pard\widctlpar\kerning0\b0 The MIT License (MIT)\par
-Copyright (c) 2005 - 2015 Giacomo Stelluti Scala & Contributors\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs20\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Nlohmann.json v.3.7.3\par
-
-\pard\widctlpar\kerning0\b0 Copyright \'a9 2013-2022 Niels Lohmann\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is\par
-furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs20\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 Autodesk Artifakt Fonts\par
-
-\pard\widctlpar\kerning0\b0 Licensing information: \'a9 Autodesk, Inc. All Rights Reserved.\par
-\par
-The Artifakt font software is Autodesk proprietary and confidential, and may be used only by authorized users and only for Autodesk business purposes. Any use not authorized by Autodesk is not permitted and is an infringement of Autodesk's intellectual property rights as well as a breach of your agreement with Autodesk. Go to {\cf0{\field{\*\fldinst{HYPERLINK https://brand.autodesk.com/brand-system/typography }}{\fldrslt{https://brand.autodesk.com/brand-system/typography\ul0\cf0}}}}\f0\fs22  for detailed usage guidelines on when and how to use the Artifakt designer collection.\par
-\cf0\f1\fs20\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\b\f0\fs22 DirectX\par
-{\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/DirectX%20SDK%20EULA.txt" }}{\fldrslt{https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/DirectX SDK EULA.txt\par
-}}}}{\cf2\kerning0\ul\b0\f0\fs22{\field{\*\fldinst{HYPERLINK "https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License%20Agreements/directx%20redist.txt" }}{\fldrslt{https://github.com/DynamoDS/Dynamo/tree/master/tools/install/Extra/DirectX/License Agreements/directx redist.txt\par
-}}}}\cf0\kerning1\ulnone\b\f0\fs24\par
-\cf1\fs22 ImageMagick\par
-{\cf0\kerning0\b0{\field{\*\fldinst{HYPERLINK https://imagemagick.org/script/license.php }}{\fldrslt{https://imagemagick.org/script/license.php\ul0\cf0}}}}\cf0\kerning0\b0\f0\fs22\par
-\par
-
-\pard\widctlpar\cf1\kerning1\b LiveChartsCore v.2.0.0-rc3.3:\par
-LiveChartsCore.SkiaSharpView v.2.0.0- rc3.3:\par
-LiveChartsCore.SkiaSharpView.WPF v.2.0.0- rc3.3:\par
-Copyright (c) 2021 Alberto Rodriguez Orozco\par
-\par
-MIT License\par
-\par
-\kerning0\b0 Permission is hereby granted, free of charge, to any person obtaining a copy\par
-of this software and associated documentation files (the "Software"), to deal\par
-in the Software without restriction, including without limitation the rights\par
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\par
-copies of the Software, and to permit persons to whom the Software is\par
-furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all\par
-copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\par
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\par
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\par
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\par
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\par
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\cf0\f1\fs20\par
-\cf1\kerning1\b\f0\fs22 Magick.NET.Core v7.0.1:\par
-
-\pard\nowidctlpar\sl288\slmult1 Copyright [2013] [dlemstra]\par
-{\cf0\kerning0\b0{\field{\*\fldinst{HYPERLINK https://github.com/dlemstra/Magick.NET/blob/main/License.txt }}{\fldrslt{https://github.com/dlemstra/Magick.NET/blob/main/License.txt\ul0\cf0}}}}\cf0\kerning0\b0\f0\fs22\par
-\cf2\ul\par
-
-\pard\widctlpar\cf1\ulnone Licensed under the Apache License, Version 2.0 (the "License");\par
-you may not use this file except in compliance with the License.\par
-You may obtain a copy of the License at\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1 {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\cf2\ul\f0\fs22\par
-
-\pard\widctlpar\cf1\ulnone\par
-Unless required by applicable law or agreed to in writing, software\par
-distributed under the License is distributed on an "AS IS" BASIS,\par
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\par
-See the License for the specific language governing permissions and\par
-limitations under the License.\par
-
-\pard\nowidctlpar\sl288\slmult1\cf0\fs24\par
-Magick.NET-Q8-AnyCPU v7.24.1:\par
-{\fs22{\field{\*\fldinst{HYPERLINK https://imagemagick.org/script/license.php }}{\fldrslt{https://imagemagick.org/script/license.php\ul0\cf0}}}}\cf2\ul\f0\fs22\par
-
-\pard\widctlpar\cf1\ulnone Copyright 1999-2021 ImageMagick Studio LLC, a non-profit organization dedicated to making software imaging solutions freely available.\par
-
-\pard\nowidctlpar\sl288\slmult1\cf0\fs24\par
-\cf1\kerning1\b\fs22 Open XML SDK\par
-{\cf0\kerning0\b0{\field{\*\fldinst{HYPERLINK https://github.com/OfficeDev/Open-XML-SDK }}{\fldrslt{https://github.com/OfficeDev/Open-XML-SDK\ul0\cf0}}}}\cf2\kerning0\ul\b0\f0\fs22\par
-{\cf0\ulnone{\field{\*\fldinst{HYPERLINK https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE }}{\fldrslt{https://github.com/OfficeDev/Open-XML-SDK/blob/main/LICENSE\ul0\cf0}}}}\f0\fs22\par
-\cf0\kerning1\ulnone\b\fs24\par
-\cf1\fs22\lang1053 Python Standard Library\par
-{\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://docs.python.org/2.7/library/" }}{\fldrslt{https://docs.python.org/2.7/library/\par
-}}}}{\cf2\kerning0\ul\b0\f0\fs22{\field{\*\fldinst{HYPERLINK "https://docs.python.org/2.7/license.html" }}{\fldrslt{https://docs.python.org/2.7/license.html\par
-}}}}\cf1\kerning1\ulnone\b\f0\fs22\par
-\lang1033 Python Modules\cf4\highlight5\kerning0\b0\par
-
-\pard\nowidctlpar\sl276\slmult1 {\cf0\highlight0{\field{\*\fldinst{HYPERLINK https://numpy.org/ }}{\fldrslt{https://numpy.org/\ul0\cf0}}}}\cf2\highlight0\ul\f0\fs22  \cf1\ulnone License: Distributed under a liberal\cf6\highlight5\~{\cf0\highlight0{\field{\*\fldinst{HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }}{\fldrslt{\ul\cf3\cf7\highlight5\ul BSD license}}}}\cf0\highlight0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK https://pandas.pydata.org/ }}{\fldrslt{https://pandas.pydata.org/\ul0\cf0}}}}\cf2\ul\f0\fs22  \cf1\ulnone License\b :\b0  BSD 3-Clause "New" or "Revised" License\cf8\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://scipy.org/ }}{\fldrslt{https://scipy.org/\ul0\cf0}}}}\cf0\f0\fs22  \cf1 License:\b  \b0 Distributed under a liberal\b\~{\cf0\b0{\field{\*\fldinst{HYPERLINK "https://github.com/numpy/numpy/blob/main/LICENSE.txt" }}{\fldrslt{\ul\cf3\cf7\highlight5\ul BSD license}}}}\cf0\b0\f0\fs22\par
-{{\field{\*\fldinst{HYPERLINK https://pypi.org/project/openpyxl/ }}{\fldrslt{https://pypi.org/project/openpyxl/\ul0\cf0}}}}\f0\fs22  \cf1 License:\~MIT License (MIT)\cf4\highlight5\par
-{\cf0\highlight0{\field{\*\fldinst{HYPERLINK https://matplotlib.org/ }}{\fldrslt{https://matplotlib.org/\ul0\cf0}}}}\cf0\highlight0\f0\fs22  \cf1 License\b : \b0 Matplotlib only uses BSD compatible code, and its license is based on the\~{{\field{\*\fldinst{HYPERLINK "https://docs.python.org/3/license.html" }}{\fldrslt{\ul\cf3\cf3\ul PSF}}}}\f0\fs22\~license\cf6\highlight5\par
-{\cf0\highlight0{\field{\*\fldinst{HYPERLINK https://pypi.org/project/Pillow/ }}{\fldrslt{https://pypi.org/project/Pillow/\ul0\cf0}}}}\f0\fs22  \cf1\highlight0\b License:\b0\~Historical Permission Notice\b  and Disclaimer (HPND) \cf4\highlight5\b0\par
-
-\pard\nowidctlpar\sl288\slmult1\cf0\highlight0\kerning1\fs24\par
-\par
-\cf1\b\fs22\par
-Xceed Extended WPF Toolkit v.5.0.103\par
-{\cf2\kerning0\ul\b0\lang1036{\field{\*\fldinst{HYPERLINK "https://opensource.org/licenses/ms-pl.html" }}{\fldrslt{Microsoft Public License\par
-}}}}{\cf0\kerning0\b0\f0\fs22\lang1036{\field{\*\fldinst{HYPERLINK https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md }}{\fldrslt{https://github.com/xceedsoftware/wpftoolkit/blob/0ed4ed84152d6a3e2a627f2ef05f82627fdaf3fc/license.md\ul0\cf0}}}}\cf1\kerning1\ulnone\b\f0\fs22\lang1033\par
-
-\pard\widctlpar\cf0\f1\fs20\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\f0\fs22 Microsoft.Web.WebView2 v.1.0.2478.35\par
-
-\pard\widctlpar\kerning0\b0 Copyright (C) Microsoft Corporation. All rights reserved.\par
-\par
-Redistribution and use in source and binary forms, with or without\par
-modification, are permitted provided that the following conditions are\par
-met:\par
-\par
-   * Redistributions of source code must retain the above copyright\par
-notice, this list of conditions and the following disclaimer.\par
-   * Redistributions in binary form must reproduce the above\par
-copyright notice, this list of conditions and the following disclaimer\par
-in the documentation and/or other materials provided with the\par
-distribution.\par
-   * The name of Microsoft Corporation, or the names of its contributors \par
-may not be used to endorse or promote products derived from this\par
-software without specific prior written permission.\par
-\par
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\par
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\par
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\par
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\par
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\par
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\par
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\par
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\par
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\par
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\par
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\par
-\par
-\kerning1\b\lang1053 Lucene.Net v.4.8.0-beta00016\par
-Lucene.Net.Analysis.Common v.4.8.0-beta00016\par
-Lucene.Net.Queries v.4.8.0-beta00016\par
-Lucene.Net.QueryParser v.4.8.0-beta00016\par
-
-\pard\nowidctlpar\sl288\slmult1 Lucene.Net.Sandbox v.4.8.0-beta00016\par
-{\cf2\kerning0\ul\b0{\field{\*\fldinst{HYPERLINK "https://lucenenet.apache.org/"}}{\fldrslt{https://lucenenet.apache.org/\par
-}}}}{\cf0\kerning0\b0\f0\fs22{\field{\*\fldinst{HYPERLINK https://github.com/apache/lucenenet/blob/master/LICENSE.txt }}{\fldrslt{https://github.com/apache/lucenenet/blob/master/LICENSE.txt\ul0\cf0}}}}\cf1\kerning1\ulnone\b\f0\fs22\par
-\lang1033 Copyright 2022 Apache Lucene.NET\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs22  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.\par
-\par
-\lang1036 Microsoft.Extensions.Configuration.Json v6.0.0\par
-\b0\lang1033 The MIT License (MIT)\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/dotnet/runtime/blob/main/LICENSE.TXT }}{\fldrslt{https://github.com/dotnet/runtime/blob/main/LICENSE.TXT\ul0\cf0}}}}\cf2\f0\fs22\par
-\b\par
-\cf1\b0 Copyright (c) .NET Foundation and Contributors\par
-All rights reserved.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\cf2\b\par
-\cf1\par
-CsvHelper v30.0.1\par
-\b0 Apache 2.0\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt }}{\fldrslt{https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt\ul0\cf0}}}}\cf2\f0\fs22\par
-
-\pard\widctlpar\cf1\kerning0\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs22  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b\par
-Prism.Core v8.1.97\par
-\b0 The MIT License (MIT)\par
-{\cf0\kerning0\fs24{\field{\*\fldinst{HYPERLINK https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt }}{\fldrslt{https://github.com/PrismLibrary/Prism/blob/master/LICENSE.txt\ul0\cf0}}}}\cf2\kerning0\ul\f0\fs24\par
-\cf1\kerning1\ulnone\b\fs22\par
-
-\pard\widctlpar\kerning0\b0 Copyright (c) Prism Library\par
-\par
-All rights reserved. Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-
-\pard\nowidctlpar\sl288\slmult1 {\cf2\ul{\field{\*\fldinst{HYPERLINK "https://lucenenet.apache.org/"}}{\fldrslt{\par
-}}}}\kerning1\b\f0\fs22 MimeMapping v2.0.0\par
-\b0 MIT License\par
-
-\pard\widctlpar {\cf0{\field{\*\fldinst{HYPERLINK https://licenses.nuget.org/MIT }}{\fldrslt{https://licenses.nuget.org/MIT\ul0\cf0}}}}\cf2\f0\fs22\par
-\cf1\kerning0 Copyright (c) <year> <copyright holders>\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of\~\i this software and associated documentation files\i0\~(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-The above copyright notice and this permission notice\~\i (including the next paragraph)\i0\~shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\~\i THE AUTHORS OR COPYRIGHT HOLDERS\i0\~BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\cf7\ul\par
-\cf1\ulnone\par
-
-\pard\nowidctlpar\sl288\slmult1\kerning1\b DotNetProjects.Extended.Wpf.Toolkit v5.0.103\par
-\b0 Microsoft Public License\par
-
-\pard\widctlpar {\cf0\kerning0{\field{\*\fldinst{HYPERLINK https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md }}{\fldrslt{https://github.com/dotnetprojects/WpfExtendedToolkit/blob/Extended/LICENSE.md\ul0\cf0}}}}\cf2\kerning0\ul\f0\fs22\par
-\par
-
-\pard\nowidctlpar\sl288\slmult1\cf1\kerning1\ulnone This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.\par
-\par
-1. Definitions\par
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law. A "contribution" is the original software, or any additions or changes to the software. A "contributor" is any person that distributes its contribution under this license. "Licensed patents" are a contributor's patent claims that read directly on its contribution.\par
-2. Grant of Rights\par
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.\par
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.\par
-3. Conditions and Limitations\par
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.\par
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.\par
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.\par
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.\par
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees, or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.\par
-
-\pard\widctlpar\kerning0\par
-CastleCore v.5.1.1\par
-APACHE 2.0\par
-Copyright 2004-2021 Castle Project - {\cf0{\field{\*\fldinst{HYPERLINK http://www.castleproject.org/ }}{\fldrslt{http://www.castleproject.org/\ul0\cf0}}}}\f0\fs22\par
-\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/castleproject/Core/blob/master/LICENSE }}{\fldrslt{https://github.com/castleproject/Core/blob/master/LICENSE\ul0\cf0}}}}\f0\fs22\par
-\par
-DynamicLanguageRuntime v.1.2.2\par
-APACHE 2.0\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/IronLanguages/dlr/blob/master/LICENSE }}{\fldrslt{https://github.com/IronLanguages/dlr/blob/master/LICENSE\ul0\cf0}}}}\f0\fs22\par
-\par
-Copyright (c) .NET Foundation and Contributors\par
-           All Rights Reserved\par
-\par
-Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\cf0{\field{\*\fldinst{HYPERLINK http://www.apache.org/licenses/LICENSE-2.0 }}{\fldrslt{http://www.apache.org/licenses/LICENSE-2.0\ul0\cf0}}}}\f0\fs22  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an ""AS IS"" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\par
-\par
-HarfBuzzSharp v.2.8.2.4-preview.84\par
-HarfBuzzSharp.NativeAssets.macOS v.2.8.2.4-preview.84\par
-HarfBuzzSharp.NativeAssets.Win32 v.2.8.2.4-preview.84\par
-Copyright (c) 2015-2016 Xamarin, Inc.\par
-Copyright (c) 2017-2018 Microsoft Corporation.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-SkiaSharp v.2.88.6\par
-SkiaSharp.HarfBuzz v.2.88.6\par
-SkiaSharp.NativeAssets.macOS v.2.88.6\par
-SkiaSharp.NativeAssets.Win32 v.2.88.6\par
-SkiaSharp.Views.Desktop.Common v.2.88.6\par
-SkiaSharp.Views.WPF v.2.88.6\par
-Copyright (c) 2015-2016 Xamarin, Inc.\par
-Copyright (c) 2017-2018 Microsoft Corporation.\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
-\par
-coverlet.collector v.3.1.2\par
-The MIT License (MIT)\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE }}{\fldrslt{https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE\ul0\cf0}}}}\f0\fs22\par
-\par
-Copyright (c) 2018 Toni Solarin-Sodara\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy\par
-of this software and associated documentation files (the "Software"), to deal\par
-in the Software without restriction, including without limitation the rights\par
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\par
-copies of the Software, and to permit persons to whom the Software is\par
-furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all\par
-copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\par
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\par
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\par
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\par
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\par
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\par
-SOFTWARE.\par
-\par
-J2N v.2.0.0\par
-APACHE 2.0\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt }}{\fldrslt{https://github.com/NightOwl888/J2N/blob/main/LICENSE.txt\ul0\cf0}}}}\f0\fs22\par
-\par
-\lang1053 JUnitTestLogger v.1.1.0\par
-MIT License\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE }}{\fldrslt{https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE\ul0\cf0}}}}\f0\fs22\par
-\par
-\lang1033 Copyright (c) 2017 GMV Syncromatics Engineering\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy\par
-of this software and associated documentation files (the "Software"), to deal\par
-in the Software without restriction, including without limitation the rights\par
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\par
-copies of the Software, and to permit persons to whom the Software is\par
-furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all\par
-copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\par
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\par
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\par
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\par
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\par
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\par
-SOFTWARE.\par
-\par
-JunitXml.TestLogger v.3.0.124\par
-MIT License\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md }}{\fldrslt{https://github.com/spekt/junit.testlogger/blob/master/LICENSE.md\ul0\cf0}}}}\f0\fs22\par
-\par
-Copyright (c) 2017-2018\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy\par
-of this software and associated documentation files (the "Software"), to deal\par
-in the Software without restriction, including without limitation the rights\par
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\par
-copies of the Software, and to permit persons to whom the Software is\par
-furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in all\par
-copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\par
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\par
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\par
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\par
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\par
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\par
-SOFTWARE.\par
-\par
-NUnit.Analyzers v.3.3.0\par
-{\cf0{\field{\*\fldinst{HYPERLINK https://github.com/nunit/nunit.analyzers/blob/master/license.txt }}{\fldrslt{https://github.com/nunit/nunit.analyzers/blob/master/license.txt\ul0\cf0}}}}\f0\fs22\par
-\par
-Permission is hereby granted, free of charge, to any person obtaining a copy\par
-of this software and associated documentation files (the "Software"), to deal\par
-in the Software without restriction, including without limitation the rights\par
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\par
-copies of the Software, and to permit persons to whom the Software is\par
-furnished to do so, subject to the following conditions:\par
-\par
-The above copyright notice and this permission notice shall be included in\par
-all copies or substantial portions of the Software.\par
-\par
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\par
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\par
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\par
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\par
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\par
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\par
-THE SOFTWARE.\par
-\par
-NUnit3TestAdapter v.4.2.1\par
-MIT License\par
-}
- 
+{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff31507\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi31507\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f4\fbidi \fnil\fcharset0\fprq2{\*\panose 00000000000000000000}Helvetica;}
+{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0004020202020204}Aptos Display;}
+{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0004020202020204}Aptos;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f45\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f46\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f48\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f49\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f50\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f51\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f52\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f53\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f85\fbidi \fnil\fcharset238\fprq2 Helvetica CE;}{\f86\fbidi \fnil\fcharset204\fprq2 Helvetica Cyr;}
+{\f88\fbidi \fnil\fcharset161\fprq2 Helvetica Greek;}{\f89\fbidi \fnil\fcharset162\fprq2 Helvetica Tur;}{\f92\fbidi \fnil\fcharset186\fprq2 Helvetica Baltic;}{\f93\fbidi \fnil\fcharset163\fprq2 Helvetica (Vietnamese);}
+{\f385\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f386\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f388\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f389\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}
+{\f392\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f393\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Aptos Display CE;}{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Aptos Display Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Aptos Display Greek;}
+{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Aptos Display Tur;}{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Aptos Display Baltic;}{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Aptos Display (Vietnamese);}
+{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
+{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
+{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Aptos CE;}{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Aptos Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Aptos Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Aptos Tur;}
+{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Aptos Baltic;}{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Aptos (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;
+\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;
+\caccentone\ctint255\cshade191\red15\green71\blue97;\chyperlink\ctint255\cshade255\red70\green120\blue134;\red96\green94\blue92;\red225\green223\blue221;\red165\green165\blue165;}{\*\defchp \fs24\kerning2\loch\af31506\hich\af31506\dbch\af31505 }
+{\*\defpap \ql \li0\ri0\sa160\sl278\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 
+\ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\s3\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel2\rin0\lin0\itap0 \rtlch\fcs1 
+\af31507\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink17 \sqformat heading 3;}{\s4\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel3\rin0\lin0\itap0 
+\rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink18 \sqformat heading 4;}{\*\cs10 \additive \sunhideused \spriority1 Default Paragraph Font;}{\*
+\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl278\slmult1
+\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\kerning2\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 
+\snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \af31503\afs40 \ltrch\fcs0 \fs40\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 
+\af31503\afs32 \ltrch\fcs0 \fs32\cf19\kerning0\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \ssemihidden \spriority9 Heading 2 Char;}{\*\cs17 \additive \rtlch\fcs1 \af31503\afs28 \ltrch\fcs0 \fs28\cf19\kerning0\dbch\af31501 
+\sbasedon10 \slink3 \ssemihidden \spriority9 Heading 3 Char;}{\*\cs18 \additive \rtlch\fcs1 \ai\af31503 \ltrch\fcs0 \i\cf19\kerning0\dbch\af31501 \sbasedon10 \slink4 \ssemihidden \spriority9 Heading 4 Char;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
+\ul\cf20 \sbasedon10 \sunhideused \styrsid18236 Hyperlink;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf21\chshdng0\chcfpat0\chcbpat22 \sbasedon10 \ssemihidden \sunhideused \styrsid18236 Unresolved Mention;}}{\*\rsidtbl \rsid18236\rsid4806956
+\rsid13316325}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Ashish Aggarwal}{\creatim\yr2025\mo2\dy20\hr16\min39}{\revtim\yr2025\mo2\dy20\hr16\min42}
+{\version2}{\edmins3}{\nofpages1}{\nofwords115}{\nofchars658}{\nofcharsws772}{\vern3845}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale178\viewnobound1\rsidroot18236 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
+\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
+\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
+{\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\ql \li0\ri0\sb240\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af4\hich\af4\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf23\lang2057\langfe1033\langnp2057\insrsid13316325 \hich\af4\dbch\af31505\loch\f4 \hich\f4 @DYNAMO v.3.5.0 \'a9\loch\f4 
+ 2024 Autodesk, Inc.}{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf23\lang2057\langfe1033\langnp2057\insrsid18236 \hich\af4\dbch\af31505\loch\f4  }{\rtlch\fcs1 \ab\af4\afs22 \ltrch\fcs0 \b\fs22\cf23\lang2057\langfe1033\langnp2057\insrsid13316325 
+\hich\af4\dbch\af31505\loch\f4 All rights reserved.
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 \hich\af4\dbch\af31505\loch\f4 This Offering is subject to the Autodesk Terms of Use found\~}{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\fs22\cf23\insrsid18236\charrsid18236 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://www.autodesk.com/company/terms-of-use/en/general-terms" \\t "_blank"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 {\*\datafield }}
+}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf20\insrsid18236\charrsid18236 \hich\af4\dbch\af31505\loch\f4 here}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 
+\hich\af4\dbch\af31505\loch\f4 , which you accepted during your Autodesk account registration or subscription process, or by installing, accessing or using this Offering. To learn more about Autodesk\hich\f4 \rquote \loch\f4 
+s online and offline privacy practices, please see the\~}{\field\fldedit{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 \hich\af4\dbch\af31505\loch\f4 
+HYPERLINK "http://www.autodesk.com/company/legal-notices-trademarks/privacy-statement" \\t "_blank"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 {\*\datafield }}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 
+\cs19\fs22\ul\cf20\insrsid18236\charrsid18236 \hich\af4\dbch\af31505\loch\f4 Autodesk Privacy Statement}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 .}{\rtlch\fcs1 \af4\afs22 
+\ltrch\fcs0 \fs22\cf23\insrsid18236 
+\par }{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236\charrsid18236 \line \hich\af4\dbch\af31505\loch\f4 For information regarding Autodesk Trademarks, Patents, Autodesk Internal Components and Third-Party components, please see\~}
+{\field{\*\fldinst {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236 \hich\af4\dbch\af31505\loch\f4 HYPERLINK "https://github.com/DynamoDS/Dynamo/blob/master/LICENSE.txt"}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8e000000680074007400700073003a002f002f006700690074006800750062002e0063006f006d002f00440079006e0061006d006f00440053002f00440079006e0061006d006f002f0062006c006f0062002f006d00
+610073007400650072002f004c004900430045004e00530045002e007400780074000000795881f43b1d7f48af2c825dc48527630000000085ab0000}}}{\fldrslt {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \cs19\fs22\ul\cf20\insrsid18236\charrsid18236 \hich\af4\dbch\af31505\loch\f4 here}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid18236 .}{\rtlch\fcs1 \af4\afs22 \ltrch\fcs0 \fs22\cf23\insrsid13316325\charrsid18236 
+\par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
+9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
+5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
+b01d583deee5f99824e290b4ba3f364eac4a430883b3c092d4eca8f946c916422ecab927f52ea42b89a1cd59c254f919b0e85e6535d135a8de20f20b8c12c3b0
+0c895fcf6720192de6bf3b9e89ecdbd6596cbcdd8eb28e7c365ecc4ec1ff1460f53fe813d3cc7f5b7f020000ffff0300504b030414000600080000002100a5d6
+a7e7c0000000360100000b0000005f72656c732f2e72656c73848fcf6ac3300c87ef85bd83d17d51d2c31825762fa590432fa37d00e1287f68221bdb1bebdb4f
+c7060abb0884a4eff7a93dfeae8bf9e194e720169aaa06c3e2433fcb68e1763dbf7f82c985a4a725085b787086a37bdbb55fbc50d1a33ccd311ba548b6309512
+0f88d94fbc52ae4264d1c910d24a45db3462247fa791715fd71f989e19e0364cd3f51652d73760ae8fa8c9ffb3c330cc9e4fc17faf2ce545046e37944c69e462
+a1a82fe353bd90a865aad41ed0b5b8f9d6fd010000ffff0300504b0304140006000800000021006b799616830000008a0000001c0000007468656d652f746865
+6d652f7468656d654d616e616765722e786d6c0ccc4d0ac3201040e17da17790d93763bb284562b2cbaebbf600439c1a41c7a0d29fdbd7e5e38337cedf14d59b
+4b0d592c9c070d8a65cd2e88b7f07c2ca71ba8da481cc52c6ce1c715e6e97818c9b48d13df49c873517d23d59085adb5dd20d6b52bd521ef2cdd5eb9246a3d8b
+4757e8d3f729e245eb2b260a0238fd010000ffff0300504b030414000600080000002100d0557692fa0700000d220000160000007468656d652f7468656d652f
+7468656d65312e786d6cec5a4b8f1bb911be07c87f68f45d5677eb3db0bcd0d3b3f68c3db064077ba4244a4d0fbb2934a99911160b04de532e0b2cb00972c802
+b9e5100459200b64914b7e8c011bc9e647a448b65aa444791e30022398994b37f555f16355b1aa9add0f3fbb4aa87781334e58daf6c30781efe174ca66245db4
+fd97e361a9e97b5ca07486284b71db5f63ee7ff6e897bf78888e448c13ec817cca8f50db8f85581e95cb7c0ac3883f604b9cc26f73962548c06db628cf327409
+7a135a8e82a05e4e10497d2f4509a87d3e9f9329f6c652a5ff68a37c40e136155c0e4c693692aab125a1b0b3f35022f89af768e65d20daf6619e19bb1ce32be1
+7b1471013fb4fd40fdf9e5470fcbe82817a2e280ac2137547fb95c2e303b8fd49cd962524c1a0ca266352cf42b0015fbb84153fe17fa14004da7b052cdc5d419
+d6ea4133cab106485f3a74b71a61c5c61bfa2b7b9cc356bd1b552dfd0aa4f557f7f0c1b035e8d72cbc02697c6d0fdf09a26eab62e11548e3eb7bf8eaa0d38806
+165e81624ad2f37d74bdd16cd673740199337aec84b7eaf5a0d1cfe15b144443115d728a394bc5a1584bd06b960d0120811409927a62bdc473348528ee2c05e3
+5e9ff025456bdf5ba29471180ea23084d0ab0651f1af2c8e8e3032a4252f60c2f786241f8f4f33b2146dff0968f50dc8bb9f7e7afbe6c7b76ffefef6ebafdfbe
+f9ab774216b1d0aa2cb963942e4cb99ffff4ed7fbeffb5f7efbffdf1e7ef7eebc67313fffe2fbf79ff8f7f7e483d6cb5ad29defdee87f73ffef0eef7dffcebcf
+df39b477323431e1639260ee3dc397de0b96c00295296cfe7892dd4e621c23624a74d205472992b338f40f446ca19fad11450e5c17db767c9541aa71011faf5e
+5b844771b612c4a1f1699c58c053c66897654e2b3c957319661eafd2857bf26c65e25e2074e19abb8752cbcb83d512722c71a9ecc5d8a27946512ad002a75878
+f237768eb163755f1062d9f5944c33c6d95c785f10af8b88d3246332b1a2692b744c12f0cbda4510fc6dd9e6f495d765d4b5ea3ebeb091b0371075901f636a99
+f1315a0994b8548e51424d839f2011bb488ed6d9d4c40db8004f2f3065de60863977c93ccf60bd86d39f22c86e4eb79fd27562233341ce5d3a4f106326b2cfce
+7b314a962eec88a4b189fd9c9f438822ef8c0917fc94d93b44de831f507ad0ddaf08b6dc7d7d36780959cea4b40d10f9cb2a73f8f2316656fc8ed6748eb02bd5
+74b2c44ab19d8c38a3a3bb5a58a17d823145976886b1f7f27307832e5b5a36df927e12435639c6aec07a82ec5895f729e6d02bc9e6663f4f9e106e85ec082fd8
+013ea7eb9dc4b3466982b2439a9f81d74d9b0f26196c460785e7747a6e029f11e801215e9c4679ce418711dc07b59ec5c82a60f29ebbe3759d59febbc91e837d
+f9daa271837d0932f8d63290d84d990fda668ca835c13660c6887827ae740b2296fbb722b2b82ab195536e6e6fdaad1ba03bb29a9e84a4d77440ffbbce07fa8b
+777ff8de11821fa7db712bb652d52dfb9c43a9e478a7bb3984dbed697a2c9b914fbfa5e9a3557a86a18aece7abfb8ee6bea3f1ffef3b9a43fbf9be8f39d46ddc
+f7313ef417f77d4c7eb4f271fa986deb025d8d3c5ed0c73cead0273978e63327948ec49ae213ae8e7d383ccdcc863028e5d479272ece0097315cca32071358b8
+4586948c9731f12b22e2518c96703614fa52c982e7aa17dc5b320e47466ad8a95be2e92a3965337dd4a9ce96025d593912dbf1a006874e7a1c8ea98446d71bf9
+a0e4a7ce5381af62bb50c7ac1b0252f636248cc96c12150789c666f01a12f2d4ece3b068395834a5fa8dabf64c01d40aafc0e3b6070fe96dbf569584e08c9c4f
+a1359f493f69576fbcab9cf9313d7dc8985604c0b1a25e091cca179e6e49ae07972757a743ed069eb64828a7e8b0b24928cba8068fc7f0109c47a71cbd098ddb
+fabab575a9454f9a42cd07f1bda5d1687e88c55d7d0d72bbb981a666a6a0a977097b3c824de77b53b46cfb73383386cb6409c1c3e52317a20b78f1321599def1
+77492dcb8c8b3ee2b1b6b8ca3ada3f091138f32849dabe5c7fe1079aaa24a2c9b560eb7eaae422b9e13e3572e075dbcb783ec75361fadd189196d6b790e275b2
+70feaac4ef0e96926c05ee1ec5b34b6f4257d90b0421566b84d2bb33c2e1d541a85d3d23f02eacc864dbf8dba94c79f6375f46a918d2e3882e63949714339b6b
+b82a28051d7557d8c0b8cbd70c06354c9257c2c9425658d3a856392d6a97e670b0ec5e2f242d6764cd6dd1b4d28a2c9bee3466cdb0a9033bb6bc5b9537586d4c
+0c49cd2cf13a77efe6dcd626d9ed340a4599008317f6bb5bed37a86d27b3a849c6fb795826ed7cd42e1e9b055e43ed2655c248fbf58dda1dbb1545c2391d0cde
+a9f483dc6ed4c2d07cd3582a4bab97e6e67b6d36790dc9a30f6dee8aea37dd34853b19957c799629df4ed86c9d5f52ae138df6b96c4a2592a62ff0dc23b3abb6
+1fb93a47fdb635ccbb01859662b2781582ce6ecf16ccf152546fd84258077811547a53dac285849a197aef42589d28ba688bab0d65d9ab035e9990eb55836973
+4bc1d5be15e1743c43d0db8e5467a7732fd0be12797e812b6f9591b6ff6550eb547b51ad570a9ab541a95aa906a566ad5329756ab54a38a88541bf1b7d05f444
+9c8435fdd5c3105e02d175feed831adffbfe21d9bce77a30654999a9ef1bcacafbeafb87303afcfd033812684583b01a75a25ea9d70feba56ad4af979a8d4aa7
+d48beafda80345bb3eec7ce57b170a1c76fbfde1b01695ea3dc055834eadd4e9567aa57a73d08d86e1a0da0f009c979f2b788a019b6d6c01978ad7a3ff020000
+ffff0300504b0304140006000800000021000dd1909fb60000001b010000270000007468656d652f7468656d652f5f72656c732f7468656d654d616e61676572
+2e786d6c2e72656c73848f4d0ac2301484f78277086f6fd3ba109126dd88d0add40384e4350d363f2451eced0dae2c082e8761be9969bb979dc9136332de3168
+aa1a083ae995719ac16db8ec8e4052164e89d93b64b060828e6f37ed1567914b284d262452282e3198720e274a939cd08a54f980ae38a38f56e422a3a641c8bb
+d048f7757da0f19b017cc524bd62107bd5001996509affb3fd381a89672f1f165dfe514173d9850528a2c6cce0239baa4c04ca5bbabac4df000000ffff030050
+4b01022d0014000600080000002100e9de0fbfff0000001c0200001300000000000000000000000000000000005b436f6e74656e745f54797065735d2e786d6c
+504b01022d0014000600080000002100a5d6a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c73504b01022d0014
+0006000800000021006b799616830000008a0000001c00000000000000000000000000190200007468656d652f7468656d652f7468656d654d616e616765722e
+786d6c504b01022d0014000600080000002100d0557692fa0700000d2200001600000000000000000000000000d60200007468656d652f7468656d652f746865
+6d65312e786d6c504b01022d00140006000800000021000dd1909fb60000001b0100002700000000000000000000000000040b00007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73504b050600000000050005005d010000ff0b00000000}
+{\*\colorschememapping 3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d22796573223f3e0d0a3c613a636c724d
+617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
+6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
+656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
+{\*\latentstyles\lsdstimax376\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
+\lsdqformat1 \lsdlocked0 heading 3;\lsdqformat1 \lsdlocked0 heading 4;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 4;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 8;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 9;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 4;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 5;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 7;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 8;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Indent;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 header;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footer;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index heading;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority35 \lsdlocked0 caption;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of figures;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope return;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation reference;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 line number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 page number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote text;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of authorities;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 macro;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 toa heading;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 5;\lsdqformat1 \lsdpriority10 \lsdlocked0 Title;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Closing;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Signature;\lsdsemihidden1 \lsdunhideused1 \lsdpriority1 \lsdlocked0 Default Paragraph Font;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 4;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Message Header;\lsdqformat1 \lsdpriority11 \lsdlocked0 Subtitle;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Salutation;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Date;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Note Heading;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Block Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 FollowedHyperlink;\lsdqformat1 \lsdpriority22 \lsdlocked0 Strong;
+\lsdqformat1 \lsdpriority20 \lsdlocked0 Emphasis;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Document Map;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Plain Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 E-mail Signature;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Top of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Bottom of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal (Web);\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Acronym;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Cite;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Code;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Definition;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Keyboard;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Preformatted;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Sample;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Typewriter;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Variable;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Table;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation subject;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 No List;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 1;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 3;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 6;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Contemporary;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Elegant;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Professional;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Subtle 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Subtle 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 2;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Balloon Text;\lsdpriority39 \lsdlocked0 Table Grid;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Theme;\lsdsemihidden1 \lsdlocked0 Placeholder Text;
+\lsdqformat1 \lsdpriority1 \lsdlocked0 No Spacing;\lsdpriority60 \lsdlocked0 Light Shading;\lsdpriority61 \lsdlocked0 Light List;\lsdpriority62 \lsdlocked0 Light Grid;\lsdpriority63 \lsdlocked0 Medium Shading 1;\lsdpriority64 \lsdlocked0 Medium Shading 2;
+\lsdpriority65 \lsdlocked0 Medium List 1;\lsdpriority66 \lsdlocked0 Medium List 2;\lsdpriority67 \lsdlocked0 Medium Grid 1;\lsdpriority68 \lsdlocked0 Medium Grid 2;\lsdpriority69 \lsdlocked0 Medium Grid 3;\lsdpriority70 \lsdlocked0 Dark List;
+\lsdpriority71 \lsdlocked0 Colorful Shading;\lsdpriority72 \lsdlocked0 Colorful List;\lsdpriority73 \lsdlocked0 Colorful Grid;\lsdpriority60 \lsdlocked0 Light Shading Accent 1;\lsdpriority61 \lsdlocked0 Light List Accent 1;
+\lsdpriority62 \lsdlocked0 Light Grid Accent 1;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 1;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 1;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 1;\lsdsemihidden1 \lsdlocked0 Revision;
+\lsdqformat1 \lsdpriority34 \lsdlocked0 List Paragraph;\lsdqformat1 \lsdpriority29 \lsdlocked0 Quote;\lsdqformat1 \lsdpriority30 \lsdlocked0 Intense Quote;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 1;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 1;
+\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 1;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 1;\lsdpriority70 \lsdlocked0 Dark List Accent 1;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 1;\lsdpriority72 \lsdlocked0 Colorful List Accent 1;
+\lsdpriority73 \lsdlocked0 Colorful Grid Accent 1;\lsdpriority60 \lsdlocked0 Light Shading Accent 2;\lsdpriority61 \lsdlocked0 Light List Accent 2;\lsdpriority62 \lsdlocked0 Light Grid Accent 2;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 2;
+\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 2;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 2;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 2;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 2;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 2;
+\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 2;\lsdpriority70 \lsdlocked0 Dark List Accent 2;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 2;\lsdpriority72 \lsdlocked0 Colorful List Accent 2;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 2;
+\lsdpriority60 \lsdlocked0 Light Shading Accent 3;\lsdpriority61 \lsdlocked0 Light List Accent 3;\lsdpriority62 \lsdlocked0 Light Grid Accent 3;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 3;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 3;
+\lsdpriority65 \lsdlocked0 Medium List 1 Accent 3;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 3;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 3;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 3;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 3;
+\lsdpriority70 \lsdlocked0 Dark List Accent 3;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 3;\lsdpriority72 \lsdlocked0 Colorful List Accent 3;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 3;\lsdpriority60 \lsdlocked0 Light Shading Accent 4;
+\lsdpriority61 \lsdlocked0 Light List Accent 4;\lsdpriority62 \lsdlocked0 Light Grid Accent 4;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 4;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 4;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 4;
+\lsdpriority66 \lsdlocked0 Medium List 2 Accent 4;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 4;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 4;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 4;\lsdpriority70 \lsdlocked0 Dark List Accent 4;
+\lsdpriority71 \lsdlocked0 Colorful Shading Accent 4;\lsdpriority72 \lsdlocked0 Colorful List Accent 4;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 4;\lsdpriority60 \lsdlocked0 Light Shading Accent 5;\lsdpriority61 \lsdlocked0 Light List Accent 5;
+\lsdpriority62 \lsdlocked0 Light Grid Accent 5;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 5;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 5;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 5;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 5;
+\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 5;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 5;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 5;\lsdpriority70 \lsdlocked0 Dark List Accent 5;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 5;
+\lsdpriority72 \lsdlocked0 Colorful List Accent 5;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 5;\lsdpriority60 \lsdlocked0 Light Shading Accent 6;\lsdpriority61 \lsdlocked0 Light List Accent 6;\lsdpriority62 \lsdlocked0 Light Grid Accent 6;
+\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 6;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 6;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 6;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 6;
+\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 6;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 6;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 6;\lsdpriority70 \lsdlocked0 Dark List Accent 6;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 6;
+\lsdpriority72 \lsdlocked0 Colorful List Accent 6;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 6;\lsdqformat1 \lsdpriority19 \lsdlocked0 Subtle Emphasis;\lsdqformat1 \lsdpriority21 \lsdlocked0 Intense Emphasis;
+\lsdqformat1 \lsdpriority31 \lsdlocked0 Subtle Reference;\lsdqformat1 \lsdpriority32 \lsdlocked0 Intense Reference;\lsdqformat1 \lsdpriority33 \lsdlocked0 Book Title;\lsdsemihidden1 \lsdunhideused1 \lsdpriority37 \lsdlocked0 Bibliography;
+\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority39 \lsdlocked0 TOC Heading;\lsdpriority41 \lsdlocked0 Plain Table 1;\lsdpriority42 \lsdlocked0 Plain Table 2;\lsdpriority43 \lsdlocked0 Plain Table 3;\lsdpriority44 \lsdlocked0 Plain Table 4;
+\lsdpriority45 \lsdlocked0 Plain Table 5;\lsdpriority40 \lsdlocked0 Grid Table Light;\lsdpriority46 \lsdlocked0 Grid Table 1 Light;\lsdpriority47 \lsdlocked0 Grid Table 2;\lsdpriority48 \lsdlocked0 Grid Table 3;\lsdpriority49 \lsdlocked0 Grid Table 4;
+\lsdpriority50 \lsdlocked0 Grid Table 5 Dark;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 1;
+\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 1;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 1;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 1;
+\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 1;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 2;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 2;
+\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 2;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 2;
+\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 3;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 3;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 3;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 3;
+\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 3;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 4;
+\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 4;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 4;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 4;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 4;
+\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 4;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 5;
+\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 5;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 5;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 5;
+\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 5;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 6;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 6;
+\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 6;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 6;
+\lsdpriority46 \lsdlocked0 List Table 1 Light;\lsdpriority47 \lsdlocked0 List Table 2;\lsdpriority48 \lsdlocked0 List Table 3;\lsdpriority49 \lsdlocked0 List Table 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark;
+\lsdpriority51 \lsdlocked0 List Table 6 Colorful;\lsdpriority52 \lsdlocked0 List Table 7 Colorful;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 List Table 2 Accent 1;\lsdpriority48 \lsdlocked0 List Table 3 Accent 1;
+\lsdpriority49 \lsdlocked0 List Table 4 Accent 1;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 1;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 1;
+\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 List Table 2 Accent 2;\lsdpriority48 \lsdlocked0 List Table 3 Accent 2;\lsdpriority49 \lsdlocked0 List Table 4 Accent 2;
+\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 2;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 3;
+\lsdpriority47 \lsdlocked0 List Table 2 Accent 3;\lsdpriority48 \lsdlocked0 List Table 3 Accent 3;\lsdpriority49 \lsdlocked0 List Table 4 Accent 3;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 3;
+\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 4;\lsdpriority47 \lsdlocked0 List Table 2 Accent 4;
+\lsdpriority48 \lsdlocked0 List Table 3 Accent 4;\lsdpriority49 \lsdlocked0 List Table 4 Accent 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 4;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 4;
+\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 List Table 2 Accent 5;\lsdpriority48 \lsdlocked0 List Table 3 Accent 5;
+\lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
+\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
+\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;}}{\*\datastore }}


### PR DESCRIPTION
### Purpose

This change will update the contents of the About Box, now we will have much shorter content that will offer links to the actual license file in the Git repository. Going forward, this change will be conducted with each release, as each release version should have a license file link pointing to its specific RC branch file. 

![Screenshot 2025-02-20 at 4 44 42 PM](https://github.com/user-attachments/assets/dc307203-32fe-4919-87e3-86c53ca634a6)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Update About Box content to move the license information to an online file

### Reviewers

@DynamoDS/dynamo 
