### PR TITLE
DYN-8461: Publishing a new version of a package should reflect correct version number

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/NumericUpDownControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/NumericUpDownControl.xaml.cs
@@ -141,10 +141,11 @@ namespace Dynamo.PackageManager.UI
         // Handles the direct input of text (via keyboard)
         private void inputField_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if (Int32.TryParse(inputField.Text, out int value))
+            var val = Int32.TryParse(inputField.Text, out int value);
+            if(val || value == 0)
             {
                 Value = value.ToString();
-            };
+            }
         }
 
         // When user clicks on the watermark label at first, hide the watermark and pass the focus to the input textbox

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/NumericUpDownControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/NumericUpDownControl.xaml.cs
@@ -141,11 +141,8 @@ namespace Dynamo.PackageManager.UI
         // Handles the direct input of text (via keyboard)
         private void inputField_TextChanged(object sender, TextChangedEventArgs e)
         {
-            var val = Int32.TryParse(inputField.Text, out int value);
-            if(val || value == 0)
-            {
-                Value = value.ToString();
-            }
+            Int32.TryParse(inputField.Text, out int value);
+            Value = value.ToString();
         }
 
         // When user clicks on the watermark label at first, hide the watermark and pass the focus to the input textbox

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -204,6 +204,18 @@ namespace DynamoCoreWpfTests.PackageManager
 
             isValidOutput = updownControl.IsValidInput("1");
             Assert.IsTrue(isValidOutput, "Should allow positive integers in numeric input.");
+
+            // Arrange
+            var inputField = updownControl.inputField;
+
+            // Act & Assert
+            Assert.AreEqual("0", updownControl.Value);
+
+            inputField.Text = "1";
+            Assert.AreEqual("1", updownControl.Value);
+
+            inputField.Text = "";
+            Assert.AreEqual("0", updownControl.Value);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

When deleting a version numeral from the UI, the change event skipped empty values (`""`). The update should now consider empty values and update version as `0`.

Added test

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Publishing a new version of a package should reflect correct version number

### Reviewers

@DynamoDS/dynamo 
