### PR TITLE
[DYN-6757] Updating Unclear note of "Code Block" node in Code Blocks sample

### DIFF
--- a/doc/distrib/Samples/en-US/Core/Core_CodeBlocks.dyn
+++ b/doc/distrib/Samples/en-US/Core/Core_CodeBlocks.dyn
@@ -3677,7 +3677,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "3.1.0.3411",
+      "Version": "3.4.1.7055",
       "RunType": "Automatic",
       "RunPeriod": "100"
     },
@@ -6053,15 +6053,15 @@
       },
       {
         "Id": "48b10f5b91ed46d0b5dda59e32d479ea",
-        "Title": "Multiple variables are defined within the same code block and a list is ",
+        "Title": "Multiple variables are defined in this code block, and at the end, a list is created containing all of them.",
         "DescriptionText": null,
         "IsExpanded": true,
         "WidthAdjustment": 0.0,
         "HeightAdjustment": 0.0,
         "Nodes": [],
         "HasNestedGroups": false,
-        "Left": 1724.432352015569,
-        "Top": -2243.085156559914,
+        "Left": 1723.432352015569,
+        "Top": -2257.085156559914,
         "Width": 0.0,
         "Height": 0.0,
         "FontSize": 36.0,
@@ -6094,8 +6094,8 @@
         "PinnedNode": "8abf1aba83174c3d872cbd5cdb9c4437"
       }
     ],
-    "X": -1040.4433766526004,
-    "Y": 5113.380799475012,
-    "Zoom": 0.7418323047017593
+    "X": 250.04723266959417,
+    "Y": 1153.6778111637072,
+    "Zoom": 0.16318736607140552
   }
 }


### PR DESCRIPTION
### Purpose

This PR address [DYN-6757](https://jira.autodesk.com/browse/DYN-6757). It updates the note for the Code Block node in the create lists example.

Before:
![image](https://github.com/user-attachments/assets/a9b68631-bdb8-4aee-9d71-f3ca4b0f5951)


After:
![image](https://github.com/user-attachments/assets/4b451c13-16eb-48cd-8988-fd186da82c5c)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Updating the Core_CodeBlocks.dyn sample file. Specifically updating a note under the "Create lists" example to finish off the text within the note.

### Reviewers

@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol
