### PR TITLE
DYN-7925: make access token accessible to all package authors using static method

### DIFF
--- a/src/DynamoCore/Configuration/ExecutionSession.cs
+++ b/src/DynamoCore/Configuration/ExecutionSession.cs
@@ -26,7 +26,6 @@ namespace Dynamo.Configuration
             parameters[ParameterKeys.LastExecutionDuration] = new TimeSpan(updateTask.ExecutionEndTime.TickCount - updateTask.ExecutionStartTime.TickCount);
             parameters[ParameterKeys.PackagePaths] = pathManager.PackagesDirectories;
             parameters[ParameterKeys.Logger] = model.Logger;
-            parameters[ParameterKeys.AuthTokenProvider] = model.AuthenticationManager.AuthProvider as Greg.IOAuth2AccessTokenProvider;
         }
 
         /// <summary>

--- a/src/DynamoCore/Configuration/ExecutionSession.cs
+++ b/src/DynamoCore/Configuration/ExecutionSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Dynamo.Interfaces;
@@ -26,6 +26,7 @@ namespace Dynamo.Configuration
             parameters[ParameterKeys.LastExecutionDuration] = new TimeSpan(updateTask.ExecutionEndTime.TickCount - updateTask.ExecutionStartTime.TickCount);
             parameters[ParameterKeys.PackagePaths] = pathManager.PackagesDirectories;
             parameters[ParameterKeys.Logger] = model.Logger;
+            parameters[ParameterKeys.AuthTokenProvider] = model.AuthenticationManager.AuthProvider as Greg.IOAuth2AccessTokenProvider;
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -993,7 +993,7 @@ namespace Dynamo.Models
             LogWarningMessageEvents.LogInfoMessage += LogInfoMessage;
 
 #pragma warning disable AUTH_SERVICES
-            AuthServicesEvents.RequestAuthProvider += AuthServicesEvents_AuthProviderRequested;
+            AuthServices.RequestAuthProvider += AuthServicesEvents_AuthProviderRequested;
 #pragma warning restore AUTH_SERVICES
 
             DynamoConsoleLogger.LogMessageToDynamoConsole += LogMessageWrapper;
@@ -1473,7 +1473,7 @@ namespace Dynamo.Models
             LogWarningMessageEvents.LogInfoMessage -= LogInfoMessage;
 
 #pragma warning disable AUTH_SERVICES
-            AuthServicesEvents.RequestAuthProvider -= AuthServicesEvents_AuthProviderRequested;
+            AuthServices.RequestAuthProvider -= AuthServicesEvents_AuthProviderRequested;
 #pragma warning restore AUTH_SERVICES
 
             DynamoConsoleLogger.LogMessageToDynamoConsole -= LogMessageWrapper;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -991,7 +991,11 @@ namespace Dynamo.Models
 
             LogWarningMessageEvents.LogWarningMessage += LogWarningMessage;
             LogWarningMessageEvents.LogInfoMessage += LogInfoMessage;
+
+#pragma warning disable AUTH_SERVICES
             AuthServicesEvents.RequestAuthProvider += AuthServicesEvents_AuthProviderRequested;
+#pragma warning restore AUTH_SERVICES
+
             DynamoConsoleLogger.LogMessageToDynamoConsole += LogMessageWrapper;
             DynamoConsoleLogger.LogErrorToDynamoConsole += LogErrorMessageWrapper;
             if (!IsServiceMode)
@@ -1021,9 +1025,9 @@ namespace Dynamo.Models
             DynamoReady(new ReadyParams(this));
         }
 
-        private void AuthServicesEvents_AuthProviderRequested(RequstAuthProviderEventArgs args)
+        private void AuthServicesEvents_AuthProviderRequested(RequestAuthProviderEventArgs args)
         {
-            args.FoundAuthProvider = AuthenticationManager.AuthProvider;
+            args.AuthProvider = AuthenticationManager.AuthProvider;
         }
 
         /// <summary>
