### PR TITLE
[DYN-6370] Restore UI change in group context menu

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4127,7 +4127,8 @@
         </Setter>
     </Style>
 
-    <Style x:Key="PackageManagerContextMenuItemStyle" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource ContextMenuItemStyle}">
+    <!--  This context menu style is similar to the ContextMenuItemStyle and the only difference is the background at IsMouseOve = False  -->
+    <Style x:Key="DarkContextMenuItemStyle" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource ContextMenuItemStyle}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuItem}">
@@ -4370,13 +4371,13 @@
         </Style.Resources>
     </Style>
 
-    <Style x:Key="PackageManagerContextMenuStyle" TargetType="{x:Type ContextMenu}" BasedOn="{StaticResource ContextMenuStyle}">
+    <Style x:Key="DarkContextMenuStyle" TargetType="{x:Type ContextMenu}" BasedOn="{StaticResource ContextMenuStyle}">
         <Style.Resources>
             <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
                BasedOn="{StaticResource ContextMenuSeparatorStyle}"
                TargetType="Separator" />
             <Style x:Key="{x:Type MenuItem}"
-               BasedOn="{StaticResource PackageManagerContextMenuItemStyle}"
+               BasedOn="{StaticResource DarkContextMenuItemStyle}"
                TargetType="MenuItem" />
         </Style.Resources>
     </Style>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4115,6 +4115,102 @@
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericMouseOverBackgroundColorBrush}" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
+                            <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="checkBox" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="ContentPresenter" Property="TextBlock.FontFamily" Value="{StaticResource ArtifaktElementBold}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PackageManagerContextMenuItemStyle" TargetType="{x:Type MenuItem}" BasedOn="{StaticResource ContextMenuItemStyle}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type MenuItem}">
+                    <DockPanel x:Name="dockPanel"
+                           HorizontalAlignment="Stretch"
+                           Background="Transparent"
+                           SnapsToDevicePixels="true">
+                        <Label x:Name="checkBox"
+                           Margin="0,0,-20,0"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Center"
+                           HorizontalContentAlignment="Center"
+                           VerticalContentAlignment="Center"
+                           Content="✓"
+                           DockPanel.Dock="Left"
+                           FontSize="9px"
+                           Foreground="{StaticResource PreferencesWindowButtonColor}"
+                           Visibility="Collapsed" />
+                        <ContentPresenter x:Name="ContentPresenter"
+                                      Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="Center"
+                                      ContentSource="Header"
+                                      DockPanel.Dock="Left"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      TextBlock.Foreground="{StaticResource NodeContextMenuForeground}" />
+                        <Label x:Name="subMenuArrow"
+                           Margin="0,0,15,7"
+                           Padding="0"
+                           VerticalAlignment="Center"
+                           Content="&gt;"
+                           DockPanel.Dock="Right"
+                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                           FontSize="13px"
+                           Foreground="{StaticResource Blue300Brush}">
+                            <Label.RenderTransform>
+                                <ScaleTransform ScaleX="1" ScaleY="1.5" />
+                            </Label.RenderTransform>
+                            <Label.Style>
+                                <Style TargetType="{x:Type Label}">
+                                    <Setter Property="Visibility" Value="Hidden" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type MenuItem}}, Path=HasItems}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Label.Style>
+                        </Label>
+                        <Popup x:Name="PART_Popup"
+                           AllowsTransparency="true"
+                           Focusable="false"
+                           HorizontalOffset="0"
+                           IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                           Placement="Right"
+                           VerticalOffset="-2">
+                            <Border Background="{TemplateBinding Background}"
+                                BorderBrush="Transparent"
+                                BorderThickness="0">
+                                <ScrollViewer x:Name="SubMenuScrollViewer"
+                                          CanContentScroll="true"
+                                          Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer,
+                                                                                        TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                    <Grid RenderOptions.ClearTypeHint="Enabled">
+                                        <ItemsPresenter x:Name="ItemsPresenter"
+                                                    Grid.IsSharedSizeScope="true"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                    </Grid>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </DockPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="ContentPresenter" Property="TextBlock.Opacity" Value="0.5" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericMouseOverBackgroundColorBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericBorderBackgroundColorBrush}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
@@ -4271,6 +4367,17 @@
             <Style x:Key="{x:Type MenuItem}"
                    BasedOn="{StaticResource ContextMenuItemStyle}"
                    TargetType="MenuItem" />
