### PR TITLE
DYN-8331: Lucene performance regression

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1621,7 +1621,7 @@ namespace Dynamo.Models
 
             SearchModel?.Add(symbolSearchElement);
             SearchModel?.Add(outputSearchElement);
-            LuceneUtility.AddNodeTypeToSearchIndexBulk([cnbNode, symbolSearchElement, outputSearchElement], iDoc);
+            LuceneUtility.AddNodeTypeToSearchIndex([cnbNode, symbolSearchElement, outputSearchElement], iDoc);
 
         }
 
@@ -1785,7 +1785,7 @@ namespace Dynamo.Models
                     Logger.Log(e);
                 }
             }
-            LuceneUtility.AddNodeTypeToSearchIndexBulk(nodeSearchElements, iDoc);
+            LuceneUtility.AddNodeTypeToSearchIndex(nodeSearchElements, iDoc);
         }
 
         private void InitializePreferences()
@@ -3500,7 +3500,7 @@ namespace Dynamo.Models
                     }
                 }
             }
-            LuceneUtility.AddNodeTypeToSearchIndexBulk(nodes, iDoc);
+            LuceneUtility.AddNodeTypeToSearchIndex(nodes, iDoc);
         }
 
         /// <summary>

--- a/src/DynamoCore/Search/NodeSearchModel.cs
+++ b/src/DynamoCore/Search/NodeSearchModel.cs
@@ -11,6 +11,7 @@ using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
 using DynamoUtilities;
 using Lucene.Net.Documents;
+using Lucene.Net.Index;
 using Lucene.Net.QueryParsers.Classic;
 using Lucene.Net.Search;
 
@@ -245,10 +246,8 @@ namespace Dynamo.Search
 
             if (luceneSearchUtility != null)
             {
-                if (luceneSearchUtility.Searcher == null)
-                {
-                    throw new Exception("Invalid IndexSearcher found");
-                }
+                luceneSearchUtility.dirReader = luceneSearchUtility.writer != null ? luceneSearchUtility.writer.GetReader(applyAllDeletes: true) : DirectoryReader.Open(luceneSearchUtility.indexDir);
+                luceneSearchUtility.Searcher = new(luceneSearchUtility.dirReader);
 
                 string searchTerm = search.Trim();
                 var candidates = new List<NodeSearchElement>();

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -50,7 +50,7 @@ namespace Dynamo.Utilities
         internal Lucene.Net.Store.Directory indexDir;
 
         /// <summary>
-        /// Lucene Index write. Make sure to call InitializeIndexSearcher after every index change.
+        /// Lucene Index write.
         /// </summary>
         internal IndexWriter writer;
 
@@ -191,16 +191,6 @@ namespace Dynamo.Utilities
         }
 
         /// <summary>
-        /// InitializeIndexSearcher initializes the dirReader and Searcher of this class.
-        /// This method should be called after every index change. 
-        /// </summary>
-        private void InitializeIndexSearcher()
-        {
-            dirReader = writer != null ? writer.GetReader(applyAllDeletes: true) : DirectoryReader.Open(indexDir);
-            Searcher = new(dirReader);
-        }
-
-        /// <summary>
         /// Initialize Lucene index document object for reuse
         /// </summary>
         /// <returns></returns>
@@ -263,7 +253,11 @@ namespace Dynamo.Utilities
             {
                 writer.DeleteAll();
                 var iDoc = InitializeIndexDocumentForNodes();
-                AddNodeTypeToSearchIndexBulk(nodeList, iDoc);
+
+                foreach (var node in nodeList)
+                {
+                    AddNodeTypeToSearchIndex(node, iDoc);
+                }
             }         
         }
 
@@ -594,8 +588,6 @@ namespace Dynamo.Utilities
         {
             //Commit the info indexed if index writer exists
             writer?.Commit();
-
-            InitializeIndexSearcher();
         }
 
         /// <summary>
@@ -603,7 +595,7 @@ namespace Dynamo.Utilities
         /// </summary>
         /// <param name="node">node info that will be indexed</param>
         /// <param name="doc">Lucene document in which the node info will be indexed</param>