@@ -1467,7 +1471,11 @@ namespace Dynamo.Models
 
             LogWarningMessageEvents.LogWarningMessage -= LogWarningMessage;
             LogWarningMessageEvents.LogInfoMessage -= LogInfoMessage;
+
+#pragma warning disable AUTH_SERVICES
             AuthServicesEvents.RequestAuthProvider -= AuthServicesEvents_AuthProviderRequested;
+#pragma warning restore AUTH_SERVICES
+
             DynamoConsoleLogger.LogMessageToDynamoConsole -= LogMessageWrapper;
             DynamoConsoleLogger.LogErrorToDynamoConsole -= LogErrorMessageWrapper;
             foreach (var ws in _workspaces)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -991,6 +991,7 @@ namespace Dynamo.Models
 
             LogWarningMessageEvents.LogWarningMessage += LogWarningMessage;
             LogWarningMessageEvents.LogInfoMessage += LogInfoMessage;
+            AuthServicesEvents.RequestAuthProvider += AuthServicesEvents_AuthProviderRequested;
             DynamoConsoleLogger.LogMessageToDynamoConsole += LogMessageWrapper;
             DynamoConsoleLogger.LogErrorToDynamoConsole += LogErrorMessageWrapper;
             if (!IsServiceMode)
@@ -1018,6 +1019,11 @@ namespace Dynamo.Models
                  
             // This event should only be raised at the end of this method.
             DynamoReady(new ReadyParams(this));
+        }
+
+        private void AuthServicesEvents_AuthProviderRequested(RequstAuthProviderEventArgs args)
+        {
+            args.FoundAuthProvider = AuthenticationManager.AuthProvider;
         }
 
         /// <summary>
@@ -1461,6 +1467,7 @@ namespace Dynamo.Models
 
             LogWarningMessageEvents.LogWarningMessage -= LogWarningMessage;
             LogWarningMessageEvents.LogInfoMessage -= LogInfoMessage;
+            AuthServicesEvents.RequestAuthProvider -= AuthServicesEvents_AuthProviderRequested;
             DynamoConsoleLogger.LogMessageToDynamoConsole -= LogMessageWrapper;
             DynamoConsoleLogger.LogErrorToDynamoConsole -= LogErrorMessageWrapper;
             foreach (var ws in _workspaces)

--- a/src/NodeServices/AuthServices.cs
+++ b/src/NodeServices/AuthServices.cs
@@ -8,24 +8,30 @@ namespace DynamoServices
     /// <summary>
     /// Event arguments for the RequestAuthProvider event.
     /// </summary>
-    internal class RequstAuthProviderEventArgs : EventArgs
+    internal class RequestAuthProviderEventArgs : EventArgs
     {
         /// <summary>
-        /// Gets or sets the found auth provider.
+        /// Gets or sets the found auth provider, if one is found. It's possible that
+        /// this willl be null.
         /// </summary>
-        internal object FoundAuthProvider { get; set; }
+        internal object AuthProvider { get; set; }
     }
 
     /// <summary>
     /// Delegate for handling the RequestAuthProvider event.
     /// </summary>
     /// <param name="args">The event arguments.</param>
-    internal delegate void RequestAuthProviderEventHandler(RequstAuthProviderEventArgs args);
+    internal delegate void RequestAuthProviderEventHandler(RequestAuthProviderEventArgs args);
 
 
     /// <summary>
     /// Static class containing authentication service events. Useful if you want to make authenticated requests from your nodes.
     /// </summary>