+        </Style.Resources>
+    </Style>
+
+    <Style x:Key="PackageManagerContextMenuStyle" TargetType="{x:Type ContextMenu}" BasedOn="{StaticResource ContextMenuStyle}">
+        <Style.Resources>
+            <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
+               BasedOn="{StaticResource ContextMenuSeparatorStyle}"
+               TargetType="Separator" />
+            <Style x:Key="{x:Type MenuItem}"
+               BasedOn="{StaticResource PackageManagerContextMenuItemStyle}"
+               TargetType="MenuItem" />
         </Style.Resources>
     </Style>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
@@ -177,7 +177,7 @@ namespace Dynamo.PackageManager.UI
             commandParameterBinding.Source = button.DataContext;
 
             var contextMenuStyle = new Style(typeof(ContextMenu));
-            contextMenuStyle.BasedOn = (Style)SharedDictionaryManager.DynamoModernDictionary["PackageManagerContextMenuStyle"];
+            contextMenuStyle.BasedOn = (Style)SharedDictionaryManager.DynamoModernDictionary["DarkContextMenuStyle"];
 
             //Apply the Style to the ContextMenu
             contextMenu.Style = contextMenuStyle;

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml.cs
@@ -177,7 +177,7 @@ namespace Dynamo.PackageManager.UI
             commandParameterBinding.Source = button.DataContext;
 
             var contextMenuStyle = new Style(typeof(ContextMenu));
-            contextMenuStyle.BasedOn = (Style)SharedDictionaryManager.DynamoModernDictionary["ContextMenuStyle"];
+            contextMenuStyle.BasedOn = (Style)SharedDictionaryManager.DynamoModernDictionary["PackageManagerContextMenuStyle"];
 
             //Apply the Style to the ContextMenu
             contextMenu.Style = contextMenuStyle;

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerSearchControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerSearchControl.xaml
@@ -136,7 +136,7 @@
                             <ContextMenu Width="Auto"
                                          MinWidth="180"
                                          Background="{StaticResource GenericBorderBackgroundColorBrush}"
-                                         Style="{StaticResource PackageManagerContextMenuStyle}">
+                                         Style="{StaticResource DarkContextMenuStyle}">
 
                                 <!--  Sub-Title 'SORT BY'  -->
                                 <Separator>
@@ -152,7 +152,7 @@
                                 <!--  Sort By Package Name  -->
                                 <MenuItem Command="{Binding Path=SetSortingKeyCommand}"
                                           CommandParameter="Name"
-                                          Style="{StaticResource PackageManagerContextMenuItemStyle}"
+                                          Style="{StaticResource DarkContextMenuItemStyle}"
                                           Header="{x:Static p:Resources.PackageSearchViewContextMenuSortByName}"
                                           IsCheckable="True"
                                           IsChecked="{Binding Path=SortingKey, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Name, Mode=TwoWay}" />
@@ -255,9 +255,9 @@
                                          DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Mode=Self}}"
                                          DisplayMemberPath="FilterName"
                                          StaysOpen="True"
-                                         Style="{StaticResource PackageManagerContextMenuStyle}">
+                                         Style="{StaticResource DarkContextMenuStyle}">
                                 <ContextMenu.Resources>
-                                    <Style BasedOn="{StaticResource PackageManagerContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
+                                    <Style BasedOn="{StaticResource DarkContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
                                         <Setter Property="IsCheckable" Value="True" />
                                         <Setter Property="StaysOpenOnClick" Value="True" />
                                         <Setter Property="Command" Value="{Binding FilterCommand}" />

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerSearchControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerSearchControl.xaml
@@ -136,7 +136,7 @@
                             <ContextMenu Width="Auto"
                                          MinWidth="180"
                                          Background="{StaticResource GenericBorderBackgroundColorBrush}"
-                                         Style="{StaticResource ContextMenuStyle}">
+                                         Style="{StaticResource PackageManagerContextMenuStyle}">
 
                                 <!--  Sub-Title 'SORT BY'  -->
                                 <Separator>
