### PR TITLE
DYN-7512: Fix auto layout cleanup for group nodes with external connections

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/LayoutExtensions.cs
@@ -257,12 +257,11 @@ namespace Dynamo.Graph.Workspaces
         /// <param name="end"></param>
         private static void AddConnectorEdgesIncludingPinEdges(GraphLayout.Graph combinedGraph, ConnectorModel connector, Guid? start = null, Guid? end = null)
         {
+            Guid startGuid = start == null ? connector.Start.Owner.GUID : (Guid)start;
+            Guid endGuid = end == null ? connector.End.Owner.GUID : (Guid)end;
             // Bail if there are no connectorPins
             if (connector.ConnectorPinModels.Count < 1)
             {
-                Guid startGuid = start == null ? connector.Start.Owner.GUID : (Guid)start;
-                Guid endGuid = end == null ? connector.End.Owner.GUID : (Guid)end;
-
                 combinedGraph.AddEdge(startGuid, endGuid,
                        connector.Start.Center.X, connector.Start.Center.Y, connector.End.Center.X, connector.End.Center.Y);
                 return;
@@ -270,7 +269,7 @@ namespace Dynamo.Graph.Workspaces
 
             // Add an edge between the left-most (start) node 
             // (its corresponding port) to which this connector connects, and the first connectorPin.
-            combinedGraph.AddEdge(connector.Start.Owner.GUID, 
+            combinedGraph.AddEdge(startGuid, 
                 connector.ConnectorPinModels[0].GUID,
                 connector.Start.Center.X, 
                 connector.Start.Center.Y, 
@@ -294,8 +293,8 @@ namespace Dynamo.Graph.Workspaces
 
             // Add an edge between the last connectorPin and the right-most (end) node
             // (its corresponding port) to which this connector connects.
-            combinedGraph.AddEdge(connector.ConnectorPinModels[connector.ConnectorPinModels.Count - 1].GUID, 
-                connector.End.Owner.GUID,
+            combinedGraph.AddEdge(connector.ConnectorPinModels[connector.ConnectorPinModels.Count - 1].GUID,
+                endGuid,
                 connector.ConnectorPinModels[connector.ConnectorPinModels.Count - 1].CenterX, 
                 connector.ConnectorPinModels[connector.ConnectorPinModels.Count - 1].CenterY, 
                 connector.End.Center.X, 


### PR DESCRIPTION
### Purpose

The PR fixes the issue with Auto Layout Cleanup setting in a graph. The method was behaving differently for nodes which belonged to a group but had a connecting wire outside of it which also had a pin that was not part of the group. The method used to ignore those wires, which made nodes and other groups wires behave differently when auto layout was applied.

Before:
![DynamoSandbox_54MWnL4dHN](https://github.com/user-attachments/assets/a8ec8932-9d10-4e81-a52a-0ea1baac9c15)


After:
![DynamoSandbox_PVKqfxmVd7](https://github.com/user-attachments/assets/a1243ff8-85d9-46cb-851f-c6d1e0d40d9c)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixed the issue with Auto Layout Cleanup setting in a graph

### Reviewers

@DynamoDS/dynamo 