+    #if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.Experimental("AUTH_SERVICES")]
+#else
+        [Obsolete("This method is for evaluation purposes only and is subject to change or removal in future updates.")]
+#endif
     public static class AuthServicesEvents
     {
         /// <summary>
@@ -35,13 +41,19 @@ namespace DynamoServices
 
         /// <summary>
         /// Invokes the RequestAuthProvider event and returns an IOAuth2AccessTokenProvider if one is found.
+        /// If no auth provider is found, this will return null.
         /// </summary>
         /// <returns>The found IOAuth2AccessTokenProvider.</returns>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.Experimental("REQUEST_AUTHPROVIDER")]
+#else
+        [Obsolete("This method is for evaluation purposes only and is subject to change or removal in future updates.")]
+#endif
         public static object OnRequestAuthProvider()
         {
-            var args = new RequstAuthProviderEventArgs();
+            var args = new RequestAuthProviderEventArgs();
             RequestAuthProvider?.Invoke(args);
-            return args.FoundAuthProvider;
+            return args.AuthProvider;
         }
     }
 }

--- a/src/NodeServices/AuthServices.cs
+++ b/src/NodeServices/AuthServices.cs
@@ -32,7 +32,7 @@ namespace DynamoServices
 #else
         [Obsolete("This method is for evaluation purposes only and is subject to change or removal in future updates.")]
 #endif
-    public static class AuthServicesEvents
+    public static class AuthServices
     {
         /// <summary>
         /// Event triggered to request an authentication provider.

--- a/src/NodeServices/AuthServices.cs
+++ b/src/NodeServices/AuthServices.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DynamoServices
+{
+
+    /// <summary>
+    /// Event arguments for the RequestAuthProvider event.
+    /// </summary>
+    public class RequstAuthProviderEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the found auth provider.
+        /// </summary>
+        public object FoundAuthProvider { get; internal set; }
+    }
+
+    /// <summary>
+    /// Delegate for handling the RequestAuthProvider event.
+    /// </summary>
+    /// <param name="args">The event arguments.</param>
+    public delegate void RequestAuthProviderEventHandler(RequstAuthProviderEventArgs args);
+
+
+    /// <summary>
+    /// Static class containing authentication service events. Useful if you want to make authenticated requests from your nodes.
+    /// </summary>
+    public static class AuthServicesEvents
+    {
+        /// <summary>
+        /// Event triggered to request an authentication provider.
+        /// </summary>
+        internal static event RequestAuthProviderEventHandler RequestAuthProvider;
+
+        /// <summary>
+        /// Invokes the RequestAuthProvider event and returns an IOAuth2AccessTokenProvider if one is found.
+        /// </summary>
+        /// <returns>The found IOAuth2AccessTokenProvider.</returns>
+        public static object OnRequestAuthProvider()
+        {
+            var args = new RequstAuthProviderEventArgs();
+            RequestAuthProvider?.Invoke(args);
+            return args.FoundAuthProvider;
+        }
+    }
+}

--- a/src/NodeServices/AuthServices.cs
+++ b/src/NodeServices/AuthServices.cs
@@ -8,19 +8,19 @@ namespace DynamoServices
     /// <summary>
     /// Event arguments for the RequestAuthProvider event.
     /// </summary>
-    public class RequstAuthProviderEventArgs : EventArgs
+    internal class RequstAuthProviderEventArgs : EventArgs
     {
         /// <summary>
         /// Gets or sets the found auth provider.
         /// </summary>
-        public object FoundAuthProvider { get; internal set; }
+        internal object FoundAuthProvider { get; set; }
     }
 
     /// <summary>
     /// Delegate for handling the RequestAuthProvider event.
     /// </summary>
     /// <param name="args">The event arguments.</param>
-    public delegate void RequestAuthProviderEventHandler(RequstAuthProviderEventArgs args);
+    internal delegate void RequestAuthProviderEventHandler(RequstAuthProviderEventArgs args);
 
 
     /// <summary>

--- a/src/NodeServices/AuthServices.cs
+++ b/src/NodeServices/AuthServices.cs
@@ -40,20 +40,23 @@ namespace DynamoServices
         internal static event RequestAuthProviderEventHandler RequestAuthProvider;
 
         /// <summary>
