### PR TITLE
DYN-8398 : separate commands

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -535,11 +535,6 @@ namespace Dynamo.Graph.Nodes
 
             return null;
         }
-
-        internal bool CanAutoCompleteInput()
-        {
-            return !(PortType == PortType.Input && Connectors?.FirstOrDefault()?.Start?.Owner != null);
-        }
     }
 
     /// <summary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/InPorts.xaml
@@ -38,11 +38,6 @@
                 </views:HandlingEventTrigger>
             </interactivity:Interaction.Triggers>
 
-            <!--  Bind NodeAutoComplete to double left click  -->
-            <Grid.InputBindings>
-                <MouseBinding Command="{Binding Path=NodeAutoCompleteCommand}" MouseAction="LeftDoubleClick" />
-            </Grid.InputBindings>
-
             <!--  Enables Port Snapping  -->
             <Rectangle x:Name="PortSnapping"
                        Grid.Column="0"

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -29,7 +29,6 @@ namespace Dynamo.ViewModels
         private bool showUseLevelMenu;
         private const double autocompletePopupSpacing = 2.5;
         private const double proxyPortContextMenuOffset = 20;
-        internal bool inputPortDisconnectedByConnectCommand = false;
         private bool nodeAutoCompleteMarkerVisible;
         protected static readonly SolidColorBrush PortBackgroundColorPreviewOff = new SolidColorBrush(Color.FromRgb(102, 102, 102));
         protected static readonly SolidColorBrush PortBackgroundColorDefault = new SolidColorBrush(Color.FromRgb(60, 60, 60));
@@ -505,24 +504,13 @@ namespace Dynamo.ViewModels
         {
             //handle the mouse event to prevent connection from starting
             MouseButtonEventArgs evArgs = parameter as MouseButtonEventArgs;
-            evArgs.Handled = true;
+            if (evArgs != null)
+            {
+                evArgs.Handled = true;
+            }            
 
             var wsViewModel = node?.WorkspaceViewModel;
             if (wsViewModel is null || wsViewModel.NodeAutoCompleteSearchViewModel is null)
-            {
-                return;
-            }
-
-            // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
-            if (inputPortDisconnectedByConnectCommand)
-            {
-                wsViewModel.DynamoViewModel.Model.CurrentWorkspace.Undo();
-            }
-
-            // Bail out from connect state
-            wsViewModel.CancelActiveState();
-
-            if (PortModel != null && !PortModel.CanAutoCompleteInput())
             {
                 return;
             }
@@ -547,20 +535,6 @@ namespace Dynamo.ViewModels
             
             var wsViewModel = node.WorkspaceViewModel;
             wsViewModel.NodeAutoCompleteSearchViewModel.PortViewModel = this;
-
-            // If the input port is disconnected by the 'Connect' command while triggering Node AutoComplete, undo the port disconnection.
-            if (this.inputPortDisconnectedByConnectCommand)
-            {
-                wsViewModel.DynamoViewModel.Model.CurrentWorkspace.Undo();
-            }
-
-            // Bail out from connect state
-            wsViewModel.CancelActiveState();
-
-            if (PortModel != null && !PortModel.CanAutoCompleteInput())
-            {
-                return;
-            }
 
             // CreateMockCluster();
 
@@ -702,8 +676,11 @@ namespace Dynamo.ViewModels
             {
                 dynamoViewModel.MainGuideManager.CreateRealTimeInfoWindow(Wpf.Properties.Resources.NodeAutoCompleteNotAvailableForCollapsedGroups);
             }
-            // If the feature is enabled from Dynamo experiment setting and if user interaction is not on proxy ports.
-            return dynamoViewModel.EnableNodeAutoComplete && !port.IsProxyPort;
+
+            // We can AutoComplete if the feature is enabled from Dynamo experiment setting,
+            // if user interaction is not on proxy ports and if the port is not an input already connected.
+            return dynamoViewModel.EnableNodeAutoComplete && !port.IsProxyPort &&
+                !(PortType == PortType.Input && PortModel?.Connectors?.FirstOrDefault()?.Start?.Owner != null);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -1066,10 +1066,6 @@ namespace Dynamo.ViewModels
 
                 var portModel = portViewModel.PortModel;
 
-                // When the connect command is triggered, set portDisconnectedByConnectCommand flag based on the port connectors.
-                // If the current port has any connectors, then it will be disconnected. Otherwise a new connection will be made. 
-                portViewModel.inputPortDisconnectedByConnectCommand = portViewModel.PortType == PortType.Input && portModel.Connectors.Count > 0;
-
                 var workspaceViewModel = owningWorkspace.DynamoViewModel.CurrentSpaceViewModel;
 
                 if (this.currentState != State.Connection) // Not in a connection attempt...

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -340,7 +340,7 @@ namespace Dynamo.Wpf.ViewModels
             
             // Avoid triggering auto complete for an already connected input.
             PortModel portModel = parameter as PortModel;
-            return parameter as PortModel != null ? portModel.CanAutoCompleteInput() : true;
+            return portModel?.PortType != PortType.Input || portModel?.Connectors?.FirstOrDefault()?.Start?.Owner is null;
         }
 
         private Rect2D GetNodesBoundingBox(IEnumerable<NodeModel> nodes)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -547,14 +547,17 @@ namespace Dynamo.Controls
 
             if (ViewModel.NodeModel is not CodeBlockNodeModel && ViewModel.NodeModel is not CoreNodeModels.Watch && ViewModel.NodeModel is not PythonNodeModels.PythonNode && ViewModel.NodeModel is not PythonNodeModels.PythonStringNode)
             {
-                var ports = new List<PortViewModel>(ViewModel.InPorts);
-                ports.AddRange(ViewModel.OutPorts);
-
-                foreach (PortViewModel port in ports)
+                //For input ports, if there are connectors present, do not show marker.
+                foreach (PortViewModel port in ViewModel.InPorts)
                 {
-                    //if there are connectors present, do not show marker.
                     //We check for connector count because 'IsConnected' returns true for use of default value
                     port.NodeAutoCompleteMarkerVisible = port.PortModel.Connectors.Count < 1;
+                }
+
+                //For output ports, we always show the marker.
+                foreach (PortViewModel port in ViewModel.OutPorts)
+                {
+                    port.NodeAutoCompleteMarkerVisible = true;
                 }
             }
         }


### PR DESCRIPTION
### Purpose
Separate NodeConnect and AutoComplete commands in order to avoid interaction with the undo stack.
We recently introduced a new command for AutoComplete and now this PR just makes some adjustments related to that.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
