### PR TITLE
DYN-5861: Reopening python editor should restore the editor window

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -601,6 +601,7 @@ namespace Dynamo.Controls
             if (tabItem != null)
             {
                 tabDynamic.SelectedItem = tabItem;
+                if (ExtensionsCollapsed) ToggleExtensionBarCollapseStatus();
                 return tabItem;
             }
 

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -230,6 +230,10 @@ namespace PythonNodeModelsWpf
                     {
                         editWindow.Activate();
                         dynamoView = editWindow.Owner as DynamoView;
+                        if (editWindow.WindowState == WindowState.Minimized)
+                        {
+                            editWindow.WindowState = WindowState.Normal;
+                        }
                     }
                     else
                     {

--- a/test/DynamoCoreWpf3Tests/PythonNodeCustomizationTests.cs
+++ b/test/DynamoCoreWpf3Tests/PythonNodeCustomizationTests.cs
@@ -263,6 +263,49 @@ namespace DynamoCoreWpfTests
         }
 
         /// <summary>
+        /// The next test validate that the script editor is
+        /// restored from a minimized state, when triggered again.
+        /// </summary>
+        [Test]
+        public void RestoreWindowOnEditorOpenTest()
+        {
+            Open(@"core\python\python_check_output.dyn");
+            ViewModel.HomeSpace.Run();
+
+            var nodeView = NodeViewWithGuid("3bcad14e-d086-4278-9e08-ed2759ef92f3");
+            var nodeModel = nodeView.ViewModel.NodeModel as PythonNodeBase;
+            Assert.NotNull(nodeModel);
+
+            var scriptWindow = EditPythonCode(nodeView, View);
+            Assert.IsTrue(scriptWindow.WindowState == WindowState.Normal);
+
+            //minimize editor
+            scriptWindow.WindowState = WindowState.Minimized;
+            Assert.IsTrue(scriptWindow.WindowState == WindowState.Minimized);
+
+            //reopen editor
+            EditPythonCode(nodeView, View);
+
+            //assert that window was restored
+            Assert.IsTrue(scriptWindow.WindowState == WindowState.Normal);
+
+            //dock editor
+            scriptWindow.DockWindow();
+            Assert.IsTrue(ViewModel.DockedNodeWindows.Contains(nodeModel.GUID.ToString()));
+            Assert.IsFalse(this.View.ExtensionsCollapsed);
+
+            //collapse right sidebar
+            this.View.ToggleExtensionBarCollapseStatus();
+            Assert.IsTrue(this.View.ExtensionsCollapsed);
+
+            //reopen editor
+            EditPythonCode(nodeView, View);
+
+            //assert that docked sidebar was restored
+            Assert.IsFalse(this.View.ExtensionsCollapsed);
+        }
+
+        /// <summary>
         /// The test to validate that the editor window will not retain changes
         /// and revert to the last saved state when the editor is closed without saving.
         /// The test will execute the events:
@@ -593,7 +636,7 @@ namespace DynamoCoreWpfTests
 
             editMenuItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
             DispatcherUtil.DoEvents();
-            return window.GetChildrenWindowsOfType<ScriptEditorWindow>().First();
+            return window.GetChildrenWindowsOfType<ScriptEditorWindow>().FirstOrDefault();
         }
 
         private static void SetTextEditorText(ScriptEditorWindow view,string code)


### PR DESCRIPTION
### Purpose

When the python editor is minimized or docked away in the collapsed (right) sidebar, it won't reappear double clicking the python node, or when opening using the context menu.
This change should restore the minimized editor window, or if it was docked in the collapsed extension, the right sidebar will be restored as well.

Added a test.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

- Reopening python editor should restore the editor window

### Reviewers

@DynamoDS/dynamo 