-        /// Invokes the RequestAuthProvider event and returns an IOAuth2AccessTokenProvider if one is found.
-        /// If no auth provider is found, this will return null.
+        /// Returns the active DynamoModel's AuthProvider.
         /// </summary>
-        /// <returns>The found IOAuth2AccessTokenProvider.</returns>
+        /// <returns>The IOAuth2AccessTokenProvider associated with the active DynamoModel.
+        /// It's possible this property might be null.</returns>
 #if NET8_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.Experimental("REQUEST_AUTHPROVIDER")]
 #else
-        [Obsolete("This method is for evaluation purposes only and is subject to change or removal in future updates.")]
+        [Obsolete("This property is for evaluation purposes only and is subject to change or removal in future updates.")]
 #endif
-        public static object OnRequestAuthProvider()
+        public static object AuthProvider
         {
-            var args = new RequestAuthProviderEventArgs();
-            RequestAuthProvider?.Invoke(args);
-            return args.AuthProvider;
+            get
+            {
+                var args = new RequestAuthProviderEventArgs();
+                RequestAuthProvider?.Invoke(args);
+                return args.AuthProvider;
+            }
         }
     }
 }

--- a/src/NodeServices/DynamoServices.csproj
+++ b/src/NodeServices/DynamoServices.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DynamoServices</RootNamespace>
     <AssemblyName>DynamoServices</AssemblyName>
     <DocumentationFile>$(OutputPath)\DynamoServices.XML</DocumentationFile>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>MSB3539;CS1591;NUnit2005;NUnit2007;CS0618;CS0612;CS0672</NoWarn>

--- a/src/NodeServices/ExecutionSession.cs
+++ b/src/NodeServices/ExecutionSession.cs
@@ -81,11 +81,5 @@ namespace Dynamo.Session
         /// The return value is an ILogger
         /// </summary>
         public static readonly string Logger = nameof(Logger);
-
-        /// <summary>
-        /// This key is used to get an instance of the current IOAuth2AccessTokenProvider.
-        /// </summary>
-        public static readonly string AuthTokenProvider = nameof(AuthTokenProvider);
-
     }
 }

--- a/src/NodeServices/ExecutionSession.cs
+++ b/src/NodeServices/ExecutionSession.cs
@@ -81,6 +81,11 @@ namespace Dynamo.Session
         /// The return value is an ILogger
         /// </summary>
         public static readonly string Logger = nameof(Logger);
-        
+
+        /// <summary>
+        /// This key is used to get an instance of the current IOAuth2AccessTokenProvider.
+        /// </summary>
+        public static readonly string AuthTokenProvider = nameof(AuthTokenProvider);
+
     }
 }

--- a/test/DynamoCoreTests/AuthenticationManagerTests.cs
+++ b/test/DynamoCoreTests/AuthenticationManagerTests.cs
@@ -1,7 +1,10 @@
 using Dynamo.Core;
-
+using Dynamo.Interfaces;
+using Dynamo.Models;
+using Dynamo.Scheduler;
+using DynamoServices;
 using Greg;
-
+using Greg.AuthProviders;
 using Moq;
 
 using NUnit.Framework;
@@ -31,7 +34,7 @@ namespace Dynamo.Tests
 
             Assert.IsTrue(logoutCalled);
         }
-        
+
         #endregion
 
         #region Login
@@ -117,5 +120,35 @@ namespace Dynamo.Tests
         }
 
         #endregion