@@ -152,6 +152,7 @@
                                 <!--  Sort By Package Name  -->
                                 <MenuItem Command="{Binding Path=SetSortingKeyCommand}"
                                           CommandParameter="Name"
+                                          Style="{StaticResource PackageManagerContextMenuItemStyle}"
                                           Header="{x:Static p:Resources.PackageSearchViewContextMenuSortByName}"
                                           IsCheckable="True"
                                           IsChecked="{Binding Path=SortingKey, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Name, Mode=TwoWay}" />
@@ -254,9 +255,9 @@
                                          DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Mode=Self}}"
                                          DisplayMemberPath="FilterName"
                                          StaysOpen="True"
-                                         Style="{StaticResource ContextMenuStyle}">
+                                         Style="{StaticResource PackageManagerContextMenuStyle}">
                                 <ContextMenu.Resources>
-                                    <Style BasedOn="{StaticResource ContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
+                                    <Style BasedOn="{StaticResource PackageManagerContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
                                         <Setter Property="IsCheckable" Value="True" />
                                         <Setter Property="StaysOpenOnClick" Value="True" />
                                         <Setter Property="Command" Value="{Binding FilterCommand}" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -189,7 +189,7 @@
                             MinWidth="180"
                             Width="Auto"
                             Background="{StaticResource NodeContextMenuBackground}"
-                            Style="{StaticResource PackageManagerContextMenuStyle}">
+                            Style="{StaticResource DarkContextMenuStyle}">
 
                             <!--  Sub-Title 'SORT BY'  -->
                             <Separator>
@@ -315,9 +315,9 @@
                             DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Mode=Self}}"
                             DisplayMemberPath="FilterName"
                             ItemsSource="{Binding HostFilter}"
-                            Style="{StaticResource PackageManagerContextMenuStyle}">
+                            Style="{StaticResource DarkContextMenuStyle}">
                             <ContextMenu.ItemContainerStyle>
-                                <Style BasedOn="{StaticResource PackageManagerContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
+                                <Style BasedOn="{StaticResource DarkContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
                                     <Setter Property="IsCheckable" Value="True" />
                                     <Setter Property="Command" Value="{Binding FilterCommand}" />
                                     <Setter Property="CommandParameter" Value="{Binding FilterName}" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -189,7 +189,7 @@
                             MinWidth="180"
                             Width="Auto"
                             Background="{StaticResource NodeContextMenuBackground}"
-                            Style="{StaticResource ContextMenuStyle}">
+                            Style="{StaticResource PackageManagerContextMenuStyle}">
 
                             <!--  Sub-Title 'SORT BY'  -->
                             <Separator>
@@ -315,9 +315,9 @@
                             DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Mode=Self}}"
                             DisplayMemberPath="FilterName"
                             ItemsSource="{Binding HostFilter}"
-                            Style="{StaticResource ContextMenuStyle}">
+                            Style="{StaticResource PackageManagerContextMenuStyle}">
                             <ContextMenu.ItemContainerStyle>
-                                <Style BasedOn="{StaticResource ContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
+                                <Style BasedOn="{StaticResource PackageManagerContextMenuItemStyle}" TargetType="{x:Type MenuItem}">
                                     <Setter Property="IsCheckable" Value="True" />
                                     <Setter Property="Command" Value="{Binding FilterCommand}" />
                                     <Setter Property="CommandParameter" Value="{Binding FilterName}" />


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-6370](https://jira.autodesk.com/browse/DYN-6370) where some of the items in the group context menu have darker background that the rest.

Issue :
The inconsistency is there because the Package Manager context menus (which should be dark grey) share the same context menu item style as the group, connector, connector pin, and 3D watch node context menus (which should be light grey).

Fix :
I've created a separate style that applies a darker background color when IsMouseOver = False. It can be reused for future dark grey context menus.

![DYN-6370-Fix](https://github.com/user-attachments/assets/152b37f5-a9f1-4aa1-a266-16eff11e70b2)


### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

All items in the group, connector, connector pin and 3D watch node context menus now have consistent light grey backgrounds.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@achintyabhat 
