### PR TITLE
[DYN-7719] Shortcut buttons blink on periodic mode

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -24,7 +24,7 @@ namespace Dynamo.Wpf.ViewModels
         private bool isSelected;
 
         /// <summary>
-        /// The enabled flag sets whether the RunType is selectablable
+        /// The enabled flag sets whether the RunType is selectable
         /// in the view.
         /// </summary>
         public bool Enabled
@@ -307,10 +307,13 @@ namespace Dynamo.Wpf.ViewModels
         #region private and internal methods
 
         /// <summary>
-        /// Notifies all relevant Dynamo features (UI elements, commands) that the Graph exection has been enabled/disabled. 
+        /// Notifies all relevant Dynamo features (UI elements, commands) that the Graph execution has been enabled/disabled. 
         /// </summary>
         void NotifyOfGraphRunChanged()
         {
+            // Skip UI updates during periodic mode to prevent unnecessary toggling of UI elements
+            if (Model.RunType == RunType.Periodic) return;
+
             RaisePropertyChanged(nameof(RunButtonEnabled));
             RaisePropertyChanged(nameof(RunButtonToolTip));
 


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-7719](https://jira.autodesk.com/browse/DYN-7719), where the New and Open shortcut buttons blink during graph execution in Periodic Run mode.

The flickering was caused by RunSettingsViewModel.NotifyOfGraphRunChanged, which was toggling the IsEnabled state of UI elements on every execution cycle. To resolve this, UI updates are suppressed when DynamoModel is in Periodic Run mode, preventing unnecessary changes to the shortcut buttons.

![DYN-7719-Fix](https://github.com/user-attachments/assets/57620911-5029-4363-b49c-74eb84d1ffc4)

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

Open and New shortcut buttons will no longer blink in periodic run mode. 

### Reviewers
@QilongTang 
@reddyashish 

### FYIs
@dnenov 
@achintyabhat 