+    }
+
+    [TestFixture]
+    public class AuthServicesTests : DynamoModelTestBase
+    {
+
+        protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPreferences settings)
+        {
+            var authProviderMock = new Mock<IAuthProvider>();
+            authProviderMock.Setup(x => x.LoginState).Returns(LoginState.LoggedIn);
+            authProviderMock.As<IOAuth2AccessTokenProvider>().Setup(x => x.GetAccessToken()).Returns("faketoken");
+
+
+            return new DynamoModel.DefaultStartConfiguration()
+            {
+                PathResolver = pathResolver,
+                StartInTestMode = true,
+                GeometryFactoryPath = preloader.GeometryFactoryPath,
+                Preferences = settings,
+                ProcessMode = TaskProcessMode.Synchronous,
+                AuthProvider = authProviderMock.Object
+            };
+        }
+
+        [Test]
+        public void Test_OnRequestAuthProvider_FindsAuthProvider()
+        {
+            var result = AuthServicesEvents.OnRequestAuthProvider();
+            Assert.AreEqual((result as IOAuth2AccessTokenProvider).GetAccessToken(), "faketoken");
+        }
     }
 }

--- a/test/DynamoCoreTests/AuthenticationManagerTests.cs
+++ b/test/DynamoCoreTests/AuthenticationManagerTests.cs
@@ -147,7 +147,12 @@ namespace Dynamo.Tests
         [Test]
         public void Test_OnRequestAuthProvider_FindsAuthProvider()
         {
+#pragma warning disable AUTH_SERVICES
+#pragma warning disable REQUEST_AUTHPROVIDER
             var result = AuthServicesEvents.OnRequestAuthProvider();
+#pragma warning restore REQUEST_AUTHPROVIDER
+#pragma warning restore AUTH_SERVICES
+
             Assert.AreEqual((result as IOAuth2AccessTokenProvider).GetAccessToken(), "faketoken");
         }
     }

