### PR TITLE
[DYN-8419] Adjust the warning bar in workspace view extension

### DIFF
--- a/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
+++ b/src/WorkspaceDependencyViewExtension/WorkspaceDependencyView.xaml
@@ -456,7 +456,7 @@
         </Grid>
 
         <!-- Template for the feedback banner -->
-        <DockPanel Name="Feedback" VerticalAlignment="Bottom" Grid.Row="4" Width="600">
+        <DockPanel Name="Feedback" VerticalAlignment="Bottom" Grid.Row="4" Width="Auto">
             <!-- Restart Banner -->
             <StatusBar
                 Name="RestartBanner"
@@ -468,7 +468,7 @@
                 <!-- Preview text -->
                 <StatusBarItem>
                     <Border Height="50">
-                        <TextBlock TextWrapping="Wrap" Width="500" Padding="10,0,10,0" FontSize="15" Foreground="White" Text="{x:Static w:Resources.RestartBannerMessage}" VerticalAlignment="Center"/>
+                        <TextBlock TextWrapping="Wrap" MinWidth="350" Padding="10,0,10,0" FontSize="15" Foreground="White" Text="{x:Static w:Resources.RestartBannerMessage}" VerticalAlignment="Center"/>
                     </Border>
                 </StatusBarItem>
             </StatusBar>


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-8419](https://jira.autodesk.com/browse/DYN-8419) where the status bar of Worskspace View Extension is misplaced.

I've updated WorkspaceDependencyView.cs to ensure that the status bar sticks to the right of the sidebar and always covers its full width.

![DYN-8419-Fix](https://github.com/user-attachments/assets/343fef36-2a55-4723-9169-fc9d2ba5ba5e)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

The status bar of the Worskspace View Extension now sticks to the right of the side bar and always covers its full width.

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@achintyabhat 
