### PR TITLE
[DYN-5517] Analytics tracking for file operations.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2622,6 +2622,22 @@ namespace Dynamo.ViewModels
                 if (!isBackup && hasSaved)
                 {
                     AddToRecentFiles(path);
+
+                    // Track save and save-as operations on workspace, excluding the backup files.
+                    if (saveContext.Equals(SaveContext.Save))
+                    {
+                        Analytics.TrackTaskFileOperationEvent(
+                                  path,
+                                  Logging.Actions.Save,
+                                  Model.CurrentWorkspace.Nodes.Count());
+                    }
+                    else if (saveContext.Equals(SaveContext.SaveAs))
+                    {
+                        Analytics.TrackTaskFileOperationEvent(
+                                  path,
+                                  Logging.Actions.SaveAs,
+                                  Model.CurrentWorkspace.Nodes.Count());
+                    }
                 }
             }
             catch (Exception ex)
@@ -3227,6 +3243,12 @@ namespace Dynamo.ViewModels
 
         private void CloseHomeWorkspace(object parameter)
         {
+            // Tracking analytics for workspace file close operation.
+            Analytics.TrackTaskFileOperationEvent(
+                                     model.CurrentWorkspace.FileName,
+                                     Logging.Actions.Close,
+                                     model.CurrentWorkspace.Nodes.Count());
+
             // Upon closing a workspace, validate if the workspace is valid to be sent to the ML datapipeline and then send it.
             if (!DynamoModel.IsTestMode && !HomeSpace.HasUnsavedChanges && (currentWorkspaceViewModel?.IsHomeSpace ?? true) && HomeSpace.HasRunWithoutCrash)
             {


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-5517

Adding analytics tracking for the other file operations in Dynamo. File.Open is already tracked correcttly.
File.Close, File.Save, File.SaveAs added in this PR.

Todo:
File.Read, File.Write, File.Delete, File.New

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes
[DYN-5517] Analytics tracking for file operations.

### Reviewers
@zeusongit @QilongTang 