--- a/test/DynamoCoreTests/AuthenticationManagerTests.cs
+++ b/test/DynamoCoreTests/AuthenticationManagerTests.cs
@@ -149,7 +149,7 @@ namespace Dynamo.Tests
         {
 #pragma warning disable AUTH_SERVICES
 #pragma warning disable REQUEST_AUTHPROVIDER
-            var result = AuthServices.OnRequestAuthProvider();
+            var result = AuthServices.AuthProvider;
 #pragma warning restore REQUEST_AUTHPROVIDER
 #pragma warning restore AUTH_SERVICES
 

--- a/test/DynamoCoreTests/AuthenticationManagerTests.cs
+++ b/test/DynamoCoreTests/AuthenticationManagerTests.cs
@@ -149,7 +149,7 @@ namespace Dynamo.Tests
         {
 #pragma warning disable AUTH_SERVICES
 #pragma warning disable REQUEST_AUTHPROVIDER
-            var result = AuthServicesEvents.OnRequestAuthProvider();
+            var result = AuthServices.OnRequestAuthProvider();
 #pragma warning restore REQUEST_AUTHPROVIDER
 #pragma warning restore AUTH_SERVICES
 

--- a/test/DynamoCoreTests/Configuration/ExecutionSessionTests.cs
+++ b/test/DynamoCoreTests/Configuration/ExecutionSessionTests.cs
@@ -1,13 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Dynamo.Events;
-using Dynamo.Interfaces;
-using Dynamo.Models;
-using Dynamo.Scheduler;
-using Greg;
-using Greg.AuthProviders;
 using NUnit.Framework;
-using RestSharp;
 
 namespace Dynamo.Tests.Configuration
 {
@@ -16,7 +10,6 @@ namespace Dynamo.Tests.Configuration
     {
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private IEnumerable<string> packagePaths;
-        private object authprovider;
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -27,49 +20,6 @@ namespace Dynamo.Tests.Configuration
             libraries.Add("DSCPython.dll");
             libraries.Add("FunctionObject.ds");
             base.GetLibrariesToPreload(libraries);
-        }
-      
-        protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPreferences settings)
-        {
-            return new DynamoModel.DefaultStartConfiguration()
-            {
-                PathResolver = pathResolver,
-                StartInTestMode = true,
-                GeometryFactoryPath = preloader.GeometryFactoryPath,
-                Preferences = settings,
-                ProcessMode = TaskProcessMode.Synchronous,
-                AuthProvider = new MockTokenProvider()
-            };
-        }
-
-        private class MockTokenProvider : IAuthProvider, IOAuth2AccessTokenProvider
-        {
-            public LoginState LoginState => LoginState.LoggedIn;
-
-            public string Username => throw new NotImplementedException();
-
-            public event Func<object, bool> RequestLogin;
-            public event Action<LoginState> LoginStateChanged;
-
-            public string GetAccessToken()
-            {
-                return "faketoken";
-            }
-
-            public bool Login()
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Logout()
-            {
-                throw new NotImplementedException();
-            }
-
-            public void SignRequest(ref RestRequest m, RestClient client)
-            {
-                throw new NotImplementedException();
-            }
         }
 
         [OneTimeSetUp]
@@ -96,20 +46,9 @@ namespace Dynamo.Tests.Configuration
             ExecutionEvents.GraphPreExecution -= ExecutionEvents_GraphPreExecution;
         }
 
-        [Test]
-        [Category("UnitTests")]
-        public void TestExecutionSessionAuthProvider()
-        {
-            ExecutionEvents.GraphPreExecution += ExecutionEvents_GraphPreExecution;
-            RunModel(@"core\HomogeneousList\HomogeneousInputsValid.dyn");
-            Assert.IsInstanceOf<IOAuth2AccessTokenProvider>(authprovider, $"was not an instance of {nameof(IOAuth2AccessTokenProvider)}");
-            ExecutionEvents.GraphPreExecution -= ExecutionEvents_GraphPreExecution;
-        }
-
         private void ExecutionEvents_GraphPreExecution(Session.IExecutionSession session)
         {
             packagePaths = ExecutionEvents.ActiveSession.GetParameterValue(Session.ParameterKeys.PackagePaths) as IEnumerable<string>;
-            authprovider = ExecutionEvents.ActiveSession.GetParameterValue(Session.ParameterKeys.AuthTokenProvider);
 
         }
         

--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.DynamoServices.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.DynamoServices.nuspec
@@ -25,8 +25,13 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="DynamoServices.dll" target="lib\netstandard2.0" />
+        <file src="..\..\..\src\NodeServices\obj\netstandard2.0\DynamoServices.dll" target="lib\netstandard2.0" />
         <file src="DynamoServices.xml" target="lib\netstandard2.0" />
+
+        <file src="..\..\..\src\NodeServices\obj\net8.0\DynamoServices.dll" target="lib\net8.0" />
+        <file src="DynamoServices.xml" target="lib\net8.0" />
+
+        
         <file src="..\..\..\doc\distrib\Images\logo_square_32x32.png" target="content\images\logo.png" />
     </files>
 </package>


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7925

As we have more and more packages requiring authentication and authorization it makes sense to make it simpler for package authors to retrieve the current access token.

Currently, to retrieve the current access token, a package author needs to implement an extension, get the authprovider, then introduce a static api to retrieve the token from the extension in their nodes.

Let's just skip all that - this PR adds a method to DynamoServices: `AuthServicesEvents.OnRequestAuthProvider()` which `DynamoModel` handles by returning to the current auth provider if one exists.

It's implemented this way to avoid needing to add new references to `DynamoServices` and to enable ZT authors to avoid referencing DynamoCore.dll etc.

This should cover more use cases than the initial implementation.

This PR also starts multi targeting DynamoServices ( starts targeting net8 as well as netstd2) and adds this new target to the DynamoServices nuget package. This change was made so that we could use the `Experimental` attribute to guard the new API until we are satisfied with its design. For netstd2 builds we fallback to using the `obsolete` attribute which is less fitting and is ignorable by clients. Experimental attribute requires opt in.

![image](https://github.com/user-attachments/assets/f640ab9c-c9b9-43ae-9157-b63f83d00209)



### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Adds a static API for accessing current auth provider.

### Reviewers