-        internal void AddNodeTypeToSearchIndex_uninitialized(NodeSearchElement node, Document doc)
+        internal void AddNodeTypeToSearchIndex(NodeSearchElement node, Document doc)
         {
             if (addedFields == null) return;
             // During DynamoModel initialization, the index writer should still be valid here
@@ -641,19 +633,6 @@ namespace Dynamo.Utilities
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Parameters), node.Parameters ?? string.Empty);
 
             writer?.AddDocument(doc);
-        }
-        internal void AddNodeTypeToSearchIndex(NodeSearchElement node, Document doc)
-        {
-            AddNodeTypeToSearchIndex_uninitialized(node,doc);
-            InitializeIndexSearcher();
-        }
-        internal void AddNodeTypeToSearchIndexBulk(List<NodeSearchElement> nodes, Document doc)
-        {
-            foreach(var node in nodes)
-            {
-                AddNodeTypeToSearchIndex_uninitialized(node, doc);
-            }
-            InitializeIndexSearcher();
         }
     }
 

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -253,11 +253,7 @@ namespace Dynamo.Utilities
             {
                 writer.DeleteAll();
                 var iDoc = InitializeIndexDocumentForNodes();
-
-                foreach (var node in nodeList)
-                {
-                    AddNodeTypeToSearchIndex(node, iDoc);
-                }
+                AddNodeTypeToSearchIndexBulk(nodeList, iDoc);
             }         
         }
 
@@ -633,6 +629,14 @@ namespace Dynamo.Utilities
             SetDocumentFieldValue(doc, nameof(LuceneConfig.NodeFieldsEnum.Parameters), node.Parameters ?? string.Empty);
 
             writer?.AddDocument(doc);
+        }
+
+        internal void AddNodeTypeToSearchIndexBulk(List<NodeSearchElement> nodes, Document doc)
+        {
+            foreach(var node in nodes)
+            {
+                AddNodeTypeToSearchIndex(node, doc);
+            }
         }
     }
 

--- a/src/DynamoCore/Utilities/LuceneSearchUtility.cs
+++ b/src/DynamoCore/Utilities/LuceneSearchUtility.cs
@@ -253,7 +253,7 @@ namespace Dynamo.Utilities
             {
                 writer.DeleteAll();
                 var iDoc = InitializeIndexDocumentForNodes();
-                AddNodeTypeToSearchIndexBulk(nodeList, iDoc);
+                AddNodeTypeToSearchIndex(nodeList, iDoc);
             }         
         }
 
@@ -631,7 +631,7 @@ namespace Dynamo.Utilities
             writer?.AddDocument(doc);
         }
 
-        internal void AddNodeTypeToSearchIndexBulk(List<NodeSearchElement> nodes, Document doc)
+        internal void AddNodeTypeToSearchIndex(List<NodeSearchElement> nodes, Document doc)
         {
             foreach(var node in nodes)
             {

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeAutoCompleteSearchViewModel.cs
@@ -750,7 +750,7 @@ namespace Dynamo.ViewModels
                     //Memory indexing process for Node Autocomplete (indexing just the nodes returned by the NodeAutocomplete service so we limit the scope of the query search)
                     var doc = LuceneUtility.InitializeIndexDocumentForNodes();
                     List<NodeSearchElement> nodeSearchElements = [.. searchElementsCache.Select(x => x.Model)];
-                    LuceneUtility.AddNodeTypeToSearchIndexBulk(nodeSearchElements, doc);
+                    LuceneUtility.AddNodeTypeToSearchIndex(nodeSearchElements, doc);
 
                     //Write the Lucene documents to memory
                     LuceneUtility.CommitWriterChanges();


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-8331

Revert changes related to the caching of the Lucene Searcher from this PR:
https://github.com/DynamoDS/Dynamo/pull/15773

This PR basically removes the `InitializeIndexSearcher` method and adds back the Searcher initialization on every triggered search.


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. Use N/A to indicate that the changes in this pull request do not apply to Release Notes. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
