### PR TITLE
[DYN-8072] Opening file from home tab should check is workspace has unsaved changes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2073,6 +2073,12 @@ namespace Dynamo.ViewModels
         /// <param name="parameters"></param>
         private void Open(object parameters)
         {
+            if (CurrentSpaceViewModel.HasUnsavedChanges)
+            {
+                if (!AskUserToSaveWorkspaceOrCancel(HomeSpace))
+                    return;
+            }
+
             // try catch for exceptions thrown while opening files, say from a future version, 
             // that can't be handled reliably
             filePath = string.Empty;
@@ -3316,9 +3322,10 @@ namespace Dynamo.ViewModels
         {
             var args = new WorkspaceSaveEventArgs(workspace, allowCancel);
             OnRequestUserSaveWorkflow(this, args);
-            if (!args.Success)
-                return false;
-            return true;
+
+            workspace.HasUnsavedChanges = !args.Success;
+
+            return args.Success;
         }
 
         internal bool CanAddToSelection(object parameters)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2073,7 +2073,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameters"></param>
         private void Open(object parameters)
         {
-            if (CurrentSpaceViewModel.HasUnsavedChanges)
+            if (CurrentSpaceViewModel != null && CurrentSpaceViewModel.HasUnsavedChanges)
             {
                 if (!AskUserToSaveWorkspaceOrCancel(HomeSpace))
                     return;

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -856,6 +856,37 @@ namespace Dynamo.Tests
             System.IO.File.Delete(newPath);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void EnsureSavePromptOnRecentGraphOpen()
+        {
+            // Open an existing graph
+            string openPath = Path.Combine(TestDirectory, @"UI\GroupTest.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+
+            // Assert workspace is opened
+            Assert.IsNotNull(ViewModel.Model.CurrentWorkspace);
+
+            // Mark workspace as having unsaved changes
+            ViewModel.Model.CurrentWorkspace.HasUnsavedChanges = true;
+            Assert.IsTrue(ViewModel.Model.CurrentWorkspace.HasUnsavedChanges);
+
+            // Move to Home workspace
+            ViewModel.ShowStartPage = true;
+            Assert.IsTrue(ViewModel.ShowStartPage);
+
+            // Attempt to open a recent file
+            var eventCount = 0;
+            var handler = new WorkspaceSaveEventHandler((o, e) => { eventCount++; });
+            ViewModel.RequestUserSaveWorkflow += handler;
+            ViewModel.OpenRecentCommand.Execute(openPath);
+            ViewModel.RequestUserSaveWorkflow -= handler;
+
+            // Assert save prompt was triggered and the workspace was opened
+            Assert.AreEqual(1, eventCount);
+            Assert.AreEqual(openPath, ViewModel.Model.CurrentWorkspace.FileName);
+        }
+
         #region CustomNodeWorkspaceModel SaveAs side effects
 
         [Test]


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-8072](https://jira.autodesk.com/browse/DYN-8072) where users were not always prompted to save changes when opening a new graph from the Recent Files section.

Changes Implemented:
 - Ensured that `AskUserToSaveWorkspaceOrCancel` is called when opening a new graph.
 - Updated `HasUnsavedChanges` handling. 
Now, after the user confirms saving or discarding changes, `workspace.HasUnsavedChanges` is properly set.

Expected Behavior After the Fix:
 - If the current graph has unsaved changes, the user will always be prompted before opening a new graph.
 - If the user chooses to save or discard changes, `HasUnsavedChanges` is correctly updated.

![DYN-8072-Fix](https://github.com/user-attachments/assets/8cb626a9-b212-4712-b695-887eeb41235b)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Changes Implemented:
 - Ensured that AskUserToSaveWorkspaceOrCancel is called when opening a new graph.
 - Updated HasUnsavedChanges handling. 
Now, after the user confirms saving or discarding changes, workspace.HasUnsavedChanges is properly set.

Expected Behavior After the Fix:
 - If the current graph has unsaved changes, the user will always be prompted before opening a new graph.
 - If the user chooses to save or discard changes, HasUnsavedChanges is correctly updated.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@achintyabhat 
