### PR TITLE
NodeModel dispose on workspace close

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -240,14 +240,9 @@ namespace Dynamo.Graph.Connectors
         /// </summary>
         internal void Delete()
         {
-            if (Start != null && Start.Connectors.Contains(this))
-            {
-                Start.Connectors.Remove(this);
-            }
-            if (End != null && End.Connectors.Contains(this))
-            {
-                End.Connectors.Remove(this);
-            }
+            Start?.Connectors.Remove(this);
+            End?.Connectors.Remove(this);
+
             OnDeleted();
         }
 

--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -234,6 +234,11 @@ namespace Dynamo.Graph
         }
 
         /// <summary>
+        /// Has this <see cref="ModelBase"/> been disposed? Gets set when <see cref="Dispose"/> is called.
+        /// </summary>
+        protected bool HasBeenDisposed { get; private set; }
+
+        /// <summary>
         /// Protected constructor.
         /// </summary>
         protected ModelBase()
@@ -280,8 +285,6 @@ namespace Dynamo.Graph
             height = h;
             RaisePropertyChanged("Position");
         }
-
-        protected bool HasBeenDisposed { get; private set; }
 
         /// <summary>
         /// Invokes Dispose on the object.

--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -281,12 +281,17 @@ namespace Dynamo.Graph
             RaisePropertyChanged("Position");
         }
 
+        protected bool HasBeenDisposed { get; private set; }
+
         /// <summary>
         /// Invokes Dispose on the object.
         /// </summary>
         public virtual void Dispose()
         {
-            Disposed?.Invoke(this);
+            var wasDisposed = HasBeenDisposed;
+            HasBeenDisposed = true;
+
+            if (!wasDisposed) Disposed?.Invoke(this);
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -291,10 +291,11 @@ namespace Dynamo.Graph
         /// </summary>
         public virtual void Dispose()
         {
-            var wasDisposed = HasBeenDisposed;
-            HasBeenDisposed = true;
-
-            if (!wasDisposed) Disposed?.Invoke(this);
+            if (!HasBeenDisposed)
+            {
+                HasBeenDisposed = true;
+                Disposed?.Invoke(this);
+            }
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1486,14 +1486,16 @@ namespace Dynamo.Graph.Workspaces
             // lot of graph executions. As connectors are deleted, nodes will
             // have invalid inputs, so these executions are meaningless and may
             // cause invalid GC. See comments in MAGN-7229.
-            var nodes = Nodes; 
-            foreach (NodeModel node in nodes)
+            foreach (NodeModel node in Nodes)
             {
                 node.RaisesModificationEvents = false;
+                // Dispose here so that all nodes stop listening to disconnect events before
+                // the connectors are deleted. Otherwise remaining undisposed nodes will react
+                // to delete events when an input connector is deleted.
                 node.Dispose();
             }
 
-            foreach (NodeModel el in nodes)
+            foreach (NodeModel el in Nodes)
             {
                 foreach (PortModel p in el.InPorts)
                 {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1486,13 +1486,15 @@ namespace Dynamo.Graph.Workspaces
             // lot of graph executions. As connectors are deleted, nodes will
             // have invalid inputs, so these executions are meaningless and may
             // cause invalid GC. See comments in MAGN-7229.
-            foreach (NodeModel node in Nodes)
-                node.RaisesModificationEvents = false;
-
-            foreach (NodeModel el in Nodes)
+            var nodes = Nodes; 
+            foreach (NodeModel node in nodes)
             {
-                el.Dispose();
+                node.RaisesModificationEvents = false;
+                node.Dispose();
+            }
 
+            foreach (NodeModel el in nodes)
+            {
                 foreach (PortModel p in el.InPorts)
                 {
                     for (int i = p.Connectors.Count - 1; i >= 0; i--)

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -760,6 +760,7 @@ Dynamo.Graph.ModelBase.CenterY.set -> void
 Dynamo.Graph.ModelBase.DeletionStarted -> System.EventHandler<System.ComponentModel.CancelEventArgs>
 Dynamo.Graph.ModelBase.Deserialize(System.Xml.XmlElement element, Dynamo.Graph.SaveContext context) -> void
 Dynamo.Graph.ModelBase.Disposed -> System.Action<Dynamo.Graph.ModelBase>
+Dynamo.Graph.ModelBase.HasBeenDisposed.get -> bool
 Dynamo.Graph.ModelBase.IsSelected.get -> bool
 Dynamo.Graph.ModelBase.IsSelected.set -> void
 Dynamo.Graph.ModelBase.Log(Dynamo.Logging.ILogMessage obj) -> void


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

When a workspace is closed, a majority of the time is spent by nodes reacting to connector deletions. By unsubscribing from connector events before the a workspace closes, the time to get back to the main menu goes down substantially.

For the MaRS graph, this takes workspace close from about 8 to 4 seconds. For the Car_Configurator graph, this takes workspace close from about 2 minutes down to 40 seconds.

#### Performance

Old
![closemodel](https://github.com/user-attachments/assets/a54e8b3e-033c-43f5-b2e8-fcfc38390eea)

New
![closemodel_improved_dispose](https://github.com/user-attachments/assets/57d065ad-08a5-49e9-8cdf-fd84de48e07e)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@mjkkirschner 

### FYIs

@dimven 
