### PR TITLE
DYN-8398 : separate nodeconnect and autocomplete commands

### DIFF
--- a/src/DynamoCoreWpf/Commands/PortCommands.cs
+++ b/src/DynamoCoreWpf/Commands/PortCommands.cs
@@ -33,7 +33,7 @@ namespace Dynamo.ViewModels
             get
             {
                 if (autoCompleteCommand == null)
-                    autoCompleteCommand ??= new DelegateCommand(NodeViewModel.WorkspaceViewModel.DynamoViewModel.IsDNAClusterPlacementEnabled ? AutoCompleteCluster : AutoComplete, CanAutoComplete);
+                    autoCompleteCommand ??= new DelegateCommand(NodeViewModel.WorkspaceViewModel.DynamoViewModel.IsDNAClusterPlacementEnabled ? AutoCompleteCluster : AutoComplete);
 
                 return autoCompleteCommand;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -1066,10 +1066,6 @@ namespace Dynamo.ViewModels
 
                 var portModel = portViewModel.PortModel;
 
-                // When the connect command is triggered, set portDisconnectedByConnectCommand flag based on the port connectors.
-                // If the current port has any connectors, then it will be disconnected. Otherwise a new connection will be made. 
-                portViewModel.inputPortDisconnectedByConnectCommand = portViewModel.PortType == PortType.Input && portModel.Connectors.Count > 0;
-
                 var workspaceViewModel = owningWorkspace.DynamoViewModel.CurrentSpaceViewModel;
 
                 if (this.currentState != State.Connection) // Not in a connection attempt...


### PR DESCRIPTION
### Purpose
Separate NodeConnect and AutoComplete command in order to avoid interaction with Undo stack.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
