### PR TITLE
DYN-8457 Fix when inserting groups from Help doc should have correct name

### DIFF
--- a/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
+++ b/src/DocumentationBrowserViewExtension/DocumentationBrowserViewModel.cs
@@ -438,7 +438,7 @@ namespace Dynamo.DocumentationBrowser
             {
                 if (GraphPath != null)
                 {
-                    var graphName = CurrentPackageName ?? Path.GetFileNameWithoutExtension(GraphPath);
+                    var graphName = string.IsNullOrEmpty(CurrentPackageName) ? Path.GetFileNameWithoutExtension(GraphPath) : CurrentPackageName;
                     raiseInsertGraph(this, new InsertDocumentationLinkEventArgs(GraphPath, graphName));
                 }
                 else

--- a/test/DynamoCoreWpf2Tests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
+++ b/test/DynamoCoreWpf2Tests/ViewExtensions/DocumentationBrowserViewExtensionTests.cs
@@ -802,6 +802,13 @@ namespace DynamoCoreWpfTests
             //Validates that we have 5 nodes the CurrentWorkspace (after the graph was added)
             Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Nodes.Count(), 5);
             DispatcherUtil.DoEvents();
+
+            //Validates that we have 1 group added containing the inserted graph
+            Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Annotations.Count(), 1);
+
+            //Validates that correct group name and description was set
+            Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().AnnotationText, "BasicAddition");
+            Assert.AreEqual(ViewModel.Model.CurrentWorkspace.Annotations.FirstOrDefault().AnnotationDescriptionText, "Inserted Dynamo graph");
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Fixing a regression, the group name when a graph is inserted from the help doc, should be the full name of the target node

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Fix when inserting groups from Help doc should have correct name

### Reviewers

@DynamoDS/dynamo 

