### PR TITLE
DYN-7369: Handle crash when moving nested groups

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1249,15 +1249,24 @@ namespace Dynamo.ViewModels
 
         private void UpdateAllGroupedGroups()
         {
-            using (NestedGroupsGeometries.DeferCollectionReset())
+            try
             {
-                if (ViewModelBases != null)
-                {        
-                    ViewModelBases
-                        .OfType<AnnotationViewModel>()
-                        .ToList()
-                        .ForEach(x => UpdateGroupCutGeometry(x));
+                using (NestedGroupsGeometries.DeferCollectionReset())
+                {
+                    if (ViewModelBases != null)
+                    {
+                        ViewModelBases
+                            .OfType<AnnotationViewModel>()
+                            .ToList()
+                            .ForEach(x => UpdateGroupCutGeometry(x));
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                WorkspaceViewModel.DynamoViewModel.Model.Logger.Log("Error updating all grouped groups");
+                WorkspaceViewModel.DynamoViewModel.Model.Logger.Log(ex);
+                WorkspaceViewModel.DynamoViewModel.Model.Logger.Log(ex.StackTrace);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1257,7 +1257,7 @@ namespace Dynamo.ViewModels
                     {
                         ViewModelBases
                             .OfType<AnnotationViewModel>()
-                            .ToList()
+                            .ToList()?
                             .ForEach(x => UpdateGroupCutGeometry(x));
                     }
                 }


### PR DESCRIPTION
### Purpose

The PR handles the crash based on the CER report(51756739), the crash seems to branch from updating nested group position. As a fix this is mitigated by catching the exception and logging it in console instead. 

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Handle crash when moving nested groups

### Reviewers

@DynamoDS/dynamo 
