### PR TITLE
WorkspaceViewModel fast node and connector lookup

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -959,10 +959,7 @@ namespace Dynamo.ViewModels
 
             foreach (var connector in connectorsToHide)
             {
-                var connectorViewModel = WorkspaceViewModel
-                    .Connectors
-                    .Where(x => connector.GUID == x.ConnectorModel.GUID)
-                    .FirstOrDefault();
+                var connectorViewModel = WorkspaceViewModel.FindConnector(connector.GUID);
 
                 connectorViewModel.IsCollapsed = true;
             }
@@ -977,10 +974,7 @@ namespace Dynamo.ViewModels
 
             foreach (var connector in allNodes.SelectMany(x => x.AllConnectors))
             {
-                var connectorViewModel = WorkspaceViewModel
-                    .Connectors
-                    .Where(x => connector.GUID == x.ConnectorModel.GUID)
-                    .FirstOrDefault();
+                var connectorViewModel = WorkspaceViewModel.FindConnector(connector.GUID);
 
                 connectorViewModel.Redraw();
                 connector.Start.Owner.ReportPosition();
@@ -1031,14 +1025,11 @@ namespace Dynamo.ViewModels
         {
             foreach (var nodeModel in nodes.OfType<NodeModel>())
             {
-                var connectorGuids = nodeModel.AllConnectors
-                    .Select(x => x.GUID);
+                var connectorViewModels = nodeModel.AllConnectors
+                    .Select(x => WorkspaceViewModel.FindConnector(x.GUID))
+                    .Where(c => c != null);
 
-                var connectorViewModels = WorkspaceViewModel.Connectors
-                    .Where(x => connectorGuids.Contains(x.ConnectorModel.GUID))
-                    .ToList();
-
-                connectorViewModels.ForEach(x => x.IsCollapsed = false);
+                foreach(var c in connectorViewModels) c.IsCollapsed = false;
 
                 // Set IsProxyPort back to false when the group is expanded.
                 nodeModel.InPorts.ToList().ForEach(x => x.IsProxyPort = false);

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -483,7 +483,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.Start.Owner.GUID);
+                return workspaceViewModel.FindNode(model.Start.Owner.GUID);
             }
         }
 
