### PR TITLE
fixed frozen state to downstream nodes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1974,6 +1974,7 @@ namespace Dynamo.ViewModels
                 if (current != null)
                 {
                     current.RaisePropertyChanged("IsFrozen");
+                    current.HandleColorOverlayChange();
                 }
             }
         }


### PR DESCRIPTION

### Purpose

Fixes downstream frozen overlays not visible in the zoomed out state.

![DynamoSandbox_yoaUOfCmSB](https://github.com/user-attachments/assets/3bd61ca8-35c7-4c1a-b9c0-fea74b7e9209)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- fixed frozen state to downstream nodes when zoomed out
- the way IsFrozen getter works bypasses the notification system for downstream nodes. This fix addresses that

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
