### PR TITLE
DYN-5796-DynamoView-DisplayLocation-Bug

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -161,10 +161,25 @@ namespace Dynamo.Controls
             // of the available monitors.
             if (CheckVirtualScreenSize())
             {
+                System.Windows.Forms.Screen[] screens = System.Windows.Forms.Screen.AllScreens;
+                int leftLimit = 0;
+                int topLimit = 0;
+                foreach (var screen in screens)
+                {
+                    leftLimit += screen.Bounds.Width;
+                    topLimit += screen.Bounds.Height;
+                }   
+
                 Left = dynamoViewModel.Model.PreferenceSettings.WindowX;
                 Top = dynamoViewModel.Model.PreferenceSettings.WindowY;
                 Width = dynamoViewModel.Model.PreferenceSettings.WindowW;
                 Height = dynamoViewModel.Model.PreferenceSettings.WindowH;
+
+                //When the previous location was in a secondary screen then the next time Dynamo is launched will try to use the same location, then we need to added this validations to show Dynamo in the right place
+                if (Left > leftLimit)
+                    Left = 0;
+                if (Top > topLimit)
+                    Top = 0;
             }
             else
             {


### PR DESCRIPTION
### Purpose

Fixing bug of showing Dynamo is a not available monitor
When launching DynamoView in a multimonitor display and closing it in the second monitor is saving the location in the DynamoSettings.xml so the next time Dynamo is opened is putting the DynamoView in previously the saved location, then if the second display is missing DynamoView is located in a position where the user cannot interact with the Window. For fixing this problem I've added a validation for putting dynamo in the first monitor (X =0,  Y = 0) when the saved location is not valid (this fix is valid for any position horizontally and vertically).

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fixing bug of showing Dynamo is a not available monitor

### Reviewers

@QilongTang 

### FYIs

@twastvedt 