@@ -491,7 +491,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.End.Owner.GUID);
+                return workspaceViewModel.FindNode(model.End.Owner.GUID);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -232,8 +232,7 @@ namespace Dynamo.Wpf.ViewModels.Core
 
             foreach (Guid t in nodeGuids)
             {
-                var nodeViewModel = Nodes.FirstOrDefault(x => x.NodeModel.GUID == t);
-                if (nodeViewModel != null)
+                if (FindNode(t) is NodeViewModel nodeViewModel)
                 {
                     nodeViewModel.ShowExecutionPreview = nodeViewModel.DynamoViewModel.ShowRunPreview;
                     nodeViewModel.IsNodeAddedRecently = false;
@@ -358,7 +357,7 @@ namespace Dynamo.Wpf.ViewModels.Core
 
             foreach (var messageID in evalargs.MessageKeys)
             {
-                var node = Nodes.FirstOrDefault(n => n.Id == messageID);
+                var node = FindNode(messageID);
                 if (node == null) continue;
 
                 node.UpdateBubbleContent();

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1970,7 +1970,7 @@ namespace Dynamo.ViewModels
 
             foreach (var inode in nodes)
             {
-                var current = this.WorkspaceViewModel.Nodes.FirstOrDefault(x => x.NodeLogic == inode);
+                var current = WorkspaceViewModel.FindNode(inode.GUID);
                 if (current != null)
                 {
                     current.RaisePropertyChanged("IsFrozen");

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -136,9 +136,7 @@ namespace Dynamo.ViewModels
                     return null;
                 }
 
-                return WorkspaceViewModel.Nodes
-                    .Where(x => x.Id == Model.PinnedNode.GUID)
-                    .FirstOrDefault();
+                return WorkspaceViewModel.FindNode(Model.PinnedNode.GUID);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/OutPortViewModel.cs
@@ -302,9 +302,9 @@ namespace Dynamo.ViewModels
             Analytics.TrackEvent(Actions.Break, Categories.ConnectorOperations, port.PortType.ToString(), port.Connectors.Count);
             for (var i = port.Connectors.Count - 1; i >= 0; i--)
             {
+                var portConnectorGuid = port.Connectors[i].GUID;
                 // Attempting to get the relevant ConnectorViewModel via matching GUID
-                ConnectorViewModel connectorViewModel = node.WorkspaceViewModel.Connectors
-                    .FirstOrDefault(x => x.ConnectorModel.GUID == port.Connectors[i].GUID);
+                ConnectorViewModel connectorViewModel = node.WorkspaceViewModel.FindConnector(portConnectorGuid);
 
                 if (connectorViewModel == null)
                 {
@@ -325,8 +325,7 @@ namespace Dynamo.ViewModels
             foreach(var connector in port.Connectors)
             {
                 // Attempting to get the relevant ConnectorViewModel via matching GUID
-                var connectorViewModel = node.WorkspaceViewModel.Connectors
-                    .FirstOrDefault(x => x.ConnectorModel.GUID == connector.GUID);
+                var connectorViewModel = node.WorkspaceViewModel.FindConnector(connector.GUID);
                 connectorViewModel?.ShowhideConnectorCommand.Execute(!AreConnectorsHidden);
             }
             if (AreConnectorsHidden)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1923,10 +1923,10 @@ namespace Dynamo.ViewModels
         /// <returns>Found <see cref="ViewModelBase"/> object.</returns>
         internal ViewModelBase GetViewModelInternal(Guid modelGuid)
         {
-            ViewModelBase foundModel = (Connectors.FirstOrDefault(c => c.ConnectorModel.GUID == modelGuid)
-                ?? FindNode(modelGuid) as ViewModelBase)
-                ?? (Notes.FirstOrDefault(note => note.Model.GUID == modelGuid)
-                ?? Annotations.FirstOrDefault(annotation => annotation.AnnotationModel.GUID == modelGuid) as ViewModelBase);
+            ViewModelBase foundModel = FindConnector(modelGuid) as ViewModelBase
+                ?? FindNode(modelGuid) as ViewModelBase
+                ?? Notes.FirstOrDefault(note => note.Model.GUID == modelGuid) as ViewModelBase
+                ?? Annotations.FirstOrDefault(annotation => annotation.AnnotationModel.GUID == modelGuid) as ViewModelBase;
 
             return foundModel;
         }


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

When changing many nodes and connectors at the same time during deletion, undo and redo, a lot of time is spent looking for the end nodes of connectors. The current implementation of the WorkspaceViewModel uses an ObservableCollection to hold the nodes, which essentially is the same as a list. Since the connector ends are being looked up using linq, this has much worse performance than looking up nodes in a dictionary.

This PR adds a dictionary that lives alongside the ObservableCollection. This increases memory usage somewhat, but means lookups can be much faster.

Deleting and undoing a large amount of nodes on the MaRS model takes delete from about 10 to 5 seconds, and undo from about 40 to aobut 5 seconds.

Doing the same on the Car_Configurator takes the delete time from about 2m20s to about 12 seconds, and undo from about 2m35s to 30s.

#### Performance

Deletion (old)
![deletemany_linq_issues](https://github.com/user-attachments/assets/4230edd9-5a4a-4b69-a1a8-fb2c68204d61)
Deletion (new)
![deletemany_linq_removed](https://github.com/user-attachments/assets/4e0d9a37-a5dd-43f3-87d5-96dc67a0707f)

Undo deletion (old)
![loadconnector_linq](https://github.com/user-attachments/assets/1b3a90b3-178a-4254-843a-06f5bf39f2db)
Undo deletion (new)
![loadconnector_linq_removed](https://github.com/user-attachments/assets/7eca6983-0670-4b05-84a4-3db6ddd0d566)

Open json from path (old)
![openjson_connector](https://github.com/user-attachments/assets/85a7da20-1fbe-46d3-8e29-258b6ab58d1a)
Open json from path (new)
![openjson_connector_dict](https://github.com/user-attachments/assets/4290c621-d5a6-4656-aa1f-71f34388e2da)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

N/A

### Reviewers

@mjkkirschner 

### FYIs

@dimven 
